### PR TITLE
packaging in a clean directory does not work

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -13,7 +13,7 @@ eskip:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build github.com/zalando/skipper/cmd/eskip
 
 clean:
-	rm skipper eskip
+	rm -f skipper eskip
 
 docker-build: clean skipper eskip
 	docker build -t $(IMAGE) .


### PR DESCRIPTION
We use the packaging Makefile in our Jenkins task to build and we have a clean directory, so this will break.

    rm skipper eskip
    rm: cannot remove 'skipper': No such file or directory
    rm: cannot remove 'eskip': No such file or directory
    Makefile:16: recipe for target 'clean' failed
    make: *** [clean] Error 1