### PR TITLE
Fix error handling on failed tee requests

### DIFF
--- a/filters/tee/tee.go
+++ b/filters/tee/tee.go
@@ -88,7 +88,9 @@ func (r *tee) Request(fc filters.FilterContext) {
 		if err != nil {
 			log.Warn("error while tee request", err)
 		}
-		defer rsp.Body.Close()
+		if err == nil {
+			defer rsp.Body.Close()
+		}
 	}()
 }
 


### PR DESCRIPTION
@aryszka When Tee downstream has some errors, body.close were creating seg faults since body is not there