### PR TITLE
Support HTTPS requests in the Docker image

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine
 MAINTAINER Skipper Maintainers <team-pathfinder@zalando.de>
+RUN apk --no-cache add ca-certificates && update-ca-certificates
 RUN mkdir -p /usr/bin
 ADD skipper eskip /usr/bin/
 ENV PATH $PATH:/usr/bin

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -13,7 +13,7 @@ eskip:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build github.com/zalando/skipper/cmd/eskip
 
 clean:
-	rm skipper eskip
+	rm -f skipper eskip
 
 docker-build: clean skipper eskip
 	docker build -t $(IMAGE) .

--- a/packaging/readme.md
+++ b/packaging/readme.md
@@ -8,14 +8,14 @@ package managers. (Currently, only docker.)
 Use the provided Dockerfile to build a docker image with Alpine Linux and the latest version of skipper and
 eskip.
 
-Use the SKIPPER_VERSION and SKIPPER_REPOSITORY or SKIPPER_IMAGE environment variables to set the docker tag.
-SKIPPER_VERSION defaults to the hash of the current git head, which revision is also used to build the packaged
+Use the `VERSION` and `REGISTRY` or `IMAGE` environment variables to set the docker tag.
+`VERSION` defaults to the hash of the current git head, which revision is also used to build the packaged
 binary of skipper and eskip.
 
 **Example:**
 
 ```
-SKIPPER_REPOSITORY=my-repo SKIPPER_VERSION=latest-SNAPSHOT make docker-build docker-push
+REGISTRY=my-repo VERSION=latest-SNAPSHOT make docker-build docker-push
 ```
 
 The above command will build a docker image with a tag 'my-repo/skipper:latest-SNAPSHOT' and push it to


### PR DESCRIPTION
Added certificates to `Dockerfile` to support HTTPS requests. Without it, I got errors like `x509: failed to load system roots and no roots provided`.

Also:

- Updated env variables in the packaging README
- Fixed error on the first docker build