### PR TITLE
Accept integers in programmatically created filter/predicate arguments. #296

### DIFF
--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -302,7 +302,7 @@ func TestParseFilters(t *testing.T) {
 	}, {
 		"success",
 		`filter1(3.14) -> filter2("key", 42)`,
-		[]*Filter{{Name: "filter1", Args: []interface{}{3.14}}, {Name: "filter2", Args: []interface{}{"key", float64(42)}}},
+		[]*Filter{{Name: "filter1", Args: []interface{}{3.14}}, {Name: "filter2", Args: []interface{}{"key", int64(42)}}},
 		false,
 	}} {
 		fs, err := ParseFilters(ti.expression)

--- a/eskip/parser.go
+++ b/eskip/parser.go
@@ -6,10 +6,19 @@ import __yyfmt__ "fmt"
 //line parser.y:16
 import "strconv"
 
+type Number interface{}
+
 // conversion error ignored, tokenizer expression already checked format
-func convertNumber(s string) float64 {
+func convertNumber(s string) interface{} {
+	var number Number
 	n, _ := strconv.ParseFloat(s, 64)
-	return n
+	if n == float64(int64(n)) {
+		t, _ := strconv.ParseInt(s, 10, 64)
+		number = t
+	} else {
+		number = n
+	}
+	return number
 }
 
 //line parser.y:28
@@ -27,7 +36,7 @@ type eskipSymType struct {
 	backend   string
 	shunt     bool
 	loopback  bool
-	numval    float64
+	numval    interface{}
 	stringval string
 	regexpval string
 }

--- a/eskip/parser.y
+++ b/eskip/parser.y
@@ -17,10 +17,19 @@ package eskip
 
 import "strconv"
 
+type Number interface {}
+
 // conversion error ignored, tokenizer expression already checked format
-func convertNumber(s string) float64 {
+func convertNumber(s string) interface{} {
+	var number Number
 	n, _ := strconv.ParseFloat(s, 64)
-	return n
+	if n == float64(int64(n)) {
+		t, _ := strconv.ParseInt(s,10,64)
+		number = t
+	} else {
+		number = n
+	}
+	return number
 }
 
 %}
@@ -38,7 +47,7 @@ func convertNumber(s string) float64 {
 	backend string
 	shunt bool
 	loopback bool
-	numval float64
+	numval interface{}
 	stringval string
 	regexpval string
 }

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -34,6 +34,8 @@ func argsString(args []interface{}) string {
 	var sargs []string
 	for _, a := range args {
 		switch v := a.(type) {
+		case int64:
+			sargs = appendFmt(sargs, "%d", a)
 		case float64:
 			f := "%g"
 

--- a/eskip/string_test.go
+++ b/eskip/string_test.go
@@ -189,16 +189,12 @@ func TestParseAndStringAndParse(t *testing.T) {
 	doc = testDoc(t, doc)
 }
 
-func TestNumberString(t *testing.T) {
+func TestFloat64String(t *testing.T) {
 	for _, ti := range []float64{
-		0,
-		1,
 		0.1,
 		0.123,
 		0.123456789,
 		0.12345678901234568901234567890,
-		123,
-		123456789,
 		123456789012345678901234567890,
 	} {
 		t.Run(fmt.Sprint(ti), func(t *testing.T) {
@@ -217,6 +213,36 @@ func TestNumberString(t *testing.T) {
 			}
 
 			if v, ok := out[0].Filters[0].Args[0].(float64); !ok || v != ti {
+				t.Error("print/parse failed", v, ti)
+			}
+		})
+	}
+}
+
+func TestInt64String(t *testing.T) {
+	for _, ti := range []int64{
+		0,
+		1,
+		3,
+		123,
+		123456789,
+	} {
+		t.Run(fmt.Sprint(ti), func(t *testing.T) {
+			in := &Route{Filters: []*Filter{{Name: "filter", Args: []interface{}{ti}}}}
+			str := String(in)
+			t.Log("output", str)
+			out, err := Parse(str)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if len(out) != 1 || len(out[0].Filters) != 1 || len(out[0].Filters[0].Args) != 1 {
+				t.Error("parse failed")
+				return
+			}
+
+			if v, ok := out[0].Filters[0].Args[0].(int64); !ok || v != ti {
 				t.Error("print/parse failed", v, ti)
 			}
 		})

--- a/filters/builtin/redirect.go
+++ b/filters/builtin/redirect.go
@@ -62,9 +62,20 @@ func (spec *redirect) CreateFilter(config []interface{}) (filters.Filter, error)
 		return invalidArgs()
 	}
 
+	var statusCode int64
+	var httpCode int
 	code, ok := config[0].(float64)
 	if !ok {
-		return invalidArgs()
+		statusCode, ok = config[0].(int64)
+		if !ok {
+			return invalidArgs()
+		}
+	}
+
+	if code == 0 {
+		httpCode = int(statusCode)
+	} else {
+		httpCode = int(code)
 	}
 
 	location, ok := config[1].(string)
@@ -77,7 +88,7 @@ func (spec *redirect) CreateFilter(config []interface{}) (filters.Filter, error)
 		return invalidArgs()
 	}
 
-	return &redirect{spec.deprecated, int(code), u}, nil
+	return &redirect{spec.deprecated, httpCode, u}, nil
 }
 
 func getRequestHost(r *http.Request) string {

--- a/filters/builtin/status.go
+++ b/filters/builtin/status.go
@@ -19,6 +19,8 @@ func (s *statusSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 	}
 
 	switch c := args[0].(type) {
+	case int64:
+		return statusFilter(c), nil
 	case int:
 		return statusFilter(c), nil
 	case float64:

--- a/filters/builtin/status_test.go
+++ b/filters/builtin/status_test.go
@@ -27,6 +27,14 @@ func TestStatus(t *testing.T) {
 		expectedCode: http.StatusNotFound,
 	}, {
 		msg:          "set status",
+		args:         []interface{}{int64(http.StatusTeapot)},
+		expectedCode: http.StatusTeapot,
+	}, {
+		msg:          "too many arguments",
+		args:         []interface{}{int64(http.StatusTeapot), "something else"},
+		expectedCode: http.StatusNotFound,
+	}, {
+		msg:          "set status",
 		args:         []interface{}{float64(http.StatusTeapot)},
 		expectedCode: http.StatusTeapot,
 	}} {

--- a/innkeeper/client_test.go
+++ b/innkeeper/client_test.go
@@ -569,7 +569,7 @@ func TestUsesPreAndPostRouteFilters(t *testing.T) {
 		if r.Filters[1].Name != "filter2" ||
 			len(r.Filters[1].Args) != 2 ||
 			r.Filters[1].Args[0] != "key" ||
-			r.Filters[1].Args[1] != float64(42) {
+			r.Filters[1].Args[1] != int64(42) {
 			t.Error("failed to parse filters 3")
 		}
 


### PR DESCRIPTION
Modified eskip to parse numbers as int64 too.

This is a possible solution for #296 and I'd like to get feedback if it's in the right path.