### PR TITLE
Check length of flag.Args() to ensure the were parsed correctly

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -227,6 +227,11 @@ func init() {
 	flag.StringVar(&pluginDir, "plugindir", ".", pluginDirUsage)
 	flag.IntVar(&defaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
 	flag.Parse()
+
+	// check if arguments were correctly parsed.
+	if len(flag.Args()) != 0 {
+		log.Fatalf("Invalid arguments: %s", flag.Args())
+	}
 }
 
 func parseDurationFlag(ds string) (time.Duration, error) {


### PR DESCRIPTION
This checks the length of `flag.Args()` which will be non-empty in case some flags were not parsed. This is to ensure that you don't accidentally run skipper with the wrong args.

We had an issue were the args were specified like: `./skipper skipper -kubernetes ..` which means non of the args are parsed because the `skipper` command is invalid meaning it's the same as running `./skipper`. With this check skipper would crash rather then running with the unintended default configuration.