### PR TITLE
Remove catchAll route for kube ingress

### DIFF
--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -703,10 +703,8 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
-			"kube_namespace1__mega__foo_example_org____":                    "",
 			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
-			"kube_namespace1__mega__bar_example_org____":                    "",
 		})
 	})
 
@@ -757,10 +755,8 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
-			"kube_namespace1__mega__foo_example_org____":                    "",
 			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
-			"kube_namespace1__mega__bar_example_org____":                    "",
 		})
 	})
 
@@ -849,10 +845,8 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__mega______",
 			"kube_namespace1__mega__foo_example_org___test1__service1",
 			"kube_namespace1__mega__foo_example_org___test2__service2",
-			"kube_namespace1__mega__foo_example_org____",
 			"kube_namespace1__mega__bar_example_org___test1__service1",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org____",
 		)
 	})
 
@@ -882,7 +876,6 @@ func TestIngress(t *testing.T) {
 			d,
 			"kube_namespace1__mega__bar_example_org___test1__service1",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org____",
 		)
 	})
 
@@ -998,7 +991,6 @@ func TestIngress(t *testing.T) {
 			d,
 			"kube_namespace1__mega__bar_example_org___test1__service1",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org____",
 		)
 	})
 	t.Run("has ingresses, add new ones and filter not valid ones using class ingress", func(t *testing.T) {
@@ -1106,7 +1098,6 @@ func TestConvertPathRule(t *testing.T) {
 
 		checkRoutes(t, r, map[string]string{
 			"kube_namespace1__new1__new1_example_org___test1__service1": "http://1.2.3.4:8080",
-			"kube_namespace1__new1__new1_example_org____":               "",
 			"kube_namespace1__new1__new1_example_org___test2__service1": "http://1.2.3.4:8080",
 		})
 	})
@@ -1430,10 +1421,8 @@ func TestHealthcheckReload(t *testing.T) {
 			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
-			"kube_namespace1__mega__foo_example_org____":                    "",
 			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
 			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
-			"kube_namespace1__mega__bar_example_org____":                    "",
 		})
 	})
 }
@@ -1768,49 +1757,6 @@ func TestHealthcheckOnTerm(t *testing.T) {
 
 		checkHealthcheck(t, r, true, false)
 	})
-}
-
-func TestCatchAllRoutes(t *testing.T) {
-	for _, tc := range []struct {
-		msg         string
-		routes      []*eskip.Route
-		hasCatchAll bool
-	}{
-		{
-			msg: "empty path expression is a catchall",
-			routes: []*eskip.Route{
-				{
-					PathRegexps: []string{},
-				},
-			},
-			hasCatchAll: true,
-		},
-		{
-			msg: "^/ path expression is a catchall",
-			routes: []*eskip.Route{
-				{
-					PathRegexps: []string{"^/"},
-				},
-			},
-			hasCatchAll: true,
-		},
-		{
-			msg: "^/test path expression is not a catchall",
-			routes: []*eskip.Route{
-				{
-					PathRegexps: []string{"^/test"},
-				},
-			},
-			hasCatchAll: false,
-		},
-	} {
-		t.Run(tc.msg, func(t *testing.T) {
-			catchAll := catchAllRoutes(tc.routes)
-			if catchAll != tc.hasCatchAll {
-				t.Errorf("expected %t, got %t", tc.hasCatchAll, catchAll)
-			}
-		})
-	}
 }
 
 func TestComputeBackendWeights(t *testing.T) {


### PR DESCRIPTION
Removes the `catchAll` route for Kubernetes ingress which was introduced
in #425.

The catchall was only per ingress object, but since the same hostname can be specified for multiple ingresses the catchall can overwrite a valid route in that case.

Example of the problem:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test-1
spec:
  rules:
  - host: example.org
    http:
      paths:
      - backend:
          serviceName: my-svc
          servicePort: 80
        path: /path1

---

apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test-2
spec:
  rules:
  - host: example.org
    http:
      paths:
      - backend:
          serviceName: my-svc
          servicePort: 80
```

The ingress definition for `test-1` would generate a catchall 404 route since only `/path1` is specified. The catch all would shadow the route created from the `test-2` ingress definition.

I think it's ok to remove this catchall for now since the behaviour is the same as long as you don't run with a custom value for `--default-http-status`.

I have created #436 to track properly implementing a catchall which is per hostname and not per ingress object.

Let me know what you think @aryszka @szuecs 