### PR TITLE
Updating link to packaging readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,4 +90,4 @@ Skipper's [godoc](https://godoc.org/github.com/zalando/skipper) page includes de
 
 ### Packaging support
 
-See https://github.com/zalando/skipper/packaging/readme.md
+See https://github.com/zalando/skipper/blob/master/packaging/readme.md


### PR DESCRIPTION
The previous link landed on a "Not found" page