### PR TITLE
fix license badge, provide coverage for sub packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ example.eskip
 Godeps/_workspace
 packaging/skipper
 packaging/eskip
+.coverprofile

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 [![Build Status](https://travis-ci.org/zalando/skipper.svg)](https://travis-ci.org/zalando/skipper)
 [![GoDoc](https://godoc.org/github.com/zalando/skipper/proxy?status.svg)](https://godoc.org/github.com/zalando/skipper/proxy)
-[![License](https://img.shields.io/badge/license-APACHE-red.svg?style=flat)](https://raw.githubusercontent.com/zalando/skipper/master/LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Go Report Card](https://goreportcard.com/badge/zalando/skipper)](https://goreportcard.com/report/zalando/skipper)
-[![Coverage](http://gocover.io/_badge/github.com/zalando/skipper)](http://gocover.io/github.com/zalando/skipper)
+[![codecov](https://codecov.io/gh/zalando/skipper/branch/master/graph/badge.svg)](https://codecov.io/gh/zalando/skipper)
 
 <p align="center"><img height="360" alt="Skipper" src="https://raw.githubusercontent.com/zalando/skipper/gh-pages/img/skipper.h360.png"></p>
 


### PR DESCRIPTION
- fix the license badge to point to the official url
- generate test coverage on merge to master and show it with codecov.io

fixes #348