### PR TITLE
implement traffic switching based on internal code

### DIFF
--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -6,6 +6,7 @@ package builtin
 import (
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/auth"
+	"github.com/zalando/skipper/filters/cookie"
 	"github.com/zalando/skipper/filters/diag"
 	"github.com/zalando/skipper/filters/flowid"
 	"github.com/zalando/skipper/filters/tee"
@@ -78,6 +79,9 @@ func MakeRegistry() filters.Registry {
 		tee.NewTee(),
 		tee.NewTeeDeprecated(),
 		auth.NewBasicAuth(),
+		cookie.NewRequestCookie(),
+		cookie.NewResponseCookie(),
+		cookie.NewJSCookie(),
 	} {
 		r.Register(s)
 	}

--- a/filters/cookie/cookie.go
+++ b/filters/cookie/cookie.go
@@ -1,0 +1,209 @@
+/*
+Package cookie implements filters to append to requests or responses.
+
+It implements two filters, one for appending cookies to requests in
+the "Cookie" header, and one for appending cookies to responses in the
+"Set-Cookie" header.
+
+Both the request and response cookies expect a name and a value argument.
+
+The response cookie accepts an optional argument to control the max-age
+property of the cookie, of type number, in seconds.
+
+The response cookie accepts an optional fourth argument, "change-only",
+to control if the cookie should be set on every response, or only if the
+request doesn't contain a cookie with the provided name and value. If the
+fourth argument is "change-only", and a cookie with the same name and value
+is found in the request, the cookie is not set. This argument can be used
+to disable sliding TTL of the cookie.
+
+The JS cookie behaves exactly as the response cookie, but it doesn't
+set the HttpOnly directive, so these cookies will be
+accessible from JS code running in web browsers.
+
+Examples:
+
+    requestCookie("test-session", "abc")
+
+    responseCookie("test-session", "abc", 31536000)
+
+    responseCookie("test-session", "abc", 31536000, "change-only")
+
+    // response cookie without HttpOnly:
+    jsCookie("test-session-info", "abc-debug", 31536000, "change-only")
+*/
+package cookie
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/zalando/skipper/filters"
+)
+
+const (
+	RequestCookieFilterName    = "requestCookie"
+	ResponseCookieFilterName   = "responseCookie"
+	ResponseJSCookieFilterName = "jsCookie"
+	ChangeOnlyArg              = "change-only"
+	SetCookieHttpHeader        = "Set-Cookie"
+)
+
+type direction int
+
+const (
+	request direction = iota
+	response
+	responseJS
+)
+
+type spec struct {
+	typ        direction
+	filterName string
+}
+
+type filter struct {
+	typ        direction
+	name       string
+	value      string
+	ttl        time.Duration
+	changeOnly bool
+}
+
+// Creates a filter spec for appending cookies to requests.
+// Name: requestCookie
+func NewRequestCookie() filters.Spec {
+	return &spec{request, RequestCookieFilterName}
+}
+
+// Creates a filter spec for appending cookies to responses.
+// Name: responseCookie
+func NewResponseCookie() filters.Spec {
+	return &spec{response, ResponseCookieFilterName}
+}
+
+// Creates a filter spec for appending cookies to responses without the
+// HttpOnly directive.
+// Name: jsCookie
+func NewJSCookie() filters.Spec {
+	return &spec{responseJS, ResponseJSCookieFilterName}
+}
+
+func (s *spec) Name() string { return s.filterName }
+
+func (s *spec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) < 2 || (len(args) > 2 && s.typ == request) || len(args) > 4 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	f := &filter{typ: s.typ}
+
+	if name, ok := args[0].(string); ok && name != "" {
+		f.name = name
+	} else {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	if value, ok := args[1].(string); ok {
+		f.value = value
+	} else {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	if len(args) >= 3 {
+		if ttl, ok := args[2].(float64); ok {
+			f.ttl = time.Duration(ttl) * time.Second
+		} else {
+			return nil, filters.ErrInvalidFilterParameters
+		}
+	}
+
+	if len(args) == 4 {
+		f.changeOnly = args[3] == ChangeOnlyArg
+	}
+
+	return f, nil
+}
+
+func (f *filter) Request(ctx filters.FilterContext) {
+	if f.typ != request {
+		return
+	}
+
+	ctx.StateBag()["CookieSet:"+f.name] = f.value
+
+	ctx.Request().AddCookie(&http.Cookie{Name: f.name, Value: f.value})
+}
+
+func (f *filter) Response(ctx filters.FilterContext) {
+	var set func(filters.FilterContext, string, string, time.Duration)
+	switch f.typ {
+	case request:
+		return
+	case response:
+		set = configSetCookie(false)
+	case responseJS:
+		set = configSetCookie(true)
+	default:
+		panic("invalid cookie filter type")
+	}
+
+	ctx.StateBag()["CookieSet:"+f.name] = f.value
+
+	if !f.changeOnly {
+		set(ctx, f.name, f.value, f.ttl)
+		return
+	}
+
+	var req *http.Request
+	if req = ctx.OriginalRequest(); req == nil {
+		req = ctx.Request()
+	}
+
+	requestCookie, err := req.Cookie(f.name)
+	if err == nil && requestCookie.Value == f.value {
+		return
+	}
+
+	set(ctx, f.name, f.value, f.ttl)
+}
+
+func setCookie(ctx filters.FilterContext, name, value string, ttl time.Duration, jsEnabled bool) {
+	var req = ctx.Request()
+	if ctx.OriginalRequest() != nil {
+		req = ctx.OriginalRequest()
+	}
+	d := extractDomainFromHost(req.Host)
+	c := &http.Cookie{
+		Name:     name,
+		Value:    value,
+		HttpOnly: !jsEnabled,
+		Secure:   true,
+		Domain:   d,
+		Path:     "/",
+		MaxAge:   int(ttl.Seconds())}
+
+	ctx.Response().Header.Add(SetCookieHttpHeader, c.String())
+}
+
+func configSetCookie(jscookie bool) func(filters.FilterContext, string, string, time.Duration) {
+	return func(ctx filters.FilterContext, name, value string, ttl time.Duration) {
+		setCookie(ctx, name, value, ttl, jscookie)
+	}
+}
+
+func extractDomainFromHost(host string) string {
+	h, _, err := net.SplitHostPort(host)
+
+	if err != nil {
+		h = host
+	}
+
+	if strings.Count(h, ".") < 2 {
+		return h
+	}
+
+	return strings.Join(strings.Split(h, ".")[1:], ".")
+}

--- a/filters/cookie/cookie_test.go
+++ b/filters/cookie/cookie_test.go
@@ -1,0 +1,384 @@
+package cookie
+
+import (
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCreateFilter(t *testing.T) {
+	for _, ti := range []struct {
+		msg   string
+		typ   direction
+		args  []interface{}
+		check filter
+		err   bool
+	}{{
+		"too few arguments",
+		response,
+		[]interface{}{"test-cookie"},
+		filter{},
+		true,
+	}, {
+		"too many arguments",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg, "something"},
+		filter{},
+		true,
+	}, {
+		"too few arguments, js",
+		responseJS,
+		[]interface{}{"test-cookie"},
+		filter{},
+		true,
+	}, {
+		"too many arguments, js",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg, "something"},
+		filter{},
+		true,
+	}, {
+		"too many arguments for request cookie",
+		request,
+		[]interface{}{"test-cookie", "A", 42.0},
+		filter{},
+		true,
+	}, {
+		"wrong name type",
+		response,
+		[]interface{}{3.14, "A", 42.0},
+		filter{},
+		true,
+	}, {
+		"empty name",
+		response,
+		[]interface{}{"", "A", 42.0},
+		filter{},
+		true,
+	}, {
+		"wrong value type",
+		response,
+		[]interface{}{"test-cookie", 3.14, 42.0},
+		filter{},
+		true,
+	}, {
+		"wrong ttl type",
+		response,
+		[]interface{}{"test-cookie", "A", "42"},
+		filter{},
+		true,
+	}, {
+		"wrong name type, JS",
+		responseJS,
+		[]interface{}{3.14, "A", 42.0},
+		filter{},
+		true,
+	}, {
+		"empty name, JS",
+		responseJS,
+		[]interface{}{"", "A", 42.0},
+		filter{},
+		true,
+	}, {
+		"wrong value type, JS",
+		responseJS,
+		[]interface{}{"test-cookie", 3.14, 42.0},
+		filter{},
+		true,
+	}, {
+		"wrong ttl type, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", "42"},
+		filter{},
+		true,
+	}, {
+		"request cookie",
+		request,
+		[]interface{}{"test-cookie", "A"},
+		filter{typ: request, name: "test-cookie", value: "A"},
+		false,
+	}, {
+		"response session cookie",
+		response,
+		[]interface{}{"test-cookie", "A"},
+		filter{typ: response, name: "test-cookie", value: "A"},
+		false,
+	}, {
+		"response persistent cookie",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0},
+		filter{typ: response, name: "test-cookie", value: "A", ttl: 42 * time.Second},
+		false,
+	}, {
+		"response persistent cookie, not change only, explicit",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0, "always"},
+		filter{typ: response, name: "test-cookie", value: "A", ttl: 42 * time.Second},
+		false,
+	}, {
+		"response persistent cookie, change only",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		filter{typ: response, name: "test-cookie", value: "A", ttl: 42 * time.Second, changeOnly: true},
+		false,
+	}, {
+		"response session cookie, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A"},
+		filter{typ: response, name: "test-cookie", value: "A"},
+		false,
+	}, {
+		"response persistent cookie, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0},
+		filter{typ: response, name: "test-cookie", value: "A", ttl: 42 * time.Second},
+		false,
+	}, {
+		"response persistent cookie, not change only, explicit, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0, "always"},
+		filter{typ: response, name: "test-cookie", value: "A", ttl: 42 * time.Second},
+		false,
+	}, {
+		"response persistent cookie, change only, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		filter{typ: response, name: "test-cookie", value: "A", ttl: 42 * time.Second, changeOnly: true},
+		false,
+	}} {
+		var s filters.Spec
+		switch ti.typ {
+		case request:
+			s = NewRequestCookie()
+		case response:
+			s = NewResponseCookie()
+		case responseJS:
+			s = NewJSCookie()
+		}
+
+		f, err := s.CreateFilter(ti.args)
+		if err == nil && ti.err || err != nil && !ti.err {
+			t.Error(ti.msg, "failure case", err, ti.err)
+		} else if !ti.err {
+			ff := f.(*filter)
+
+			if ff.typ != ti.typ {
+				t.Error(ti.msg, "direction", ff.typ, ti.typ)
+			}
+
+			if ff.name != ti.check.name {
+				t.Error(ti.msg, "name", ff.name, ti.check.name)
+			}
+
+			if ff.value != ti.check.value {
+				t.Error(ti.msg, "value", ff.value, ti.check.value)
+			}
+
+			if ff.ttl != ti.check.ttl {
+				t.Error(ti.msg, "ttl", ff.ttl, ti.check.ttl)
+			}
+		}
+	}
+}
+
+func TestSetCookie(t *testing.T) {
+	const (
+		domain = "example.org"
+		host   = "www.example.org:80"
+	)
+
+	for _, ti := range []struct {
+		msg           string
+		typ           direction
+		args          []interface{}
+		requestCookie string
+		check         *http.Cookie
+	}{{
+		"request cookie",
+		request,
+		[]interface{}{"test-cookie", "A"},
+		"",
+		&http.Cookie{Name: "test-cookie", Value: "A"},
+	}, {
+		"response cookie",
+		response,
+		[]interface{}{"test-cookie", "A"},
+		"",
+		&http.Cookie{
+			Name:     "test-cookie",
+			Value:    "A",
+			HttpOnly: true,
+			Domain:   domain,
+			Path:     "/"},
+	}, {
+		"response cookie, with ttl",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0},
+		"",
+		&http.Cookie{
+			Name:     "test-cookie",
+			Value:    "A",
+			HttpOnly: true,
+			Domain:   domain,
+			Path:     "/",
+			MaxAge:   42},
+	}, {
+		"response cookie, with non-sliding ttl",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		"",
+		&http.Cookie{
+			Name:     "test-cookie",
+			Value:    "A",
+			HttpOnly: true,
+			Domain:   domain,
+			Path:     "/",
+			MaxAge:   42},
+	}, {
+		"response cookie, with non-sliding ttl, request contains different value",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		"B",
+		&http.Cookie{
+			Name:     "test-cookie",
+			Value:    "A",
+			HttpOnly: true,
+			Domain:   domain,
+			Path:     "/",
+			MaxAge:   42},
+	}, {
+		"response cookie, with non-sliding ttl, request contains the same value",
+		response,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		"A",
+		nil,
+	}, {
+		"response cookie, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A"},
+		"",
+		&http.Cookie{
+			Name:   "test-cookie",
+			Value:  "A",
+			Domain: domain,
+			Path:   "/"},
+	}, {
+		"response cookie, with ttl, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0},
+		"",
+		&http.Cookie{
+			Name:   "test-cookie",
+			Value:  "A",
+			Domain: domain,
+			Path:   "/",
+			MaxAge: 42},
+	}, {
+		"response cookie, with non-sliding ttl, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		"",
+		&http.Cookie{
+			Name:   "test-cookie",
+			Value:  "A",
+			Domain: domain,
+			Path:   "/",
+			MaxAge: 42},
+	}, {
+		"response cookie, with non-sliding ttl, request contains different value, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		"B",
+		&http.Cookie{
+			Name:   "test-cookie",
+			Value:  "A",
+			Domain: domain,
+			Path:   "/",
+			MaxAge: 42},
+	}, {
+		"response cookie, with non-sliding ttl, request contains the same value, JS",
+		responseJS,
+		[]interface{}{"test-cookie", "A", 42.0, ChangeOnlyArg},
+		"A",
+		nil,
+	}} {
+		var s filters.Spec
+		switch ti.typ {
+		case request:
+			s = NewRequestCookie()
+		case response:
+			s = NewResponseCookie()
+		case responseJS:
+			s = NewJSCookie()
+		}
+
+		f, err := s.CreateFilter(ti.args)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		ctx := &filtertest.Context{
+			FRequest: &http.Request{
+				Header: http.Header{},
+				Host:   host},
+			FStateBag: map[string]interface{}{},
+			FResponse: &http.Response{Header: http.Header{}}}
+		if ti.requestCookie != "" {
+			ctx.Request().AddCookie(&http.Cookie{
+				Name:  ti.args[0].(string),
+				Value: ti.requestCookie})
+		}
+
+		if ti.typ == request {
+			f.Request(ctx)
+			if _, err := ctx.Request().Cookie(ti.check.Name); err != nil {
+				t.Error(ti.msg, "request cookie")
+			}
+		} else {
+			f.Response(ctx)
+			if ti.check == nil {
+				if len(ctx.Response().Cookies()) > 0 {
+					t.Error(ti.msg, "cookie should not have been set")
+				}
+
+				continue
+			}
+
+			var c *http.Cookie
+			for _, ci := range ctx.Response().Cookies() {
+				if ci.Name == ti.check.Name {
+					c = ci
+					break
+				}
+			}
+
+			if c == nil {
+				t.Error(ti.msg, "missing cookie")
+				continue
+			}
+
+			if c.Value != ti.check.Value {
+				t.Error(ti.msg, "value", c.Value, ti.check.Value)
+			}
+
+			if c.HttpOnly != ti.check.HttpOnly {
+				t.Error(ti.msg, "HttpOnly", c.HttpOnly, ti.check.HttpOnly)
+			}
+
+			if c.Domain != ti.check.Domain {
+				t.Error(ti.msg, "domain", c.Domain, ti.check.Domain)
+			}
+
+			if c.Path != ti.check.Path {
+				t.Error(ti.msg, "path", c.Path, ti.check.Path)
+			}
+
+			if c.MaxAge != ti.check.MaxAge {
+				t.Error(ti.msg, "max-age", c.MaxAge, ti.check.MaxAge)
+			}
+		}
+	}
+}

--- a/predicates/traffic/traffic.go
+++ b/predicates/traffic/traffic.go
@@ -1,14 +1,15 @@
 /*
-Package traffic implements a custom predicate to control
-traffic by setting rates for certain routes.
+Package traffic implements a predicate to control the matching
+probability for a given route by setting its weight.
 
-The chance for hitting a route is defined by the mandatory first
-parameter, that must be a number between 0 and 1.
+The probability for matching a route is defined by the mandatory first
+parameter, that must be a decimal number between 0.0 and 1.0 (both
+exclusive).
 
-The optional second argument is used to specify the cookie
-name for the traffic group.
-
-Stickiness of traffic is supported by the optional third
+The optional second argument is used to specify the cookie name for
+the traffic group, in case you want to use stickiness. Stickiness
+allows all subsequent requests from the same client to match the same
+route. Stickiness of traffic is supported by the optional third
 parameter, indicating whether the request being matched belongs to the
 traffic group of the current route. If yes, the predicate matches
 ignoring the chance argument.
@@ -21,7 +22,7 @@ setting the traffic group cookie remains to either a filter or the
 backend service.
 
 The below example, shows a possible eskip document used for green-blue
-deployments of non sticky APIs:
+deployments of APIS, which usually don't require stickiness:
 
     // hit by 10% percent chance
     v2:
@@ -101,7 +102,7 @@ func (s *spec) Create(args []interface{}) (routing.Predicate, error) {
 
 	p := &predicate{}
 
-	if c, ok := args[0].(float64); ok {
+	if c, ok := args[0].(float64); ok && 0.0 <= c && c < 1.0 {
 		p.chance = c
 	} else {
 		return nil, predicates.ErrInvalidPredicateParameters

--- a/predicates/traffic/traffic.go
+++ b/predicates/traffic/traffic.go
@@ -1,0 +1,131 @@
+/*
+Package traffic implements a custom predicate to control
+traffic by setting rates for certain routes.
+
+The chance for hitting a route is defined by the mandatory first
+parameter, that must be a number between 0 and 1.
+
+Stickiness of traffic is supported by the optional second parameter,
+indicating whether the request being matched belongs to the traffic
+group of the current route. If yes, the predicate matches ignoring
+the chance argument.
+
+Predicates cannot modify the response, so the responsibility of
+setting the traffic group cookie remains to either a filter or the
+backend service.
+
+The optional third argument is used to specify the cookie name for
+the traffic group. This argument should be used in cases when there
+are multiple, independent sets of routes under traffic control.
+
+The below example, shows a possible eskip document with two,
+independent traffic controlled route sets:
+
+    // hit by 5% percent chance
+    cartTest:
+        Traffic(.05, "cart-test", "test") && Path("/cart") ->
+        responseCookie("cart-test", "test") ->
+        "https://cart-test";
+
+    // hit by remaining chance
+    cart:
+        Path("/cart") ->
+        responseCookie("cart-test", "default") ->
+        "https://cart";
+
+    // hit by 15% percent chance
+    catalogTestA:
+        Traffic(.15, "catalog-test", "A") ->
+        responseCookie("catalog-test", "A") ->
+        "https://catalog-test-a";
+
+    // hit by 30% percent chance
+    catalogTestB:
+        Traffic(.3, "catalog-test", "B") ->
+        responseCookie("catalog-test", "B") ->
+        "https://catalog-test-b";
+
+    // hit by remaining chance
+    catalog:
+        * ->
+        responseCookie("catalog-test", "default") ->
+        "https://catalog";
+
+*/
+package traffic
+
+import (
+	"math/rand"
+	"net/http"
+
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/routing"
+)
+
+const (
+	// The eskip name of the predicate.
+	PredicateName = "Traffic"
+)
+
+type spec struct{}
+
+type predicate struct {
+	chance             float64
+	trafficGroup       string
+	trafficGroupCookie string
+}
+
+// Creates a new traffic control predicate specification.
+func New() routing.PredicateSpec { return &spec{} }
+
+func (s *spec) Name() string { return PredicateName }
+
+func (s *spec) Create(args []interface{}) (routing.Predicate, error) {
+	if len(args) == 0 || len(args) > 3 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	p := &predicate{}
+
+	if c, ok := args[0].(float64); ok {
+		p.chance = c
+	} else {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	if len(args) > 1 {
+		if tgc, ok := args[1].(string); ok {
+			p.trafficGroupCookie = tgc
+		} else {
+			return nil, predicates.ErrInvalidPredicateParameters
+		}
+	}
+
+	if len(args) > 2 {
+		if tg, ok := args[2].(string); ok {
+			p.trafficGroup = tg
+		} else {
+			return nil, predicates.ErrInvalidPredicateParameters
+		}
+	} else {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	return p, nil
+}
+
+func (p *predicate) takeChance() bool {
+	return rand.Float64() < p.chance
+}
+
+func (p *predicate) Match(r *http.Request) bool {
+	if p.trafficGroup == "" {
+		return p.takeChance()
+	}
+
+	if c, err := r.Cookie(p.trafficGroupCookie); err == nil {
+		return c.Value == p.trafficGroup
+	} else {
+		return p.takeChance()
+	}
+}

--- a/predicates/traffic/traffic_test.go
+++ b/predicates/traffic/traffic_test.go
@@ -1,0 +1,125 @@
+package traffic
+
+import (
+	"net/http"
+	"testing"
+)
+
+const (
+	defaultTrafficGroupCookie = "testcookie"
+)
+
+func TestCreate(t *testing.T) {
+	for _, ti := range []struct {
+		msg   string
+		args  []interface{}
+		check predicate
+		err   bool
+	}{{
+		"no args",
+		nil,
+		predicate{},
+		true,
+	}, {
+		"too many args",
+		[]interface{}{.3, "testname", "group", "something"},
+		predicate{},
+		true,
+	}, {
+		"first not number",
+		[]interface{}{"something"},
+		predicate{},
+		true,
+	}, {
+		"second not string",
+		[]interface{}{.3, .2},
+		predicate{},
+		true,
+	}, {
+		"third not string",
+		[]interface{}{.3, .2, "group"},
+		predicate{},
+		true,
+	}, {
+		"you have 1 parameter but need to have 3 parameters",
+		[]interface{}{.3},
+		predicate{chance: .3},
+		true,
+	}, {
+		"you have 2 parameters but need to have 3 parameters",
+		[]interface{}{.3, "foo"},
+		predicate{chance: .3},
+		true,
+	}, {
+		"chance and group",
+		[]interface{}{.3, "testname", "group"},
+		predicate{chance: .3, trafficGroup: "group", trafficGroupCookie: "testname"},
+		false,
+	}, {
+		"chance and group and cookie name",
+		[]interface{}{.3, "test"},
+		predicate{chance: .3, trafficGroupCookie: "test"},
+		true,
+	}} {
+		pi, err := (&spec{}).Create(ti.args)
+		if err == nil && ti.err || err != nil && !ti.err {
+			t.Error(ti.msg, "failure case", err, ti.err)
+		} else if err == nil {
+			p := pi.(*predicate)
+			if p.chance != ti.check.chance {
+				t.Error(ti.msg, "chance", p.chance, ti.check.chance)
+			}
+
+			if p.trafficGroup != ti.check.trafficGroup {
+				t.Error(ti.msg, "traffic group", p.trafficGroup, ti.check.trafficGroup)
+			}
+
+			if p.trafficGroupCookie != ti.check.trafficGroupCookie {
+				t.Error(ti.msg, "traffic group cookie", p.trafficGroupCookie, ti.check.trafficGroupCookie)
+			}
+		}
+	}
+}
+
+func TestMatch(t *testing.T) {
+	for _, ti := range []struct {
+		msg   string
+		p     predicate
+		r     http.Request
+		match bool
+	}{{
+		"not sticky, no match",
+		predicate{chance: 0},
+		http.Request{},
+		false,
+	}, {
+		"not sticky, match",
+		predicate{chance: 1},
+		http.Request{},
+		true,
+	}, {
+		"sticky, has cookie, no match",
+		predicate{chance: 1, trafficGroup: "A", trafficGroupCookie: defaultTrafficGroupCookie},
+		http.Request{Header: http.Header{"Cookie": []string{defaultTrafficGroupCookie + "=B"}}},
+		false,
+	}, {
+		"sticky, has cookie, match",
+		predicate{chance: 0, trafficGroup: "A", trafficGroupCookie: defaultTrafficGroupCookie},
+		http.Request{Header: http.Header{"Cookie": []string{defaultTrafficGroupCookie + "=A"}}},
+		true,
+	}, {
+		"sticky, no cookie, no match",
+		predicate{chance: 0, trafficGroup: "A", trafficGroupCookie: defaultTrafficGroupCookie},
+		http.Request{Header: http.Header{}},
+		false,
+	}, {
+		"sticky, no cookie, match",
+		predicate{chance: 1, trafficGroup: "A", trafficGroupCookie: defaultTrafficGroupCookie},
+		http.Request{Header: http.Header{}},
+		true,
+	}} {
+		if (&ti.p).Match(&ti.r) != ti.match {
+			t.Error(ti.msg)
+		}
+	}
+}

--- a/predicates/traffic/traffic_test.go
+++ b/predicates/traffic/traffic_test.go
@@ -37,29 +37,24 @@ func TestCreate(t *testing.T) {
 		true,
 	}, {
 		"third not string",
-		[]interface{}{.3, .2, "group"},
+		[]interface{}{.3, "testname", .2},
 		predicate{},
 		true,
 	}, {
-		"you have 1 parameter but need to have 3 parameters",
+		"only chance",
 		[]interface{}{.3},
 		predicate{chance: .3},
-		true,
+		false,
 	}, {
-		"you have 2 parameters but need to have 3 parameters",
+		"you have 2 parameters but need to have 1 or 3 parameters",
 		[]interface{}{.3, "foo"},
 		predicate{chance: .3},
 		true,
 	}, {
-		"chance and group",
+		"chance and stickyness",
 		[]interface{}{.3, "testname", "group"},
 		predicate{chance: .3, trafficGroup: "group", trafficGroupCookie: "testname"},
 		false,
-	}, {
-		"chance and group and cookie name",
-		[]interface{}{.3, "test"},
-		predicate{chance: .3, trafficGroupCookie: "test"},
-		true,
 	}} {
 		pi, err := (&spec{}).Create(ti.args)
 		if err == nil && ti.err || err != nil && !ti.err {

--- a/predicates/traffic/traffic_test.go
+++ b/predicates/traffic/traffic_test.go
@@ -46,6 +46,16 @@ func TestCreate(t *testing.T) {
 		predicate{chance: .3},
 		false,
 	}, {
+		"wrong chance, bigger than 1",
+		[]interface{}{1.3},
+		predicate{chance: 1.3},
+		true,
+	}, {
+		"wrong chance, less than 0",
+		[]interface{}{-0.3},
+		predicate{chance: -0.3},
+		true,
+	}, {
 		"you have 2 parameters but need to have 1 or 3 parameters",
 		[]interface{}{.3, "foo"},
 		predicate{chance: .3},

--- a/skipper.go
+++ b/skipper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zalando/skipper/predicates/interval"
 	"github.com/zalando/skipper/predicates/query"
 	"github.com/zalando/skipper/predicates/source"
+	"github.com/zalando/skipper/predicates/traffic"
 	"github.com/zalando/skipper/proxy"
 	"github.com/zalando/skipper/routing"
 )
@@ -408,7 +409,8 @@ func Run(o Options) error {
 		interval.NewBefore(),
 		interval.NewAfter(),
 		cookie.New(),
-		query.New())
+		query.New(),
+		traffic.New())
 
 	// create a routing engine
 	routing := routing.New(routing.Options{


### PR DESCRIPTION
The below example, shows a possible eskip document used for green-blue
deployments of APIS, which usually don't require stickiness:

    // hit by 10% percent chance
    v2:
        Traffic(.1) ->
        "https://api-test-green";

    // hit by remaining chance
    v1:
        "https://api-test-blue";

stickyness example:

    // hit by 5% percent chance
    cartTest:
        Traffic(.05, "cart-test", "test") && Path("/cart") ->
        responseCookie("cart-test", "test") ->
        "https://cart-test"\;

    // hit by remaining chance
    cart:
        Path("/cart") ->
        responseCookie("cart-test", "default") ->
        "https://cart"\;