### PR TITLE
first draft of fswatch on the routes file

### DIFF
--- a/eskipfile/file.go
+++ b/eskipfile/file.go
@@ -16,36 +16,73 @@
 Package eskipfile implements a DataClient for reading the skipper route
 definitions from an eskip formatted file when opened.
 
+It supports runtime updates of routes by watching changes to the file.
+
 (See the DataClient interface in the skipper/routing package and the eskip
 format in the skipper/eskip package.)
 */
 package eskipfile
 
 import (
-	"github.com/zalando/skipper/eskip"
 	"io/ioutil"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/rjeczalik/notify"
+	"github.com/zalando/skipper/eskip"
 )
 
 // A Client contains the route definitions from an eskip file.
-type Client struct{ routes []*eskip.Route }
+type Client struct {
+	path     string
+	routes   []*eskip.Route
+	fsevents chan notify.EventInfo
+}
 
-// Opens an eskip file and parses it, returning a DataClient implementation.
+// Open reads an eskip file and parses it, returning a DataClient implementation.
 // If reading or parsing the file fails, returns an error.
-func Open(path string) (*Client, error) {
+func Open(p string) (*Client, error) {
+	r, err := readRoutesFromFile(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{routes: r, path: p}, nil
+}
+
+// Watch behaves like Open but it starts watching the eskip file for changes.
+// This enabled runtime updates of routes when using this DataClient.
+// The filesystem watcher created by this call should be properly Closed using this Client's Close function.
+func Watch(p string) (*Client, error) {
+	c, err := Open(p)
+	if err != nil {
+		return nil, err
+	}
+	c.fsevents = make(chan notify.EventInfo, 1)
+	// We only care about Write events and Rename for "atomic" saves from some editors
+	if err := notify.Watch(c.path, c.fsevents, notify.Write, notify.Rename); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Close does a clean shutdown of the Client. It is not needed unless the Client was created using the
+// Watch function, since it creates a filesystem watcher
+func (c *Client) Close() {
+	if c.fsevents != nil {
+		notify.Stop(c.fsevents)
+	}
+}
+
+func readRoutesFromFile(path string) ([]*eskip.Route, error) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	routes, err := eskip.Parse(string(content))
-	if err != nil {
-		return nil, err
-	}
-
-	return &Client{routes}, nil
+	return eskip.Parse(string(content))
 }
 
-func (c Client) LoadAndParseAll() (routeInfos []*eskip.RouteInfo, err error) {
+func (c *Client) LoadAndParseAll() (routeInfos []*eskip.RouteInfo, err error) {
 	for _, route := range c.routes {
 		routeInfos = append(routeInfos, &eskip.RouteInfo{Route: *route})
 	}
@@ -53,8 +90,31 @@ func (c Client) LoadAndParseAll() (routeInfos []*eskip.RouteInfo, err error) {
 }
 
 // Returns the parsed route definitions found in the file.
-func (c Client) LoadAll() ([]*eskip.Route, error) { return c.routes, nil }
+func (c *Client) LoadAll() ([]*eskip.Route, error) { return c.routes, nil }
 
-// Noop. The current implementation doesn't support watching the eskip
-// file for changes.
-func (c Client) LoadUpdate() ([]*eskip.Route, []string, error) { return nil, nil, nil }
+// LoadUpdate is No-Op if the Client was created using Open.
+// When created using Watch, it monitors the filesystem for changes on the eskip file and enables runtime updates
+// of the routes
+func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
+	if c.fsevents == nil {
+		return nil, nil, nil
+	}
+
+	for {
+		// TODO: should we have a timeout to bail every n secs or something?
+		select {
+		case _, ok := <-c.fsevents:
+			if ok {
+				log.Infof("detected changes in routes file %q, reloading ...", c.path)
+				// TODO: do we care about deletes here?
+				r, err := readRoutesFromFile(c.path)
+				if err != nil {
+					return nil, nil, err
+				}
+				return r, nil, nil
+			}
+		}
+	}
+
+	return nil, nil, nil
+}

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -48,12 +48,12 @@ func (d *incomingData) log(l logging.Logger) {
 	}
 }
 
-// continously receives route definitions from a data client on the the output channel.
+// continuously receives route definitions from a data client on the the output channel.
 // The function does not return unless quit is closed. When started, it request for the
 // whole current set of routes, and continues polling for the subsequent updates. When a
 // communication error occurs, it re-requests the whole valid set, and continues polling.
 // Currently, the routes with the same id coming from different sources are merged in an
-// undeterministic way, but this may change in the future.
+// non deterministic way, but this may change in the future.
 func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <-chan struct{}) {
 	initial := true
 	for {
@@ -142,7 +142,7 @@ func mergeDefs(defsByClient map[DataClient]routeDefs) []*eskip.Route {
 	return all
 }
 
-// receives the initial set of the route definitiosn and their
+// receives the initial set of the route definitions and their
 // updates from multiple data clients, merges them by route id
 // and sends the merged route definitions to the output channel.
 //


### PR DESCRIPTION
DON'T MERGE
This is a first draft for #248 and I'd like to get early feedback.

It seems to work fine on Mac OS X. It would be great if someone else out there could test with other OSes.
Under Docker, both with alpine and ubuntu I couldn't make it work. I tried both by having the file inside the container and also by mapping a volume.

```
docker run --name skipper --rm -v $(pwd)/example.eskip:/example.eskip -t skipper -routes-file example.eskip
```

inotifywatch did get the events
```
root@40c37740610e:/# inotifywatch -v -t 10 /example.eskip 
Establishing watches...
Total of 1 watches.
Finished establishing watches, now collecting statistics.
Will listen for events for 10 seconds.
total  modify  attrib  filename
12     6       6       /example.eskip
```