### PR TITLE
add prefix to error messages where it was missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ vet: $(SOURCES)
 	go vet ./...
 
 fmt: $(SOURCES)
-	gofmt -w $(SOURCES)
+	@gofmt -w $(SOURCES)
 
 check-fmt: $(SOURCES)
 	if [ "$$(gofmt -d $(SOURCES))" != "" ]; then false; else true; fi

--- a/filters/diag/diag.go
+++ b/filters/diag/diag.go
@@ -140,7 +140,7 @@ func (r *random) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 		ni, err := w.Write(b)
 		if err != nil {
-			log.Error(err)
+			log.Error("error while writing random content", err)
 			return
 		}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -576,7 +576,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 				sendError(w, http.StatusText(code), code)
 				p.metrics.MeasureServe(rt.Id, r.Host, r.Method, code, startServe)
-				log.Error(err)
+				log.Error("error during backend roundtrip", err)
 				return
 			}
 		}
@@ -597,7 +597,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer func(body io.Closer) {
 			err := body.Close()
 			if err != nil {
-				log.Error(err)
+				log.Error("error during closing the response body", err)
 			}
 		}(c.res.Body)
 	}
@@ -621,7 +621,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := copyStream(w.(flusherWriter), response.Body)
 		if err != nil {
 			p.metrics.IncErrorsStreaming(rt.Id)
-			log.Error(err)
+			log.Error("error while copying the response stream", err)
 		} else {
 			p.metrics.MeasureResponse(response.StatusCode, r.Method, rt.Id, start)
 		}

--- a/skipper.go
+++ b/skipper.go
@@ -199,7 +199,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 	if o.RoutesFile != "" {
 		f, err := eskipfile.Open(o.RoutesFile)
 		if err != nil {
-			log.Error(err)
+			log.Error("error while opening eskip file", err)
 			return nil, err
 		}
 
@@ -216,7 +216,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 		})
 
 		if err != nil {
-			log.Error(err)
+			log.Error("error while initializing Innkeeper client", err)
 			return nil, err
 		}
 


### PR DESCRIPTION
add a prefix to error messages that log only an error object. Closes #263 