### PR TITLE
Added a check for repeating route ids to `eskip check`

### DIFF
--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -77,6 +77,17 @@ func loadRoutesChecked(in *medium) ([]*eskip.Route, error) {
 	return lr.routes, checkParseErrors(lr)
 }
 
+func checkRepeatedRouteIds(routes []*eskip.Route) error {
+	ids := map[string]struct{}{}
+	for _, route := range routes {
+		if _, ok := ids[route.Id]; ok {
+			return errors.New("Repeating route with id " + route.Id)
+		}
+		ids[route.Id] = struct{}{}
+	}
+	return nil
+}
+
 // load and parse routes, ignore parse errors.
 func loadRoutesUnchecked(in *medium) []*eskip.Route {
 	lr, _ := loadRoutes(in)
@@ -85,8 +96,12 @@ func loadRoutesUnchecked(in *medium) []*eskip.Route {
 
 // command executed for check.
 func checkCmd(a cmdArgs) error {
-	_, err := loadRoutesChecked(a.in)
-	return err
+	routes, err := loadRoutesChecked(a.in)
+	if err != nil {
+		return err
+	}
+
+	return checkRepeatedRouteIds(routes)
 }
 
 // command executed for print.

--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -78,12 +78,12 @@ func loadRoutesChecked(in *medium) ([]*eskip.Route, error) {
 }
 
 func checkRepeatedRouteIds(routes []*eskip.Route) error {
-	ids := map[string]struct{}{}
+	ids := map[string]bool{}
 	for _, route := range routes {
-		if _, ok := ids[route.Id]; ok {
+		if ids[route.Id] {
 			return errors.New("Repeating route with id " + route.Id)
 		}
-		ids[route.Id] = struct{}{}
+		ids[route.Id] = true
 	}
 	return nil
 }

--- a/cmd/eskip/load_test.go
+++ b/cmd/eskip/load_test.go
@@ -127,6 +127,20 @@ func TestCheckFile(t *testing.T) {
 	}
 }
 
+func TestCheckRepeatingRouteIds(t *testing.T) {
+	const name = "testFile"
+	err := withFile(name, `foo: Method("POST") -> "https://www.example1.org";foo: Method("POST") -> "https://www.example1.org";`, func(_ *os.File) {
+		err := checkCmd(cmdArgs{in: &medium{typ: file, path: name}})
+		if err == nil {
+			t.Error("Expected an error for repeating route names")
+		}
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestCheckEtcdInvalid(t *testing.T) {
 	urls, err := stringsToUrls(etcdtest.Urls...)
 	if err != nil {


### PR DESCRIPTION
This is a quite easy mistake to make, and hard to debug, so I've added a check for it.