### PR TITLE
silence the command expression for the format check in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ fmt: $(SOURCES)
 	@gofmt -w $(SOURCES)
 
 check-fmt: $(SOURCES)
-	if [ "$$(gofmt -d $(SOURCES))" != "" ]; then false; else true; fi
+	@if [ "$$(gofmt -d $(SOURCES))" != "" ]; then false; else true; fi
 
 precommit: build shortcheck fmt vet
 


### PR DESCRIPTION
silence the format check in the Makefile to avoid polluting the build output with all the source files