### PR TITLE
#203 Share TLSClientConfig with upgrade protocol proxy

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -153,7 +153,7 @@ type bodyBuffer struct {
 // initializing, see the WithParams the constructor and Params.
 type Proxy struct {
 	routing             *routing.Routing
-	roundTripper        http.RoundTripper
+	roundTripper        *http.Transport
 	priorityRoutes      []PriorityRoute
 	flags               Flags
 	metrics             *metrics.Metrics
@@ -545,9 +545,10 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				reverseProxy := httputil.NewSingleHostReverseProxy(backendURL)
 				reverseProxy.FlushInterval = p.flushInterval
 				upgradeProxy := upgradeProxy{
-					backendAddr:  backendURL,
-					reverseProxy: reverseProxy,
-					insecure:     p.flags.Insecure(),
+					backendAddr:     backendURL,
+					reverseProxy:    reverseProxy,
+					insecure:        p.flags.Insecure(),
+					tlsClientConfig: p.roundTripper.TLSClientConfig,
 				}
 				upgradeProxy.serveHTTP(w, rr)
 				log.Debugf("Finished upgraded protocol %s session", getUpgradeRequest(r))

--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -147,9 +147,7 @@ func (p *upgradeProxy) dialBackend(req *http.Request) (net.Conn, error) {
 			}
 			err = tlsConn.VerifyHostname(hostToVerify)
 			if err != nil {
-				if tlsConn != nil {
-					_ = tlsConn.Close()
-				}
+				tlsConn.Close()
 				return nil, err
 			}
 		}

--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -40,9 +40,10 @@ func getUpgradeRequest(req *http.Request) string {
 
 // UpgradeProxy stores everything needed to make the connection upgrade.
 type upgradeProxy struct {
-	backendAddr  *url.URL
-	reverseProxy *httputil.ReverseProxy
-	insecure     bool
+	backendAddr     *url.URL
+	reverseProxy    *httputil.ReverseProxy
+	insecure        bool
+	tlsClientConfig *tls.Config
 }
 
 // TODO: add user here
@@ -134,30 +135,25 @@ func (p *upgradeProxy) dialBackend(req *http.Request) (net.Conn, error) {
 	case "http":
 		return net.Dial("tcp", dialAddr)
 	case "https":
-		if p.insecure {
-			tlsConn, err := tls.Dial("tcp", dialAddr, &tls.Config{InsecureSkipVerify: true})
+		tlsConn, err := tls.Dial("tcp", dialAddr, p.tlsClientConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		if !p.insecure {
+			hostToVerify, _, err := net.SplitHostPort(dialAddr)
 			if err != nil {
 				return nil, err
 			}
-			return tlsConn, err
-		}
-		// TODO: If skipper supports using a different CA, we should support it here, too
-		hostToVerify, _, err := net.SplitHostPort(dialAddr)
-		if err != nil {
-			return nil, err
-		}
-		// system Roots are used
-		tlsConn, err := tls.Dial("tcp", dialAddr, &tls.Config{})
-		if err != nil {
-			return nil, err
-		}
-		err = tlsConn.VerifyHostname(hostToVerify)
-		if err != nil {
-			if tlsConn != nil {
-				_ = tlsConn.Close()
+			err = tlsConn.VerifyHostname(hostToVerify)
+			if err != nil {
+				if tlsConn != nil {
+					_ = tlsConn.Close()
+				}
+				return nil, err
 			}
-			return nil, err
 		}
+
 		return tlsConn, nil
 	default:
 		return nil, fmt.Errorf("unknown scheme: %s", p.backendAddr.Scheme)


### PR DESCRIPTION
Normal proxy and upgrade proxy should configure tls the same way, so it
makes sense to share the `*tls.Config` already initilized with the
normal proxy.

Note this exposes the `*http.Transport` instead of "hiding" it behind the `RoundTripper` interface.

Close #203 
