### PR TITLE
Add support for kubernetes.io/ingress.class annotation

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -47,6 +47,7 @@ const (
 	kubernetesURLUsage             = "kubernetes API base URL for the ingress data client; requires kubectl proxy running; omit if kubernetes-in-cluster is set to true"
 	kubernetesHealthcheckUsage     = "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes"
 	kubernetesHTTPSRedirectUsage   = "automatic HTTP->HTTPS redirect route; valid only with kubernetes"
+	kubernetesIngressClassUsage    = "ingress class used to filter ingress resources on kubernetes"
 	innkeeperUrlUsage              = "API endpoint of the Innkeeper service, storing route definitions"
 	innkeeperAuthTokenUsage        = "fixed token for innkeeper authentication"
 	innkeeperPreRouteFiltersUsage  = "filters to be prepended to each route loaded from Innkeeper"
@@ -101,6 +102,7 @@ var (
 	kubernetesURL             string
 	kubernetesHealthcheck     bool
 	kubernetesHTTPSRedirect   bool
+	kubernetesIngressClass    string
 	innkeeperUrl              string
 	sourcePollTimeout         int64
 	routesFile                string
@@ -146,6 +148,7 @@ func init() {
 	flag.StringVar(&kubernetesURL, "kubernetes-url", "", kubernetesURLUsage)
 	flag.BoolVar(&kubernetesHealthcheck, "kubernetes-healthcheck", true, kubernetesHealthcheckUsage)
 	flag.BoolVar(&kubernetesHTTPSRedirect, "kubernetes-https-redirect", true, kubernetesHTTPSRedirectUsage)
+	flag.StringVar(&kubernetesIngressClass, "kubernetes-ingress-class", "", kubernetesIngressClassUsage)
 	flag.StringVar(&innkeeperUrl, "innkeeper-url", "", innkeeperUrlUsage)
 	flag.Int64Var(&sourcePollTimeout, "source-poll-timeout", defaultSourcePollTimeout, sourcePollTimeoutUsage)
 	flag.StringVar(&routesFile, "routes-file", "", routesFileUsage)
@@ -229,6 +232,7 @@ func main() {
 		KubernetesURL:             kubernetesURL,
 		KubernetesHealthcheck:     kubernetesHealthcheck,
 		KubernetesHTTPSRedirect:   kubernetesHTTPSRedirect,
+		KubernetesIngressClass:    kubernetesIngressClass,
 		InnkeeperUrl:              innkeeperUrl,
 		SourcePollTimeout:         time.Duration(sourcePollTimeout) * time.Millisecond,
 		RoutesFile:                routesFile,

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -569,15 +569,13 @@ func (c *Client) filterIngressesByClass(items []*ingressItem) []*ingressItem {
 	validIngs := []*ingressItem{}
 
 	for _, ing := range items {
-		// no metadata is the same as no annotations for us
-		if ing.Metadata == nil {
-			continue
-		}
-
-		cls, ok := ing.Metadata.Annotations[ingressClassKey]
-		// skip loop iteration if not valid ingress (non defined, empty or non defined one)
-		if ok && cls != "" && cls != c.ingressClass {
-			continue
+		// No metadata is the same as no annotations for us
+		if ing.Metadata != nil {
+			cls, ok := ing.Metadata.Annotations[ingressClassKey]
+			// Skip loop iteration if not valid ingress (non defined, empty or non defined one)
+			if ok && cls != "" && cls != c.ingressClass {
+				continue
+			}
 		}
 		validIngs = append(validIngs, ing)
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -80,6 +80,13 @@ type Options struct {
 	// expected to be set by the load-balancer.
 	KubernetesHTTPSRedirect bool
 
+	// KubernetesIngressClass, will make skipper only load the ingress
+	// resources that match the kubernetes.io/ingress.class annotation
+	// specified on this setting, for backwards compatibility it will
+	// loadd the ingresses without annotation, or with this annotation
+	// set to an empty value
+	KubernetesIngressClass string
+
 	// API endpoint of the Innkeeper service, storing route definitions.
 	InnkeeperUrl string
 
@@ -270,6 +277,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 			KubernetesURL:        o.KubernetesURL,
 			ProvideHealthcheck:   o.KubernetesHealthcheck,
 			ProvideHTTPSRedirect: o.KubernetesHTTPSRedirect,
+			IngressClass:         o.KubernetesIngressClass,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Hi!

This PR adds support for the k8s `kubernetes.io/ingress.class` [annotation on the ingress rules](https://github.com/nginxinc/kubernetes-ingress/tree/master/examples/multiple-ingress-controllers), this way you can have multiple ingress controllers.

In the end it will filter the ingresses obtained from k8s checking this annotation with these cases as result:
* If no annotation: valid
* If empty annotation: valid
* If different annotation from the desired one: invalid 
* If same annotarion as the desired one: valid

This way, the change is backwards compatible with all the ingresses that where previously being used.

By default if no ingress class is configured on run, it will be set `skipper` by default.

For example this would be a valid ingress for skipper:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: valid-ingress
  annotations:
    kubernetes.io/ingress.class: "skipper"
...
```
and this not:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: invalid-ingress
  annotations:
    kubernetes.io/ingress.class: "nginx"
...
```
 