### PR TITLE
Add replicateTo filter. Which can be used for shadow backends

### DIFF
--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/diag"
 	"github.com/zalando/skipper/filters/flowid"
+	"github.com/zalando/skipper/filters/tee"
 )
 
 const (
@@ -67,6 +68,7 @@ func MakeRegistry() filters.Registry {
 		diag.NewBackendLatency(),
 		diag.NewBackendBandwidth(),
 		diag.NewBackendChunks(),
+		tee.NewTee(),
 	} {
 		r.Register(s)
 	}

--- a/filters/tee/tee.go
+++ b/filters/tee/tee.go
@@ -1,0 +1,140 @@
+package tee
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/zalando/skipper/filters"
+	"net/http"
+	"net/url"
+	"regexp"
+)
+
+const (
+	Name = "tee"
+)
+
+type teeSpec struct{}
+
+type teeType int
+
+const (
+	asBackend teeType = iota + 1
+	pathModified
+)
+
+type tee struct {
+	client      *http.Client
+	typ         teeType
+	host        string
+	scheme      string
+	rx          *regexp.Regexp
+	replacement string
+}
+
+// Returns a new tee filter Spec, whose instances execute
+// the exact same Request against a shadow backend.
+// parameters: shadow backend url, optional - the path(as a regexp) to match and the replacement string.
+// Name: "tee".
+// Example
+// Path("/api/v3") -> tee("https://api.example.com") -> "http://example.org/"
+// This route wil send incoming  request to http://example.org/api/v3 but will also send
+// a copy of the query to https://api.example.com/api/v3.
+// Example
+// Path("/api/v3") -> tee("https://api.example.com", ".*", "/v1/" ) -> "http://example.org/"
+// This route wil send incoming request to http://example.org/api/v3 but will also send
+// a copy of the request to https://api.example.com/v1/ . Note that scheme and path are changed
+
+func NewTee() *teeSpec {
+	return &teeSpec{}
+}
+
+//We do not touch response at all
+func (r *tee) Response(filters.FilterContext) {}
+
+// Request is copied and then modified to adopt changes in new backend
+func (r *tee) Request(fc filters.FilterContext) {
+	copyOfRequest := cloneRequest(r, fc.Request())
+	go func() {
+		rsp, err := r.client.Do(&copyOfRequest)
+		if err != nil {
+			log.Warn("error while tee request", err)
+		}
+		defer rsp.Body.Close()
+	}()
+}
+
+// copies requests changes URL and Host in request.
+// If 2nd and 3rd params are given path is also modified by applying regexp
+func cloneRequest(rep *tee, req *http.Request) http.Request {
+	copyOfRequest := new(http.Request)
+	*copyOfRequest = *req
+	copyUrl := new(url.URL)
+	*copyUrl = *req.URL
+	copyOfRequest.URL = copyUrl
+	copyOfRequest.URL.Host = rep.host
+	copyOfRequest.URL.Scheme = rep.scheme
+	copyOfRequest.Host = rep.host
+	//Need toc copy body
+	// copyOfRequest.Body = ???
+	//request URI should be empty
+	copyOfRequest.RequestURI = ""
+	if rep.typ == pathModified {
+		copyOfRequest.URL.Path = string(rep.rx.ReplaceAllString(copyOfRequest.URL.Path, rep.replacement))
+	}
+	return *copyOfRequest
+}
+
+// Creates out tee Filter
+// If only one parameter is given shadow backend is used as it is specified
+// If second and third parameters are also set, then path is modified
+func (spec *teeSpec) CreateFilter(config []interface{}) (filters.Filter, error) {
+	var teeInit tee = tee{client: &http.Client{}}
+
+	if len(config) == 0 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+	backend, ok := config[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	if url, err := url.Parse(backend); err == nil {
+		teeInit.host = url.Host
+		teeInit.scheme = url.Scheme
+	} else {
+		return nil, err
+	}
+
+	if len(config) == 1 {
+		teeInit.typ = asBackend
+		return &teeInit, nil
+	}
+
+	//modpath
+	if len(config) == 3 {
+		expr, ok := config[1].(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid filter config in %s, expecting regexp and string, got: %v", Name, config)
+		}
+
+		replacement, ok := config[2].(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid filter config in %s, expecting regexp and string, got: %v", Name, config)
+		}
+
+		rx, err := regexp.Compile(expr)
+
+		if err != nil {
+			return nil, err
+		}
+		teeInit.typ = pathModified
+		teeInit.rx = rx
+		teeInit.replacement = replacement
+
+		return &teeInit, nil
+	}
+
+	return nil, filters.ErrInvalidFilterParameters
+}
+
+func (spec *teeSpec) Name() string { return Name }

--- a/filters/tee/tee_test.go
+++ b/filters/tee/tee_test.go
@@ -1,0 +1,83 @@
+package tee
+
+import (
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"net/http"
+	"testing"
+)
+
+var (
+	testTeeSpec        = NewTee()
+	teeArgsAsBackend   = []interface{}{"https://api.example.com"}
+	teeArgsWithModPath = []interface{}{"https://api.example.com", ".*", "/v1/"}
+)
+
+func TestTeeHostHeaderChanges(t *testing.T) {
+	f, _ := testTeeSpec.CreateFilter(teeArgsAsBackend)
+	fc := buildfilterContext()
+
+	rep, _ := f.(*tee)
+	modifiedRequest := cloneRequest(rep, fc.Request())
+	if modifiedRequest.Host != "api.example.com" {
+		t.Error("Tee Request Host not modified")
+	}
+
+	originalRequest := fc.Request()
+	if originalRequest.Host == "api.example.com" {
+		t.Error("Incoming Request Host was modified")
+	}
+}
+
+func TestTeeSchemeChanges(t *testing.T) {
+	f, _ := testTeeSpec.CreateFilter(teeArgsAsBackend)
+	fc := buildfilterContext()
+
+	rep, _ := f.(*tee)
+	modifiedRequest := cloneRequest(rep, fc.Request())
+	if modifiedRequest.URL.Scheme != "https" {
+		t.Error("Tee Request Scheme not modified")
+	}
+
+	originalRequest := fc.Request()
+	if originalRequest.URL.Scheme == "https" {
+		t.Error("Incoming Request Scheme was modified")
+	}
+}
+
+func TestTeeUrlHostChanges(t *testing.T) {
+	f, _ := testTeeSpec.CreateFilter(teeArgsAsBackend)
+	fc := buildfilterContext()
+
+	rep, _ := f.(*tee)
+	modifiedRequest := cloneRequest(rep, fc.Request())
+	if modifiedRequest.URL.Host != "api.example.com" {
+		t.Error("Tee Request Url Host not modified")
+	}
+
+	originalRequest := fc.Request()
+	if originalRequest.URL.Host == "api.example.com" {
+		t.Error("Incoming Request Url Host was modified")
+	}
+}
+
+func TestTeeWithPathChanges(t *testing.T) {
+	f, _ := testTeeSpec.CreateFilter(teeArgsWithModPath)
+	fc := buildfilterContext()
+
+	rep, _ := f.(*tee)
+	modifiedRequest := cloneRequest(rep, fc.Request())
+	if modifiedRequest.URL.Path != "/v1/" {
+		t.Errorf("Tee Request Path not modified, %v", modifiedRequest.URL.Path)
+	}
+
+	originalRequest := fc.Request()
+	if originalRequest.URL.Path != "/api/v3" {
+		t.Errorf("Incoming Request Scheme modified, %v", originalRequest.URL.Path)
+	}
+}
+
+func buildfilterContext() filters.FilterContext {
+	r, _ := http.NewRequest("GET", "http://example.org/api/v3", nil)
+	return &filtertest.Context{FRequest: r}
+}


### PR DESCRIPTION
Addin `replicateTo` filter for shadow backends.
I used DefaultHttp client but not sure with its performance as we discussed with @lmineiro 
Looking for your feedbacks @aryszka @lmineiro 