### PR TITLE
Flowid generators interface

### DIFF
--- a/filters/flowid/generator.go
+++ b/filters/flowid/generator.go
@@ -1,9 +1,0 @@
-package flowid
-
-// flowIdGenerator interface should be implemented by types that can generate request tracing Flow IDs.
-type flowIDGenerator interface {
-	// Generate returns a new Flow ID using the implementation specific format or an error in case of failure.
-	Generate() (string, error)
-	// MustGenerate behaves like Generate but panics on failure instead of returning an error.
-	MustGenerate() string
-}

--- a/filters/flowid/standard.go
+++ b/filters/flowid/standard.go
@@ -23,10 +23,11 @@ var (
 // NewFlowId creates a new built-in generator with the defined length and returns a flowid
 // This exported function is deprecated and the new flowIdGenerator interface should be used
 func NewFlowId(l int) (string, error) {
-	g, err := newBuiltInGenerator(l)
+	g, err := NewStandardGenerator(l)
 	if err != nil {
 		return "", fmt.Errorf("deprecated new flowid: %v", err)
 	}
+
 	return g.Generate()
 }
 
@@ -34,25 +35,25 @@ func isValid(flowId string) bool {
 	return len(flowId) >= MinLength && len(flowId) <= MaxLength && flowIdRegex.MatchString(flowId)
 }
 
-// builtInGenerator is the default flowID generator
+// standardGenerator is the default flowID generator
 // The alphabet is limited to 64 elements and requires a random 6 bit value to index any of them.
 // The cost to rnd.IntXX is not very relevant but the bit shifting operations are faster.
 // For this reason a single call to rnd.Int63 is used and its bits are mapped up to 10 chunks of 6 bits each.
 // The byte data type carries 2 additional bits for the next chunk which are cleared with the alphabet bit mask.
-type builtInGenerator struct {
+type standardGenerator struct {
 	length int
 }
 
-func newBuiltInGenerator(l int) (flowIDGenerator, error) {
+func NewStandardGenerator(l int) (Generator, error) {
 	if l < MinLength || l > MaxLength {
 		return nil, ErrInvalidLen
 	}
 
-	return &builtInGenerator{length: l}, nil
+	return &standardGenerator{length: l}, nil
 }
 
 // Generate returns a new Flow ID from the built-in generator with the configured length
-func (g *builtInGenerator) Generate() (string, error) {
+func (g *standardGenerator) Generate() (string, error) {
 	u := make([]byte, g.length)
 	for i := 0; i < g.length; i += 10 {
 		b := rand.Int63()
@@ -65,8 +66,7 @@ func (g *builtInGenerator) Generate() (string, error) {
 	return string(u), nil
 }
 
-// MustGenerate is a convenience function equivalent to Generate that panics on failure instead of returning an error.
-func (g *builtInGenerator) MustGenerate() string {
+func (g *standardGenerator) MustGenerate() string {
 	id, err := g.Generate()
 	if err != nil {
 		panic(err)

--- a/filters/flowid/standard_test.go
+++ b/filters/flowid/standard_test.go
@@ -52,9 +52,6 @@ func TestDeprecatedNewFlowID(t *testing.T) {
 	}
 }
 
-func mustGenerate() {
-}
-
 func BenchmarkFlowIdBuiltInGenerator(b *testing.B) {
 	for _, l := range []int{8, 10, 12, 14, 16, 26, 32, 64} {
 		b.Run(strconv.Itoa(l), func(b *testing.B) {

--- a/filters/flowid/standard_test.go
+++ b/filters/flowid/standard_test.go
@@ -20,7 +20,7 @@ func TestFlowIdInvalidLength(t *testing.T) {
 func TestFlowIdLength(t *testing.T) {
 	for expected := MinLength; expected <= MaxLength; expected++ {
 		t.Run(strconv.Itoa(expected), func(t *testing.T) {
-			g, err := newBuiltInGenerator(expected)
+			g, err := NewStandardGenerator(expected)
 			if err != nil {
 				t.Errorf("failed to create built-in generator: %v", err)
 			} else {
@@ -52,11 +52,14 @@ func TestDeprecatedNewFlowID(t *testing.T) {
 	}
 }
 
+func mustGenerate() {
+}
+
 func BenchmarkFlowIdBuiltInGenerator(b *testing.B) {
 	for _, l := range []int{8, 10, 12, 14, 16, 26, 32, 64} {
 		b.Run(strconv.Itoa(l), func(b *testing.B) {
 			b.ResetTimer()
-			gen, _ := newBuiltInGenerator(l)
+			gen, _ := NewStandardGenerator(l)
 			for i := 0; i < b.N; i++ {
 				gen.MustGenerate()
 			}

--- a/filters/flowid/ulid.go
+++ b/filters/flowid/ulid.go
@@ -13,11 +13,11 @@ type ulidGenerator struct {
 	r io.Reader
 }
 
-func newULIDGenerator() flowIDGenerator {
-	return newULIDGeneratorWithEntropyProvider(rand.New(rand.NewSource(time.Now().UTC().UnixNano())))
+func NewULIDGenerator() Generator {
+	return NewULIDGeneratorWithEntropy(rand.New(rand.NewSource(time.Now().UTC().UnixNano())))
 }
 
-func newULIDGeneratorWithEntropyProvider(r io.Reader) flowIDGenerator {
+func NewULIDGeneratorWithEntropy(r io.Reader) Generator {
 	return &ulidGenerator{r: r}
 }
 

--- a/filters/flowid/ulid_test.go
+++ b/filters/flowid/ulid_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestUlidGenerator(t *testing.T) {
-	g := newULIDGenerator()
+	g := NewULIDGenerator()
 	id, err := g.Generate()
 	if err != nil {
 		t.Fatal(err)
@@ -28,7 +28,7 @@ func (r *brokenReader) Read(p []byte) (int, error) {
 }
 
 func TestBuiltInGeneratorBrokenEntropyProvider(t *testing.T) {
-	g := newULIDGeneratorWithEntropyProvider(new(brokenReader))
+	g := NewULIDGeneratorWithEntropy(new(brokenReader))
 	_, err := g.Generate()
 	if err == nil {
 		t.Fatal("expected an error from the entropy provider bur err is nil")
@@ -44,7 +44,7 @@ func TestBuiltInGeneratorBrokenEntropyProvider(t *testing.T) {
 
 func BenchmarkFlowIdULIDGenerator(b *testing.B) {
 	b.Run("Std", func(b *testing.B) {
-		gen := newULIDGenerator()
+		gen := NewULIDGenerator()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			gen.MustGenerate()


### PR DESCRIPTION
this sub PR contains some suggestions to the package's exported interface. It provides the possibility to define new filters with custom generator implementations. It contains two open questions:

- shall we split `flowId("reuse", 8)` and `flowId("reuse", "ulid")` to `flowId("reuse", 8)` and `ulidFlowId("reuse")`?
- whether it is fine that the custom filters created by `WithGenerator(name, g)` won't have route specific arguments this way?