### PR TITLE
Treat network errors as transient and defer updating routes

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -140,7 +140,6 @@ var nonWord = regexp.MustCompile("\\W")
 
 var (
 	errServiceNotFound      = errors.New("service not found")
-	errServicePortNotFound  = errors.New("service port not found")
 	errAPIServerURLNotFound = errors.New("kubernetes API server URL could not be constructed from env vars")
 	errInvalidCertificate   = errors.New("invalid CA")
 )
@@ -281,6 +280,10 @@ func (c *Client) getJSON(uri string, a interface{}) error {
 	log.Debugf("request to %s succeeded", url)
 	defer rsp.Body.Close()
 
+	if rsp.StatusCode == http.StatusNotFound {
+		return errServiceNotFound
+	}
+
 	if rsp.StatusCode != http.StatusOK {
 		log.Debugf("request failed, status: %d, %s", rsp.StatusCode, rsp.Status)
 		return fmt.Errorf("request failed, status: %d, %s", rsp.StatusCode, rsp.Status)
@@ -330,7 +333,7 @@ func (c *Client) getServiceURL(namespace, name string, port backendPort) (string
 	}
 
 	log.Debugf("service port not found by name: %s", pn)
-	return "", errServicePortNotFound
+	return "", errServiceNotFound
 }
 
 // TODO: find a nicer way to autogenerate route IDs
@@ -467,19 +470,14 @@ func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 				if prule.Backend.Traffic > 0 {
 					r, err := c.convertPathRule(i.Metadata.Namespace, i.Metadata.Name, rule.Host, prule, servicesURLs)
 					if err != nil {
-						// fail when there's a temporary network error so that we keep the last known rules
-						// active until the next sync loop.
-						if err, ok := err.(net.Error); ok {
-							log.Errorf("temporary error while getting service, deferring update: %v", err)
-							return nil, err
+						// if the service is not found the route should be removed
+						if err == errServiceNotFound {
+							continue
 						}
 
-						// tolerate permanent errors such as references to non-existing services
-						//
 						// TODO:
 						// - check how to set failures in ingress status
-						log.Debugf("permanent error while getting service, skipping: %v", err)
-						continue
+						return nil, fmt.Errorf("error while getting service: %v", err)
 					}
 
 					r.HostRegexps = host

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b32ab68082d8773a25dc4ff8236d060a3680e5d4e7f322b248b8b4a06d52e334
-updated: 2017-07-17T18:21:39.526808142+02:00
+hash: 8b21cac50e021fde6af96060d188dd3d6736efd9d5a5441fe0b4721d5be5d728
+updated: 2017-08-10T14:30:16.475291934+02:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: efc9484eee77263a11f158ef4f30fcc30298a942
@@ -17,8 +17,6 @@ imports:
   version: a3f95b5c423586578a4e099b11a46c2479628cac
 - name: github.com/sony/gobreaker
   version: e9556a45379ef1da12e54847edb2fb3d7d566f36
-- name: github.com/zalando/pathmux
-  version: 90241ddcbc6161a874026d890f4bed831b5dfbb5
 - name: golang.org/x/crypto
   version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,6 @@ import:
 - package: github.com/rcrowley/go-metrics
 - package: github.com/sirupsen/logrus
   version: ~1.0.0
-- package: github.com/zalando/pathmux
 - package: golang.org/x/crypto
   subpackages:
   - ssh/terminal


### PR DESCRIPTION
Follow up of https://github.com/zalando/skipper/pull/409#issuecomment-321256681

It restores the original test suite that tolerates misconfiguration such as Ingresses referencing missing services (404 from the API server).

However, this adds an early return in case of network errors such as an unavailable API server. This has the effect that Skipper won't remove its routes until it gets a successful response from the API server. (Note that successful includes 500s in this case. I guess we should treat 500s in a similar "don't change the routes" way)