### PR TITLE
set the default command to skipper

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -3,3 +3,5 @@ MAINTAINER Skipper Maintainers <team-pathfinder@zalando.de>
 RUN mkdir -p /usr/bin
 ADD skipper eskip /usr/bin/
 ENV PATH $PATH:/usr/bin
+
+CMD ["/usr/bin/skipper"]


### PR DESCRIPTION
Run the default binary, which is skipper: 

    % docker run registry.opensource.zalan.do/pathfinder/skipper

Overwrite the command to eskip:

    % docker run registry.opensource.zalan.do/pathfinder/skipper /usr/bin/eskip