### PR TITLE
Setting Content-Type header to application/json in debug

### DIFF
--- a/proxy/debug.go
+++ b/proxy/debug.go
@@ -125,8 +125,11 @@ func convertDebugInfo(d *debugInfo) debugDocument {
 }
 
 func dbgResponse(w http.ResponseWriter, d *debugInfo) {
+	w.Header().Set("Content-Type", "application/json")
+
 	doc := convertDebugInfo(d)
 	enc := json.NewEncoder(w)
+
 	if err := enc.Encode(&doc); err != nil {
 		log.Error("[debug response]", err)
 	}


### PR DESCRIPTION
`Content-Type` header of responses from debug listener have `plain/text`, however the body contains JSON. This change replaces it with `application/json`.