### PR TITLE
Fix escaping when unmarshal json

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -373,11 +373,11 @@ func (c *Client) convertPathRule(ns, name, host string, prule *pathRule, service
 
 	var pathExpressions []string
 	if prule.Path != "" {
-		res, err := strconv.Unquote(`"` + prule.Path + `"`)
+		unquotedPath, err := strconv.Unquote(`"` + prule.Path + `"`)
 		if err != nil {
 			pathExpressions = []string{"^" + prule.Path}
 		} else {
-			pathExpressions = []string{"^" + res}
+			pathExpressions = []string{"^" + unquotedPath}
 		}
 	}
 

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -40,6 +40,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -372,7 +373,12 @@ func (c *Client) convertPathRule(ns, name, host string, prule *pathRule, service
 
 	var pathExpressions []string
 	if prule.Path != "" {
-		pathExpressions = []string{"^" + prule.Path}
+		res, err := strconv.Unquote(`"` + prule.Path + `"`)
+		if err != nil {
+			pathExpressions = []string{"^" + prule.Path}
+		} else {
+			pathExpressions = []string{"^" + res}
+		}
 	}
 
 	r := &eskip.Route{


### PR DESCRIPTION
We have found an issue when reading from kubernetes paths rules.

When having a regular expression on an ingress rule, you have to write it escaped (the backslashes):
```
- backend:
    serviceName: my-regex-backend
    servicePort: 80
  path: /regex-path/(\\d+)(/)?$
```

Note that here we have a double backslash.

Now, when skipper reads it from the api (on a json format) and unmarshal the content, it does it as a string LITERAL. This means that go reads it char by char and put it in a string, not converting the escaped double backslash into a single one (which would be correct inside go to check on a regex).

Because of this, skipper is not able to match a real URL with the path defined into the ingress.

I've did a hack, to unquote this string and convert the double backslash into a single one.

I now this is not the best solution, and it should it be done directly during the unmarshal, but I don't know how to do it.

Could you tell me if this is correct (and merge it), or give me a better solution to fix this bug.

Thanks!