### PR TITLE
Implement caching for kubernetes service endpoints

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -349,14 +349,25 @@ func (c *Client) convertDefaultBackend(i *ingressItem) (*eskip.Route, bool, erro
 	return r, true, nil
 }
 
-func (c *Client) convertPathRule(ns, name, host string, prule *pathRule) (*eskip.Route, error) {
+func (c *Client) convertPathRule(ns, name, host string, prule *pathRule, servicesURLs map[string]string) (*eskip.Route, map[string]string, error) {
 	if prule.Backend == nil {
-		return nil, fmt.Errorf("invalid path rule, missing backend in: %s/%s/%s", ns, name, host)
+		return nil, nil, fmt.Errorf("invalid path rule, missing backend in: %s/%s/%s", ns, name, host)
 	}
-
-	address, err := c.getServiceURL(ns, prule.Backend.ServiceName, prule.Backend.ServicePort)
-	if err != nil {
-		return nil, err
+	serviceKey := ns + prule.Backend.ServiceName + prule.Backend.ServicePort.String()
+	var (
+		address string
+		err     error
+	)
+	if val, ok := servicesURLs[serviceKey]; !ok {
+		address, err = c.getServiceURL(ns, prule.Backend.ServiceName, prule.Backend.ServicePort)
+		if err != nil {
+			return nil, nil, err
+		}
+		servicesURLs[serviceKey] = address
+		log.Debugf("New route for %s/%s/%s", ns, prule.Backend.ServiceName, prule.Backend.ServicePort)
+	} else {
+		address = val
+		log.Debugf("Route for %s/%s/%s already known", ns, prule.Backend.ServiceName, prule.Backend.ServicePort)
 	}
 
 	var pathExpressions []string
@@ -370,7 +381,7 @@ func (c *Client) convertPathRule(ns, name, host string, prule *pathRule) (*eskip
 		Backend:     address,
 	}
 
-	return r, nil
+	return r, servicesURLs, nil
 }
 
 // logs if invalid, but proceeds with the valid ones
@@ -393,6 +404,12 @@ func (c *Client) ingressToRoutes(items []*ingressItem) []*eskip.Route {
 			log.Errorf("error while converting default backend: %v", err)
 		}
 
+		var (
+			r   *eskip.Route
+			err error
+		)
+		// We need this to avoid asking the k8s API for the same services
+		servicesURLs := make(map[string]string)
 		for _, rule := range i.Spec.Rules {
 			if rule.Http == nil {
 				log.Warn("invalid ingress item: rule missing http definitions")
@@ -405,7 +422,7 @@ func (c *Client) ingressToRoutes(items []*ingressItem) []*eskip.Route {
 			host := []string{"^" + strings.Replace(rule.Host, ".", "[.]", -1) + "$"}
 
 			for _, prule := range rule.Http.Paths {
-				r, err := c.convertPathRule(i.Metadata.Namespace, i.Metadata.Name, rule.Host, prule)
+				r, servicesURLs, err = c.convertPathRule(i.Metadata.Namespace, i.Metadata.Name, rule.Host, prule, servicesURLs)
 				if err != nil {
 					// tolerate single rule errors
 					//


### PR DESCRIPTION
When an ingress has a multiple routes, a request to the K8S API is made for each route and endpoint.

If the endpoint is the same, we can cache the response and there's no need to ask again. On the next iteration, this cache will be invalidated, so if the service changes, we'll be able to notice it.

This is very helpful in ingresses with many routes (we use 50+ in one real-world example) as the repeated calls to K8S API are slow and congest traffic on the whole. Also, each request generates a log entry, which can result in huge log files.