### PR TITLE
use shared compiled regular expressions

### DIFF
--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -79,7 +79,7 @@ type Route struct {
 	// E.g. route1: ...
 	Id string
 
-	// Deprecated, use Path Predicate
+	// Deprecated, use Predicate instances with the name "Path".
 	//
 	// Exact path to be matched.
 	// E.g. Path("/some/path")

--- a/logging/loggingtest/logger.go
+++ b/logging/loggingtest/logger.go
@@ -22,9 +22,10 @@ type logWatch struct {
 // Logger provides an implementation of the logging.Logger interface
 // that can be used to receive notifications about log events.
 type Logger struct {
-	save   chan string
+	logc   chan string
 	notify chan<- logSubscription
 	clear  chan struct{}
+	mute   chan bool
 	quit   chan<- struct{}
 }
 
@@ -71,37 +72,44 @@ func (lw *logWatch) clear() {
 // Returns a new, initialized instance of Logger.
 func New() *Logger {
 	lw := &logWatch{}
-	save := make(chan string)
+	logc := make(chan string)
 	notify := make(chan logSubscription)
 	clear := make(chan struct{})
+	mute := make(chan bool)
 	quit := make(chan struct{})
+	var muted bool
 
+	tl := &Logger{logc, notify, clear, mute, quit}
 	go func() {
 		for {
 			select {
-			case e := <-save:
+			case e := <-logc:
 				lw.save(e)
+				if !muted {
+					log.Println(e)
+				}
+
 			case req := <-notify:
 				lw.notify(req)
 			case <-clear:
 				lw.clear()
+			case m := <-mute:
+				muted = m
 			case <-quit:
 				return
 			}
 		}
 	}()
 
-	return &Logger{save, notify, clear, quit}
+	return tl
 }
 
 func (tl *Logger) logf(f string, a ...interface{}) {
-	log.Printf(f, a...)
-	tl.save <- fmt.Sprintf(f, a...)
+	tl.logc <- fmt.Sprintf(f, a...)
 }
 
 func (tl *Logger) log(a ...interface{}) {
-	log.Println(a...)
-	tl.save <- fmt.Sprint(a...)
+	tl.logc <- fmt.Sprint(a...)
 }
 
 // Returns nil when n logging events matching exp were received or returns
@@ -127,6 +135,14 @@ func (tl *Logger) WaitFor(exp string, to time.Duration) error {
 // Clears the stored logging events.
 func (tl *Logger) Reset() {
 	tl.clear <- struct{}{}
+}
+
+func (tl *Logger) Mute() {
+	tl.mute <- true
+}
+
+func (tl *Logger) Unmute() {
+	tl.mute <- false
 }
 
 // Closes the logger.

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -14,7 +14,7 @@ import (
 
 type TestProxy struct {
 	URL     string
-	log     *loggingtest.Logger
+	Log     *loggingtest.Logger
 	routing *routing.Routing
 	proxy   *proxy.Proxy
 	server  *httptest.Server
@@ -34,7 +34,7 @@ func WithParams(fr filters.Registry, o proxy.Params, routes ...*eskip.Route) *Te
 
 	return &TestProxy{
 		URL:     tsp.URL,
-		log:     tl,
+		Log:     tl,
 		routing: rt,
 		proxy:   pr,
 		server:  tsp}
@@ -45,7 +45,7 @@ func New(fr filters.Registry, routes ...*eskip.Route) *TestProxy {
 }
 
 func (p *TestProxy) Close() error {
-	p.log.Close()
+	p.Log.Close()
 	p.routing.Close()
 
 	err := p.proxy.Close()

--- a/routing/regexp_test.go
+++ b/routing/regexp_test.go
@@ -1,0 +1,133 @@
+package routing_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/routing/pathgen"
+)
+
+const (
+	hostRegexpRate   = 0.66
+	pathRegexpRate   = 0.66
+	totalHosts       = 15
+	totalPathRegexps = 15
+)
+
+func hostRegexp(pg *pathgen.PathGenerator) string {
+	firstTags := pg.Strs(2, 4, 1, 9)
+	domain := pg.Str(6, 24)
+	tlds := pg.Strs(3, 18, 2, 4)
+	return fmt.Sprintf(
+		"(%s)[.]%s[.](%s)",
+		strings.Join(firstTags, "|"),
+		domain,
+		strings.Join(tlds, "|"),
+	)
+}
+
+func pathRegexp(pg *pathgen.PathGenerator) string {
+	contained := pg.Str(3, 9)
+	extension := pg.Str(2, 4)
+	return fmt.Sprintf(".*%s.*[.]%s", contained, extension)
+}
+
+func benchmarkRegexp(b *testing.B, routesCount, concurrency int) {
+	pg := pathgen.New(pathgen.PathGeneratorOptions{RandSeed: 42})
+
+	hosts := make([]string, 0, totalHosts)
+	for i := 0; i < totalHosts; i++ {
+		hosts = append(hosts, hostRegexp(pg))
+	}
+
+	pathRegexps := make([]string, 0, totalPathRegexps)
+	for i := 0; i < totalPathRegexps; i++ {
+		pathRegexps = append(pathRegexps, pathRegexp(pg))
+	}
+
+	paths := make([]string, 0, routesCount)
+	for i := 0; i < routesCount; i++ {
+		paths = append(paths, pg.Next())
+	}
+
+	routes := make([]*eskip.Route, 0, routesCount)
+	for i := 0; i < routesCount; i++ {
+		r := &eskip.Route{
+			Id: fmt.Sprintf("route%d", i),
+			Filters: []*eskip.Filter{{
+				Name: "status",
+				Args: []interface{}{200},
+			}},
+			BackendType: eskip.ShuntBackend,
+		}
+
+		if pg.Rnd.Float64() < pathRegexpRate {
+			r.PathRegexps = append(
+				r.PathRegexps,
+				pathRegexps[pg.Rnd.Intn(len(pathRegexps))],
+			)
+		} else {
+			r.Predicates = append(r.Predicates, &eskip.Predicate{
+				Name: "Path",
+				Args: []interface{}{
+					paths[pg.Rnd.Intn(len(paths))],
+				},
+			})
+		}
+
+		if pg.Rnd.Float64() < hostRegexpRate {
+			r.HostRegexps = append(
+				r.HostRegexps,
+				hosts[pg.Rnd.Intn(len(hosts))],
+			)
+		}
+	}
+
+	fr := builtin.MakeRegistry()
+	p := proxytest.New(fr, routes...)
+	p.Log.Mute()
+	defer p.Close()
+
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < b.N/concurrency; j++ {
+				if b.Failed() {
+					wg.Done()
+					return
+				}
+
+				rsp, err := http.Get(p.URL + paths[pg.Rnd.Intn(len(paths))])
+				if err != nil {
+					b.Error(err)
+					wg.Done()
+					return
+				}
+
+				rsp.Body.Close()
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func BenchmarkRegexp(b *testing.B) {
+	for routesCount := 1; routesCount <= 1000000; routesCount *= 100 {
+		for concurrency := 1; concurrency <= 256; concurrency <<= 4 {
+			b.Run(fmt.Sprintf("%d %d", routesCount, concurrency), func(b *testing.B) {
+				benchmarkRegexp(b, routesCount, concurrency)
+			})
+		}
+	}
+}


### PR DESCRIPTION
using now shared compiled objects for the identical regular expressions in the host and path regexp predicates. `BenchmarkRegexp` was used to check whether this comes with degradation in the overall request processing. rx.Copy() is used according to the stdlib docs: http://godoc.org/regexp#Regexp.Copy

(to help testing, there is now a Mute/Umute function on the test logger)