### PR TITLE
rename tee to follow conventions

### DIFF
--- a/eskip/doc.go
+++ b/eskip/doc.go
@@ -160,11 +160,20 @@ filters:
 
     status(418)
 
+	tee("https://audit-logging.example.org")
+
 For details about the built-in filters, please, refer to the
 documentation of the skipper/filters package. Skipper is designed to be
 extendable primarily by implementing custom filters, for details about
 how to create custom filters, please, refer to the documentation of the
 root skipper package.
+
+
+Naming conventions
+
+Note, that the naming of predicates and filters follows the following
+convention: both predicates and filters are written in camel case, and
+predicates start with upper case, while filters start with lower case.
 
 
 Backend

--- a/eskip/doc.go
+++ b/eskip/doc.go
@@ -56,7 +56,7 @@ supports the glob standard, e.g. "/some/path/**" will work as expected.
 The arguments are available to the filters while processing the matched
 requests.
 
-	PathSubtree("/some/path")
+    PathSubtree("/some/path")
 
 The path subtree predicate behaves similar to the path predicate, but
 it matches the exact path in the definition and any sub path below it.
@@ -160,7 +160,7 @@ filters:
 
     status(418)
 
-	tee("https://audit-logging.example.org")
+    tee("https://audit-logging.example.org")
 
 For details about the built-in filters, please, refer to the
 documentation of the skipper/filters package. Skipper is designed to be

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -71,6 +71,7 @@ func MakeRegistry() filters.Registry {
 		diag.NewBackendBandwidth(),
 		diag.NewBackendChunks(),
 		tee.NewTee(),
+		tee.NewTeeDeprecated(),
 	} {
 		r.Register(s)
 	}

--- a/filters/tee/doc.go
+++ b/filters/tee/doc.go
@@ -6,7 +6,7 @@ backend of the route.
 
 Example:
 
-	* -> Tee("https://audit-logging.example.org") -> "https://foo.example.org"
+	* -> tee("https://audit-logging.example.org") -> "https://foo.example.org"
 
 This will send an identical request for foo.example.org to audit-logging.example.org.
 Another use case could be using it for benchmarking a new backend with some real traffic

--- a/filters/tee/tee.go
+++ b/filters/tee/tee.go
@@ -45,7 +45,7 @@ type teeTie struct {
 // parameters: shadow backend url, optional - the path(as a regexp) to match and the replacement string.
 //
 // Name: "tee".
-func NewTee() *teeSpec {
+func NewTee() filters.Spec {
 	return &teeSpec{}
 }
 
@@ -56,7 +56,7 @@ func NewTee() *teeSpec {
 // and NewTee() (providing the name "tee") should be used instead.
 //
 // Name: "Tee".
-func NewTeeDeprecated() *teeSpec {
+func NewTeeDeprecated() filters.Spec {
 	return &teeSpec{deprecated: true}
 }
 

--- a/filters/tee/tee.go
+++ b/filters/tee/tee.go
@@ -11,9 +11,14 @@ import (
 	"github.com/zalando/skipper/filters"
 )
 
-const Name = "tee"
+const (
+	Name           = "tee"
+	DeprecatedName = "Tee"
+)
 
-type teeSpec struct{}
+type teeSpec struct {
+	deprecated bool
+}
 
 type teeType int
 
@@ -42,6 +47,17 @@ type teeTie struct {
 // Name: "tee".
 func NewTee() *teeSpec {
 	return &teeSpec{}
+}
+
+// Returns a new tee filter Spec, whose instances execute the exact same Request against a shadow backend.
+// parameters: shadow backend url, optional - the path(as a regexp) to match and the replacement string.
+//
+// This version uses the capitalized version of the filter name and to follow conventions, it is deprecated
+// and NewTee() (providing the name "tee") should be used instead.
+//
+// Name: "Tee".
+func NewTeeDeprecated() *teeSpec {
+	return &teeSpec{deprecated: true}
 }
 
 func (tt *teeTie) Read(b []byte) (int, error) {
@@ -161,4 +177,10 @@ func (spec *teeSpec) CreateFilter(config []interface{}) (filters.Filter, error) 
 	return nil, filters.ErrInvalidFilterParameters
 }
 
-func (spec *teeSpec) Name() string { return Name }
+func (spec *teeSpec) Name() string {
+	if spec.deprecated {
+		return DeprecatedName
+	}
+
+	return Name
+}

--- a/filters/tee/tee.go
+++ b/filters/tee/tee.go
@@ -11,9 +11,7 @@ import (
 	"github.com/zalando/skipper/filters"
 )
 
-const (
-	Name = "Tee"
-)
+const Name = "tee"
 
 type teeSpec struct{}
 
@@ -38,18 +36,10 @@ type teeTie struct {
 	w *io.PipeWriter
 }
 
-// Returns a new tee filter Spec, whose instances execute
-// the exact same Request against a shadow backend.
+// Returns a new tee filter Spec, whose instances execute the exact same Request against a shadow backend.
 // parameters: shadow backend url, optional - the path(as a regexp) to match and the replacement string.
+//
 // Name: "tee".
-// Example
-// Path("/api/v3") -> tee("https://api.example.com") -> "http://example.org/"
-// This route wil send incoming  request to http://example.org/api/v3 but will also send
-// a copy of the query to https://api.example.com/api/v3.
-// Example
-// Path("/api/v3") -> tee("https://api.example.com", ".*", "/v1/" ) -> "http://example.org/"
-// This route wil send incoming request to http://example.org/api/v3 but will also send
-// a copy of the request to https://api.example.com/v1/ . Note that scheme and path are changed
 func NewTee() *teeSpec {
 	return &teeSpec{}
 }

--- a/filters/tee/tee_test.go
+++ b/filters/tee/tee_test.go
@@ -107,7 +107,7 @@ func TestTeeEndToEndBody(t *testing.T) {
 	originalUrl := originalServer.URL
 	defer originalServer.Close()
 
-	routeStr := fmt.Sprintf(`route1: * -> Tee("%v") -> "%v";`, shadowUrl, originalUrl)
+	routeStr := fmt.Sprintf(`route1: * -> tee("%v") -> "%v";`, shadowUrl, originalUrl)
 
 	route, _ := eskip.Parse(routeStr)
 	registry := make(filters.Registry)


### PR DESCRIPTION
also fixes some docs (the examples from the constructor can be already found in doc.go)
