### PR TITLE
consistency fix for metrics keys

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -212,7 +212,7 @@ func measuredMethod(m string) string {
 		"CONNECT":
 		return m
 	default:
-		return "_unknown_method_"
+		return "_unknownmethod_"
 	}
 }
 


### PR DESCRIPTION
fix of metrics keys to be consistent. (see comment in #342 )

@mo-gr chose to remove the underscore, because there was already the "_unknownroute_" before that pr.