### PR TITLE
HTTP->HTTPS redirect for Kubernetes

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -45,7 +45,8 @@ const (
 	kubernetesUsage                = "enables skipper to generate routes for ingress resources in kubernetes cluster"
 	kubernetesInClusterUsage       = "specify if skipper is running inside kubernetes cluster"
 	kubernetesURLUsage             = "kubernetes API base URL for the ingress data client; requires kubectl proxy running; omit if kubernetes-in-cluster is set to true"
-	kubernetesHealthcheckUsage     = "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes-url"
+	kubernetesHealthcheckUsage     = "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes"
+	kubernetesHTTPSRedirectUsage   = "automatic HTTP->HTTPS redirect route; valid only with kubernetes"
 	innkeeperUrlUsage              = "API endpoint of the Innkeeper service, storing route definitions"
 	innkeeperAuthTokenUsage        = "fixed token for innkeeper authentication"
 	innkeeperPreRouteFiltersUsage  = "filters to be prepended to each route loaded from Innkeeper"
@@ -97,6 +98,7 @@ var (
 	kubernetesInCluster       bool
 	kubernetesURL             string
 	kubernetesHealthcheck     bool
+	kubernetesHTTPSRedirect   bool
 	innkeeperUrl              string
 	sourcePollTimeout         int64
 	routesFile                string
@@ -139,6 +141,7 @@ func init() {
 	flag.BoolVar(&kubernetesInCluster, "kubernetes-in-cluster", false, kubernetesInClusterUsage)
 	flag.StringVar(&kubernetesURL, "kubernetes-url", "", kubernetesURLUsage)
 	flag.BoolVar(&kubernetesHealthcheck, "kubernetes-healthcheck", true, kubernetesHealthcheckUsage)
+	flag.BoolVar(&kubernetesHTTPSRedirect, "kubernetes-https-redirect", true, kubernetesHTTPSRedirectUsage)
 	flag.StringVar(&innkeeperUrl, "innkeeper-url", "", innkeeperUrlUsage)
 	flag.Int64Var(&sourcePollTimeout, "source-poll-timeout", defaultSourcePollTimeout, sourcePollTimeoutUsage)
 	flag.StringVar(&routesFile, "routes-file", "", routesFileUsage)
@@ -219,6 +222,7 @@ func main() {
 		KubernetesInCluster:       kubernetesInCluster,
 		KubernetesURL:             kubernetesURL,
 		KubernetesHealthcheck:     kubernetesHealthcheck,
+		KubernetesHTTPSRedirect:   kubernetesHTTPSRedirect,
 		InnkeeperUrl:              innkeeperUrl,
 		SourcePollTimeout:         time.Duration(sourcePollTimeout) * time.Millisecond,
 		RoutesFile:                routesFile,

--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -1,0 +1,161 @@
+package kubernetes
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/logging/loggingtest"
+	"github.com/zalando/skipper/routing"
+)
+
+type redirectTest struct {
+	router          *routing.Routing
+	api             *testAPI
+	rule            *rule
+	backend         string
+	fallbackBackend string
+	t               *testing.T
+}
+
+func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) {
+	s := testServices()
+	i := &ingressList{Items: testIngresses()}
+	api := newTestAPI(t, s, i)
+
+	dc, err := New(Options{
+		KubernetesURL:        api.server.URL,
+		ProvideHTTPSRedirect: redirectEnabled,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	l := loggingtest.New()
+	router := routing.New(routing.Options{
+		FilterRegistry: builtin.MakeRegistry(),
+		DataClients:    []routing.DataClient{dc},
+		Log:            l,
+	})
+
+	const to = 120 * time.Millisecond
+	l.WaitFor("all ingresses received", to)
+	l.WaitFor("route settings applied", to)
+
+	if err != nil {
+		t.Error(err)
+		return nil, err
+	}
+
+	ingress := i.Items[1]
+	rule := ingress.Spec.Rules[0]
+	service := s[ingress.Metadata.Namespace][rule.Http.Paths[0].Backend.ServiceName].Spec
+	fallbackService := s[i.Items[0].Metadata.Namespace][i.Items[0].Spec.DefaultBackend.ServiceName].Spec
+	backend := fmt.Sprintf("http://%s:%d", service.ClusterIP, service.Ports[0].Port)
+	fallbackBackend := fmt.Sprintf("http://%s:%d", fallbackService.ClusterIP, fallbackService.Ports[0].Port)
+
+	return &redirectTest{
+		router:          router,
+		api:             api,
+		rule:            rule,
+		backend:         backend,
+		fallbackBackend: fallbackBackend,
+		t:               t,
+	}, nil
+}
+
+func (rt *redirectTest) testRedirectRoute(req *http.Request, expectedID, expectedBackend string) bool {
+	route, _ := rt.router.Route(req)
+	switch {
+	case expectedID != "" && route.Id != expectedID:
+		return false
+	case expectedBackend != "" && route.Backend != expectedBackend:
+		return false
+	case expectedID == "" && expectedBackend == "" && route != nil:
+		return false
+	default:
+		return true
+	}
+}
+
+func (rt *redirectTest) testNormalHTTPS(expectedID, expectedBackend string) {
+	httpsRequest := &http.Request{
+		Host: rt.rule.Host,
+		URL:  &url.URL{Path: rt.rule.Http.Paths[0].Path},
+		Header: http.Header{
+			"Host": []string{rt.rule.Host},
+		},
+	}
+
+	if !rt.testRedirectRoute(httpsRequest, expectedID, expectedBackend) {
+		rt.t.Error("failed to match the right route when checking normal request")
+	}
+}
+
+func (rt *redirectTest) testRedirectHTTP(expectedID, expectedBackend string) {
+	httpRequest := &http.Request{
+		Host: rt.rule.Host,
+		URL:  &url.URL{Path: rt.rule.Http.Paths[0].Path},
+		Header: http.Header{
+			"Host":              []string{rt.rule.Host},
+			"X-Forwarded-Proto": []string{"http"},
+			"X-Forwarded-Port":  []string{"80"},
+		},
+	}
+
+	if !rt.testRedirectRoute(httpRequest, expectedID, expectedBackend) {
+		rt.t.Error("failed to match the right route when checking redirect request")
+	}
+}
+
+func (rt *redirectTest) testRedirectNotFound(expectedID, expectedBackend string) {
+	nonExistingHTTP := &http.Request{
+		Host: "www.notexists.org",
+		URL:  &url.URL{Path: "/notexists"},
+		Header: http.Header{
+			"Host":              []string{"www.notexists.org"},
+			"X-Forwarded-Proto": []string{"http"},
+			"X-Forwarded-Port":  []string{"80"},
+		},
+	}
+
+	if !rt.testRedirectRoute(nonExistingHTTP, expectedID, expectedBackend) {
+		rt.t.Error("failed to match the right route when checking unmatched redirect")
+	}
+}
+
+func (rt *redirectTest) close() {
+	rt.router.Close()
+	rt.api.Close()
+}
+
+func TestHTTPSRedirect(t *testing.T) {
+	rt, err := newRedirectTest(t, true)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	defer rt.close()
+
+	rt.testNormalHTTPS("", rt.backend)
+	rt.testRedirectHTTP(httpRedirectRouteID, "")
+	rt.testRedirectNotFound(httpRedirectRouteID, "")
+}
+
+func TestNoHTTPSRedirect(t *testing.T) {
+	rt, err := newRedirectTest(t, false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	defer rt.close()
+
+	rt.testNormalHTTPS("", rt.backend)
+	rt.testRedirectHTTP("", rt.backend)
+	rt.testRedirectNotFound("", rt.fallbackBackend)
+}

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -447,11 +447,8 @@ func healthcheckRoute(healthy bool) *eskip.Route {
 
 func httpRedirectRoute() *eskip.Route {
 	return &eskip.Route{
-		Id: httpRedirectRouteID,
-		Predicates: []*eskip.Predicate{{
-			Name: "Header",
-			Args: []interface{}{"X-Forwarded-Proto", "http"},
-		}},
+		Id:      httpRedirectRouteID,
+		Headers: map[string]string{"X-Forwarded-Proto": "http", "X-Forwarded-Port": "80"},
 		Filters: []*eskip.Filter{{
 			Name: "redirectTo",
 			Args: []interface{}{float64(301), "https:"},
@@ -511,7 +508,7 @@ func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
 	for id := range c.current {
 		if r, ok := next[id]; ok && r.String() != c.current[id].String() {
 			updatedRoutes = append(updatedRoutes, r)
-		} else if !ok && id != healthcheckRouteID {
+		} else if !ok && id != healthcheckRouteID && id != httpRedirectRouteID {
 			deletedIDs = append(deletedIDs, id)
 		}
 	}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -39,7 +39,8 @@ type testAPI struct {
 var serviceURIRx = regexp.MustCompile("^/api/v1/namespaces/([^/]+)/services/([^/]+)$")
 
 func init() {
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(log.InfoLevel)
+	// log.SetLevel(log.DebugLevel)
 }
 
 func testService(clusterIP string, ports map[string]int) *service {
@@ -479,7 +480,7 @@ func TestIngressData(t *testing.T) {
 	}
 }
 
-func Test(t *testing.T) {
+func TestIngress(t *testing.T) {
 	api := newTestAPI(t, nil, &ingressList{})
 	defer api.Close()
 
@@ -1061,7 +1062,6 @@ func TestHealthcheckReload(t *testing.T) {
 		checkHealthcheck(t, r, true, true)
 		checkRoutes(t, r, map[string]string{
 			healthcheckRouteID:                                    "",
-			httpRedirectRouteID:                                   "",
 			"kube_namespace1__default_only____":                   "http://1.2.3.4:8080",
 			"kube_namespace2__path_rule_only__www_example_org___": "http://9.0.1.2:7272",
 			"kube_namespace1__mega____":                           "http://1.2.3.4:8080",
@@ -1266,11 +1266,11 @@ func generateSSCert() []byte {
 	tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
 	tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
 
-	_, rootCertPEM, _ := CreateCert(tmpl, tmpl, &rootKey.PublicKey, rootKey)
+	_, rootCertPEM, _ := createCert(tmpl, tmpl, &rootKey.PublicKey, rootKey)
 	return rootCertPEM
 }
 
-func CreateCert(template, parent *x509.Certificate, pub interface{}, parentPriv interface{}) (
+func createCert(template, parent *x509.Certificate, pub interface{}, parentPriv interface{}) (
 	cert *x509.Certificate, certPEM []byte, err error) {
 
 	certDER, err := x509.CreateCertificate(rand.Reader, template, parent, pub, parentPriv)

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1061,6 +1061,7 @@ func TestHealthcheckReload(t *testing.T) {
 		checkHealthcheck(t, r, true, true)
 		checkRoutes(t, r, map[string]string{
 			healthcheckRouteID:                                    "",
+			httpRedirectRouteID:                                   "",
 			"kube_namespace1__default_only____":                   "http://1.2.3.4:8080",
 			"kube_namespace2__path_rule_only__www_example_org___": "http://9.0.1.2:7272",
 			"kube_namespace1__mega____":                           "http://1.2.3.4:8080",

--- a/skipper.go
+++ b/skipper.go
@@ -72,6 +72,13 @@ type Options struct {
 	// internal IPs, with the path /kube-system/healthz.
 	KubernetesHealthcheck bool
 
+	// KubernetesHTTPSRedirect, when Kubernetes ingress is set, indicates
+	// whether an automatic redirect route should be generated to redirect
+	// HTTP requests to their HTTPS equivalent. The generated route will
+	// match requests with the X-Forwarded-Proto and X-Forwarded-Port,
+	// expected to be set by the load-balancer.
+	KubernetesHTTPSRedirect bool
+
 	// API endpoint of the Innkeeper service, storing route definitions.
 	InnkeeperUrl string
 
@@ -252,9 +259,10 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 
 	if o.Kubernetes {
 		kubernetesClient, err := kubernetes.New(kubernetes.Options{
-			KubernetesInCluster: o.KubernetesInCluster,
-			KubernetesURL:       o.KubernetesURL,
-			ProvideHealthcheck:  o.KubernetesHealthcheck,
+			KubernetesInCluster:  o.KubernetesInCluster,
+			KubernetesURL:        o.KubernetesURL,
+			ProvideHealthcheck:   o.KubernetesHealthcheck,
+			ProvideHTTPSRedirect: o.KubernetesHTTPSRedirect,
 		})
 		if err != nil {
 			return nil, err

--- a/skipper.go
+++ b/skipper.go
@@ -56,11 +56,13 @@ type Options struct {
 	// If set enables skipper to generate based on ingress resources in kubernetes cluster
 	Kubernetes bool
 
-	// If set makes skipper authenticate with the kubernetes API server with service account assigned to the skipper POD
+	// If set makes skipper authenticate with the kubernetes API server with service account assigned to the
+	// skipper POD.
 	// If omitted skipper will rely on kubectl proxy to authenticate with API server
 	KubernetesInCluster bool
 
-	// Kubernetes API base URL. Only makes sense if KubernetesInCluster is set to false. If omitted and skipper is not running in-cluster, the default API URL will be used
+	// Kubernetes API base URL. Only makes sense if KubernetesInCluster is set to false. If omitted and
+	// skipper is not running in-cluster, the default API URL will be used.
 	KubernetesURL string
 
 	// KubernetesHealthcheck, when Kubernetes ingress is set, indicates


### PR DESCRIPTION
Redirect requests with `X-Forwarded-Proto: http` and `X-Forwarded-Port: 80` to HTTPS.