### PR TITLE
use metrics keys only from known hosts and methods

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -190,6 +190,7 @@ func (m *Metrics) MeasureAllFiltersResponse(routeId string, start time.Time) {
 }
 
 func (m *Metrics) MeasureResponse(code int, method string, routeId string, start time.Time) {
+	method = measuredMethod(method)
 	m.measureSince(fmt.Sprintf(KeyResponse, code, method, routeId), start)
 }
 
@@ -199,7 +200,25 @@ func hostForKey(h string) string {
 	return h
 }
 
+func measuredMethod(m string) string {
+	switch m {
+	case "OPTIONS",
+		"GET",
+		"HEAD",
+		"POST",
+		"PUT",
+		"DELETE",
+		"TRACE",
+		"CONNECT":
+		return m
+	default:
+		return "_unknown_method_"
+	}
+}
+
 func (m *Metrics) MeasureServe(routeId, host, method string, code int, start time.Time) {
+	method = measuredMethod(method)
+
 	if m.options.EnableServeRouteMetrics {
 		m.measureSince(fmt.Sprintf(KeyServeRoute, routeId, method, code), start)
 	}

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -11,6 +11,8 @@ import (
 	"github.com/zalando/skipper/routing"
 )
 
+const unknownHost = "_unknownhost_"
+
 type context struct {
 	responseWriter        http.ResponseWriter
 	request               *http.Request
@@ -182,6 +184,14 @@ func (c *context) Serve(r *http.Response) {
 
 	c.servedWithResponse = true
 	c.response = r
+}
+
+func (c *context) metricsHost() string {
+	if c.route == nil || len(c.route.HostRegexps) == 0 {
+		return unknownHost
+	}
+
+	return c.request.Host
 }
 
 func (c *context) clone() *context {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -406,7 +406,7 @@ func (p *Proxy) sendError(c *context, id string, code int) {
 	http.Error(c.responseWriter, http.StatusText(code), code)
 	p.metrics.MeasureServe(
 		id,
-		c.request.Host,
+		c.metricsHost(),
 		c.request.Method,
 		code,
 		c.startServe,
@@ -611,7 +611,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.serveResponse(ctx)
 	p.metrics.MeasureServe(
 		ctx.route.Id,
-		r.Host,
+		ctx.metricsHost(),
 		r.Method,
 		ctx.response.StatusCode,
 		ctx.startServe,


### PR DESCRIPTION
since the metrics are created on demand, and some of them have keys based on request method and host, it is possible to create unwanted number of metrics from user input. With this PR:

- use common host based metrics for those requests that were not matched against a host predicate
- allow only standard methods in metrics keys