### PR TITLE
Provide access to backend metrics from filters

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -75,11 +75,27 @@ type FilterContext interface {
 	// is 'Host' and calls this method.)
 	SetOutgoingHost(string)
 
+	// Metadata about the upstream proxy call available to the filters at response time
+	ProxyMetadata() ProxyMetadata
+
 	// Allow filters to collect metrics other than the default metrics (Filter Request, Filter Response methods)
 	Metrics() Metrics
 
 	// Allow filters to add Tags, Baggage to the trace or set the ComponentName.
 	Tracer() opentracing.Tracer
+}
+
+// ProxyMetadata provides details about the proxy level calls upstream to filters
+// this means filters can record details of the underlying backend calls if they wish
+type ProxyMetadata interface {
+	// Time spent in Skipper before sending the request to upstream proxy
+	SendingTime() time.Duration
+
+	// Time spent waiting for a response from upstream proxy
+	WaitingTime() time.Duration
+
+	// Time spent receiving the response from the upstream proxy
+	ReceivingTime() time.Duration
 }
 
 // Metrics provides possibility to use custom metrics from filter implementations. The custom metrics will

--- a/filters/filtertest/filtertest.go
+++ b/filters/filtertest/filtertest.go
@@ -43,6 +43,7 @@ type Context struct {
 	FStateBag           map[string]interface{}
 	FBackendUrl         string
 	FOutgoingHost       string
+	FProxyMetadata      filters.ProxyMetadata
 	FMetrics            filters.Metrics
 	FTracer             opentracing.Tracer
 }
@@ -51,19 +52,20 @@ func (spec *Filter) Name() string                    { return spec.FilterName }
 func (f *Filter) Request(ctx filters.FilterContext)  {}
 func (f *Filter) Response(ctx filters.FilterContext) {}
 
-func (fc *Context) ResponseWriter() http.ResponseWriter { return fc.FResponseWriter }
-func (fc *Context) Request() *http.Request              { return fc.FRequest }
-func (fc *Context) Response() *http.Response            { return fc.FResponse }
-func (fc *Context) MarkServed()                         { fc.FServed = true }
-func (fc *Context) Served() bool                        { return fc.FServed }
-func (fc *Context) PathParam(key string) string         { return fc.FParams[key] }
-func (fc *Context) StateBag() map[string]interface{}    { return fc.FStateBag }
-func (fc *Context) OriginalRequest() *http.Request      { return nil }
-func (fc *Context) OriginalResponse() *http.Response    { return nil }
-func (fc *Context) BackendUrl() string                  { return fc.FBackendUrl }
-func (fc *Context) OutgoingHost() string                { return fc.FOutgoingHost }
-func (fc *Context) SetOutgoingHost(h string)            { fc.FOutgoingHost = h }
-func (fc *Context) Metrics() filters.Metrics            { return fc.FMetrics }
+func (fc *Context) ResponseWriter() http.ResponseWriter  { return fc.FResponseWriter }
+func (fc *Context) Request() *http.Request               { return fc.FRequest }
+func (fc *Context) Response() *http.Response             { return fc.FResponse }
+func (fc *Context) MarkServed()                          { fc.FServed = true }
+func (fc *Context) Served() bool                         { return fc.FServed }
+func (fc *Context) PathParam(key string) string          { return fc.FParams[key] }
+func (fc *Context) StateBag() map[string]interface{}     { return fc.FStateBag }
+func (fc *Context) OriginalRequest() *http.Request       { return nil }
+func (fc *Context) OriginalResponse() *http.Response     { return nil }
+func (fc *Context) BackendUrl() string                   { return fc.FBackendUrl }
+func (fc *Context) OutgoingHost() string                 { return fc.FOutgoingHost }
+func (fc *Context) SetOutgoingHost(h string)             { fc.FOutgoingHost = h }
+func (fc *Context) ProxyMetadata() filters.ProxyMetadata { return fc.FProxyMetadata }
+func (fc *Context) Metrics() filters.Metrics             { return fc.FMetrics }
 func (fc *Context) Tracer() opentracing.Tracer {
 	if fc.FTracer != nil {
 		return fc.FTracer


### PR DESCRIPTION
Record send, wait & receive timings for backend calls and provide them
in the filter context for filters to use if they wish.

- Fixes #443