### PR TITLE
Make default HTTP status configurable

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -86,6 +87,7 @@ const (
 	experimentalUpgradeUsage       = "enable experimental feature to handle upgrade protocol requests"
 	versionUsage                   = "print Skipper version"
 	maxLoopbacksUsage              = "maximum number of loopbacks for an incoming request, set to -1 to disable loopbacks"
+	defaultHTTPStatusUsage         = "default HTTP status used when no route is found for a request"
 )
 
 var (
@@ -141,6 +143,7 @@ var (
 	maxLoopbacks              int
 	enableBreakers            bool
 	breakers                  breakerFlags
+	defaultHTTPStatus         int
 )
 
 func init() {
@@ -191,6 +194,7 @@ func init() {
 	flag.IntVar(&maxLoopbacks, "max-loopbacks", proxy.DefaultMaxLoopbacks, maxLoopbacksUsage)
 	flag.BoolVar(&enableBreakers, "enable-breakers", false, enableBreakersUsage)
 	flag.Var(&breakers, "breaker", breakerUsage)
+	flag.IntVar(&defaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
 	flag.Parse()
 }
 
@@ -280,6 +284,7 @@ func main() {
 		MaxLoopbacks:              maxLoopbacks,
 		EnableBreakers:            enableBreakers,
 		BreakerSettings:           breakers,
+		DefaultHTTPStatus:         defaultHTTPStatus,
 	}
 
 	if insecure {

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -466,6 +466,8 @@ func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 			// update Traffic field for each backend
 			computeBackendWeights(backendWeights, rule)
 
+			hostRoutes := make([]*eskip.Route, 0, len(rule.Http.Paths))
+
 			for _, prule := range rule.Http.Paths {
 				if prule.Backend.Traffic > 0 {
 					r, err := c.convertPathRule(i.Metadata.Namespace, i.Metadata.Name, rule.Host, prule, servicesURLs)
@@ -481,13 +483,44 @@ func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 					}
 
 					r.HostRegexps = host
-					routes = append(routes, r)
+					hostRoutes = append(hostRoutes, r)
 				}
+			}
+
+			routes = append(routes, hostRoutes...)
+
+			// if routes were configured, but there is no catchall route defined,
+			// create a route which returns 404
+			if len(hostRoutes) > 0 && !catchAllRoutes(hostRoutes) {
+				catchAll := &eskip.Route{
+					Id:          routeID(i.Metadata.Namespace, i.Metadata.Name, rule.Host, "", ""),
+					HostRegexps: host,
+					BackendType: eskip.ShuntBackend,
+				}
+				routes = append(routes, catchAll)
 			}
 		}
 	}
 
 	return routes, nil
+}
+
+// catchAllRoutes returns true if one of the routes in the list has a catchAll
+// path expression.
+func catchAllRoutes(routes []*eskip.Route) bool {
+	for _, route := range routes {
+		if len(route.PathRegexps) == 0 {
+			return true
+		}
+
+		for _, exp := range route.PathRegexps {
+			if exp == "^/" {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // computeBackendWeights computes and sets the backend traffic weights on the

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -703,8 +703,10 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube_namespace1__mega__foo_example_org____":                    "",
 			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube_namespace1__mega__bar_example_org____":                    "",
 		})
 	})
 
@@ -755,8 +757,10 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube_namespace1__mega__foo_example_org____":                    "",
 			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube_namespace1__mega__bar_example_org____":                    "",
 		})
 	})
 
@@ -845,8 +849,10 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__mega______",
 			"kube_namespace1__mega__foo_example_org___test1__service1",
 			"kube_namespace1__mega__foo_example_org___test2__service2",
+			"kube_namespace1__mega__foo_example_org____",
 			"kube_namespace1__mega__bar_example_org___test1__service1",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
+			"kube_namespace1__mega__bar_example_org____",
 		)
 	})
 
@@ -876,6 +882,7 @@ func TestIngress(t *testing.T) {
 			d,
 			"kube_namespace1__mega__bar_example_org___test1__service1",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
+			"kube_namespace1__mega__bar_example_org____",
 		)
 	})
 
@@ -991,6 +998,7 @@ func TestIngress(t *testing.T) {
 			d,
 			"kube_namespace1__mega__bar_example_org___test1__service1",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
+			"kube_namespace1__mega__bar_example_org____",
 		)
 	})
 	t.Run("has ingresses, add new ones and filter not valid ones using class ingress", func(t *testing.T) {
@@ -1098,6 +1106,7 @@ func TestConvertPathRule(t *testing.T) {
 
 		checkRoutes(t, r, map[string]string{
 			"kube_namespace1__new1__new1_example_org___test1__service1": "http://1.2.3.4:8080",
+			"kube_namespace1__new1__new1_example_org____":               "",
 			"kube_namespace1__new1__new1_example_org___test2__service1": "http://1.2.3.4:8080",
 		})
 	})
@@ -1421,8 +1430,10 @@ func TestHealthcheckReload(t *testing.T) {
 			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube_namespace1__mega__foo_example_org____":                    "",
 			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube_namespace1__mega__bar_example_org____":                    "",
 		})
 	})
 }
@@ -1757,6 +1768,49 @@ func TestHealthcheckOnTerm(t *testing.T) {
 
 		checkHealthcheck(t, r, true, false)
 	})
+}
+
+func TestCatchAllRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		msg         string
+		routes      []*eskip.Route
+		hasCatchAll bool
+	}{
+		{
+			msg: "empty path expression is a catchall",
+			routes: []*eskip.Route{
+				{
+					PathRegexps: []string{},
+				},
+			},
+			hasCatchAll: true,
+		},
+		{
+			msg: "^/ path expression is a catchall",
+			routes: []*eskip.Route{
+				{
+					PathRegexps: []string{"^/"},
+				},
+			},
+			hasCatchAll: true,
+		},
+		{
+			msg: "^/test path expression is not a catchall",
+			routes: []*eskip.Route{
+				{
+					PathRegexps: []string{"^/test"},
+				},
+			},
+			hasCatchAll: false,
+		},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			catchAll := catchAllRoutes(tc.routes)
+			if catchAll != tc.hasCatchAll {
+				t.Errorf("expected %t, got %t", tc.hasCatchAll, catchAll)
+			}
+		})
+	}
 }
 
 func TestComputeBackendWeights(t *testing.T) {

--- a/proxy/doc.go
+++ b/proxy/doc.go
@@ -31,7 +31,7 @@ Proxy Mechanism
 The incoming request is matched to the current routing tree, implemented
 in skipper/routing. The result may be a route, which will be used for
 forwarding or handling the request, or nil, in which case the proxy
-responds with 404.
+responds with a configured http status code (defaults to 404).
 
 
 2. upstream request augmentation:

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -117,6 +117,10 @@ type Params struct {
 	// find the matching circuit breaker for backend requests. If not
 	// set, no circuit breakers are used.
 	CircuitBreakers *circuit.Registry
+
+	// DefaultHTTPStatus is the HTTP status used when no routes are found
+	// for a request.
+	DefaultHTTPStatus int
 }
 
 var (
@@ -318,6 +322,10 @@ func WithParams(p Params) *Proxy {
 		p.MaxLoopbacks = DefaultMaxLoopbacks
 	} else if p.MaxLoopbacks < 0 {
 		p.MaxLoopbacks = 0
+	}
+
+	if p.DefaultHTTPStatus >= http.StatusContinue && p.DefaultHTTPStatus <= http.StatusNetworkAuthenticationRequired {
+		errRouteLookupFailed.code = p.DefaultHTTPStatus
 	}
 
 	return &Proxy{

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1224,3 +1224,19 @@ func TestRequestContentHeaders(t *testing.T) {
 	req(false)
 	req(true)
 }
+
+func TestSettingDefaultHTTPStatus(t *testing.T) {
+	params := Params{
+		DefaultHTTPStatus: http.StatusBadGateway,
+	}
+	_ = WithParams(params)
+	if errRouteLookupFailed.code != http.StatusBadGateway {
+		t.Errorf("expected default HTTP status %d, got %d", http.StatusBadGateway, errRouteLookupFailed.code)
+	}
+
+	params.DefaultHTTPStatus = http.StatusNetworkAuthenticationRequired + 1
+	_ = WithParams(params)
+	if errRouteLookupFailed.code != http.StatusBadGateway {
+		t.Errorf("expected default HTTP status %d, got %d", http.StatusNotFound, errRouteLookupFailed.code)
+	}
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1229,14 +1229,14 @@ func TestSettingDefaultHTTPStatus(t *testing.T) {
 	params := Params{
 		DefaultHTTPStatus: http.StatusBadGateway,
 	}
-	_ = WithParams(params)
-	if errRouteLookupFailed.code != http.StatusBadGateway {
-		t.Errorf("expected default HTTP status %d, got %d", http.StatusBadGateway, errRouteLookupFailed.code)
+	p := WithParams(params)
+	if p.defaultHTTPStatus != http.StatusBadGateway {
+		t.Errorf("expected default HTTP status %d, got %d", http.StatusBadGateway, p.defaultHTTPStatus)
 	}
 
 	params.DefaultHTTPStatus = http.StatusNetworkAuthenticationRequired + 1
-	_ = WithParams(params)
-	if errRouteLookupFailed.code != http.StatusBadGateway {
-		t.Errorf("expected default HTTP status %d, got %d", http.StatusNotFound, errRouteLookupFailed.code)
+	p = WithParams(params)
+	if p.defaultHTTPStatus != http.StatusNotFound {
+		t.Errorf("expected default HTTP status %d, got %d", http.StatusNotFound, p.defaultHTTPStatus)
 	}
 }

--- a/skipper.go
+++ b/skipper.go
@@ -243,6 +243,10 @@ type Options struct {
 
 	// BreakerSettings contain global and host specific settings for the circuit breakers.
 	BreakerSettings []circuit.BreakerSettings
+
+	// DefaultHTTPStatus is the HTTP status used when no routes are found
+	// for a request.
+	DefaultHTTPStatus int
 }
 
 func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.DataClient, error) {
@@ -450,6 +454,7 @@ func Run(o Options) error {
 		FlushInterval:          o.BackendFlushInterval,
 		ExperimentalUpgrade:    o.ExperimentalUpgrade,
 		MaxLoopbacks:           o.MaxLoopbacks,
+		DefaultHTTPStatus:      o.DefaultHTTPStatus,
 	}
 
 	if o.EnableBreakers || len(o.BreakerSettings) > 0 {


### PR DESCRIPTION
Makes the default 'no-routes-found' http status code configurable via
the flag `--default-http-status`.

This makes it possible to treat routes not found as server errors e.g.
502 Bad Gateway, instead of treating them as client errors (defaults to 404).

When using the Kubernetes dataclient a default catchall route which
returns 404 will be configured for any host rule which doesn't specify
its own catchall rule (`""` or `/`).

Fix #408