### PR TITLE
tee filter does not follow redirects if user prefers so

### DIFF
--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -77,6 +77,7 @@ func MakeRegistry() filters.Registry {
 		diag.NewBackendChunks(),
 		tee.NewTee(),
 		tee.NewTeeDeprecated(),
+		tee.NewTeeNoFollow(),
 		auth.NewBasicAuth(),
 	} {
 		r.Register(s)


### PR DESCRIPTION
If tee filter is created with the name `teenf`, it won't follow redirects.