### PR TITLE
Always set the Host header from the original request by default

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -154,7 +154,7 @@ func mapRequest(r *http.Request, rt *routing.Route) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	rr.Host = r.Host
 	rr.Header = cloneHeader(r.Header)
 	return rr, nil
 }


### PR DESCRIPTION
This single line is required to reuse the Host from the original request. This was our original expectation.
As we found out, the new request is built with the Host from the URL.

Go's SDK doesn't actually have the Host header in the Headers.

After we refactor the header filter we can still provide the option to change the host in the upstream request.