### PR TITLE
ratelimit support via args

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -155,6 +155,8 @@ var (
 	maxLoopbacks              int
 	enableBreakers            bool
 	breakers                  breakerFlags
+	enableRatelimiters        bool
+	ratelimits                ratelimitFlags
 	defaultHTTPStatus         int
 )
 
@@ -212,6 +214,8 @@ func init() {
 	flag.IntVar(&maxLoopbacks, "max-loopbacks", proxy.DefaultMaxLoopbacks, maxLoopbacksUsage)
 	flag.BoolVar(&enableBreakers, "enable-breakers", false, enableBreakersUsage)
 	flag.Var(&breakers, "breaker", breakerUsage)
+	flag.BoolVar(&enableRatelimiters, "enable-ratelimits", false, enableRatelimitUsage)
+	flag.Var(&ratelimits, "ratelimits", ratelimitUsage)
 	flag.IntVar(&defaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
 	flag.Parse()
 }
@@ -308,6 +312,8 @@ func main() {
 		MaxLoopbacks:                        maxLoopbacks,
 		EnableBreakers:                      enableBreakers,
 		BreakerSettings:                     breakers,
+		EnableRatelimiters:                  enableRatelimiters,
+		RatelimitSettings:                   ratelimits,
 		DefaultHTTPStatus:                   defaultHTTPStatus,
 	}
 

--- a/cmd/skipper/ratelimiterflags.go
+++ b/cmd/skipper/ratelimiterflags.go
@@ -8,11 +8,11 @@ import (
 	"github.com/zalando/skipper/ratelimit"
 )
 
-const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=local,maxHits=20,timeWindow=60
+const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=local,max-hits=20,time-window=60
 	possible ratelimit properties:
 	type: local/disabled (defaults to local)
-	maxHits: the number of hits a local (meaning per instance) ratelimiter can get
-	timeWindow: the duration of the sliding window for the rate limiter
+	max-hits: the number of hits a local (meaning per instance) ratelimiter can get
+	time-window: the duration of the sliding window for the rate limiter
 	(see also: https://godoc.org/github.com/zalando/skipper/ratelimit)`
 
 const enableRatelimitUsage = `enable ratelimit`
@@ -50,13 +50,13 @@ func (r *ratelimitFlags) Set(value string) error {
 			default:
 				return errInvalidRatelimitConfig
 			}
-		case "maxHits":
+		case "max-hits":
 			i, err := strconv.Atoi(kv[1])
 			if err != nil {
 				return err
 			}
 			s.MaxHits = i
-		case "timeWindow":
+		case "time-window":
 			d, err := parseDurationFlag(kv[1])
 			if err != nil {
 				return err
@@ -68,7 +68,7 @@ func (r *ratelimitFlags) Set(value string) error {
 		}
 	}
 
-	if s.Type == ratelimit.NonRatelimit {
+	if s.Type == ratelimit.NoRatelimit {
 		s.Type = ratelimit.DisableRatelimit
 	}
 

--- a/cmd/skipper/ratelimiterflags.go
+++ b/cmd/skipper/ratelimiterflags.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/zalando/skipper/ratelimit"
+)
+
+const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=local,maxHits=20,timeWindow=60
+	possible ratelimit properties:
+	type: local/disabled (defaults to local)
+	maxHits: the number of hits a local (meaning per instance) ratelimiter can get
+	timeWindow: the duration of the sliding window for the rate limiter
+	(see also: https://godoc.org/github.com/zalando/skipper/ratelimit)`
+
+const enableRatelimitUsage = `enable ratelimit`
+
+type ratelimitFlags []ratelimit.Settings
+
+var errInvalidRatelimitConfig = errors.New("invalid ratelimit config")
+
+func (r *ratelimitFlags) String() string {
+	s := make([]string, len(*r))
+	for i, ri := range *r {
+		s[i] = ri.String()
+	}
+
+	return strings.Join(s, "\n")
+}
+
+func (r *ratelimitFlags) Set(value string) error {
+	var s ratelimit.Settings
+
+	vs := strings.Split(value, ",")
+	for _, vi := range vs {
+		kv := strings.Split(vi, "=")
+		if len(kv) != 2 {
+			return errInvalidRatelimitConfig
+		}
+
+		switch kv[0] {
+		case "type":
+			switch kv[1] {
+			case "local":
+				s.Type = ratelimit.LocalRatelimit
+			case "disabled":
+				s.Type = ratelimit.DisableRatelimit
+			default:
+				return errInvalidRatelimitConfig
+			}
+		case "maxHits":
+			i, err := strconv.Atoi(kv[1])
+			if err != nil {
+				return err
+			}
+			s.MaxHits = i
+		case "timeWindow":
+			d, err := parseDurationFlag(kv[1])
+			if err != nil {
+				return err
+			}
+			s.TimeWindow = d
+			s.CleanInterval = d * 10
+		default:
+			return errInvalidRatelimitConfig
+		}
+	}
+
+	if s.Type == ratelimit.NonRatelimit {
+		s.Type = ratelimit.DisableRatelimit
+	}
+
+	*r = append(*r, s)
+	return nil
+}

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zalando/skipper/filters/cookie"
 	"github.com/zalando/skipper/filters/diag"
 	"github.com/zalando/skipper/filters/flowid"
+	"github.com/zalando/skipper/filters/ratelimit"
 	"github.com/zalando/skipper/filters/tee"
 )
 
@@ -87,6 +88,8 @@ func MakeRegistry() filters.Registry {
 		circuit.NewConsecutiveBreaker(),
 		circuit.NewRateBreaker(),
 		circuit.NewDisableBreaker(),
+		ratelimit.NewLocalRatelimit(),
+		ratelimit.NewDisableRatelimit(),
 	} {
 		r.Register(s)
 	}

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -1,0 +1,130 @@
+/*
+Package ratelimit provides filters to control the rate limitter settings on the route level.
+
+For detailed documentation of the ratelimit, see https://godoc.org/github.com/zalando/skipper/ratelimit.
+*/
+package ratelimit
+
+import (
+	"time"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/ratelimit"
+)
+
+// RouteSettingsKey is used as key in the context state bag
+const RouteSettingsKey = "#ratelimitsettings"
+
+type spec struct {
+	typ        ratelimit.Type
+	filterName string
+}
+
+type filter struct {
+	settings ratelimit.Settings
+}
+
+// NewLocalRatelimit creates a local measured rate limiting, that is
+// only aware of itself. If you have 5 instances with 20 req/s, then
+// it would allow 100 req/s to the backend.
+//
+// Example:
+//
+//    backendHealthcheck: Path("/healthcheck")
+//    -> localRatelimit(20, "1m")
+//    -> "https://foo.backend.net";
+func NewLocalRatelimit() filters.Spec {
+	return &spec{typ: ratelimit.LocalRatelimit, filterName: ratelimit.LocalRatelimitName}
+}
+
+// NewDisableRatelimit disables rate limiting
+//
+// Example:
+//
+//    backendHealthcheck: Path("/healthcheck")
+//    -> disableRatelimit()
+//    -> "https://foo.backend.net";
+func NewDisableRatelimit() filters.Spec {
+	return &spec{typ: ratelimit.DisableRatelimit, filterName: ratelimit.DisableRatelimitName}
+}
+
+func (s *spec) Name() string {
+	return s.filterName
+}
+
+func localRatelimitFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 2 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	var err error
+	var maxHits int
+	if len(args) > 0 {
+		maxHits, err = getIntArg(args[0])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var timeWindow time.Duration
+	if len(args) > 1 {
+		timeWindow, err = getDurationArg(args[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &filter{
+		settings: ratelimit.Settings{
+			Type:          ratelimit.LocalRatelimit,
+			MaxHits:       maxHits,
+			TimeWindow:    timeWindow,
+			CleanInterval: 10 * timeWindow,
+		},
+	}, nil
+}
+
+func disableFilter(args []interface{}) (filters.Filter, error) {
+	return &filter{
+		settings: ratelimit.Settings{
+			Type: ratelimit.DisableRatelimit,
+		},
+	}, nil
+}
+
+func (s *spec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	switch s.typ {
+	case ratelimit.LocalRatelimit:
+		return localRatelimitFilter(args)
+	default:
+		return disableFilter(args)
+	}
+}
+
+func getIntArg(a interface{}) (int, error) {
+	if i, ok := a.(int); ok {
+		return i, nil
+	}
+
+	if f, ok := a.(float64); ok {
+		return int(f), nil
+	}
+
+	return 0, filters.ErrInvalidFilterParameters
+}
+
+func getDurationArg(a interface{}) (time.Duration, error) {
+	if s, ok := a.(string); ok {
+		return time.ParseDuration(s)
+	}
+
+	i, err := getIntArg(a)
+	return time.Duration(i) * time.Second, err
+}
+
+// TODO(sszuecs): think about middleware integration
+func (f *filter) Request(ctx filters.FilterContext) {
+	ctx.StateBag()[RouteSettingsKey] = f.settings
+}
+
+func (f *filter) Response(filters.FilterContext) {}

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -26,13 +26,22 @@ type filter struct {
 
 // NewLocalRatelimit creates a local measured rate limiting, that is
 // only aware of itself. If you have 5 instances with 20 req/s, then
-// it would allow 100 req/s to the backend.
+// it would allow 100 req/s to the backend. A third argument can be
+// used to set which part of the request should be used to find the
+// same user. Third argument defaults to XForwardedForLookuper,
+// meaning X-Forwarded-For Header.
 //
 // Example:
 //
 //    backendHealthcheck: Path("/healthcheck")
 //    -> localRatelimit(20, "1m")
 //    -> "https://foo.backend.net";
+//
+// Example rate limit per Authorization Header:
+//
+//    login: Path("/login")
+//    -> localRatelimit(3, "1m", "auth")
+//    -> "https://login.backend.net";
 func NewLocalRatelimit() filters.Spec {
 	return &spec{typ: ratelimit.LocalRatelimit, filterName: ratelimit.LocalRatelimitName}
 }
@@ -53,7 +62,7 @@ func (s *spec) Name() string {
 }
 
 func localRatelimitFilter(args []interface{}) (filters.Filter, error) {
-	if len(args) != 2 {
+	if !(len(args) == 2 || len(args) == 3) {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
@@ -74,12 +83,29 @@ func localRatelimitFilter(args []interface{}) (filters.Filter, error) {
 		}
 	}
 
+	var lookuper ratelimit.Lookuper
+	if len(args) > 2 {
+		lookuperName, err := getStringArg(args[2])
+		if err != nil {
+			return nil, err
+		}
+		switch lookuperName {
+		case "auth":
+			lookuper = ratelimit.NewAuthLookuper()
+		default:
+			lookuper = ratelimit.NewXForwardedForLookuper()
+		}
+	} else {
+		lookuper = ratelimit.NewXForwardedForLookuper()
+	}
+
 	return &filter{
 		settings: ratelimit.Settings{
 			Type:          ratelimit.LocalRatelimit,
 			MaxHits:       maxHits,
 			TimeWindow:    timeWindow,
 			CleanInterval: 10 * timeWindow,
+			Lookuper:      lookuper,
 		},
 	}, nil
 }
@@ -113,6 +139,14 @@ func getIntArg(a interface{}) (int, error) {
 	return 0, filters.ErrInvalidFilterParameters
 }
 
+func getStringArg(a interface{}) (string, error) {
+	if s, ok := a.(string); ok {
+		return s, nil
+	}
+
+	return "", filters.ErrInvalidFilterParameters
+}
+
 func getDurationArg(a interface{}) (time.Duration, error) {
 	if s, ok := a.(string); ok {
 		return time.ParseDuration(s)
@@ -122,7 +156,8 @@ func getDurationArg(a interface{}) (time.Duration, error) {
 	return time.Duration(i) * time.Second, err
 }
 
-// TODO(sszuecs): think about middleware integration
+// Request stores the configured ratelimit.Settings in the state bag,
+// such that it can be used in the proxy to check ratelimit.
 func (f *filter) Request(ctx filters.FilterContext) {
 	ctx.StateBag()[RouteSettingsKey] = f.settings
 }

--- a/filters/ratelimit/ratelimit_test.go
+++ b/filters/ratelimit/ratelimit_test.go
@@ -1,0 +1,98 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/ratelimit"
+)
+
+func TestArgs(t *testing.T) {
+	test := func(s filters.Spec, fail bool, args ...interface{}) func(*testing.T) {
+		return func(t *testing.T) {
+			if _, err := s.CreateFilter(args); fail && err == nil {
+				t.Error("failed to create filter")
+			} else if !fail && err != nil {
+				t.Error(err)
+			}
+		}
+	}
+
+	testOK := func(s filters.Spec, args ...interface{}) func(*testing.T) { return test(s, false, args...) }
+	testErr := func(s filters.Spec, args ...interface{}) func(*testing.T) { return test(s, true, args...) }
+
+	t.Run("local", func(t *testing.T) {
+		rl := NewLocalRatelimit()
+		t.Run("missing", testErr(rl, nil))
+		// t.Run("too many", testErr(s, 6, "1m", 12, "30m", 42))
+		// t.Run("wrong failure count", testErr(s, "6", "1m", 12))
+		// t.Run("wrong timeout", testErr(s, 6, "foo", 12))
+		// t.Run("wrong half-open requests", testErr(s, 6, "1m", "foo"))
+		// t.Run("only failure count", testOK(s, 6))
+		// t.Run("only failure count and timeout", testOK(s, 6, "1m"))
+		// t.Run("full", testOK(s, 6, "1m", 12))
+		// t.Run("timeout as milliseconds", testOK(s, 6, 60000, 12))
+		// t.Run("with idle ttl", testOK(s, 6, 60000, 12, "30m"))
+	})
+
+	t.Run("disable", func(t *testing.T) {
+		rl := NewDisableRatelimit()
+		//t.Run("with args fail", testErr(rl, 6))
+		t.Run("no args, ok", testOK(rl))
+	})
+}
+
+func TestRateLimit(t *testing.T) {
+	test := func(
+		s func() filters.Spec,
+		expect ratelimit.Settings,
+		args ...interface{},
+	) func(*testing.T) {
+		return func(t *testing.T) {
+			s := s()
+
+			f, err := s.CreateFilter(args)
+			if err != nil {
+				t.Error(err)
+			}
+
+			// TODO(sszuecs): do we need state bag?
+			ctx := &filtertest.Context{
+				FStateBag: make(map[string]interface{}),
+			}
+
+			f.Request(ctx)
+
+			settings, ok := ctx.StateBag()[RouteSettingsKey]
+			if !ok {
+				t.Error("failed to set the ratelimit settings")
+			}
+
+			if settings != expect {
+				t.Error("invalid settings")
+				t.Log("got", settings)
+				t.Log("expected", expect)
+			}
+		}
+	}
+
+	t.Run("ratelimit local", test(
+		NewLocalRatelimit,
+		ratelimit.Settings{
+			Type:          ratelimit.LocalRatelimit,
+			MaxHits:       3,
+			TimeWindow:    1 * time.Second,
+			CleanInterval: 1 * time.Minute,
+		},
+		3,
+		"1s",
+		"1m",
+	))
+
+	t.Run("ratelimit disable", test(
+		NewDisableRatelimit,
+		ratelimit.Settings{Type: ratelimit.DisableRatelimit},
+	))
+}

--- a/filters/ratelimit/ratelimit_test.go
+++ b/filters/ratelimit/ratelimit_test.go
@@ -52,7 +52,6 @@ func TestRateLimit(t *testing.T) {
 				t.Fatalf("filter is nil, args %v: %v", args, err)
 			}
 
-			// TODO(sszuecs): do we need state bag?
 			ctx := &filtertest.Context{
 				FStateBag: map[string]interface{}{
 					RouteSettingsKey: ratelimit.Settings{},
@@ -82,6 +81,7 @@ func TestRateLimit(t *testing.T) {
 			MaxHits:       3,
 			TimeWindow:    1 * time.Second,
 			CleanInterval: 10 * time.Second,
+			Lookuper:      ratelimit.NewXForwardedForLookuper(),
 		},
 		3,
 		"1s",

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: 8b21cac50e021fde6af96060d188dd3d6736efd9d5a5441fe0b4721d5be5d728
-updated: 2017-08-13T20:09:10.397364831+02:00
+hash: ce54e6c1b180407f563a8b45ddb724ef6247731412229814c2799a9c2a176f5c
+updated: 2017-09-12T11:15:50.735670736+02:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: efc9484eee77263a11f158ef4f30fcc30298a942
 - name: github.com/dimfeld/httppath
-  version: ee938bf735983d53694d79138ad9820efff94c92
+  version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
 - name: github.com/google/go-cmp
-  version: 8099a9787ce5dc5984ed879a3bda47dc730a8e97
+  version: d5735f74713c51f7450a43d0a98d41ce2c1db3cb
   subpackages:
   - cmp
   - cmp/internal/diff
@@ -17,19 +17,22 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/sony/gobreaker
   version: e9556a45379ef1da12e54847edb2fb3d7d566f36
+- name: github.com/szuecs/rate-limit-buffer
+  version: 19fe2d3ec08a015c0d7eb4dc108e23a7d8e03eaa
 - name: golang.org/x/crypto
-  version: c2303dcbe84172e0c0da4c9f083eeca54c06f298
+  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
   subpackages:
   - bcrypt
   - blowfish
   - ssh/terminal
 - name: golang.org/x/sys
-  version: 7de4796419dc3b554e6dab3a119a62469569d299
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
+  - windows
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ce54e6c1b180407f563a8b45ddb724ef6247731412229814c2799a9c2a176f5c
-updated: 2017-09-19T19:08:03.167233505+02:00
+updated: 2017-09-20T15:32:09.381911487+02:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: efc9484eee77263a11f158ef4f30fcc30298a942
@@ -26,7 +26,7 @@ imports:
 - name: github.com/sony/gobreaker
   version: e9556a45379ef1da12e54847edb2fb3d7d566f36
 - name: github.com/szuecs/rate-limit-buffer
-  version: 19fe2d3ec08a015c0d7eb4dc108e23a7d8e03eaa
+  version: 585b0c9c230415b668ed4d42ef18f7a32c061702
 - name: golang.org/x/crypto
   version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,7 @@
 package: github.com/zalando/skipper
 import:
+- package: github.com/szuecs/rate-limit-buffer
+  version: ~0.1.0
 - package: github.com/abbot/go-http-auth
   version: ~0.3.0
 - package: github.com/dimfeld/httppath

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -10,13 +10,16 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/zalando/skipper/circuit"
 	"github.com/zalando/skipper/eskip"
 	circuitfilters "github.com/zalando/skipper/filters/circuit"
+	ratelimitfilters "github.com/zalando/skipper/filters/ratelimit"
 	"github.com/zalando/skipper/logging"
 	"github.com/zalando/skipper/metrics"
+	"github.com/zalando/skipper/ratelimit"
 	"github.com/zalando/skipper/routing"
 )
 
@@ -121,6 +124,11 @@ type Params struct {
 	// DefaultHTTPStatus is the HTTP status used when no routes are found
 	// for a request.
 	DefaultHTTPStatus int
+
+	// RateLimiters provides a registry that skipper can use to
+	// find the matching ratelimiter for backend requests. If not
+	// set, no ratelimits are used.
+	RateLimiters *ratelimit.Registry
 }
 
 var (
@@ -130,6 +138,7 @@ var (
 		err:  errors.New("circuit breaker open"),
 		code: http.StatusServiceUnavailable,
 	}
+	errRatelimitError = errors.New("ratelimited")
 )
 
 // When set, the proxy will skip the TLS verification on outgoing requests.
@@ -174,6 +183,7 @@ type Proxy struct {
 	experimentalUpgrade bool
 	maxLoops            int
 	breakers            *circuit.Registry
+	limiters            *ratelimit.Registry
 	log                 logging.Logger
 	defaultHTTPStatus   int
 }
@@ -184,9 +194,10 @@ type Proxy struct {
 // was already handled, e.g. in case of deprecated shunting or the
 // upgrade request.
 type proxyError struct {
-	err     error
-	code    int
-	handled bool
+	err              error
+	code             int
+	handled          bool
+	additionalHeader http.Header
 }
 
 func (e *proxyError) Error() string {
@@ -342,6 +353,7 @@ func WithParams(p Params) *Proxy {
 		experimentalUpgrade: p.ExperimentalUpgrade,
 		maxLoops:            p.MaxLoopbacks,
 		breakers:            p.CircuitBreakers,
+		limiters:            p.RateLimiters,
 		log:                 &logging.DefaultLog{},
 		defaultHTTPStatus:   defaultHTTPStatus,
 	}
@@ -521,12 +533,51 @@ func (p *Proxy) checkBreaker(c *context) (func(bool), bool) {
 	return done, ok
 }
 
+func ratelimitError(settings ratelimit.Settings) error {
+	return &proxyError{
+		err:  errRatelimitError,
+		code: http.StatusTooManyRequests,
+		additionalHeader: http.Header{
+			ratelimit.Header: []string{strconv.Itoa(settings.MaxHits * int(time.Hour/settings.TimeWindow))},
+		},
+	}
+}
+
+// TODO(sszuecs) not in use for the global rate limiter, but should be
+// used in per route rate limiting
+func (p *Proxy) checkRatelimit(c *context) bool {
+	if p.limiters == nil {
+		return true
+	}
+
+	settings, _ := c.stateBag[ratelimitfilters.RouteSettingsKey].(ratelimit.Settings)
+	settings.Host = c.outgoingHost
+
+	rl := p.limiters.Get(settings)
+	if rl == nil {
+		return true
+	}
+
+	s := settings.Lookuper.Lookup(c.originalRequest)
+
+	if s == "" {
+		return true
+	}
+	return rl.Allow(s)
+}
+
 func (p *Proxy) do(ctx *context) error {
 	if ctx.loopCounter > p.maxLoops {
 		return errMaxLoopbacksReached
 	}
 
 	ctx.loopCounter++
+
+	if ok, settings := p.limiters.Check(ctx.request); !ok {
+		p.log.Debugf("proxy.go limiter settings: %s", settings)
+		rerr := ratelimitError(settings)
+		return rerr
+	}
 
 	lookupStart := time.Now()
 	route, params := p.lookupRoute(ctx.request)
@@ -659,6 +710,10 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		ctx.responseWriter.Header().Set("X-Circuit-Open", "true")
 	case err == errRouteLookupFailed:
 		code = p.defaultHTTPStatus
+	case perr.err == errRatelimitError:
+		code = perr.code
+		v := perr.additionalHeader.Get(ratelimit.Header)
+		ctx.responseWriter.Header().Set(ratelimit.Header, v)
 	default:
 		p.log.Errorf("error while proxying, route %s, status code %d: %v", id, code, err)
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -584,7 +584,7 @@ func (p *Proxy) do(ctx *context) error {
 
 	ctx.loopCounter++
 
-	if ok, settings := p.limiters.Check(ctx.request); !ok {
+	if settings, ok := p.limiters.Check(ctx.request); !ok {
 		p.log.Debugf("proxy.go limiter settings: %s", settings)
 		rerr := ratelimitError(settings)
 		return rerr

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zalando/skipper/circuit"
 	"github.com/zalando/skipper/eskip"
 	circuitfilters "github.com/zalando/skipper/filters/circuit"
-	ratelimitfilters "github.com/zalando/skipper/filters/ratelimit"
 	"github.com/zalando/skipper/logging"
 	"github.com/zalando/skipper/metrics"
 	"github.com/zalando/skipper/ratelimit"
@@ -576,29 +575,6 @@ func ratelimitError(settings ratelimit.Settings) error {
 			ratelimit.Header: []string{strconv.Itoa(settings.MaxHits * int(time.Hour/settings.TimeWindow))},
 		},
 	}
-}
-
-// TODO(sszuecs) not in use for the global rate limiter, but should be
-// used in per route rate limiting
-func (p *Proxy) checkRatelimit(c *context) bool {
-	if p.limiters == nil {
-		return true
-	}
-
-	settings, _ := c.stateBag[ratelimitfilters.RouteSettingsKey].(ratelimit.Settings)
-	settings.Host = c.outgoingHost
-
-	rl := p.limiters.Get(settings)
-	if rl == nil {
-		return true
-	}
-
-	s := settings.Lookuper.Lookup(c.originalRequest)
-
-	if s == "" {
-		return true
-	}
-	return rl.Allow(s)
 }
 
 func (p *Proxy) do(ctx *context) error {

--- a/proxy/ratelimit_test.go
+++ b/proxy/ratelimit_test.go
@@ -1,0 +1,215 @@
+package proxy_test
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/proxy"
+	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/ratelimit"
+)
+
+func TestWithoutRateLimit(t *testing.T) {
+	fr := builtin.MakeRegistry()
+	backend := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer backend.Close()
+	r := &eskip.Route{Backend: backend.URL}
+	p := proxytest.New(fr, r)
+	defer p.Close()
+
+	doc := func(l int) []byte {
+		b := make([]byte, l)
+		n, err := rand.Read(b)
+		if err != nil || n != l {
+			t.Fatal("failed to generate doc", err, n, l)
+		}
+
+		return b
+	}
+
+	request := func(doc []byte) {
+		req, err := http.NewRequest("GET", p.URL+"/", nil)
+		if err != nil {
+			t.Fatal("foo", "failed to create request", err)
+			return
+		}
+
+		req.Close = true
+
+		rsp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatal("Do req", "failed to make request", err)
+			return
+		}
+
+		defer rsp.Body.Close()
+		_, err = ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			t.Fatal("read", "failed to read response", err)
+		}
+
+		if rsp.StatusCode == http.StatusTooManyRequests {
+			t.Fatal("should not be ratelimitted")
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		d0 := doc(128)
+		request(d0)
+	}
+
+}
+
+func TestCheckDisableRateLimit(t *testing.T) {
+	fr := builtin.MakeRegistry()
+	backend := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer backend.Close()
+	r := []*eskip.Route{&eskip.Route{Backend: backend.URL}}
+	p := proxytest.WithParams(fr, proxy.Params{
+		CloseIdleConnsPeriod: -time.Second,
+		RateLimiters: ratelimit.NewRegistry(ratelimit.Settings{
+			Type:          ratelimit.DisableRatelimit,
+			MaxHits:       10,
+			TimeWindow:    1 * time.Second,
+			CleanInterval: 2 * time.Second,
+		}),
+	}, r...)
+	defer p.Close()
+
+	doc := func(l int) []byte {
+		b := make([]byte, l)
+		n, err := rand.Read(b)
+		if err != nil || n != l {
+			t.Fatal("failed to generate doc", err, n, l)
+		}
+
+		return b
+	}
+
+	request := func(doc []byte) int {
+		req, err := http.NewRequest("GET", p.URL+"/", nil)
+		if err != nil {
+			t.Fatal("foo", "failed to create request", err)
+			return -1
+		}
+
+		req.Close = true
+
+		rsp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatal("Do req", "failed to make request", err)
+			return -1
+		}
+
+		defer rsp.Body.Close()
+		_, err = ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			t.Fatal("read", "failed to read response", err)
+		}
+
+		return rsp.StatusCode
+	}
+
+	for i := 0; i < 100; i++ {
+		d0 := doc(128)
+		if request(d0) == http.StatusTooManyRequests {
+			t.Fatal("should not be ratelimitted")
+		}
+	}
+
+}
+
+func TestCheckRateLimit(t *testing.T) {
+	fr := builtin.MakeRegistry()
+	backend := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer backend.Close()
+	r := []*eskip.Route{&eskip.Route{Backend: backend.URL}}
+	timeWindow := 1 * time.Second
+	ratelimitSettings := ratelimit.Settings{
+		Type:          ratelimit.LocalRatelimit,
+		MaxHits:       10,
+		TimeWindow:    timeWindow,
+		CleanInterval: 2 * timeWindow,
+	}
+	p := proxytest.WithParams(fr, proxy.Params{
+		CloseIdleConnsPeriod: -time.Second,
+		RateLimiters:         ratelimit.NewRegistry(ratelimitSettings),
+	}, r...)
+	defer p.Close()
+
+	doc := func(l int) []byte {
+		b := make([]byte, l)
+		n, err := rand.Read(b)
+		if err != nil || n != l {
+			t.Fatal("failed to generate doc", err, n, l)
+		}
+
+		return b
+	}
+
+	request := func(doc []byte) (int, http.Header) {
+		req, err := http.NewRequest("GET", p.URL+"/", nil)
+		if err != nil {
+			t.Fatal("foo", "failed to create request", err)
+			return -1, nil
+		}
+
+		req.Close = true
+
+		rsp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatal("Do req", "failed to make request", err)
+			return -1, nil
+		}
+
+		defer rsp.Body.Close()
+		_, err = ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			t.Fatal("read", "failed to read response", err)
+		}
+
+		return rsp.StatusCode, rsp.Header
+	}
+
+	for i := 0; i < 10; i++ {
+		d0 := doc(128)
+		code, _ := request(d0)
+		if code == http.StatusTooManyRequests {
+			t.Fatal("should not be ratelimitted")
+		}
+	}
+	for i := 0; i < 10; i++ {
+		d0 := doc(128)
+		code, header := request(d0)
+		if code != http.StatusTooManyRequests {
+			t.Fatal("should be ratelimitted")
+		}
+		v := header.Get(ratelimit.Header)
+		if v == "" {
+			t.Fatalf("should set ratelimit header %s", ratelimit.Header)
+		}
+		expected := ratelimitSettings.MaxHits * int(time.Hour/ratelimitSettings.TimeWindow)
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("failed to convert string number %s to number: %v", v, err)
+		}
+		if i != expected {
+			t.Fatalf("should calculateratelimit header correctly: %d expected: %d", i, expected)
+		}
+	}
+	time.Sleep(timeWindow)
+	for i := 0; i < 10; i++ {
+		d0 := doc(128)
+		code, _ := request(d0)
+		if code == http.StatusTooManyRequests {
+			t.Fatal("should not be ratelimitted")
+		}
+	}
+}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -15,7 +15,7 @@ type Type int
 const (
 	// Header is
 	Header = "X-Rate-Limit"
-	// LocalRatelimitName is the name of the LocalRatelimit, which will be shown in log
+	// LocalRatelimitName is the name of the LocalRatelimit filter, which will be shown in log
 	LocalRatelimitName = "localRatelimit"
 	// DisableRatelimitName is the name of the DisableRatelimit, which will be shown in log
 	DisableRatelimitName = "disableRatelimit"

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -22,8 +22,8 @@ const (
 )
 
 const (
-	// NonRatelimit is not used
-	NonRatelimit Type = iota
+	// NoRatelimit is not used
+	NoRatelimit Type = iota
 	// LocalRatelimit is used to have a simple local rate limit,
 	// which is calculated and measured within each instance
 	LocalRatelimit
@@ -50,7 +50,7 @@ func (s Settings) Empty() bool {
 }
 
 func (to Settings) mergeSettings(from Settings) Settings {
-	if to.Type == NonRatelimit {
+	if to.Type == NoRatelimit {
 		to.Type = from.Type
 	}
 	if to.MaxHits == 0 {
@@ -70,7 +70,7 @@ func (s Settings) String() string {
 	case DisableRatelimit:
 		return "disable"
 	case LocalRatelimit:
-		return fmt.Sprintf("ratelimit(type=local,maxHits=%d,timeWindow=%s)", s.MaxHits, s.TimeWindow)
+		return fmt.Sprintf("ratelimit(type=local,max-hits=%d,time-window=%s)", s.MaxHits, s.TimeWindow)
 	default:
 		return "non"
 	}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -31,7 +31,14 @@ const (
 	DisableRatelimit
 )
 
+// Lookuper makes it possible to be more flexible for ratelimiting.
 type Lookuper interface {
+	// Lookup is used to get the string which is used to define
+	// how the bucket of a ratelimiter looks like, which is used
+	// to decide to ratelimit or not. For example you can use the
+	// X-Forwarded-For Header if you want to rate limit based on
+	// source ip behind a proxy/loadbalancer or the Authorization
+	// Header for request per token or user.
 	Lookup(*http.Request) string
 }
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	circularbuffer "github.com/szuecs/rate-limit-buffer"
+	"github.com/zalando/skipper/net"
 )
 
 // Type defines the type of the used breaker: consecutive, rate or
@@ -40,6 +41,26 @@ type Lookuper interface {
 	// source ip behind a proxy/loadbalancer or the Authorization
 	// Header for request per token or user.
 	Lookup(*http.Request) string
+}
+
+type XForwardedForLookuper struct{}
+
+func NewXForwardedForLookuper() XForwardedForLookuper {
+	return XForwardedForLookuper{}
+}
+
+func (_ XForwardedForLookuper) Lookup(req *http.Request) string {
+	return net.RemoteHost(req).String()
+}
+
+type AuthLookuper struct{}
+
+func NewAuthLookuper() AuthLookuper {
+	return AuthLookuper{}
+}
+
+func (_ AuthLookuper) Lookup(req *http.Request) string {
+	return req.Header.Get("Authorization")
 }
 
 // Settings configures the chosen rate limiter

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,0 +1,115 @@
+package ratelimit
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	circularbuffer "github.com/szuecs/rate-limit-buffer"
+)
+
+// Type defines the type of the used breaker: consecutive, rate or
+// disabled.
+type Type int
+
+const (
+	// Header is
+	Header = "X-Rate-Limit"
+	// LocalRatelimitName is the name of the LocalRatelimit, which will be shown in log
+	LocalRatelimitName = "localRatelimit"
+	// DisableRatelimitName is the name of the DisableRatelimit, which will be shown in log
+	DisableRatelimitName = "disableRatelimit"
+)
+
+const (
+	// NonRatelimit is not used
+	NonRatelimit Type = iota
+	// LocalRatelimit is used to have a simple local rate limit,
+	// which is calculated and measured within each instance
+	LocalRatelimit
+	// DisableRatelimit is used to disable rate limit
+	DisableRatelimit
+)
+
+type Lookuper interface {
+	Lookup(*http.Request) string
+}
+
+// Settings configures the chosen rate limiter
+type Settings struct {
+	Type          Type
+	Lookuper      Lookuper
+	Host          string
+	MaxHits       int
+	TimeWindow    time.Duration
+	CleanInterval time.Duration
+}
+
+func (s Settings) Empty() bool {
+	return s == Settings{}
+}
+
+func (to Settings) mergeSettings(from Settings) Settings {
+	if to.Type == NonRatelimit {
+		to.Type = from.Type
+	}
+	if to.MaxHits == 0 {
+		to.MaxHits = from.MaxHits
+	}
+	if to.TimeWindow == 0 {
+		to.TimeWindow = from.TimeWindow
+	}
+	if to.CleanInterval == 0 {
+		to.CleanInterval = from.CleanInterval
+	}
+	return to
+}
+
+func (s Settings) String() string {
+	switch s.Type {
+	case DisableRatelimit:
+		return "disable"
+	case LocalRatelimit:
+		return fmt.Sprintf("ratelimit(type=local,maxHits=%d,timeWindow=%s)", s.MaxHits, s.TimeWindow)
+	default:
+		return "non"
+	}
+}
+
+type implementation interface {
+	Allow(string) bool
+}
+
+type Ratelimit struct {
+	settings Settings
+	ts       time.Time
+	impl     implementation
+}
+
+func (l *Ratelimit) Allow(s string) bool {
+	if l == nil {
+		return true
+	}
+	return l.impl.Allow(s)
+}
+
+type voidRatelimit struct{}
+
+func (l voidRatelimit) Allow(string) bool {
+	return true
+}
+
+func newRatelimit(s Settings) *Ratelimit {
+	var impl implementation
+	switch s.Type {
+	case LocalRatelimit:
+		impl = circularbuffer.NewRateLimiter(s.MaxHits, s.TimeWindow, s.CleanInterval, nil)
+	default:
+		impl = voidRatelimit{}
+	}
+
+	return &Ratelimit{
+		settings: s,
+		impl:     impl,
+	}
+}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -79,20 +79,3 @@ func TestDisableRatelimit(t *testing.T) {
 		checkNotRatelimitted(t, rl, client1)
 	})
 }
-
-// func TestSettingsString(t *testing.T) {
-// 	s := RatelimitSettings{
-// 		Type:          LocalRatelimit,
-// 		MaxHits:       6,
-// 		TimeWindow:    3 * time.Second,
-// 		CleanInterval: 6 * time.Second,
-// 	}
-
-// 	ss := s.String()
-// 	expect := "type=rate,host=www.example.org,window=300,failures=30,timeout=1m0s,half-open-requests=15,idle-ttl=1h0m0s"
-// 	if ss != expect {
-// 		t.Error("invalid ratelimit settings string")
-// 		t.Logf("got     : %s", ss)
-// 		t.Logf("expected: %s", expect)
-// 	}
-// }

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,0 +1,98 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func checkRatelimitted(t *testing.T, rl *Ratelimit, client string) {
+	if rl.Allow(client) {
+		t.Errorf("request is allowed for %s, but expected to be rate limitted", client)
+	}
+}
+
+func checkNotRatelimitted(t *testing.T, rl *Ratelimit, client string) {
+	if !rl.Allow(client) {
+		t.Errorf("request is rate limitted for %s, but expected to be allowed", client)
+	}
+}
+
+func TestLocalRatelimit(t *testing.T) {
+	s := Settings{
+		Type:          LocalRatelimit,
+		MaxHits:       3,
+		TimeWindow:    3 * time.Second,
+		CleanInterval: 4 * time.Second,
+	}
+	client1 := "foo"
+	client2 := "bar"
+
+	waitClean := func() {
+		time.Sleep(s.TimeWindow)
+	}
+
+	t.Run("new local ratelimitter", func(t *testing.T) {
+		rl := newRatelimit(s)
+		checkNotRatelimitted(t, rl, client1)
+	})
+
+	t.Run("does not rate limit unless we have enough calls", func(t *testing.T) {
+		rl := newRatelimit(s)
+		for i := 0; i < s.MaxHits; i++ {
+			checkNotRatelimitted(t, rl, client1)
+		}
+
+		checkRatelimitted(t, rl, client1)
+		checkNotRatelimitted(t, rl, client2)
+	})
+
+	t.Run("does not rate limit if TimeWindow is over", func(t *testing.T) {
+		rl := newRatelimit(s)
+		for i := 0; i < s.MaxHits-1; i++ {
+			checkNotRatelimitted(t, rl, client1)
+		}
+		waitClean()
+		checkNotRatelimitted(t, rl, client1)
+	})
+}
+
+func TestDisableRatelimit(t *testing.T) {
+	s := Settings{
+		Type:          DisableRatelimit,
+		MaxHits:       6,
+		TimeWindow:    3 * time.Second,
+		CleanInterval: 6 * time.Second,
+	}
+
+	client1 := "foo"
+
+	t.Run("new disabled ratelimitter", func(t *testing.T) {
+		rl := newRatelimit(s)
+		checkNotRatelimitted(t, rl, client1)
+	})
+
+	t.Run("disable ratelimitter should never rate limit", func(t *testing.T) {
+		rl := newRatelimit(s)
+		for i := 0; i < s.MaxHits; i++ {
+			checkNotRatelimitted(t, rl, client1)
+		}
+		checkNotRatelimitted(t, rl, client1)
+	})
+}
+
+// func TestSettingsString(t *testing.T) {
+// 	s := RatelimitSettings{
+// 		Type:          LocalRatelimit,
+// 		MaxHits:       6,
+// 		TimeWindow:    3 * time.Second,
+// 		CleanInterval: 6 * time.Second,
+// 	}
+
+// 	ss := s.String()
+// 	expect := "type=rate,host=www.example.org,window=300,failures=30,timeout=1m0s,half-open-requests=15,idle-ttl=1h0m0s"
+// 	if ss != expect {
+// 		t.Error("invalid ratelimit settings string")
+// 		t.Logf("got     : %s", ss)
+// 		t.Logf("expected: %s", expect)
+// 	}
+// }

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -14,9 +14,9 @@ const (
 	DefaultCleanInterval = 60 * time.Second
 )
 
-// Registry objects hold the active ratelimitters, ensure synchronized
+// Registry objects hold the active ratelimiters, ensure synchronized
 // access to them, apply default settings and recycle the idle
-// ratelimitters.
+// ratelimiters.
 type Registry struct {
 	sync.Mutex
 	defaults Settings
@@ -62,7 +62,7 @@ func (r *Registry) get(s Settings) *Ratelimit {
 
 // Get returns a Ratelimit instance for provided Settings
 func (r *Registry) Get(s Settings) *Ratelimit {
-	if s.Type == DisableRatelimit {
+	if s.Type == DisableRatelimit || s.Type == NoRatelimit {
 		return nil
 	}
 

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -1,0 +1,86 @@
+package ratelimit
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/zalando/skipper/net"
+)
+
+const (
+	DefaultMaxhits       = 20
+	DefaultTimeWindow    = 1 * time.Second
+	DefaultCleanInterval = 60 * time.Second
+)
+
+// Registry objects hold the active ratelimitters, ensure synchronized
+// access to them, apply default settings and recycle the idle
+// ratelimitters.
+type Registry struct {
+	sync.Mutex
+	defaults Settings
+	global   Settings
+	//routeSettings map[string]Settings
+	lookup map[Settings]*Ratelimit
+}
+
+// NewRegistry initializes a registry with the provided default settings.
+func NewRegistry(settings ...Settings) *Registry {
+	defaults := Settings{
+		Type:          DisableRatelimit,
+		MaxHits:       DefaultMaxhits,
+		TimeWindow:    DefaultTimeWindow,
+		CleanInterval: DefaultCleanInterval,
+	}
+
+	r := &Registry{
+		defaults: defaults,
+		global:   defaults,
+		lookup:   make(map[Settings]*Ratelimit),
+	}
+
+	if len(settings) > 0 {
+		r.global = settings[0]
+	}
+
+	return r
+}
+
+func (r *Registry) get(s Settings) *Ratelimit {
+	r.Lock()
+	defer r.Unlock()
+
+	rl, ok := r.lookup[s]
+	if !ok {
+		rl = newRatelimit(s)
+		r.lookup[s] = rl
+	}
+
+	return rl
+}
+
+// Get returns a Ratelimit instance for provided Settings
+func (r *Registry) Get(s Settings) *Ratelimit {
+	if s.Type == DisableRatelimit {
+		return nil
+	}
+
+	return r.get(s)
+}
+
+// Check returns false in case of request is ratelimitted and false
+// otherwise. It returns the used Settings as 2nd argument.
+func (r *Registry) Check(req *http.Request) (bool, Settings) {
+	if r == nil {
+		return true, Settings{}
+	}
+
+	ip := net.RemoteHost(req)
+
+	if !r.Get(r.global).Allow(ip.String()) {
+		return false, r.global
+	}
+	return true, Settings{}
+
+}

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -69,18 +69,18 @@ func (r *Registry) Get(s Settings) *Ratelimit {
 	return r.get(s)
 }
 
-// Check returns false in case of request is ratelimitted and false
-// otherwise. It returns the used Settings as 2nd argument.
-func (r *Registry) Check(req *http.Request) (bool, Settings) {
+// Check returns Settings used and false in case of request is
+// ratelimitted and false otherwise.
+func (r *Registry) Check(req *http.Request) (Settings, bool) {
 	if r == nil {
-		return true, Settings{}
+		return Settings{}, true
 	}
 
 	ip := net.RemoteHost(req)
 
 	if !r.Get(r.global).Allow(ip.String()) {
-		return false, r.global
+		return r.global, false
 	}
-	return true, Settings{}
+	return Settings{}, true
 
 }

--- a/ratelimit/registry_test.go
+++ b/ratelimit/registry_test.go
@@ -35,9 +35,10 @@ func TestRegistry(t *testing.T) {
 		checkNil(t, rl)
 	})
 	t.Run("with settings", func(t *testing.T) {
-		r := NewRegistry(createSettings(3))
+		s := createSettings(3)
+		r := NewRegistry(s)
 
-		rl := r.Get(Settings{Host: "foo"})
+		rl := r.Get(s)
 		checkNotNil(t, rl)
 	})
 }

--- a/ratelimit/registry_test.go
+++ b/ratelimit/registry_test.go
@@ -1,0 +1,43 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+// no checks, used for race detector
+func TestRegistry(t *testing.T) {
+	createSettings := func(maxHits int) Settings {
+		return Settings{
+			Type:          LocalRatelimit,
+			MaxHits:       maxHits,
+			TimeWindow:    1 * time.Second,
+			CleanInterval: 5 * time.Second,
+		}
+	}
+
+	checkNil := func(t *testing.T, rl *Ratelimit) {
+		if rl != nil {
+			t.Error("unexpected ratelimit")
+		}
+	}
+
+	checkNotNil := func(t *testing.T, rl *Ratelimit) {
+		if rl == nil {
+			t.Error("failed to receive a ratelimit")
+		}
+	}
+
+	t.Run("no settings", func(t *testing.T) {
+		r := NewRegistry()
+
+		rl := r.Get(Settings{})
+		checkNil(t, rl)
+	})
+	t.Run("with settings", func(t *testing.T) {
+		r := NewRegistry(createSettings(3))
+
+		rl := r.Get(Settings{Host: "foo"})
+		checkNotNil(t, rl)
+	})
+}

--- a/skipper.go
+++ b/skipper.go
@@ -289,7 +289,7 @@ type Options struct {
 	//
 	EnableRatelimiters bool
 
-	// RatelimitSettings contain global and host specific settings for the ratelimitters.
+	// RatelimitSettings contain global and host specific settings for the ratelimiters.
 	RatelimitSettings []ratelimit.Settings
 
 	// OpenTracing enables opentracing

--- a/skipper.go
+++ b/skipper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zalando/skipper/predicates/source"
 	"github.com/zalando/skipper/predicates/traffic"
 	"github.com/zalando/skipper/proxy"
+	"github.com/zalando/skipper/ratelimit"
 	"github.com/zalando/skipper/routing"
 )
 
@@ -276,6 +277,16 @@ type Options struct {
 	// BreakerSettings contain global and host specific settings for the circuit breakers.
 	BreakerSettings []circuit.BreakerSettings
 
+	// EnableRatelimiters enables the usage of the ratelimiter in the route definitions without initializing any
+	// by default. It is a shortcut for setting the RatelimitSettings to:
+	//
+	// 	[]ratelimit.Settings{{Type: DisableRatelimit}}
+	//
+	EnableRatelimiters bool
+
+	// RatelimitSettings contain global and host specific settings for the ratelimitters.
+	RatelimitSettings []ratelimit.Settings
+
 	// DefaultHTTPStatus is the HTTP status used when no routes are found
 	// for a request.
 	DefaultHTTPStatus int
@@ -491,6 +502,11 @@ func Run(o Options) error {
 
 	if o.EnableBreakers || len(o.BreakerSettings) > 0 {
 		proxyParams.CircuitBreakers = circuit.NewRegistry(o.BreakerSettings...)
+	}
+
+	if o.EnableRatelimiters || len(o.RatelimitSettings) > 0 {
+		log.Infof("enabled ratelimiters %v: %v", o.EnableRatelimiters, o.RatelimitSettings)
+		proxyParams.RateLimiters = ratelimit.NewRegistry(o.RatelimitSettings...)
 	}
 
 	if o.DebugListener != "" {


### PR DESCRIPTION
example: skipper -ratelimits type=local,maxHits=50,timeWindow=60s
this would be applied before the filter chain

This partially implements #424 