### PR TITLE
Error early when apiserver is unreachable

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -664,7 +664,7 @@ func (c *Client) LoadAll() ([]*eskip.Route, error) {
 	log.Debug("loading all")
 	r, err := c.loadAndConvert()
 	if err != nil {
-		log.Debugf("failed to load all: %v", err)
+		log.Errorf("failed to load all: %v", err)
 		return nil, err
 	}
 
@@ -689,7 +689,7 @@ func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
 	log.Debugf("polling for updates")
 	r, err := c.loadAndConvert()
 	if err != nil {
-		log.Debugf("polling for updates failed: %v", err)
+		log.Errorf("polling for updates failed: %v", err)
 		return nil, nil, err
 	}
 

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -423,7 +423,7 @@ func (c *Client) convertPathRule(ns, name, host string, prule *pathRule, service
 //
 // TODO:
 // - check how to set failures in ingress status
-func (c *Client) ingressToRoutes(items []*ingressItem) []*eskip.Route {
+func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 	routes := make([]*eskip.Route, 0, len(items))
 	for _, i := range items {
 		if i.Metadata == nil || i.Metadata.Namespace == "" || i.Metadata.Name == "" ||
@@ -471,8 +471,7 @@ func (c *Client) ingressToRoutes(items []*ingressItem) []*eskip.Route {
 						//
 						// TODO:
 						// - check how to set failures in ingress status
-						log.Errorf("error while getting service: %v", err)
-						continue
+						return nil, fmt.Errorf("error while getting service: %v", err)
 					}
 
 					r.HostRegexps = host
@@ -482,7 +481,7 @@ func (c *Client) ingressToRoutes(items []*ingressItem) []*eskip.Route {
 		}
 	}
 
-	return routes
+	return routes, nil
 }
 
 // computeBackendWeights computes and sets the backend traffic weights on the
@@ -598,7 +597,11 @@ func (c *Client) loadAndConvert() ([]*eskip.Route, error) {
 	log.Debugf("all ingresses received: %d", len(il.Items))
 	fItems := c.filterIngressesByClass(il.Items)
 	log.Debugf("filtered ingresses by ingress class: %d", len(fItems))
-	r := c.ingressToRoutes(fItems)
+	r, err := c.ingressToRoutes(fItems)
+	if err != nil {
+		log.Debugf("converting ingresses to routes failed: %v", err)
+		return nil, err
+	}
 	log.Debugf("all routes created: %d", len(r))
 	return r, nil
 }

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -670,12 +670,12 @@ func TestIngress(t *testing.T) {
 			t.Error(err)
 		}
 
-		if r, err := dc.LoadAll(); err != nil || len(r) != 0 {
-			t.Error("failed to load initial")
+		if _, err := dc.LoadAll(); err == nil {
+			t.Error("load initial should fail")
 		}
 
-		if r, d, err := dc.LoadUpdate(); err != nil || len(r) != 0 || len(d) != 0 {
-			t.Error("failed to load update", err)
+		if _, _, err := dc.LoadUpdate(); err == nil {
+			t.Error("load update should fail")
 		}
 	})
 
@@ -686,8 +686,8 @@ func TestIngress(t *testing.T) {
 			t.Error(err)
 		}
 
-		if r, err := dc.LoadAll(); err != nil || len(r) != 0 {
-			t.Error("failed to load initial")
+		if _, err := dc.LoadAll(); err == nil {
+			t.Error("load initial should fail")
 		}
 
 		api.services = testServices()
@@ -717,9 +717,9 @@ func TestIngress(t *testing.T) {
 			t.Error(err)
 		}
 
-		r, err := dc.LoadAll()
-		if err != nil {
-			t.Error("failed to load initial routes", err)
+		_, err = dc.LoadAll()
+		if err == nil {
+			t.Error("load initial should fail")
 			return
 		}
 
@@ -731,7 +731,13 @@ func TestIngress(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__mega__foo_example_org___test1__service1": "http://1.2.3.4:8080",
+			"kube_namespace1__default_only______":                           "http://1.2.3.4:8080",
+			"kube_namespace2__path_rule_only__www_example_org_____service3": "http://9.0.1.2:7272",
+			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
 		})
 	})
 
@@ -804,17 +810,10 @@ func TestIngress(t *testing.T) {
 
 		delete(api.services["namespace1"], "service2")
 
-		r, d, err := dc.LoadUpdate()
-		if err != nil || len(r) != 0 {
-			t.Error("failed to receive delete", err, len(r))
+		_, _, err = dc.LoadUpdate()
+		if err == nil {
+			t.Error("load update should fail")
 		}
-
-		checkIDs(
-			t,
-			d,
-			"kube_namespace1__mega__foo_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org___test2__service2",
-		)
 	})
 
 	t.Run("has ingresses, delete some ingresses", func(t *testing.T) {


### PR DESCRIPTION
This is a naive approach to fixing https://github.com/zalando/skipper/issues/406.

Skipper makes a series of requests in quick succession to the API server. If one request other than the first one fails the compiled list of rules is inconsistent and applying it does more harm than just doing nothing.

Therefore, instead of ignoring these errors we propagate them up which leads to no rules being changed in case of any failed request.

**However**, whilst doing it I discovered that this will also fail for errors such as referenced services that don't exist. Service names are provided by users and should not lead to skipper being permanently stuck with old rules. This needs to be fixed but I wanted to get this out early.

My idea would be that the returned error should be checked for whether it is *transient* or *permanent*.
* In case of *transient errors* we should skip this cycle and don't change the rules (e.g. temporary API server outage) hoping that the next cycle we'll have more luck. We should somehow report this *degraded* state via `/metrics` or similar immediately.
* However, *permanent errors* should just be ignored like before (such as broken rules due to Ingresses referencing Services that don't exist. Those errors cannot be fixed by retrying but only by users changing their manifests)

@aryszka @mikkeloscar @szuecs @hjacobs Let me know if this appraoch would make sense.