### PR TITLE
add vendoring check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,12 @@ fmt: $(SOURCES)
 check-fmt: $(SOURCES)
 	@if [ "$$(gofmt -d $(SOURCES))" != "" ]; then false; else true; fi
 
-precommit: build shortcheck fmt vet
+check-imports:
+	@glide list
 
-check-precommit: build shortcheck check-fmt vet
+precommit: check-imports fmt build shortcheck vet
+
+check-precommit: check-imports check-fmt build shortcheck vet
 
 .coverprofile-all: $(SOURCES)
 	# go list -f \

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,9 @@ check-fmt: $(SOURCES)
 	@if [ "$$(gofmt -d $(SOURCES))" != "" ]; then false; else true; fi
 
 check-imports:
-	@glide list
+	@glide list && true || \
+	(echo "run make deps and check if any new dependencies were vendored with glide get" && \
+	false)
 
 precommit: check-imports fmt build shortcheck vet
 


### PR DESCRIPTION
glide list returns with non-0 exit code if any of the imported dependencies is not vendored, 0 otherwise