### PR TITLE
add Makefile target "lint"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ packaging/eskip
 .coverprofile
 .coverprofile-all
 vendor
+linter.log

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ bench: build
 	#
 	for p in $(PACKAGES); do go test -bench . $$p; done
 
+lint: build
+	gometalinter --enable-all --deadline=60s ./... | tee -a linter.log
+
 clean:
 	go clean -i ./...
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ bench: build
 	for p in $(PACKAGES); do go test -bench . $$p; done
 
 lint: build
-	gometalinter --enable-all --deadline=60s ./... | tee -a linter.log
+	gometalinter --enable-all --deadline=60s ./... | tee linter.log
 
 clean:
 	go clean -i ./...


### PR DESCRIPTION
Make lint will run metalinter with enable-all and writes output to linter.log, because you may want to check this later. You have to install [gometalinter](https://github.com/alecthomas/gometalinter).

Install:

    % go get -u github.com/alecthomas/gometalinter
    % gometalinter -iu

Run:

    % make lint # produces linter.log and a lot of lines from linters