### PR TITLE
Get rid of kubectl proxy in skipper

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -42,7 +42,9 @@ const (
 	addressUsage                   = "network address that skipper should listen on"
 	etcdUrlsUsage                  = "urls of nodes in an etcd cluster, storing route definitions"
 	etcdPrefixUsage                = "path prefix for skipper related data in etcd"
-	kubernetesURLUsage             = "kubernetes API base url for the ingress data client; when set, it enables ingress"
+	kubernetesUsage                = "enables skipper to generate routes for ingress resources in kubernetes cluster"
+	kubernetesInClusterUsage       = "specify if skipper is running inside kubernetes cluster"
+	kubernetesURLUsage             = "kubernetes API base url for the ingress data client; requires kubectl proxy enabled; omit if kubernetes-in-cluster is set to true"
 	kubernetesHealthcheckUsage     = "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes-url"
 	innkeeperUrlUsage              = "API endpoint of the Innkeeper service, storing route definitions"
 	innkeeperAuthTokenUsage        = "fixed token for innkeeper authentication"
@@ -90,6 +92,8 @@ var (
 	proxyPreserveHost         bool
 	idleConnsPerHost          int
 	closeIdleConnsPeriod      string
+	kubernetes                bool
+	kubernetesInCluster       bool
 	kubernetesURL             string
 	kubernetesHealthcheck     bool
 	innkeeperUrl              string
@@ -129,6 +133,8 @@ func init() {
 	flag.IntVar(&idleConnsPerHost, "idle-conns-num", proxy.DefaultIdleConnsPerHost, idleConnsPerHostUsage)
 	flag.StringVar(&closeIdleConnsPeriod, "close-idle-conns-period", strconv.Itoa(int(proxy.DefaultCloseIdleConnsPeriod/time.Second)), closeIdleConnsPeriodUsage)
 	flag.StringVar(&etcdPrefix, "etcd-prefix", defaultEtcdPrefix, etcdPrefixUsage)
+	flag.BoolVar(&kubernetes, "kubernetes", false, kubernetesUsage)
+	flag.BoolVar(&kubernetesHealthcheckUsage, "kubernetes-in-cluster", false, kubernetesInCluster)
 	flag.StringVar(&kubernetesURL, "kubernetes-url", "", kubernetesURLUsage)
 	flag.BoolVar(&kubernetesHealthcheck, "kubernetes-healthcheck", true, kubernetesHealthcheckUsage)
 	flag.StringVar(&innkeeperUrl, "innkeeper-url", "", innkeeperUrlUsage)

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -44,7 +44,7 @@ const (
 	etcdPrefixUsage                = "path prefix for skipper related data in etcd"
 	kubernetesUsage                = "enables skipper to generate routes for ingress resources in kubernetes cluster"
 	kubernetesInClusterUsage       = "specify if skipper is running inside kubernetes cluster"
-	kubernetesURLUsage             = "kubernetes API base url for the ingress data client; requires kubectl proxy enabled; omit if kubernetes-in-cluster is set to true"
+	kubernetesURLUsage             = "kubernetes API base URL for the ingress data client; requires kubectl proxy running; omit if kubernetes-in-cluster is set to true"
 	kubernetesHealthcheckUsage     = "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes-url"
 	innkeeperUrlUsage              = "API endpoint of the Innkeeper service, storing route definitions"
 	innkeeperAuthTokenUsage        = "fixed token for innkeeper authentication"

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -134,7 +134,7 @@ func init() {
 	flag.StringVar(&closeIdleConnsPeriod, "close-idle-conns-period", strconv.Itoa(int(proxy.DefaultCloseIdleConnsPeriod/time.Second)), closeIdleConnsPeriodUsage)
 	flag.StringVar(&etcdPrefix, "etcd-prefix", defaultEtcdPrefix, etcdPrefixUsage)
 	flag.BoolVar(&kubernetes, "kubernetes", false, kubernetesUsage)
-	flag.BoolVar(&kubernetesHealthcheckUsage, "kubernetes-in-cluster", false, kubernetesInCluster)
+	flag.BoolVar(&kubernetesInCluster, "kubernetes-in-cluster", false, kubernetesInClusterUsage)
 	flag.StringVar(&kubernetesURL, "kubernetes-url", "", kubernetesURLUsage)
 	flag.BoolVar(&kubernetesHealthcheck, "kubernetes-healthcheck", true, kubernetesHealthcheckUsage)
 	flag.StringVar(&innkeeperUrl, "innkeeper-url", "", innkeeperUrlUsage)
@@ -212,6 +212,8 @@ func main() {
 		Address:                   address,
 		EtcdUrls:                  eus,
 		EtcdPrefix:                etcdPrefix,
+		Kubernetes:                kubernetes,
+		KubernetesInCluster:       kubernetesInCluster,
 		KubernetesURL:             kubernetesURL,
 		KubernetesHealthcheck:     kubernetesHealthcheck,
 		InnkeeperUrl:              innkeeperUrl,

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -101,10 +101,10 @@ type Client struct {
 var nonWord = regexp.MustCompile("\\W")
 
 var (
-	errServiceNotFound        = errors.New("service not found")
-	errServicePortNotFound    = errors.New("service port not found")
-	errAPIServerNotDiscovered = errors.New("kubernetes API server URL could not be constructed")
-	errInvalidCertificate     = errors.New("discovered certificate is invalid")
+	errServiceNotFound      = errors.New("service not found")
+	errServicePortNotFound  = errors.New("service port not found")
+	errAPIServerURLNotFound = errors.New("kubernetes API server URL could not be constructed from env vars")
+	errInvalidCertificate   = errors.New("discovered certificate is invalid")
 )
 
 // New creates and initializes a Kubernetes DataClient.
@@ -167,7 +167,7 @@ func buildAPIURL(o Options) (string, error) {
 
 	host, port := os.Getenv(serviceHostEnvVar), os.Getenv(servicePortEnvVar)
 	if len(host) == 0 || len(port) == 0 {
-		return "", errAPIServerNotDiscovered
+		return "", errAPIServerURLNotFound
 	}
 
 	return "https://" + net.JoinHostPort(host, port), nil

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -144,6 +144,7 @@ func readServiceAccountToken(inCluster bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	log.Debugf("service account token is found")
 
 	return string(bToken), nil
 }

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -451,7 +451,10 @@ func TestIngressData(t *testing.T) {
 		t.Run(ti.msg, func(t *testing.T) {
 			api := newTestAPI(t, ti.services, &ingressList{Items: ti.ingresses})
 			defer api.Close()
-			dc := New(Options{KubernetesURL: api.server.URL})
+			dc, err := New(Options{KubernetesURL: api.server.URL})
+			if err != nil {
+				t.Error(err)
+			}
 
 			r, err := dc.LoadAll()
 			if err != nil {
@@ -469,7 +472,10 @@ func Test(t *testing.T) {
 	defer api.Close()
 
 	t.Run("no services, no ingresses, load empty initial and update", func(t *testing.T) {
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		if r, err := dc.LoadAll(); err != nil || len(r) != 0 {
 			t.Error("failed to load initial")
@@ -482,7 +488,10 @@ func Test(t *testing.T) {
 
 	t.Run("has ingress but no according services, load empty initial and update", func(t *testing.T) {
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		if r, err := dc.LoadAll(); err != nil || len(r) != 0 {
 			t.Error("failed to load initial")
@@ -495,7 +504,10 @@ func Test(t *testing.T) {
 
 	t.Run("has ingress but no according services, service gets created", func(t *testing.T) {
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		if r, err := dc.LoadAll(); err != nil || len(r) != 0 {
 			t.Error("failed to load initial")
@@ -523,7 +535,10 @@ func Test(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 		api.ingresses.Items[2].Spec.Rules[0].Http.Paths[0].Backend.ServicePort = backendPort{"not-existing"}
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		r, err := dc.LoadAll()
 		if err != nil {
@@ -546,7 +561,10 @@ func Test(t *testing.T) {
 	t.Run("has ingresses, receive initial", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		r, err := dc.LoadAll()
 		if err != nil {
@@ -568,9 +586,12 @@ func Test(t *testing.T) {
 	t.Run("has ingresses, update some of them", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
-		_, err := dc.LoadAll()
+		_, err = dc.LoadAll()
 		if err != nil {
 			t.Error("failed to load initial routes", err)
 			return
@@ -593,9 +614,12 @@ func Test(t *testing.T) {
 	t.Run("has ingresses, loose a service", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
-		_, err := dc.LoadAll()
+		_, err = dc.LoadAll()
 		if err != nil {
 			t.Error("failed to load initial routes", err)
 			return
@@ -619,9 +643,12 @@ func Test(t *testing.T) {
 	t.Run("has ingresses, delete some ingresses", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
-		_, err := dc.LoadAll()
+		_, err = dc.LoadAll()
 		if err != nil {
 			t.Error("failed to load initial routes", err)
 			return
@@ -649,9 +676,12 @@ func Test(t *testing.T) {
 	t.Run("has ingresses, delete some ingress rules", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
-		_, err := dc.LoadAll()
+		_, err = dc.LoadAll()
 		if err != nil {
 			t.Error("failed to load initial routes", err)
 			return
@@ -675,9 +705,12 @@ func Test(t *testing.T) {
 	t.Run("has ingresses, add new ones", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
-		_, err := dc.LoadAll()
+		_, err = dc.LoadAll()
 		if err != nil {
 			t.Error("failed to load initial routes", err)
 			return
@@ -722,9 +755,12 @@ func Test(t *testing.T) {
 	t.Run("has ingresses, mixed insert, update, delete", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
-		_, err := dc.LoadAll()
+		_, err = dc.LoadAll()
 		if err != nil {
 			t.Error("failed to load initial routes", err)
 			return
@@ -783,7 +819,10 @@ func TestHealthcheckInitial(t *testing.T) {
 	defer api.Close()
 
 	t.Run("no healthcheck, empty", func(t *testing.T) {
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		r, err := dc.LoadAll()
 		if err != nil {
@@ -796,7 +835,7 @@ func TestHealthcheckInitial(t *testing.T) {
 	t.Run("no healthcheck", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
 
 		r, err := dc.LoadAll()
 		if err != nil {
@@ -808,8 +847,12 @@ func TestHealthcheckInitial(t *testing.T) {
 
 	t.Run("no healthcheck, fail", func(t *testing.T) {
 		api.failNext = true
-		dc := New(Options{KubernetesURL: api.server.URL})
-		_, err := dc.LoadAll()
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
+
+		_, err = dc.LoadAll()
 		if err == nil {
 			t.Error("failed to fail")
 		}
@@ -817,10 +860,13 @@ func TestHealthcheckInitial(t *testing.T) {
 
 	t.Run("use healthceck, empty", func(t *testing.T) {
 		api.ingresses.Items = nil
-		dc := New(Options{
+		dc, err := New(Options{
 			KubernetesURL:      api.server.URL,
 			ProvideHealthcheck: true,
 		})
+		if err != nil {
+			t.Error(err)
+		}
 
 		r, err := dc.LoadAll()
 		if err != nil {
@@ -833,10 +879,13 @@ func TestHealthcheckInitial(t *testing.T) {
 	t.Run("use healthcheck", func(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
-		dc := New(Options{
+		dc, err := New(Options{
 			KubernetesURL:      api.server.URL,
 			ProvideHealthcheck: true,
 		})
+		if err != nil {
+			t.Error(err)
+		}
 
 		r, err := dc.LoadAll()
 		if err != nil {
@@ -855,7 +904,10 @@ func TestHealthcheckUpdate(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		dc.LoadAll()
 		api.failNext = true
@@ -875,10 +927,13 @@ func TestHealthcheckUpdate(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 
-		dc := New(Options{
+		dc, err := New(Options{
 			KubernetesURL:      api.server.URL,
 			ProvideHealthcheck: true,
 		})
+		if err != nil {
+			t.Error(err)
+		}
 
 		dc.LoadAll()
 		api.failNext = true
@@ -898,10 +953,13 @@ func TestHealthcheckUpdate(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 
-		dc := New(Options{
+		dc, err := New(Options{
 			KubernetesURL:      api.server.URL,
 			ProvideHealthcheck: true,
 		})
+		if err != nil {
+			t.Error(err)
+		}
 
 		dc.LoadAll()
 
@@ -920,10 +978,13 @@ func TestHealthcheckUpdate(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 
-		dc := New(Options{
+		dc, err := New(Options{
 			KubernetesURL:      api.server.URL,
 			ProvideHealthcheck: true,
 		})
+		if err != nil {
+			t.Error(err)
+		}
 
 		dc.LoadAll()
 
@@ -950,7 +1011,10 @@ func TestHealthcheckReload(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 
-		dc := New(Options{KubernetesURL: api.server.URL})
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		dc.LoadAll()
 		api.failNext = true
@@ -967,10 +1031,13 @@ func TestHealthcheckReload(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 
-		dc := New(Options{
+		dc, err := New(Options{
 			KubernetesURL:      api.server.URL,
 			ProvideHealthcheck: true,
 		})
+		if err != nil {
+			t.Error(err)
+		}
 
 		dc.LoadAll()
 

--- a/skipper.go
+++ b/skipper.go
@@ -53,8 +53,14 @@ type Options struct {
 	// Skip TLS certificate check for etcd connections.
 	EtcdInsecure bool
 
-	// Kubernetes API base URL for ingress. If not specififed,
-	// Kubernetes ingress is disabled.
+	// If set enables skipper to generate based on ingress resources in kubernetes cluster
+	Kubernetes bool
+
+	// If set makes skipper to authenticate with the kubernetes API server with service account assigned to the skipper POD
+	// If omitted skipper will rely on kubectl proxy to authenticate with API server
+	KubernetesInCluster bool
+
+	// Kubernetes API base URL. Only makes sense if KubernetesInCluster is set to false. If omitted and skipper not deployed to the cluster, the default API URL will be used
 	KubernetesURL string
 
 	// KubernetesHealthcheck, when Kubernetes ingress is set, indicates
@@ -238,11 +244,16 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 		clients = append(clients, etcdClient)
 	}
 
-	if o.KubernetesURL != "" {
-		clients = append(clients, kubernetes.New(kubernetes.Options{
-			KubernetesURL:      o.KubernetesURL,
-			ProvideHealthcheck: o.KubernetesHealthcheck,
-		}))
+	if o.Kubernetes {
+		kubernetesClient, err := kubernetes.New(kubernetes.Options{
+			KubernetesInCluster: o.KubernetesInCluster,
+			KubernetesURL:       o.KubernetesURL,
+			ProvideHealthcheck:  o.KubernetesHealthcheck,
+		})
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, kubernetesClient)
 	}
 
 	return clients, nil

--- a/skipper.go
+++ b/skipper.go
@@ -56,11 +56,11 @@ type Options struct {
 	// If set enables skipper to generate based on ingress resources in kubernetes cluster
 	Kubernetes bool
 
-	// If set makes skipper to authenticate with the kubernetes API server with service account assigned to the skipper POD
+	// If set makes skipper authenticate with the kubernetes API server with service account assigned to the skipper POD
 	// If omitted skipper will rely on kubectl proxy to authenticate with API server
 	KubernetesInCluster bool
 
-	// Kubernetes API base URL. Only makes sense if KubernetesInCluster is set to false. If omitted and skipper not deployed to the cluster, the default API URL will be used
+	// Kubernetes API base URL. Only makes sense if KubernetesInCluster is set to false. If omitted and skipper is not running in-cluster, the default API URL will be used
 	KubernetesURL string
 
 	// KubernetesHealthcheck, when Kubernetes ingress is set, indicates


### PR DESCRIPTION
1. Add kubernetes-in-cluster flag to specify if the skipper is deployed as a pod vs running locally
2. If in-cluster use service account to authenticate with API server
3. Otherwise fall back to the current implementation 

JUST started, and I wanted to add a do-not-merge label, but apparently I don't have access to that. Will ping you once done 

