### PR TITLE
use a select for the signal in the goroutine from which the routing calls Load*

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -21,7 +21,7 @@ Ingress shutdown by healthcheck
 The Kubernetes ingress client catches TERM signals when the ProvideHealthcheck option is enabled, and reports
 failing healthcheck after the signal was received. This means that, when the Ingress client is responsible for
 the healthcheck of the cluster, and the Skipper process receives the TERM signal, it won't exit by itself
-immediately, but will start reporting failurs on healthcheck requests. Until it gets killed by the kubelet,
+immediately, but will start reporting failures on healthcheck requests. Until it gets killed by the kubelet,
 Skipper keeps serving the requests in this case.
 */
 package kubernetes

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -491,7 +491,7 @@ func httpRedirectRoute() *eskip.Route {
 func (c *Client) hasReceivedTerm() bool {
 	select {
 	case s := <-c.sigs:
-		log.Infof("shutdown, caused by %s, set healthCheck to be unhealty", s)
+		log.Infof("shutdown, caused by %s, set healthCheck to be unhealthy", s)
 		c.termReceived = true
 	default:
 	}
@@ -519,12 +519,7 @@ func (c *Client) LoadAll() ([]*eskip.Route, error) {
 	c.current = mapRoutes(r)
 	log.Debugf("all routes loaded and mapped")
 
-	go c.registerSigtermHandler()
-
 	return r, nil
-}
-
-func (c *Client) registerSigtermHandler() {
 }
 
 // TODO: implement a force reset after some time

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1286,4 +1287,105 @@ func createCert(template, parent *x509.Certificate, pub interface{}, parentPriv 
 	b := pem.Block{Type: "CERTIFICATE", Bytes: certDER}
 	certPEM = pem.EncodeToMemory(&b)
 	return
+}
+
+func TestHealthcheckOnTerm(t *testing.T) {
+	api := newTestAPI(t, testServices(), &ingressList{})
+	defer api.Close()
+
+	t.Run("no difference after term when healthcheck disabled", func(t *testing.T) {
+		c, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: false,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		c.sigs <- syscall.SIGTERM
+
+		r, err := c.LoadAll()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		checkHealthcheck(t, r, false, false)
+	})
+
+	t.Run("healthcheck false after term", func(t *testing.T) {
+		c, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		c.sigs <- syscall.SIGTERM
+
+		r, err := c.LoadAll()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		checkHealthcheck(t, r, true, false)
+	})
+
+	t.Run("no difference after term when disabled, update", func(t *testing.T) {
+		c, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: false,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		_, err = c.LoadAll()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		c.sigs <- syscall.SIGTERM
+
+		r, _, err := c.LoadUpdate()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		checkHealthcheck(t, r, false, false)
+	})
+
+	t.Run("healthcheck false after term, update", func(t *testing.T) {
+		c, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		_, err = c.LoadAll()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		c.sigs <- syscall.SIGTERM
+
+		r, _, err := c.LoadUpdate()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		checkHealthcheck(t, r, true, false)
+	})
 }

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1303,7 +1303,11 @@ func TestHealthcheckOnTerm(t *testing.T) {
 			return
 		}
 
-		c.sigs <- syscall.SIGTERM
+		// send term only when the client is handling it:
+		select {
+		case c.sigs <- syscall.SIGTERM:
+		default:
+		}
 
 		r, err := c.LoadAll()
 		if err != nil {
@@ -1324,7 +1328,11 @@ func TestHealthcheckOnTerm(t *testing.T) {
 			return
 		}
 
-		c.sigs <- syscall.SIGTERM
+		// send term only when the client is handling it:
+		select {
+		case c.sigs <- syscall.SIGTERM:
+		default:
+		}
 
 		r, err := c.LoadAll()
 		if err != nil {
@@ -1351,7 +1359,11 @@ func TestHealthcheckOnTerm(t *testing.T) {
 			return
 		}
 
-		c.sigs <- syscall.SIGTERM
+		// send term only when the client is handling it:
+		select {
+		case c.sigs <- syscall.SIGTERM:
+		default:
+		}
 
 		r, _, err := c.LoadUpdate()
 		if err != nil {
@@ -1378,7 +1390,11 @@ func TestHealthcheckOnTerm(t *testing.T) {
 			return
 		}
 
-		c.sigs <- syscall.SIGTERM
+		// send term only when the client is handling it:
+		select {
+		case c.sigs <- syscall.SIGTERM:
+		default:
+		}
 
 		r, _, err := c.LoadUpdate()
 		if err != nil {


### PR DESCRIPTION
@szuecs check this PR to your PR https://github.com/zalando/skipper/pull/306 whether it's fine with you. It removes the data race on the Client.healthy field.

Also, it becomes testable. Pushing a test in a bit.