### PR TITLE
add combined metrics for backend latency and response streaming

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -75,6 +75,7 @@ const (
 	serveHostMetricsUsage          = "enables reporting total serve time metrics for each host"
 	backendHostMetricsUsage        = "enables reporting total serve time metrics for each backend"
 	allFiltersMetricsUsage         = "enables reporting combined filter metrics for each route"
+	combinedResponseMetricsUsage   = "enables reporting combined response time metrics"
 	routeResponseMetricsUsage      = "enables reporting response time metrics for each route"
 	routeBackendErrorCountersUsage = "enables counting backend errors for each route"
 	routeStreamErrorCountersUsage  = "enables counting streaming errors for each route"
@@ -135,6 +136,7 @@ var (
 	serveHostMetrics          bool
 	backendHostMetrics        bool
 	allFiltersMetrics         bool
+	combinedResponseMetrics   bool
 	routeResponseMetrics      bool
 	routeBackendErrorCounters bool
 	routeStreamErrorCounters  bool
@@ -192,6 +194,7 @@ func init() {
 	flag.BoolVar(&serveHostMetrics, "serve-host-metrics", false, serveHostMetricsUsage)
 	flag.BoolVar(&backendHostMetrics, "backend-host-metrics", false, backendHostMetricsUsage)
 	flag.BoolVar(&allFiltersMetrics, "all-filters-metrics", false, allFiltersMetricsUsage)
+	flag.BoolVar(&combinedResponseMetrics, "combined-response-metrics", false, combinedResponseMetricsUsage)
 	flag.BoolVar(&routeResponseMetrics, "route-response-metrics", false, routeResponseMetricsUsage)
 	flag.BoolVar(&routeBackendErrorCounters, "route-backend-error-counters", false, routeBackendErrorCountersUsage)
 	flag.BoolVar(&routeStreamErrorCounters, "route-stream-error-counters", false, routeStreamErrorCountersUsage)
@@ -290,6 +293,7 @@ func main() {
 		EnableServeHostMetrics:              serveHostMetrics,
 		EnableBackendHostMetrics:            backendHostMetrics,
 		EnableAllFiltersMetrics:             allFiltersMetrics,
+		EnableCombinedResponseMetrics:       combinedResponseMetrics,
 		EnableRouteResponseMetrics:          routeResponseMetrics,
 		EnableRouteBackendErrorsCounters:    routeBackendErrorCounters,
 		EnableRouteStreamingErrorsCounters:  routeStreamErrorCounters,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -77,17 +77,19 @@ type Options struct {
 }
 
 const (
-	KeyRouteLookup      = "routelookup"
-	KeyRouteFailure     = "routefailure"
-	KeyFilterRequest    = "filter.%s.request"
-	KeyFiltersRequest   = "allfilters.request.%s"
-	KeyProxyBackend     = "backend.%s"
-	KeyProxyBackendHost = "backendhost.%s"
-	KeyFilterResponse   = "filter.%s.response"
-	KeyFiltersResponse  = "allfilters.response.%s"
-	KeyResponse         = "response.%d.%s.skipper.%s"
-	KeyServeRoute       = "serveroute.%s.%s.%d"
-	KeyServeHost        = "servehost.%s.%s.%d"
+	KeyRouteLookup          = "routelookup"
+	KeyRouteFailure         = "routefailure"
+	KeyFilterRequest        = "filter.%s.request"
+	KeyFiltersRequest       = "allfilters.request.%s"
+	KeyProxyBackend         = "backend.%s"
+	KeyProxyBackendCombined = "all.backend"
+	KeyProxyBackendHost     = "backendhost.%s"
+	KeyFilterResponse       = "filter.%s.response"
+	KeyFiltersResponse      = "allfilters.response.%s"
+	KeyResponse             = "response.%d.%s.skipper.%s"
+	KeyResponseCombined     = "all.response.%d.%s.skipper"
+	KeyServeRoute           = "serveroute.%s.%s.%d"
+	KeyServeHost            = "servehost.%s.%s.%d"
 
 	KeyErrorsBackend   = "errors.backend.%s"
 	KeyErrorsStreaming = "errors.streaming.%s"
@@ -218,6 +220,7 @@ func (m *Metrics) MeasureAllFiltersRequest(routeId string, start time.Time) {
 }
 
 func (m *Metrics) MeasureBackend(routeId string, start time.Time) {
+	m.measureSince(KeyProxyBackendCombined, start)
 	if m.options.EnableRouteBackendMetrics {
 		m.measureSince(fmt.Sprintf(KeyProxyBackend, routeId), start)
 	}
@@ -240,8 +243,9 @@ func (m *Metrics) MeasureAllFiltersResponse(routeId string, start time.Time) {
 }
 
 func (m *Metrics) MeasureResponse(code int, method string, routeId string, start time.Time) {
+	method = measuredMethod(method)
+	m.measureSince(fmt.Sprintf(KeyResponseCombined, code, method), start)
 	if m.options.EnableRouteResponseMetrics {
-		method = measuredMethod(method)
 		m.measureSince(fmt.Sprintf(KeyResponse, code, method, routeId), start)
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -44,6 +44,10 @@ type Options struct {
 	// it is enabled by default.
 	EnableAllFiltersMetrics bool
 
+	// EnableCombinedResponseMetrics enables collecting response time
+	// metrics combined for every route.
+	EnableCombinedResponseMetrics bool
+
 	// EnableRouteResponseMetrics enables collecting response time
 	// metrics per each route. Without the DisableCompatibilityDefaults,
 	// it is enabled by default.
@@ -244,7 +248,10 @@ func (m *Metrics) MeasureAllFiltersResponse(routeId string, start time.Time) {
 
 func (m *Metrics) MeasureResponse(code int, method string, routeId string, start time.Time) {
 	method = measuredMethod(method)
-	m.measureSince(fmt.Sprintf(KeyResponseCombined, code, method), start)
+	if m.options.EnableCombinedResponseMetrics {
+		m.measureSince(fmt.Sprintf(KeyResponseCombined, code, method), start)
+	}
+
 	if m.options.EnableRouteResponseMetrics {
 		m.measureSince(fmt.Sprintf(KeyResponse, code, method, routeId), start)
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -191,6 +191,10 @@ type Options struct {
 	// it is enabled by default.
 	EnableAllFiltersMetrics bool
 
+	// EnableCombinedResponseMetrics enables collecting response time
+	// metrics combined for every route.
+	EnableCombinedResponseMetrics bool
+
 	// EnableRouteResponseMetrics enables collecting response time
 	// metrics per each route. Without the DisableMetricsCompatibilityDefaults,
 	// it is enabled by default.
@@ -522,6 +526,7 @@ func Run(o Options) error {
 			EnableBackendHostMetrics:           o.EnableBackendHostMetrics,
 			EnableProfile:                      o.EnableProfile,
 			EnableAllFiltersMetrics:            o.EnableAllFiltersMetrics,
+			EnableCombinedResponseMetrics:      o.EnableCombinedResponseMetrics,
 			EnableRouteResponseMetrics:         o.EnableRouteResponseMetrics,
 			EnableRouteBackendErrorsCounters:   o.EnableRouteBackendErrorsCounters,
 			EnableRouteStreamingErrorsCounters: o.EnableRouteStreamingErrorsCounters,


### PR DESCRIPTION
adding the non route based backend and response streaming metrics. The key of the metrics has an 'all.' prefix, so that existing filter with the prefix 'backend.' or 'response.' won't include them, and so avoid ending up in duplicate sum of the values.

What I am wondering if these should be enabled only if the route based variants of these metrics are disabled. Any advice?