### PR TITLE
Move pathmux

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+Skipper is in general licensed under the following Apache Version 2.0 license with the exception
+of the pathmux subdirectory which is licensed under MIT license (see notice file below).
+
 Copyright 2015 Zalando SE
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
@@ -5,3 +8,36 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+
+Notice file for pathmux/
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Imfeld, 2015 Zalando SE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+MODIFICATIONS TO pathmux/tree.go and pathmux/tree_test.go:
+
+02.09.2015 - Exposed the internal tree implementation of http://godoc.org/github.com/dimfeld/httptreemux so that
+it can be used to look up arbitrary objects in a Patricia tree.
+
+21.04.2016 - Enabled backtracking in the tree lookup.

--- a/pathmux/LICENSE
+++ b/pathmux/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Imfeld, 2015 Zalando SE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pathmux/Makefile
+++ b/pathmux/Makefile
@@ -1,0 +1,53 @@
+.PHONY: cpu mem
+
+SOURCES = $(shell find . -name '*.go')
+
+default: build
+
+build: $(SOURCES)
+	go build
+
+install: $(SOURCES)
+	go install
+
+check: build
+	go test -race
+
+shortcheck: build
+	go test -test.short -run ^Test
+
+bench: build
+	go test -cpuprofile cpu.out -memprofile mem.out -bench .
+
+cpu:
+	go tool pprof -top cpu.out # Run 'make bench' to generate profile.
+
+mem:
+	go tool pprof -top mem.out # Run 'make bench' to generate profile.
+
+gencover: build
+	go test -coverprofile cover.out
+
+cover: gencover
+	go tool cover -func cover.out
+
+showcover: gencover
+	go tool cover -html cover.out
+
+fmt: $(SOURCES)
+	gofmt -w -s ./*.go
+
+vet: $(SOURCES)
+	go vet
+
+check-ineffassign: $(SOURCES)
+	ineffassign .
+
+check-spell: $(SOURCES) README.md Makefile
+	misspell -error README.md Makefile *.go
+
+lint: $(SOURCES)
+	golint -set_exit_status -min_confidence 0.9
+
+precommit: build check fmt cover vet check-ineffassign check-spell lint
+	# ok

--- a/pathmux/README.md
+++ b/pathmux/README.md
@@ -1,0 +1,66 @@
+[![GoDoc](https://godoc.org/github.com/zalando/pathmux?status.svg)](https://godoc.org/github.com/zalando/pathmux)
+[![Go Report Card](https://goreportcard.com/badge/github.com/zalando/pathmux)](https://goreportcard.com/report/github.com/zalando/pathmux)
+[![Go Cover](https://gocover.io/_badge/github.com/zalando/pathmux)](https://gocover.io/github.com/zalando/pathmux)
+
+# Pathmux: tree lookup with wildcard matching
+
+Pathmux is a package that implements an effective tree lookup with wildcard matching. It is a fork of the awesome [httptreemux](https://github.com/dimfeld/httptreemux). This fork makes visible the interface of the internal tree lookup implementation of the original httptreemux package, and with the HTTP-related wrapper code stripped away.
+
+In addition to having the original httptreemux logic, pathmux offers one small feature: backtracking. This means that when a
+path is matched, it is possible to instruct the lookup not to return the found object when other, custom
+conditions are not met, but instead continue the lookup by backtracking from the current point in the tree.
+
+Pathmux is used by [Skipper](https://github.com/zalando/skipper), an extensible HTTP routing server used in production at Zalando.
+
+### When to Use pathmux Instead of httptreemux
+
+Almost never, except when:
+
+- you want to store a large number of **custom** objects in an effective lookup tree, keyed by path values
+- you want to use the backtracking feature to refine the evaluation of wildcard matching with custom logic
+
+### Installation
+
+```
+go get github.com/zalando/pathmux
+```
+
+Pathmux is 'go get compatible'. The master head is always stable (at least by intent), and it doesn't use any vendoring itself. However, we strongly recommend that you use vendoring in the final, importing, executable package.
+
+### Documentation
+
+You can find detailed package documentation [here](https://godoc.org/github.com/zalando/pathmux).
+
+### Working with the Code
+
+While it is enough to use `go get` to import the package, when modifying the code, it is worth cherry-picking from the tasks in the provided simple Makefile. 
+
+### Contributing
+See our detailed [contribution guidelines](https://github.com/zalando/pathmux/blob/master/CONTRIBUTING.md). If you plan on contributing to the current repository, please make sure:
+
+1. to run the precommit checks:
+
+```
+make precommit
+```
+
+Please fix all reported errors and please make sure that the overall test coverage is not decreased. (Please
+feel free to provide tests for the missing spots :))
+
+2. compare the performance of the new version to the current master, and avoid degradations:
+
+```
+make bench
+```
+
+(Comparison currently can happen only by running the same `make bench` on the master branch. Automating the comparison would be a nice contribution.)
+
+### License
+
+Copyright (c) 2014 Daniel Imfeld, 2015 Zalando SE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pathmux/tree.go
+++ b/pathmux/tree.go
@@ -1,0 +1,361 @@
+/*
+Package pathmux implements a tree lookup for values associated to
+paths.
+
+This package is a fork of https://github.com/dimfeld/httptreemux.
+*/
+package pathmux
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Matcher objects, when using the LookupMatch function, can be used for additional checks and to override the
+// default result in case of path matches. The argument passed to the Match function is the original value
+// passed to the Tree.Add function.
+type Matcher interface {
+
+	// Match should return true and the object to be returned by the lookup, when the argument value fulfils the
+	// conditions defined by the custom logic in the matcher itself. If it returns false, it instructs the
+	// lookup to continue with backtracking from the current tree position.
+	Match(value interface{}) (bool, interface{})
+}
+
+type trueMatcher struct{}
+
+func (m *trueMatcher) Match(value interface{}) (bool, interface{}) {
+	return true, value
+}
+
+var tm *trueMatcher
+
+func init() {
+	tm = &trueMatcher{}
+}
+
+type node struct {
+	path string
+
+	priority int
+
+	// The list of static children to check.
+	staticIndices []byte
+	staticChild   []*node
+
+	// If none of the above match, check the wildcard children
+	wildcardChild *node
+
+	// If none of the above match, then we use the catch-all, if applicable.
+	catchAllChild *node
+
+	isCatchAll bool
+
+	leafValue interface{}
+
+	// The names of the parameters to apply.
+	leafWildcardNames []string
+}
+
+// Tree structure to store values associated to paths.
+type Tree node
+
+func (n *node) sortStaticChild(i int) {
+	for i > 0 && n.staticChild[i].priority > n.staticChild[i-1].priority {
+		n.staticChild[i], n.staticChild[i-1] = n.staticChild[i-1], n.staticChild[i]
+		n.staticIndices[i], n.staticIndices[i-1] = n.staticIndices[i-1], n.staticIndices[i]
+		i -= 1
+	}
+}
+
+func (n *node) addPath(path string, wildcards []string) (*node, error) {
+	leaf := len(path) == 0
+	if leaf {
+		if wildcards != nil {
+			// Make sure the current wildcards are the same as the old ones.
+			// If not then we have an ambiguous path.
+			if n.leafWildcardNames != nil {
+				if len(n.leafWildcardNames) != len(wildcards) {
+					// This should never happen.
+					return nil, errors.New("damaged tree")
+				}
+
+				for i := 0; i < len(wildcards); i++ {
+					if n.leafWildcardNames[i] != wildcards[i] {
+						return nil, fmt.Errorf(
+							"Wildcards %v are ambiguous with wildcards %v",
+							n.leafWildcardNames, wildcards)
+					}
+				}
+			} else {
+				// No wildcards yet, so just add the existing set.
+				n.leafWildcardNames = wildcards
+			}
+		}
+
+		return n, nil
+	}
+
+	c := path[0]
+	nextSlash := strings.Index(path, "/")
+	var thisToken string
+	var tokenEnd int
+
+	if c == '/' {
+		thisToken = "/"
+		tokenEnd = 1
+	} else if nextSlash == -1 {
+		thisToken = path
+		tokenEnd = len(path)
+	} else {
+		thisToken = path[0:nextSlash]
+		tokenEnd = nextSlash
+	}
+	remainingPath := path[tokenEnd:]
+
+	if c == '*' {
+		// Token starts with a *, so it's a catch-all
+		thisToken = thisToken[1:]
+		if n.catchAllChild == nil {
+			n.catchAllChild = &node{path: thisToken, isCatchAll: true}
+		}
+
+		if path[1:] != n.catchAllChild.path {
+			return nil, fmt.Errorf(
+				"Catch-all name in %s doesn't match %s",
+				path, n.catchAllChild.path)
+		}
+
+		if nextSlash != -1 {
+			return nil, fmt.Errorf("/ after catch-all found in %s", path)
+		}
+
+		if wildcards == nil {
+			wildcards = []string{thisToken}
+		} else {
+			wildcards = append(wildcards, thisToken)
+		}
+		n.catchAllChild.leafWildcardNames = wildcards
+
+		return n.catchAllChild, nil
+	} else if c == ':' {
+		// Token starts with a :
+		thisToken = thisToken[1:]
+
+		if wildcards == nil {
+			wildcards = []string{thisToken}
+		} else {
+			wildcards = append(wildcards, thisToken)
+		}
+
+		if n.wildcardChild == nil {
+			n.wildcardChild = &node{path: "wildcard"}
+		}
+
+		return n.wildcardChild.addPath(remainingPath, wildcards)
+
+	} else {
+		if strings.ContainsAny(thisToken, ":*") {
+			return nil, fmt.Errorf("* or : in middle of path component %s", path)
+		}
+
+		// Do we have an existing node that starts with the same letter?
+		for i, index := range n.staticIndices {
+			if c == index {
+				// Yes. Split it based on the common prefix of the existing
+				// node and the new one.
+				child, prefixSplit := n.splitCommonPrefix(i, thisToken)
+				child.priority++
+				n.sortStaticChild(i)
+				return child.addPath(path[prefixSplit:], wildcards)
+			}
+		}
+
+		// No existing node starting with this letter, so create it.
+		child := &node{path: thisToken}
+
+		if n.staticIndices == nil {
+			n.staticIndices = []byte{c}
+			n.staticChild = []*node{child}
+		} else {
+			n.staticIndices = append(n.staticIndices, c)
+			n.staticChild = append(n.staticChild, child)
+		}
+		return child.addPath(remainingPath, wildcards)
+	}
+}
+
+func (n *node) splitCommonPrefix(existingNodeIndex int, path string) (*node, int) {
+	childNode := n.staticChild[existingNodeIndex]
+
+	if strings.HasPrefix(path, childNode.path) {
+		// No split needs to be done. Rather, the new path shares the entire
+		// prefix with the existing node, so the new node is just a child of
+		// the existing one. Or the new path is the same as the existing path,
+		// which means that we just move on to the next token. Either way,
+		// this return accomplishes that
+		return childNode, len(childNode.path)
+	}
+
+	var i int
+	// Find the length of the common prefix of the child node and the new path.
+	for i = range childNode.path {
+		if i == len(path) {
+			break
+		}
+		if path[i] != childNode.path[i] {
+			break
+		}
+	}
+
+	commonPrefix := path[0:i]
+	childNode.path = childNode.path[i:]
+
+	// Create a new intermediary node in the place of the existing node, with
+	// the existing node as a child.
+	newNode := &node{
+		path:     commonPrefix,
+		priority: childNode.priority,
+		// Index is the first letter of the non-common part of the path.
+		staticIndices: []byte{childNode.path[0]},
+		staticChild:   []*node{childNode},
+	}
+	n.staticChild[existingNodeIndex] = newNode
+
+	return newNode, i
+}
+
+func (n *node) search(path string, m Matcher) (found *node, params []string, value interface{}) {
+	pathLen := len(path)
+	if pathLen == 0 {
+		if n.leafValue == nil {
+			return nil, nil, nil
+		}
+
+		var match bool
+		match, value = m.Match(n.leafValue)
+
+		if !match {
+			return nil, nil, nil
+		}
+
+		return n, nil, value
+	}
+
+	// First see if this matches a static token.
+	firstChar := path[0]
+	for i, staticIndex := range n.staticIndices {
+		if staticIndex == firstChar {
+			child := n.staticChild[i]
+			childPathLen := len(child.path)
+			if pathLen >= childPathLen && child.path == path[:childPathLen] {
+				nextPath := path[childPathLen:]
+				found, params, value = child.search(nextPath, m)
+			}
+			break
+		}
+	}
+
+	if found != nil {
+		return
+	}
+
+	if n.wildcardChild != nil {
+		// Didn't find a static token, so check for a wildcard.
+		nextSlash := 0
+		for nextSlash < pathLen && path[nextSlash] != '/' {
+			nextSlash++
+		}
+
+		thisToken := path[0:nextSlash]
+		nextToken := path[nextSlash:]
+
+		if len(thisToken) > 0 { // Don't match on empty tokens.
+			found, params, value = n.wildcardChild.search(nextToken, m)
+			if found != nil {
+				unescaped, err := url.QueryUnescape(thisToken)
+				if err != nil {
+					unescaped = thisToken
+				}
+
+				if params == nil {
+					params = []string{unescaped}
+				} else {
+					params = append(params, unescaped)
+				}
+
+				return
+			}
+		}
+	}
+
+	catchAllChild := n.catchAllChild
+	if catchAllChild != nil {
+		// Hit the catchall, so just assign the whole remaining path.
+		unescaped, err := url.QueryUnescape(path)
+		if err != nil {
+			unescaped = path
+		}
+
+		var match bool
+		match, value = m.Match(catchAllChild.leafValue)
+
+		if !match {
+			return nil, nil, nil
+		}
+
+		return catchAllChild, []string{unescaped}, value
+	}
+
+	return nil, nil, nil
+}
+
+// Add a value to the tree associated with a path. Paths may contain
+// wildcards. Wildcards can be of two types:
+//
+// - simple wildcard: e.g. /some/:wildcard/path, where a wildcard is
+// matched to a single name in the path.
+//
+// - free wildcard: e.g. /some/path/*wildcard, where a wildcard at the
+// end of a path matches anything.
+func (t *Tree) Add(path string, value interface{}) error {
+	n, err := (*node)(t).addPath(path[1:], nil)
+	if err != nil {
+		return err
+	}
+
+	n.leafValue = value
+	return nil
+}
+
+// Lookup tries to find a value in the tree associated to a path. If the found path definition contains
+// wildcards, the names and values of the wildcards are returned in the second argument.
+func (t *Tree) Lookup(path string) (interface{}, map[string]string) {
+	node, params, _ := t.LookupMatcher(path, tm)
+	return node, params
+}
+
+// LookupMatcher tries to find value in the tree associated to a path. If the found path definition contains
+// wildcards, the names and values of the wildcards are returned in the second argument. When a value is found,
+// the matcher is called to check if the value meets the conditions implemented by the custom matcher. If it
+// returns true, then the lookup is done and the additional return value from the matcher is returned as the
+// lookup result. If it returns false, the lookup continues with backtracking from the current tree position.
+func (t *Tree) LookupMatcher(path string, m Matcher) (interface{}, map[string]string, interface{}) {
+	if path == "" {
+		path = "/"
+	}
+
+	node, params, value := (*node)(t).search(path[1:], m)
+	if node == nil {
+		return nil, nil, nil
+	}
+
+	paramMap := make(map[string]string)
+	for i, p := range params {
+		paramMap[node.leafWildcardNames[len(node.leafWildcardNames)-i-1]] = p
+	}
+
+	return node.leafValue, paramMap, value
+}

--- a/pathmux/tree_test.go
+++ b/pathmux/tree_test.go
@@ -1,0 +1,377 @@
+package pathmux
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type HandlerFunc func(w http.ResponseWriter, r *http.Request, urlParams map[string]string)
+
+func dummyHandler(w http.ResponseWriter, r *http.Request, urlParams map[string]string) {
+
+}
+
+func addPath(t *testing.T, tree *node, path string) {
+	t.Logf("Adding path %s", path)
+	n, err := tree.addPath(path[1:], nil)
+	if err != nil {
+		t.Error(err)
+	}
+	handler := HandlerFunc(func(w http.ResponseWriter, r *http.Request, urlParams map[string]string) {
+		urlParams["path"] = path
+	})
+	n.leafValue = handler
+}
+
+var test *testing.T
+
+func testPath(t *testing.T, tree *node, path string, expectPath string, expectedParams map[string]string) {
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	expectCatchAll := strings.Contains(expectPath, "/*")
+
+	t.Log("Testing", path)
+	n, paramList, _ := tree.search(path[1:], tm)
+	if expectPath != "" && n == nil {
+		t.Errorf("No match for %s, expected %s", path, expectPath)
+		return
+	} else if expectPath == "" && n != nil {
+		t.Errorf("Expected no match for %s but got %v with params %v", path, n, expectedParams)
+		t.Error("Node and subtree was\n")
+		return
+	}
+
+	if n == nil {
+		return
+	}
+
+	if expectCatchAll != n.isCatchAll {
+		t.Errorf("For path %s expectCatchAll %v but saw %v", path, expectCatchAll, n.isCatchAll)
+	}
+
+	handler, ok := n.leafValue.(HandlerFunc)
+	if !ok {
+		t.Errorf("Path %s returned node without handler", path)
+		t.Error("Node and subtree was\n")
+		return
+	}
+
+	pathMap := make(map[string]string)
+	handler(nil, nil, pathMap)
+	matchedPath := pathMap["path"]
+
+	if matchedPath != expectPath {
+		t.Errorf("Path %s matched %s, expected %s", path, matchedPath, expectPath)
+		t.Error("Node and subtree was\n")
+	}
+
+	if expectedParams == nil {
+		if len(paramList) != 0 {
+			t.Errorf("Path %s expected no parameters, saw %v", path, paramList)
+		}
+	} else {
+		if len(paramList) != len(n.leafWildcardNames) {
+			t.Errorf("Got %d params back but node specifies %d",
+				len(paramList), len(n.leafWildcardNames))
+		}
+
+		params := map[string]string{}
+		for i := 0; i < len(paramList); i++ {
+			params[n.leafWildcardNames[len(paramList)-i-1]] = paramList[i]
+		}
+		t.Log("\tGot params", params)
+
+		for key, val := range expectedParams {
+			sawVal, ok := params[key]
+			if !ok {
+				t.Errorf("Path %s matched without key %s", path, key)
+			} else if sawVal != val {
+				t.Errorf("Path %s expected param %s to be %s, saw %s", path, key, val, sawVal)
+			}
+
+			delete(params, key)
+		}
+
+		for key, val := range params {
+			t.Errorf("Path %s returned unexpected param %s=%s", path, key, val)
+		}
+	}
+
+}
+
+func checkHandlerNodes(t *testing.T, n *node) {
+	hasHandlers := n.leafValue != nil
+	hasWildcards := len(n.leafWildcardNames) != 0
+
+	if hasWildcards && !hasHandlers {
+		t.Errorf("Node %s has wildcards without handlers", n.path)
+	}
+}
+
+func TestTree(t *testing.T) {
+	test = t
+	tree := &node{path: "/"}
+
+	addPath(t, tree, "/")
+	addPath(t, tree, "/i")
+	addPath(t, tree, "/i/:aaa")
+	addPath(t, tree, "/images")
+	addPath(t, tree, "/images/abc.jpg")
+	addPath(t, tree, "/images/:imgname")
+	addPath(t, tree, "/images/*path")
+	addPath(t, tree, "/ima")
+	addPath(t, tree, "/ima/:par")
+	addPath(t, tree, "/images1")
+	addPath(t, tree, "/images2")
+	addPath(t, tree, "/apples")
+	addPath(t, tree, "/app/les")
+	addPath(t, tree, "/apples1")
+	addPath(t, tree, "/appeasement")
+	addPath(t, tree, "/appealing")
+	addPath(t, tree, "/date/:year/:month")
+	addPath(t, tree, "/date/:year/month")
+	addPath(t, tree, "/date/:year/:month/abc")
+	addPath(t, tree, "/date/:year/:month/:post")
+	addPath(t, tree, "/date/:year/:month/*post")
+	addPath(t, tree, "/:page")
+	addPath(t, tree, "/:page/:index")
+	addPath(t, tree, "/post/:post/page/:page")
+	addPath(t, tree, "/plaster")
+	addPath(t, tree, "/users/:pk/:related")
+	addPath(t, tree, "/users/:id/updatePassword")
+	addPath(t, tree, "/:something/abc")
+	addPath(t, tree, "/:something/def")
+
+	testPath(t, tree, "/users/abc/updatePassword", "/users/:id/updatePassword",
+		map[string]string{"id": "abc"})
+	testPath(t, tree, "/users/all/something", "/users/:pk/:related",
+		map[string]string{"pk": "all", "related": "something"})
+
+	testPath(t, tree, "/aaa/abc", "/:something/abc",
+		map[string]string{"something": "aaa"})
+	testPath(t, tree, "/aaa/def", "/:something/def",
+		map[string]string{"something": "aaa"})
+
+	testPath(t, tree, "/paper", "/:page",
+		map[string]string{"page": "paper"})
+
+	testPath(t, tree, "/", "/", nil)
+	testPath(t, tree, "/i", "/i", nil)
+	testPath(t, tree, "/images", "/images", nil)
+	testPath(t, tree, "/images/abc.jpg", "/images/abc.jpg", nil)
+	testPath(t, tree, "/images/something", "/images/:imgname",
+		map[string]string{"imgname": "something"})
+	testPath(t, tree, "/images/long/path", "/images/*path",
+		map[string]string{"path": "long/path"})
+	testPath(t, tree, "/images/even/longer/path", "/images/*path",
+		map[string]string{"path": "even/longer/path"})
+	testPath(t, tree, "/ima", "/ima", nil)
+	testPath(t, tree, "/apples", "/apples", nil)
+	testPath(t, tree, "/app/les", "/app/les", nil)
+	testPath(t, tree, "/abc", "/:page",
+		map[string]string{"page": "abc"})
+	testPath(t, tree, "/abc/100", "/:page/:index",
+		map[string]string{"page": "abc", "index": "100"})
+	testPath(t, tree, "/post/a/page/2", "/post/:post/page/:page",
+		map[string]string{"post": "a", "page": "2"})
+	testPath(t, tree, "/date/2014/5", "/date/:year/:month",
+		map[string]string{"year": "2014", "month": "5"})
+	testPath(t, tree, "/date/2014/month", "/date/:year/month",
+		map[string]string{"year": "2014"})
+	testPath(t, tree, "/date/2014/5/abc", "/date/:year/:month/abc",
+		map[string]string{"year": "2014", "month": "5"})
+	testPath(t, tree, "/date/2014/5/def", "/date/:year/:month/:post",
+		map[string]string{"year": "2014", "month": "5", "post": "def"})
+	testPath(t, tree, "/date/2014/5/def/hij", "/date/:year/:month/*post",
+		map[string]string{"year": "2014", "month": "5", "post": "def/hij"})
+	testPath(t, tree, "/date/2014/5/def/hij/", "/date/:year/:month/*post",
+		map[string]string{"year": "2014", "month": "5", "post": "def/hij/"})
+
+	testPath(t, tree, "/date/2014/ab%2f", "/date/:year/:month",
+		map[string]string{"year": "2014", "month": "ab/"})
+	testPath(t, tree, "/post/ab%2fdef/page/2%2f", "/post/:post/page/:page",
+		map[string]string{"post": "ab/def", "page": "2/"})
+
+	testPath(t, tree, "/ima/bcd/fgh", "", nil)
+	testPath(t, tree, "/date/2014//month", "", nil)
+	testPath(t, tree, "/date/2014/05/", "", nil) // Empty catchall should not match
+	testPath(t, tree, "/post//abc/page/2", "", nil)
+	testPath(t, tree, "/post/abc//page/2", "", nil)
+	testPath(t, tree, "/post/abc/page//2", "", nil)
+	testPath(t, tree, "//post/abc/page/2", "", nil)
+	testPath(t, tree, "//post//abc//page//2", "", nil)
+
+	t.Log("Test retrieval of duplicate paths")
+	params := make(map[string]string)
+	p := "date/:year/:month/abc"
+	n, err := tree.addPath(p, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if n == nil {
+		t.Errorf("Duplicate add of %s didn't return a node", p)
+	} else {
+		handler, ok := n.leafValue.(HandlerFunc)
+		matchPath := ""
+		if ok {
+			handler(nil, nil, params)
+			matchPath = params["path"]
+		}
+
+		if len(matchPath) < 2 || matchPath[1:] != p {
+			t.Errorf("Duplicate add of %s returned node for %s\n", p, matchPath)
+
+		}
+	}
+
+	checkHandlerNodes(t, tree)
+
+	test = nil
+}
+
+func TestPanics(t *testing.T) {
+	sawPanic := false
+
+	addPathPanic := func(p ...string) {
+		sawPanic = false
+		tree := &node{path: "/"}
+		for _, path := range p {
+			_, err := tree.addPath(path, nil)
+			if err != nil {
+				sawPanic = true
+			}
+		}
+	}
+
+	addPathPanic("abc/*path/")
+	if !sawPanic {
+		t.Error("Expected panic with slash after catch-all")
+	}
+
+	addPathPanic("abc/*path/def")
+	if !sawPanic {
+		t.Error("Expected panic with path segment after catch-all")
+	}
+
+	addPathPanic("abc/*path", "abc/*paths")
+	if !sawPanic {
+		t.Error("Expected panic when adding conflicting catch-alls")
+	}
+
+	addPathPanic("abc/ab:cd")
+	if !sawPanic {
+		t.Error("Expected panic with : in middle of path segment")
+	}
+
+	addPathPanic("abc/ab", "abc/ab:cd")
+	if !sawPanic {
+		t.Error("Expected panic with : in middle of path segment with existing path")
+	}
+
+	addPathPanic("abc/ab*cd")
+	if !sawPanic {
+		t.Error("Expected panic with * in middle of path segment")
+	}
+
+	addPathPanic("abc/ab", "abc/ab*cd")
+	if !sawPanic {
+		t.Error("Expected panic with * in middle of path segment with existing path")
+	}
+
+	twoPathPanic := func(first, second string) {
+		addPathPanic(first, second)
+		if !sawPanic {
+			t.Errorf("Expected panic with ambiguous wildcards on paths %s and %s", first, second)
+		}
+	}
+
+	twoPathPanic("abc/:ab/def/:cd", "abc/:ad/def/:cd")
+	twoPathPanic("abc/:ab/def/:cd", "abc/:ab/def/:ef")
+	twoPathPanic(":abc", ":def")
+	twoPathPanic(":abc/ggg", ":def/ggg")
+}
+
+type TestMatcher struct {
+	match bool
+}
+
+func (fm *TestMatcher) Match(value interface{}) (bool, interface{}) {
+	return fm.match, value
+}
+
+func TestFalseMatcher(t *testing.T) {
+	tree := &Tree{}
+	err := tree.Add("/some/path", 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, _, _ := tree.LookupMatcher("/some/path", &TestMatcher{false})
+
+	if v != nil {
+		t.Error("failed, no match expected for false matcher")
+	}
+}
+
+func TestTrueMatcher(t *testing.T) {
+	tree := &Tree{}
+	err := tree.Add("/some/path", 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, _, _ := tree.LookupMatcher("/some/path", &TestMatcher{true})
+
+	if v == nil {
+		t.Error("failed, match expected for true matcher")
+	}
+}
+
+func TestDefaultMatcher(t *testing.T) {
+	tree := &Tree{}
+	err := tree.Add("/some/path", 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, _ := tree.Lookup("/some/path")
+
+	if v == nil {
+		t.Error("failed, match expected for true matcher")
+	}
+}
+
+func BenchmarkTreeNullRequest(b *testing.B) {
+	b.ReportAllocs()
+	tree := &node{path: "/"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree.search("", tm)
+	}
+}
+
+func BenchmarkTreeOneStatic(b *testing.B) {
+	b.ReportAllocs()
+	tree := &node{path: "/"}
+	tree.addPath("abc", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree.search("abc", tm)
+	}
+}
+
+func BenchmarkTreeOneParam(b *testing.B) {
+	b.ReportAllocs()
+	tree := &node{path: "/"}
+	tree.addPath(":abc", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree.search("abc", tm)
+	}
+}

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 
 	"github.com/dimfeld/httppath"
-	"github.com/zalando/pathmux"
+	"github.com/zalando/skipper/pathmux"
 )
 
 type leafRequestMatcher struct {

--- a/routing/matcher_test.go
+++ b/routing/matcher_test.go
@@ -3,8 +3,8 @@ package routing
 import (
 	"errors"
 	"fmt"
-	"github.com/zalando/pathmux"
 	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/pathmux"
 	"log"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
move pathmux (https://github.com/zalando/pathmux) to skipper:

- copy pathmux code under a subdirectory: pathmux/
- update the main license file to incorporate the different license and copyright