### PR TITLE
Basic per backend host metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -39,19 +39,24 @@ type Options struct {
 	// If set, detailed total response time metrics will be collected
 	// for each host, additionally grouped by status and method.
 	EnableServeHostMetrics bool
+
+	// If set, detailed response time metrics will be collected
+	// for each backend host
+	EnableBackendHostMetrics bool
 }
 
 const (
-	KeyRouteLookup     = "routelookup"
-	KeyRouteFailure    = "routefailure"
-	KeyFilterRequest   = "filter.%s.request"
-	KeyFiltersRequest  = "allfilters.request.%s"
-	KeyProxyBackend    = "backend.%s"
-	KeyFilterResponse  = "filter.%s.response"
-	KeyFiltersResponse = "allfilters.response.%s"
-	KeyResponse        = "response.%d.%s.skipper.%s"
-	KeyServeRoute      = "serveroute.%s.%s.%d"
-	KeyServeHost       = "servehost.%s.%s.%d"
+	KeyRouteLookup      = "routelookup"
+	KeyRouteFailure     = "routefailure"
+	KeyFilterRequest    = "filter.%s.request"
+	KeyFiltersRequest   = "allfilters.request.%s"
+	KeyProxyBackend     = "backend.%s"
+	KeyProxyBackendHost = "backendhost.%s"
+	KeyFilterResponse   = "filter.%s.response"
+	KeyFiltersResponse  = "allfilters.response.%s"
+	KeyResponse         = "response.%d.%s.skipper.%s"
+	KeyServeRoute       = "serveroute.%s.%s.%d"
+	KeyServeHost        = "servehost.%s.%s.%d"
 
 	KeyErrorsBackend   = "errors.backend.%s"
 	KeyErrorsStreaming = "errors.streaming.%s"
@@ -153,6 +158,12 @@ func (m *Metrics) MeasureAllFiltersRequest(routeId string, start time.Time) {
 
 func (m *Metrics) MeasureBackend(routeId string, start time.Time) {
 	m.measureSince(fmt.Sprintf(KeyProxyBackend, routeId), start)
+}
+
+func (m *Metrics) MeasureBackendHost(routeBackendHost string, start time.Time) {
+	if m.options.EnableBackendHostMetrics {
+		m.measureSince(fmt.Sprintf(KeyProxyBackendHost, hostForKey(routeBackendHost)), start)
+	}
 }
 
 func (m *Metrics) MeasureFilterResponse(filterName string, start time.Time) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -578,6 +578,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		p.metrics.MeasureBackend(rt.Id, start)
+		p.metrics.MeasureBackendHost(rt.Host, start)
 		c.res = rs
 	}
 


### PR DESCRIPTION
The background of this PR is the following:

We would like to create a dashboard, that shows us a distribution of where
skipper routes the requests to. Skipper currently supports metrics on a
per-backend base, but only keyed via the route-id. For our use-case, we would
need a mapping from route-id to backend-host. This is very brittle.

This is a simple solution, that would also provide a metric based on the
hostname of the backend. This would allow us to aggregate in ZMON. We could for
example create three buckets:
1. all requests, that go to *.example.org
2. all requests, that go to *.example.com
3. all others.
Plotting the request count over those three buckets would be exactly what
we want.

I tried to keep this as general as possible to be useful to others as well and
made it opt-in, because it might not be interesting for all users of skipper.