### PR TITLE
preserve incoming content length settings

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -252,6 +252,7 @@ func mapRequest(r *http.Request, rt *routing.Route, host string) (*http.Request,
 	}
 
 	rr, err := http.NewRequest(r.Method, u.String(), body)
+	rr.ContentLength = r.ContentLength
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
preserve incoming content length, not only from the header map, but from the parsed http.request object