### PR TITLE
provide a shortcut flag to enable breakers without global settings

### DIFF
--- a/cmd/skipper/breakerflags.go
+++ b/cmd/skipper/breakerflags.go
@@ -19,6 +19,8 @@ const breakerUsage = `set global or host specific circuit breakers, e.g. -breake
 	idle-ttl: duration string or milliseconds after the breaker is considered idle and reset
 	(see also: https://godoc.org/github.com/zalando/skipper/circuit)`
 
+const enableBreakersUsage = `enable breakers to be set from filters without providing gobal or host settings (equivalent to: -breaker type=disabled)`
+
 type breakerFlags []circuit.BreakerSettings
 
 var errInvalidBreakerConfig = errors.New("invalid breaker config")

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -139,6 +139,7 @@ var (
 	experimentalUpgrade       bool
 	printVersion              bool
 	maxLoopbacks              int
+	enableBreakers            bool
 	breakers                  breakerFlags
 )
 
@@ -188,6 +189,7 @@ func init() {
 	flag.BoolVar(&experimentalUpgrade, "experimental-upgrade", defaultExperimentalUpgrade, experimentalUpgradeUsage)
 	flag.BoolVar(&printVersion, "version", false, versionUsage)
 	flag.IntVar(&maxLoopbacks, "max-loopbacks", proxy.DefaultMaxLoopbacks, maxLoopbacksUsage)
+	flag.BoolVar(&enableBreakers, "enable-breakers", false, enableBreakersUsage)
 	flag.Var(&breakers, "breaker", breakerUsage)
 	flag.Parse()
 }
@@ -276,6 +278,7 @@ func main() {
 		BackendFlushInterval:      backendFlushInterval,
 		ExperimentalUpgrade:       experimentalUpgrade,
 		MaxLoopbacks:              maxLoopbacks,
+		EnableBreakers:            enableBreakers,
 		BreakerSettings:           breakers,
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -235,7 +235,7 @@ type Options struct {
 	MaxLoopbacks int
 
 	// EnableBreakers enables the usage of the breakers in the route definitions without initializing any
-	// by default. It a shortcut for setting the BreakerSettings to:
+	// by default. It is a shortcut for setting the BreakerSettings to:
 	//
 	// 	[]circuit.BreakerSettings{{Type: BreakerDisabled}}
 	//

--- a/skipper.go
+++ b/skipper.go
@@ -234,6 +234,13 @@ type Options struct {
 	// contains loop backends (<loopback>).
 	MaxLoopbacks int
 
+	// EnableBreakers enables the usage of the breakers in the route definitions without initializing any
+	// by default. It a shortcut for setting the BreakerSettings to:
+	//
+	// 	[]circuit.BreakerSettings{{Type: BreakerDisabled}}
+	//
+	EnableBreakers bool
+
 	// BreakerSettings contain global and host specific settings for the circuit breakers.
 	BreakerSettings []circuit.BreakerSettings
 }
@@ -445,7 +452,7 @@ func Run(o Options) error {
 		MaxLoopbacks:           o.MaxLoopbacks,
 	}
 
-	if len(o.BreakerSettings) > 0 {
+	if o.EnableBreakers || len(o.BreakerSettings) > 0 {
 		proxyParams.CircuitBreakers = circuit.NewRegistry(o.BreakerSettings...)
 	}
 


### PR DESCRIPTION
this is a convenience flag for letting filters define breakers without having a dummy global set of settings