### PR TITLE
Replace ReplaceAll with ReplaceAllString

### DIFF
--- a/filters/builtin/path.go
+++ b/filters/builtin/path.go
@@ -20,7 +20,7 @@ type modPath struct {
 }
 
 // Returns a new modpath filter Spec, whose instances execute
-// regexp.ReplaceAll on the request path. Instances expect two
+// regexp.ReplaceAllString on the request path. Instances expect two
 // parameters: the expression to match and the replacement string.
 // Name: "modpath".
 func NewModPath() filters.Spec { return &modPath{behavior: regexpReplace} }
@@ -91,12 +91,12 @@ func (spec *modPath) CreateFilter(config []interface{}) (filters.Filter, error) 
 	}
 }
 
-// Modifies the path with regexp.ReplaceAll.
+// Modifies the path with regexp.ReplaceAllString.
 func (f *modPath) Request(ctx filters.FilterContext) {
 	req := ctx.Request()
 	switch f.behavior {
 	case regexpReplace:
-		req.URL.Path = string(f.rx.ReplaceAll([]byte(req.URL.Path), []byte(f.replacement)))
+		req.URL.Path = f.rx.ReplaceAllString(req.URL.Path, f.replacement)
 	case fullReplace:
 		req.URL.Path = f.replacement
 	default:
@@ -105,4 +105,4 @@ func (f *modPath) Request(ctx filters.FilterContext) {
 }
 
 // Noop.
-func (f *modPath) Response(ctx filters.FilterContext) {}
+func (_ *modPath) Response(_ filters.FilterContext) {}

--- a/filters/builtin/path_test.go
+++ b/filters/builtin/path_test.go
@@ -33,6 +33,13 @@ func TestModifyPath(t *testing.T) {
 	}
 }
 
+func TestModifyPathWithInvalidExpression(t *testing.T) {
+	spec := NewModPath()
+	if f, err := spec.CreateFilter([]interface{}{"(?=;)", "foo"}); err == nil || f != nil {
+		t.Error("Expected error for invalid regular expression parameter")
+	}
+}
+
 func TestSetPath(t *testing.T) {
 	spec := NewSetPath()
 	f, err := spec.CreateFilter([]interface{}{"/baz/qux"})


### PR DESCRIPTION
Very small changes here
1. Renamed to file to a more general `path` since it also does setPath now
2. It looked like what we really wanted was ReplaceAllString
3. My coverage metrics showed that we were missing the failure to compile the regex test case