### PR TITLE
update dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,17 @@
-hash: b32ab68082d8773a25dc4ff8236d060a3680e5d4e7f322b248b8b4a06d52e334
-updated: 2017-07-17T18:21:39.526808142+02:00
+hash: 8b21cac50e021fde6af96060d188dd3d6736efd9d5a5441fe0b4721d5be5d728
+updated: 2017-08-13T20:09:10.397364831+02:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: efc9484eee77263a11f158ef4f30fcc30298a942
 - name: github.com/dimfeld/httppath
-  version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
+  version: ee938bf735983d53694d79138ad9820efff94c92
 - name: github.com/google/go-cmp
-  version: e6ff442c1751c5257df71dd2a42b9bcbbd6f01a6
+  version: 8099a9787ce5dc5984ed879a3bda47dc730a8e97
   subpackages:
   - cmp
+  - cmp/internal/diff
+  - cmp/internal/function
+  - cmp/internal/value
 - name: github.com/oklog/ulid
   version: d311cb43c92434ec4072dfbbda3400741d0a6337
 - name: github.com/rcrowley/go-metrics
@@ -18,13 +21,13 @@ imports:
 - name: github.com/sony/gobreaker
   version: e9556a45379ef1da12e54847edb2fb3d7d566f36
 - name: golang.org/x/crypto
-  version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
+  version: c2303dcbe84172e0c0da4c9f083eeca54c06f298
   subpackages:
   - bcrypt
   - blowfish
   - ssh/terminal
 - name: golang.org/x/sys
-  version: f7928cfef4d09d1b080aa2b6fd3ca9ba1567c733
+  version: 7de4796419dc3b554e6dab3a119a62469569d299
   subpackages:
   - unix
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -17,8 +17,6 @@ imports:
   version: a3f95b5c423586578a4e099b11a46c2479628cac
 - name: github.com/sony/gobreaker
   version: e9556a45379ef1da12e54847edb2fb3d7d566f36
-- name: github.com/zalando/pathmux
-  version: 90241ddcbc6161a874026d890f4bed831b5dfbb5
 - name: golang.org/x/crypto
   version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,6 @@ import:
 - package: github.com/rcrowley/go-metrics
 - package: github.com/sirupsen/logrus
   version: ~1.0.0
-- package: github.com/zalando/pathmux
 - package: golang.org/x/crypto
   subpackages:
   - ssh/terminal


### PR DESCRIPTION
update dependencies, because of:

    % glide-report
    [WARN]  Disclaimer, this report is to help highlight things to consider. It is
    [WARN]  alpha software and the rules are still under consideration.
    [INFO]  Reading glide.yaml file to understand configured versions and ranges
    [INFO]  Reading glide.lock file to understand pinned revisions
    [INFO]  Fetching dependency data, this may take a moment...
    Report on github.com/zalando/skipper
    
    ------------------------------------------------------------------------------
    Direct Imports
    ------------------------------------------------------------------------------
    
    Analysis of github.com/abbot/go-http-auth:
    ✓ Dependency provides Semantic Version releases
    ● Using recent release (1 behind latest, latest: v0.4.0, using: v0.3)
    ✓ Using latest Major Semantic Version
    
    Analysis of github.com/dimfeld/httppath:
    ● Dependency does not provide Semantic Version releases
    X Using revision over six months behind the tip of the branch (1162 days)
    
    Analysis of github.com/oklog/ulid:
    ✓ Dependency provides Semantic Version releases
    ✓ Using latest release (v0.3.0)
    
    Analysis of github.com/rcrowley/go-metrics:
    ● Dependency does not provide Semantic Version releases
    ● Using revision within three month from the tip of the branch (0 days)
    
    Analysis of github.com/sirupsen/logrus:
    ✓ Dependency provides Semantic Version releases
    ✓ Using latest release (1.0.2)
    
    Analysis of github.com/sony/gobreaker:
    ● Dependency does not provide Semantic Version releases
    ● Using revision within three month from the tip of the branch (0 days)
    
    Analysis of golang.org/x/crypto:
    ● Dependency does not provide Semantic Version releases
    [ERROR] Unable to get cached repo data: open /Users/sszuecs/.glide/cache/info/https-go.googlesource.com-crypto.json: no such file or directory
    zsh: exit 1     glide-report
