### PR TITLE
Implement traffic switching in kubernetes dataclient

### DIFF
--- a/dataclients/kubernetes/definitions.go
+++ b/dataclients/kubernetes/definitions.go
@@ -7,8 +7,9 @@ import (
 )
 
 type metadata struct {
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
+	Namespace   string            `json:"namespace"`
+	Name        string            `json:"name"`
+	Annotations map[string]string `json:"annotations"`
 }
 
 type backendPort struct {
@@ -70,6 +71,8 @@ func (p backendPort) String() string {
 type backend struct {
 	ServiceName string      `json:"serviceName"`
 	ServicePort backendPort `json:"servicePort"`
+	// Traffic field used for custom traffic weights, but not part of the ingress spec.
+	Traffic float64
 }
 
 type pathRule struct {

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -225,7 +225,7 @@ func addTreeMatchers(pathTree *pathmux.Tree, matchers map[string]*pathMatcher, s
 	for p, m := range matchers {
 
 		// sort leaves during construction time, based on their priority
-		sort.Sort(m.leaves)
+		sort.Stable(m.leaves)
 
 		if p == "" {
 			p = "/"
@@ -305,7 +305,7 @@ func newMatcher(rs []*Route, o MatchingOptions) (*matcher, []*definitionError) {
 	errors = append(errors, addTreeMatchers(pathTree, subtreeMatchers, true)...)
 
 	// sort root leaves during construction time, based on their priority
-	sort.Sort(rootLeaves)
+	sort.Stable(rootLeaves)
 
 	return &matcher{pathTree, rootLeaves, o}, errors
 }


### PR DESCRIPTION
This implements `backend-weights` (or traffic switching) using an annotation `zalando.org/backend-weights` as described in #324.

It works by parsing the annotation of format:

```
zalando.org/backend-weights: |
  {"my-app-v1": 90, "my-app-v2": 10}
```

and maps the weights defined in the annotation to the backend services defined in the ingress spec.

The traffic weights are computed relative to the number of backends, and subsequent backends for a path will get higher relative weight because of how the `Traffic` predicate in skipper works. E.g. if you have the following backends and weights:

```
* backend-1: 0.2
* backend-2: 0.6
* backend-3: 0.2
```

The computed traffic values will be:

```
* backend-1: 0.2
* backend-2: 0.75
* backend-3: 1.0
```

Which results in the following eskip rules:

```
backend-1:
  Traffic(0.2) ->

backend-2:
  Traffic(0.75) ->

backend-3:
  * ->
```