### PR TITLE
Fixed error handling in applyPredicates

### DIFF
--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -229,7 +229,7 @@ func applyPredicates(route *Route, proute *parsedRoute) error {
 		}
 	}
 
-	return nil
+	return err
 }
 
 // Converts a parsing route objects to the exported route definition with

--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -71,6 +71,11 @@ func TestParseRouteExpression(t *testing.T) {
 		&Route{Method: "HEAD", Backend: "https://www.example.org"},
 		false,
 	}, {
+		"invalid method predicate",
+		`Path("/endpoint") && Method("GET", "POST") -> "https://www.example.org"`,
+		nil,
+		true,
+	}, {
 		"host regexps",
 		`Host(/^www[.]/) && Host(/[.]org$/) -> "https://www.example.org"`,
 		&Route{HostRegexps: []string{"^www[.]", "[.]org$"}, Backend: "https://www.example.org"},


### PR DESCRIPTION
The situation was not specific to the Method predicate.

Any other route with multiple predicates, where the last predicate had an error, would still return a valid route, with the last predicate stripped.

This could, effectively, lead to some nasty situations.

Thanks a lot for finding this and creating the issue.

This closes #169 