### PR TITLE
Upgrade static

### DIFF
--- a/filters/builtin/static.go
+++ b/filters/builtin/static.go
@@ -39,7 +39,6 @@ type static struct {
 // waits until WriteHeader of the response writer completes
 // and delayes Write, until the body read is started
 func newDelayed(req *http.Request, p string) *http.Response {
-	println(p)
 	pr, pw := io.Pipe()
 	rsp := &http.Response{Header: make(http.Header)}
 	db := &delayedBody{

--- a/filters/builtin/static_test.go
+++ b/filters/builtin/static_test.go
@@ -18,7 +18,10 @@ import (
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/proxy/proxytest"
+	"io"
 	"io/ioutil"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"testing"
@@ -30,6 +33,7 @@ func TestStatic(t *testing.T) {
 	for _, ti := range []struct {
 		msg             string
 		args            []interface{}
+		content         string
 		removeFile      bool
 		path            string
 		expectedStatus  int
@@ -37,35 +41,48 @@ func TestStatic(t *testing.T) {
 	}{{
 		msg:            "invalid number of args",
 		args:           nil,
+		content:        testData,
 		path:           "/static/static-test",
 		expectedStatus: http.StatusNotFound,
 	}, {
 		msg:            "not string web root",
 		args:           []interface{}{3.14, "/tmp"},
+		content:        testData,
 		path:           "/static/static-test",
 		expectedStatus: http.StatusNotFound,
 	}, {
 		msg:            "not string fs root",
 		args:           []interface{}{"/static", 3.14},
+		content:        testData,
 		path:           "/static/static-test",
 		expectedStatus: http.StatusNotFound,
 	}, {
 		msg:            "web root cannot be clipped",
 		args:           []interface{}{"/static", "/tmp"},
+		content:        testData,
 		path:           "/a",
 		expectedStatus: http.StatusNotFound,
 	}, {
 		msg:            "not found",
 		args:           []interface{}{"/static", "/tmp"},
+		content:        testData,
 		removeFile:     true,
 		path:           "/static/static-test",
 		expectedStatus: http.StatusNotFound,
 	}, {
 		msg:             "found",
 		args:            []interface{}{"/static", "/tmp"},
+		content:         testData,
 		path:            "/static/static-test",
 		expectedStatus:  http.StatusOK,
 		expectedContent: testData,
+	}, {
+		msg:             "found, empty",
+		args:            []interface{}{"/static", "/tmp"},
+		content:         "",
+		path:            "/static/static-test",
+		expectedStatus:  http.StatusOK,
+		expectedContent: "",
 	}} {
 		if ti.removeFile {
 			if err := os.Remove("/tmp/static-test"); err != nil && !os.IsNotExist(err) {
@@ -73,7 +90,7 @@ func TestStatic(t *testing.T) {
 				continue
 			}
 		} else {
-			if err := ioutil.WriteFile("/tmp/static-test", []byte(testData), os.ModePerm); err != nil {
+			if err := ioutil.WriteFile("/tmp/static-test", []byte(ti.content), os.ModePerm); err != nil {
 				t.Error(ti.msg, err)
 				continue
 			}
@@ -111,5 +128,99 @@ func TestStatic(t *testing.T) {
 		if string(content) != ti.expectedContent {
 			t.Error(ti.msg, "content doesn't match", string(content), ti.expectedContent)
 		}
+	}
+}
+
+func TestSameFileMultipleTimes(t *testing.T) {
+	const n = 6
+
+	if err := ioutil.WriteFile("/tmp/static-test", []byte("test content"), os.ModePerm); err != nil {
+		t.Error(err)
+		return
+	}
+
+	fr := make(filters.Registry)
+	fr.Register(NewStatic())
+	pr := proxytest.New(fr, &eskip.Route{
+		Filters: []*eskip.Filter{{Name: StaticName, Args: []interface{}{"/static", "/tmp"}}},
+		Shunt:   true})
+
+	for i := 0; i < n; i++ {
+		rsp, err := http.Get(pr.URL + "/static/static-test")
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		defer rsp.Body.Close()
+		_, err = ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+	}
+}
+
+func TestMultipleRanges(t *testing.T) {
+	const fcontent = "test content"
+	if err := ioutil.WriteFile("/tmp/static-test", []byte(fcontent), os.ModePerm); err != nil {
+		t.Error(err)
+		return
+	}
+
+	fr := make(filters.Registry)
+	fr.Register(NewStatic())
+	pr := proxytest.New(fr, &eskip.Route{
+		Filters: []*eskip.Filter{{Name: StaticName, Args: []interface{}{"/static", "/tmp"}}},
+		Shunt:   true})
+
+	req, err := http.NewRequest("GET", pr.URL+"/static/static-test", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	req.Header.Set("Range", "bytes=1-3,5-8")
+
+	rsp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	defer rsp.Body.Close()
+	_, params, err := mime.ParseMediaType(rsp.Header.Get("Content-Type"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	mp := multipart.NewReader(rsp.Body, params["boundary"])
+	parts := [][]int{{1, 4}, {5, 9}}
+	for {
+		p, err := mp.NextPart()
+		if err != nil {
+			if err != io.EOF {
+				t.Error(err)
+			}
+
+			break
+		}
+
+		partContent, err := ioutil.ReadAll(p)
+		if err != nil {
+			t.Error(err)
+			break
+		}
+
+		if string(partContent) != fcontent[parts[0][0]:parts[0][1]] {
+			t.Error("failed to receive multiple ranges")
+		}
+
+		parts = parts[1:]
+	}
+
+	if len(parts) != 0 {
+		t.Error("failed to receive all ranges")
 	}
 }


### PR DESCRIPTION
This pull request aims to fix the static filter to comply with the new way of shunting. The piping is a delicate issue. The reason is to fulfil 3 requirements:

1. benefit from the net/http.ServeFile implementation
2. still allow downstream filters to modify the response metadata
3. avoid buffering whole files