### PR TITLE
Small fix to filtertest mocks

### DIFF
--- a/filters/filtertest/filtertest.go
+++ b/filters/filtertest/filtertest.go
@@ -62,6 +62,7 @@ func (fc *Context) SetOutgoingHost(h string)            { fc.FOutgoingHost = h }
 func (fc *Context) Serve(resp *http.Response) {
 	fc.FServedWithResponse = true
 	fc.FResponse = resp
+	fc.FServed = true
 }
 
 func (spec *Filter) CreateFilter(config []interface{}) (filters.Filter, error) {


### PR DESCRIPTION
A while ago, the MarkServed was deprecated. Serve is supposed to handle it. This wasn't reflected in the filtertest mocks. This fixes it