### PR TITLE
Added Godeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ oauth/client.json
 oauth/user.json
 .idea
 example.eskip
+Godeps/_workspace

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,317 @@
+{
+	"ImportPath": "github.com/Raffo/skipper",
+	"GoVersion": "go1.5.1",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "bitbucket.org/ww/goautoneg",
+			"Comment": "null-5",
+			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+		},
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.8.6-1-g8bca266",
+			"Rev": "8bca2664072173a3c71db4c28ca8d304079b1787"
+		},
+		{
+			"ImportPath": "github.com/beorn7/perks/quantile",
+			"Rev": "b965b613227fddccbfffe13eae360ed3fa822f8d"
+		},
+		{
+			"ImportPath": "github.com/boltdb/bolt",
+			"Comment": "v1.1.0-19-g0b00eff",
+			"Rev": "0b00effdd7a8270ebd91c24297e51643e370dd52"
+		},
+		{
+			"ImportPath": "github.com/bradfitz/http2",
+			"Rev": "3e36af6d3af0e56fa3da71099f864933dea3d9fb"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/client",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/discovery",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/error",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/etcdmain",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/etcdserver",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/cors",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/crc",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/fileutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/flags",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/httputil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/idutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/ioutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/logutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/netutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/osutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/pbutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/runtime",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/timeutil",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/transport",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/types",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/wait",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/proxy",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/raft",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/rafthttp",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/snap",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/storage",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/store",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/version",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/wal",
+			"Comment": "v2.3.0-alpha.0-139-g769f874",
+			"Rev": "769f874542fecb42877f47a9e9eb5a27df8c1c5a"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-etcd/etcd",
+			"Comment": "v2.0.0-38-g003851b",
+			"Rev": "003851be7bb0694fe3cc457a49529a19388ee7cf"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-semver/semver",
+			"Rev": "568e959cd89871e61434c1143528d9162da89ef2"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-systemd/daemon",
+			"Comment": "v3-6-gcea488b",
+			"Rev": "cea488b4e6855fee89b6c22a811e3c5baca861b6"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-systemd/journal",
+			"Comment": "v3-6-gcea488b",
+			"Rev": "cea488b4e6855fee89b6c22a811e3c5baca861b6"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-systemd/util",
+			"Comment": "v3-6-gcea488b",
+			"Rev": "cea488b4e6855fee89b6c22a811e3c5baca861b6"
+		},
+		{
+			"ImportPath": "github.com/coreos/pkg/capnslog",
+			"Rev": "2c77715c4df99b5420ffcae14ead08f52104065d"
+		},
+		{
+			"ImportPath": "github.com/dimfeld/httppath",
+			"Rev": "c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc"
+		},
+		{
+			"ImportPath": "github.com/gogo/protobuf/proto",
+			"Rev": "64f27bf06efee53589314a6e5a4af34cdd85adf6"
+		},
+		{
+			"ImportPath": "github.com/golang/glog",
+			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "5677a0e3d5e89854c9974e1256839ee23f8233ca"
+		},
+		{
+			"ImportPath": "github.com/google/btree",
+			"Rev": "cc6329d4279e3f025a53a83c397d2339b5705c45"
+		},
+		{
+			"ImportPath": "github.com/jonboulle/clockwork",
+			"Rev": "72f9bd7c4e0c2a40055ab3d0f09654f730cce982"
+		},
+		{
+			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"Rev": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_golang/prometheus",
+			"Comment": "0.7.0-52-ge51041b",
+			"Rev": "e51041b3fa41cece0dca035740ba6411905be473"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_model/go",
+			"Comment": "model-0.0.2-12-gfa8ad6f",
+			"Rev": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/expfmt",
+			"Rev": "ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/model",
+			"Rev": "ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650"
+		},
+		{
+			"ImportPath": "github.com/prometheus/procfs",
+			"Rev": "454a56f35412459b5e684fd5ec0f9211b94f002a"
+		},
+		{
+			"ImportPath": "github.com/rcrowley/go-metrics",
+			"Rev": "3e5e593311103d49927c8d2b0fd93ccdfe4a525c"
+		},
+		{
+			"ImportPath": "github.com/ugorji/go/codec",
+			"Rev": "f1f1a805ed361a0e078bb537e4ea78cd37dcf065"
+		},
+		{
+			"ImportPath": "github.com/xiang90/probing",
+			"Rev": "6a0cc1ae81b4cc11db5e491e030e4b98fba79c19"
+		},
+		{
+			"ImportPath": "github.com/zalando/pathmux",
+			"Rev": "9da5d66a7685723a10a6820d7721ca9fff9e0033"
+		},
+		{
+			"ImportPath": "github.com/zalando/skipper",
+			"Comment": "prerelease-87-g1c1d6ac",
+			"Rev": "1c1d6ac507adb7902c1c2709c457dba35c6e91eb"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/bcrypt",
+			"Rev": "1351f936d976c60a0a48d728281922cf63eafb8d"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/blowfish",
+			"Rev": "1351f936d976c60a0a48d728281922cf63eafb8d"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/ssh/terminal",
+			"Rev": "1351f936d976c60a0a48d728281922cf63eafb8d"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "d5cd7348bfebdf7dbb6dbb18fa488525f9024293"
+		},
+		{
+			"ImportPath": "golang.org/x/net/netutil",
+			"Rev": "d5cd7348bfebdf7dbb6dbb18fa488525f9024293"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2",
+			"Rev": "3046bc76d6dfd7d3707f6640f85e42d9c4050f50"
+		},
+		{
+			"ImportPath": "google.golang.org/cloud/compute/metadata",
+			"Rev": "f20d6dcccb44ed49de45ae3703312cb46e627db1"
+		},
+		{
+			"ImportPath": "google.golang.org/cloud/internal",
+			"Rev": "f20d6dcccb44ed49de45ae3703312cb46e627db1"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc",
+			"Rev": "f5ebd86be717593ab029545492c93ddf8914832b"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.


### PR DESCRIPTION
Godeps added and Godeps/_workspace added to `.gitignore`. In this way you will NOT commit the sources of the imported projects. The dependencies can then be restored using `godep restore`. 
Let me know if this PR suits your needs. 