### PR TITLE
Added write flag to log file

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -212,7 +212,7 @@ func getLogOutput(name string) (io.Writer, error) {
 		return os.Stderr, nil
 	}
 
-	return os.OpenFile(name, os.O_APPEND, os.ModeAppend)
+	return os.OpenFile(name, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
 }
 
 func initLog(o Options) error {


### PR DESCRIPTION
By default OpenFile will use the O_RDONLY but to write to the access log file it must be opened with write access.