### PR TITLE
Add visualization Tree built from pathmux

### DIFF
--- a/pathmux/tree_test.go
+++ b/pathmux/tree_test.go
@@ -8,10 +8,6 @@ import (
 
 type HandlerFunc func(w http.ResponseWriter, r *http.Request, urlParams map[string]string)
 
-func dummyHandler(w http.ResponseWriter, r *http.Request, urlParams map[string]string) {
-
-}
-
 func addPath(t *testing.T, tree *node, path string) {
 	t.Logf("Adding path %s", path)
 	n, err := tree.addPath(path[1:], nil)
@@ -24,7 +20,6 @@ func addPath(t *testing.T, tree *node, path string) {
 	n.leafValue = handler
 }
 
-var test *testing.T
 
 func testPath(t *testing.T, tree *node, path string, expectPath string, expectedParams map[string]string) {
 	if t.Failed() {
@@ -112,7 +107,6 @@ func checkHandlerNodes(t *testing.T, n *node) {
 }
 
 func TestTree(t *testing.T) {
-	test = t
 	tree := &node{path: "/"}
 
 	addPath(t, tree, "/")
@@ -229,7 +223,6 @@ func TestTree(t *testing.T) {
 
 	checkHandlerNodes(t, tree)
 
-	test = nil
 }
 
 func TestPanics(t *testing.T) {

--- a/pathmux/tree_test.go
+++ b/pathmux/tree_test.go
@@ -20,7 +20,6 @@ func addPath(t *testing.T, tree *node, path string) {
 	n.leafValue = handler
 }
 
-
 func testPath(t *testing.T, tree *node, path string, expectPath string, expectedParams map[string]string) {
 	if t.Failed() {
 		t.FailNow()

--- a/pathmux/viztree.go
+++ b/pathmux/viztree.go
@@ -1,41 +1,53 @@
 package pathmux
 
-type vizNode struct {
-	path     string
-	children []*vizNode
+// Exploded version of the pathmux tree designed for being easy to use in a visualization.
+// Simple wildcard nodes are represented by the ':' prefix and free wildcard nodes with the '*' prefix.
+type VizTree struct {
+	Path     string // string representation of the node path
+	children []*VizTree
 	canMatch bool
 
 	// The wildcard names still waiting to be processed, should be always nil after the end of the conversion.
 	leafWildcardNames []string
 }
 
-type VizTree vizNode
-
+// Creates a new visualization tree from a pathmux.Tree.
 func NewVizTree(tree *Tree) *VizTree {
 	vizTree := aggregateTree((*node)(tree), "/")
-	return (*VizTree)(vizTree[0])
+	return vizTree[0]
 }
 
-func aggregateTree(tree *node, previousPath string) []*vizNode {
+// Return a child referenced by direct Path
+//
+// Example:
+//
+// - in a tree such as: / -> images -> abc
+//
+// looking for images in the root tree would yield the images subtree.
+func (n *VizTree) Child(path string) *VizTree {
+	return findNode(n.children, path)
+}
+
+func aggregateTree(tree *node, previousPath string) []*VizTree {
 	if tree == nil {
 		return nil
 	}
-	var currentNode, middleNode *vizNode
+	var currentNode, middleNode *VizTree
 	nextPath := previousPath + tree.path
-	// On every slash we create new nodes if the previous path has a value, otherwise we ignore it
+	// On every slash we create new nodes if the previous Path has a value, otherwise we ignore it
 	if tree.path == "/" {
 		if previousPath != "" {
-			currentNode = &vizNode{previousPath, nil, tree.leafValue != nil, tree.leafWildcardNames}
+			currentNode = &VizTree{previousPath, nil, tree.leafValue != nil, tree.leafWildcardNames}
 		}
 		nextPath = ""
 	} else {
 		// This is to handle intermediate nodes that are matched without a slash
 		if tree.leafValue != nil {
-			middleNode = &vizNode{nextPath, nil, true, tree.leafWildcardNames}
+			middleNode = &VizTree{nextPath, nil, true, tree.leafWildcardNames}
 		}
 	}
 	numberOfChildren := len(tree.staticChild)
-	children := make([]*vizNode, 0, numberOfChildren)
+	children := make([]*VizTree, 0, numberOfChildren)
 	for i := 0; i < numberOfChildren; i++ {
 		childrenNodes := aggregateTree(tree.staticChild[i], nextPath)
 		children = append(children, childrenNodes...)
@@ -46,18 +58,18 @@ func aggregateTree(tree *node, previousPath string) []*vizNode {
 	children = append(children, childrenNodes...)
 
 	if tree.catchAllChild != nil && tree.catchAllChild.leafValue != nil {
-		children = append(children, &vizNode{"*" + tree.catchAllChild.path, nil, true, sliceLeafNames(tree.catchAllChild.leafWildcardNames)})
+		children = append(children, &VizTree{"*" + tree.catchAllChild.path, nil, true, sliceLeafNames(tree.catchAllChild.leafWildcardNames)})
 	}
 	if currentNode != nil {
 		if leafWildcardNames != nil {
 			currentNode.leafWildcardNames = leafWildcardNames
 		}
 		currentNode.children = children
-		return []*vizNode{currentNode}
+		return []*VizTree{currentNode}
 	}
 	if middleNode != nil {
 		// Prevent duplication of intermediate nodes
-		if previousNode := getNode(children, middleNode.path); previousNode == nil {
+		if previousNode := findNode(children, middleNode.Path); previousNode == nil {
 			if leafWildcardNames != nil {
 				middleNode.leafWildcardNames = leafWildcardNames
 			}
@@ -72,25 +84,16 @@ func aggregateTree(tree *node, previousPath string) []*vizNode {
 	return children
 }
 
-func (n *vizNode) child(path string) *vizNode {
-	for i := 0; i < len(n.children); i++ {
-		child := n.children[i]
-		if path == child.path {
-			return child
-		}
-	}
-	return nil
-}
-func processWildCardNode(tree *node) []*vizNode {
+func processWildCardNode(tree *node) []*VizTree {
 	if tree == nil {
 		return nil
 	}
 	numberOfChildren := len(tree.staticChild)
 	if tree.leafWildcardNames != nil && numberOfChildren == 0 {
 		currentPath, leafWildcardNames := tree.leafWildcardNames[len(tree.leafWildcardNames)-1], sliceLeafNames(tree.leafWildcardNames)
-		return []*vizNode{{":" + currentPath, nil, tree.leafValue != nil, leafWildcardNames}}
+		return []*VizTree{{":" + currentPath, nil, tree.leafValue != nil, leafWildcardNames}}
 	}
-	children := make([]*vizNode, 0, numberOfChildren)
+	children := make([]*VizTree, 0, numberOfChildren)
 	for i := 0; i < numberOfChildren; i++ {
 		childrenNodes := aggregateTree(tree.staticChild[i], "")
 		for j := 0; j < len(childrenNodes); j++ {
@@ -98,8 +101,8 @@ func processWildCardNode(tree *node) []*vizNode {
 			if child.leafWildcardNames != nil {
 				currentPath, leafWildcardNames := ":"+child.leafWildcardNames[len(child.leafWildcardNames)-1], sliceLeafNames(child.leafWildcardNames)
 				child.leafWildcardNames = nil
-				if previousNode := getNode(children, currentPath); previousNode == nil {
-					child = &vizNode{currentPath, []*vizNode{child}, tree.leafValue != nil, leafWildcardNames}
+				if previousNode := findNode(children, currentPath); previousNode == nil {
+					child = &VizTree{currentPath, []*VizTree{child}, tree.leafValue != nil, leafWildcardNames}
 				} else {
 					previousNode.children = append(previousNode.children, child)
 					child = nil
@@ -113,16 +116,18 @@ func processWildCardNode(tree *node) []*vizNode {
 
 	return children
 }
-func getNode(children []*vizNode, path string) *vizNode {
+
+func findNode(children []*VizTree, path string) *VizTree {
 	for i := 0; i < len(children); i++ {
 		child := children[i]
-		if path == child.path {
+		if path == child.Path {
 			return child
 		}
 	}
 	return nil
 }
-func getLeafNames(children []*vizNode, removeFromChildren bool) []string {
+
+func getLeafNames(children []*VizTree, removeFromChildren bool) []string {
 	var leafWildcardNames []string
 	for i := 0; i < len(children); i++ {
 		if children[i].leafWildcardNames != nil {
@@ -134,6 +139,7 @@ func getLeafNames(children []*vizNode, removeFromChildren bool) []string {
 	}
 	return leafWildcardNames
 }
+
 func sliceLeafNames(names []string) []string {
 	if names == nil || len(names) < 2 {
 		return nil

--- a/pathmux/viztree.go
+++ b/pathmux/viztree.go
@@ -1,0 +1,97 @@
+package pathmux
+
+type vizNode struct {
+	path     string
+	children []*vizNode
+	canMatch bool
+}
+
+func MakeVizTree(tree *node) (*vizNode) {
+	return aggregateTree(tree, nil, "/")
+}
+
+func aggregateTree(tree *node, vizTree *vizNode, previousPath string) (*vizNode) {
+	numberOfChildren := len(tree.staticChild)
+	if numberOfChildren == 0 {
+		// No leafValue means this node should be ignored
+		if tree.leafValue == nil {
+			var previousNode *vizNode
+			if vizTree != nil {
+				previousNode = vizTree.child(previousPath)
+			}
+			if tree.catchAllChild != nil && tree.catchAllChild.leafValue != nil {
+				catchAllChild := &vizNode{"*" + tree.catchAllChild.path, nil, true}
+				if previousNode != nil {
+					previousNode.children = append(previousNode.children, catchAllChild)
+				} else if vizTree != nil {
+					vizTree.children = append(vizTree.children, catchAllChild)
+				} else {
+					return catchAllChild
+				}
+			}
+			return vizTree
+		}
+		var childPath string
+		if tree.path == "/" {
+			childPath = previousPath
+		} else {
+			childPath = previousPath + tree.path
+		}
+		newChildNode := &vizNode{childPath, nil, true}
+		if vizTree != nil {
+			vizTree.children = append(vizTree.children, newChildNode)
+		} else {
+			vizTree = newChildNode
+		}
+		return vizTree
+	}
+	var newChildNode *vizNode
+	nextPath := previousPath + tree.path
+	if tree.path == "/" {
+		nextPath = ""
+		var previousNode *vizNode
+		if vizTree != nil {
+			previousNode = vizTree.child(previousPath)
+		}
+		if previousNode == nil {
+			newChildNode = &vizNode{previousPath, nil, tree.leafValue != nil}
+			if vizTree != nil {
+				vizTree.children = append(vizTree.children, newChildNode)
+			} else {
+				vizTree = newChildNode
+			}
+		} else {
+			newChildNode = previousNode
+		}
+	} else {
+		if tree.leafValue != nil {
+			newChildNode = &vizNode{nextPath, nil, true}
+			if vizTree != nil {
+				vizTree.children = append(vizTree.children, newChildNode)
+			} else {
+				vizTree = newChildNode
+			}
+		}
+		newChildNode = vizTree
+
+	}
+	for i := 0; i < numberOfChildren; i++ {
+		child := tree.staticChild[i]
+		aggregateTree(child, newChildNode, nextPath)
+	}
+	if tree.catchAllChild != nil && tree.catchAllChild.leafValue != nil {
+		catchAllChild := &vizNode{"*" + tree.catchAllChild.path, nil, true}
+		newChildNode.children = append(newChildNode.children, catchAllChild)
+	}
+	return vizTree
+}
+
+func (n *vizNode) child(path string) (*vizNode) {
+	for i := 0; i < len(n.children); i++ {
+		child := n.children[i]
+		if path == child.path {
+			return child
+		}
+	}
+	return nil
+}

--- a/pathmux/viztree.go
+++ b/pathmux/viztree.go
@@ -11,12 +11,12 @@ type vizNode struct {
 
 type VizTree vizNode
 
-func NewVizTree(tree *Tree) (*VizTree) {
+func NewVizTree(tree *Tree) *VizTree {
 	vizTree := aggregateTree((*node)(tree), "/")
 	return (*VizTree)(vizTree[0])
 }
 
-func aggregateTree(tree *node, previousPath string) ([]*vizNode) {
+func aggregateTree(tree *node, previousPath string) []*vizNode {
 	if tree == nil {
 		return nil
 	}
@@ -72,7 +72,7 @@ func aggregateTree(tree *node, previousPath string) ([]*vizNode) {
 	return children
 }
 
-func (n *vizNode) child(path string) (*vizNode) {
+func (n *vizNode) child(path string) *vizNode {
 	for i := 0; i < len(n.children); i++ {
 		child := n.children[i]
 		if path == child.path {
@@ -81,7 +81,7 @@ func (n *vizNode) child(path string) (*vizNode) {
 	}
 	return nil
 }
-func processWildCardNode(tree *node) ([]*vizNode) {
+func processWildCardNode(tree *node) []*vizNode {
 	if tree == nil {
 		return nil
 	}
@@ -113,7 +113,7 @@ func processWildCardNode(tree *node) ([]*vizNode) {
 
 	return children
 }
-func getNode(children []*vizNode, path string) (*vizNode) {
+func getNode(children []*vizNode, path string) *vizNode {
 	for i := 0; i < len(children); i++ {
 		child := children[i]
 		if path == child.path {
@@ -122,7 +122,7 @@ func getNode(children []*vizNode, path string) (*vizNode) {
 	}
 	return nil
 }
-func getLeafNames(children []*vizNode, removeFromChildren bool) ([]string) {
+func getLeafNames(children []*vizNode, removeFromChildren bool) []string {
 	var leafWildcardNames []string
 	for i := 0; i < len(children); i++ {
 		if children[i].leafWildcardNames != nil {
@@ -134,7 +134,7 @@ func getLeafNames(children []*vizNode, removeFromChildren bool) ([]string) {
 	}
 	return leafWildcardNames
 }
-func sliceLeafNames(names []string) ([]string) {
+func sliceLeafNames(names []string) []string {
 	if names == nil || len(names) < 2 {
 		return nil
 	}

--- a/pathmux/viztree_test.go
+++ b/pathmux/viztree_test.go
@@ -49,36 +49,36 @@ func TestVizTree(t *testing.T) {
 	addPathToTree(t, tree, "/:something/abc")
 	addPathToTree(t, tree, "/:something/def")
 
-	vizTree := (*vizNode)(NewVizTree(tree))
+	vizTree := (*VizTree)(NewVizTree(tree))
 	if !vizTree.canMatch {
 		t.Error("/ should match")
 		return
 	}
 	testChildren(t, vizTree, []string{"i", "ima", "images", "images1", "images2", "apples", "apples1", "appeasement", "appealing", "app", "date", "plaster", ":page", "post", "users", ":something"})
 	testIfChildMatch(t, vizTree, "i")
-	testChildren(t, vizTree.child("i"), []string{":aaa"})
+	testChildren(t, vizTree.Child("i"), []string{":aaa"})
 	testIfChildMatch(t, vizTree, "images")
-	testChildren(t, vizTree.child("images"), []string{"abc.jpg", "*path", ":imgname"})
-	testChildren(t, vizTree.child("images").child("abc.jpg"), []string{":size"})
+	testChildren(t, vizTree.Child("images"), []string{"abc.jpg", "*path", ":imgname"})
+	testChildren(t, vizTree.Child("images").Child("abc.jpg"), []string{":size"})
 	testIfChildMatch(t, vizTree, "images1")
-	testChildren(t, vizTree.child("images1"), []string{"*path1"})
+	testChildren(t, vizTree.Child("images1"), []string{"*path1"})
 	testIfChildMatch(t, vizTree, "app")
-	testChildren(t, vizTree.child("app"), []string{"les"})
-	testChildren(t, vizTree.child(":something"), []string{"abc", "def"})
-	testChildren(t, vizTree.child("users"), []string{":pk", ":id"})
-	testChildren(t, vizTree.child("users").child(":pk"), []string{":related"})
-	testChildren(t, vizTree.child("users").child(":id"), []string{"updatePassword"})
-	testChildren(t, vizTree.child("post").child(":post").child("page"), []string{":page"})
-	testChildren(t, vizTree.child("date"), []string{":year"})
-	testChildren(t, vizTree.child("date").child(":year"), []string{":month", "month"})
-	testChildren(t, vizTree.child("date").child(":year").child(":month"), []string{":post", "abc", "*post"})
+	testChildren(t, vizTree.Child("app"), []string{"les"})
+	testChildren(t, vizTree.Child(":something"), []string{"abc", "def"})
+	testChildren(t, vizTree.Child("users"), []string{":pk", ":id"})
+	testChildren(t, vizTree.Child("users").Child(":pk"), []string{":related"})
+	testChildren(t, vizTree.Child("users").Child(":id"), []string{"updatePassword"})
+	testChildren(t, vizTree.Child("post").Child(":post").Child("page"), []string{":page"})
+	testChildren(t, vizTree.Child("date"), []string{":year"})
+	testChildren(t, vizTree.Child("date").Child(":year"), []string{":month", "month"})
+	testChildren(t, vizTree.Child("date").Child(":year").Child(":month"), []string{":post", "abc", "*post"})
 }
 
-func testChildren(t *testing.T, tree *vizNode, expectedChildren []string) {
+func testChildren(t *testing.T, tree *VizTree, expectedChildren []string) {
 	if t.Failed() {
 		t.FailNow()
 	}
-	t.Log("Testing children of", tree.path)
+	t.Log("Testing children of", tree.Path)
 	children, err := childrenString(tree)
 	if err != nil || children == nil {
 		t.Errorf("No children found")
@@ -98,20 +98,20 @@ func testChildren(t *testing.T, tree *vizNode, expectedChildren []string) {
 		return
 	}
 }
-func testIfChildMatch(t *testing.T, tree *vizNode, childPath string) {
+func testIfChildMatch(t *testing.T, tree *VizTree, childPath string) {
 	if t.Failed() {
 		t.FailNow()
 	}
-	t.Logf("Looking for child %v of %v", childPath, tree.path)
-	if tree.child(childPath) == nil {
-		t.Errorf("No children %v found in %v", childPath, tree.path)
+	t.Logf("Looking for child %v of %v", childPath, tree.Path)
+	if tree.Child(childPath) == nil {
+		t.Errorf("No children %v found in %v", childPath, tree.Path)
 		return
 	}
 }
 
-func childrenString(n *vizNode) (children []string, err error) {
+func childrenString(n *VizTree) (children []string, err error) {
 	for i := 0; i < len(n.children); i++ {
-		children = append(children, n.children[i].path)
+		children = append(children, n.children[i].Path)
 	}
 	return
 }

--- a/pathmux/viztree_test.go
+++ b/pathmux/viztree_test.go
@@ -71,16 +71,16 @@ func TestVizTree(t *testing.T) {
 	testIfChildMatches(t, vizTree, "images2")
 	testChildren(t, vizTree.child("images1"), "*path1")
 	testIfChildMatches(t, vizTree.child("images1"), "*path1")
-	testIfChildDoesNotMatches(t, vizTree, "app")
+	testIfChildDoesNotMatch(t, vizTree, "app")
 	testChildren(t, vizTree.child("app"), "les")
 	testIfChildMatches(t, vizTree.child("app"), "les")
 	testIfChildMatches(t, vizTree, "apples")
 	testIfChildMatches(t, vizTree, "apples1")
 	testIfChildMatches(t, vizTree, "appeasement")
 	testIfChildMatches(t, vizTree, "appealing")
-	testIfChildDoesNotMatches(t, vizTree, "date")
+	testIfChildDoesNotMatch(t, vizTree, "date")
 	testChildren(t, vizTree.child("date"), ":year")
-	testIfChildDoesNotMatches(t, vizTree.child("date"), ":year")
+	testIfChildDoesNotMatch(t, vizTree.child("date"), ":year")
 	testChildren(t, vizTree.child("date").child(":year"), ":month", "month")
 	testIfChildMatches(t, vizTree.child("date").child(":year"), ":month")
 	testIfChildMatches(t, vizTree.child("date").child(":year"), "month")
@@ -91,22 +91,22 @@ func TestVizTree(t *testing.T) {
 	testIfChildMatches(t, vizTree, ":page")
 	testChildren(t, vizTree.child(":page"), ":index")
 	testIfChildMatches(t, vizTree.child(":page"), ":index")
-	testIfChildDoesNotMatches(t, vizTree, "post")
+	testIfChildDoesNotMatch(t, vizTree, "post")
 	testChildren(t, vizTree.child("post"), ":post")
-	testIfChildDoesNotMatches(t, vizTree.child("post"), ":post")
+	testIfChildDoesNotMatch(t, vizTree.child("post"), ":post")
 	testChildren(t, vizTree.child("post").child(":post"), "page")
-	testIfChildDoesNotMatches(t, vizTree.child("post").child(":post"), "page")
+	testIfChildDoesNotMatch(t, vizTree.child("post").child(":post"), "page")
 	testChildren(t, vizTree.child("post").child(":post").child("page"), ":page")
 	testIfChildMatches(t, vizTree.child("post").child(":post").child("page"), ":page")
 	testIfChildMatches(t, vizTree, "plaster")
-	testIfChildDoesNotMatches(t, vizTree, ":something")
+	testIfChildDoesNotMatch(t, vizTree, ":something")
 	testChildren(t, vizTree.child(":something"), "abc", "def")
 	testIfChildMatches(t, vizTree.child(":something"), "abc")
 	testIfChildMatches(t, vizTree.child(":something"), "def")
-	testIfChildDoesNotMatches(t, vizTree, "users")
+	testIfChildDoesNotMatch(t, vizTree, "users")
 	testChildren(t, vizTree.child("users"), ":pk", ":id")
-	testIfChildDoesNotMatches(t, vizTree.child("users"), ":pk")
-	testIfChildDoesNotMatches(t, vizTree.child("users"), ":id")
+	testIfChildDoesNotMatch(t, vizTree.child("users"), ":pk")
+	testIfChildDoesNotMatch(t, vizTree.child("users"), ":id")
 	testChildren(t, vizTree.child("users").child(":pk"), ":related")
 	testChildren(t, vizTree.child("users").child(":id"), "updatePassword")
 	testIfChildMatches(t, vizTree.child("users").child(":pk"), ":related")
@@ -115,8 +115,8 @@ func TestVizTree(t *testing.T) {
 
 func testChildren(t *testing.T, tree *VizTree, expectedChildren ...string) {
 	t.Log("Testing children of", tree.Path)
-	children, err := childrenString(tree)
-	if err != nil || children == nil {
+	children := childrenString(tree)
+	if children == nil {
 		t.Fatalf("No children found")
 		return
 	}
@@ -144,7 +144,7 @@ func testIfChildMatches(t *testing.T, tree *VizTree, childPath string) {
 	}
 }
 
-func testIfChildDoesNotMatches(t *testing.T, tree *VizTree, childPath string) {
+func testIfChildDoesNotMatch(t *testing.T, tree *VizTree, childPath string) {
 	t.Logf("Checking if child %v of %v has no matcher", childPath, tree.Path)
 	child := tree.child(childPath)
 	if child == nil {
@@ -159,7 +159,7 @@ func (n *VizTree) child(path string) *VizTree {
 	return findNode(n.Children, path)
 }
 
-func childrenString(n *VizTree) (children []string, err error) {
+func childrenString(n *VizTree) (children []string) {
 	for _, child := range n.Children {
 		children = append(children, child.Path)
 	}

--- a/pathmux/viztree_test.go
+++ b/pathmux/viztree_test.go
@@ -1,0 +1,113 @@
+package pathmux
+
+import (
+	"testing"
+	"reflect"
+	"fmt"
+)
+
+
+func addPathToTree(t *testing.T, tree *node, path string) {
+	t.Logf("Adding path %s", path)
+	n, err := tree.addPath(path[1:], nil)
+	if err != nil {
+		t.Error(err)
+	}
+	n.leafValue = true // To make sure it is properly marked as a used node
+}
+
+func TestVizTree(t *testing.T) {
+	tree := &node{path: "/"}
+
+	addPathToTree(t, tree, "/")
+	addPathToTree(t, tree, "/i")
+	addPathToTree(t, tree, "/i/:aaa")
+	addPathToTree(t, tree, "/images")
+	addPathToTree(t, tree, "/images/abc.jpg")
+	addPathToTree(t, tree, "/images/:imgname")
+	addPathToTree(t, tree, "/images/*path")
+	addPathToTree(t, tree, "/ima")
+	addPathToTree(t, tree, "/ima/:par")
+	addPathToTree(t, tree, "/images1")
+	addPathToTree(t, tree, "/images1/*path1")
+	addPathToTree(t, tree, "/images2")
+	addPathToTree(t, tree, "/apples")
+	addPathToTree(t, tree, "/app/les")
+	addPathToTree(t, tree, "/apples1")
+	addPathToTree(t, tree, "/appeasement")
+	addPathToTree(t, tree, "/appealing")
+	addPathToTree(t, tree, "/date/:year/:month")
+	addPathToTree(t, tree, "/date/:year/month")
+	addPathToTree(t, tree, "/date/:year/:month/abc")
+	addPathToTree(t, tree, "/date/:year/:month/:post")
+	addPathToTree(t, tree, "/date/:year/:month/*post")
+	addPathToTree(t, tree, "/:page")
+	addPathToTree(t, tree, "/:page/:index")
+	addPathToTree(t, tree, "/post/:post/page/:page")
+	addPathToTree(t, tree, "/plaster")
+	addPathToTree(t, tree, "/users/:pk/:related")
+	addPathToTree(t, tree, "/users/:id/updatePassword")
+	addPathToTree(t, tree, "/:something/abc")
+	addPathToTree(t, tree, "/:something/def")
+
+	vizTree := MakeVizTree(tree)
+	printVizTree(vizTree)
+	if !vizTree.canMatch {
+		t.Error("/ should match")
+		return
+	}
+	testChildren(t, vizTree,  []string {"i", "ima", "images", "images1", "images2", "apples",  "apples1",  "appeasement","appealing", "app", "plaster"})
+	testIfChildMatch(t, vizTree, "images")
+	testChildren(t, vizTree.child("images"),  []string {"abc.jpg", "*path"})
+	testIfChildMatch(t, vizTree, "images1")
+	testChildren(t, vizTree.child("images1"),  []string {"*path1"})
+	testIfChildMatch(t, vizTree, "app")
+	testChildren(t, vizTree.child("app"),  []string {"les"})
+}
+
+func testChildren(t *testing.T, tree *vizNode, expectedChildren []string) {
+	if t.Failed() {
+		t.FailNow()
+	}
+	t.Log("Testing children of", tree.path)
+	children, err := childrenString(tree)
+	if err != nil || children == nil {
+		t.Errorf("No children found")
+		return
+	}
+	if !reflect.DeepEqual(children, expectedChildren) {
+		t.Errorf("Children  %v are different from expected children %v", children, expectedChildren)
+		return
+	}
+}
+func testIfChildMatch(t *testing.T, tree *vizNode, childPath string) {
+	if t.Failed() {
+		t.FailNow()
+	}
+	t.Logf("Looking for child %v of %v", childPath, tree.path)
+	if tree.child(childPath) == nil {
+		t.Errorf("No children %v found in %v", childPath, tree.path)
+		return
+	}
+}
+
+func childrenString(n *vizNode) (children []string, err error) {
+	for i := 0; i < len(n.children); i++ {
+		children = append(children, n.children[i].path)
+	}
+	return
+}
+
+func printVizTree(vizTree *vizNode) {
+	if len(vizTree.children) > 0 {
+		fmt.Println("printing vizsubtree ", vizTree.path)
+	}
+	for i := 0; i < len(vizTree.children); i++ {
+		child := vizTree.children[i]
+		fmt.Println("path ", child.path)
+	}
+	for i := 0; i < len(vizTree.children); i++ {
+		child := vizTree.children[i]
+		printVizTree(child)
+	}
+}

--- a/pathmux/viztree_test.go
+++ b/pathmux/viztree_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"reflect"
 	"fmt"
+	"sort"
 )
-
 
 func addPathToTree(t *testing.T, tree *node, path string) {
 	t.Logf("Adding path %s", path)
@@ -24,6 +24,7 @@ func TestVizTree(t *testing.T) {
 	addPathToTree(t, tree, "/i/:aaa")
 	addPathToTree(t, tree, "/images")
 	addPathToTree(t, tree, "/images/abc.jpg")
+	addPathToTree(t, tree, "/images/abc.jpg/:size")
 	addPathToTree(t, tree, "/images/:imgname")
 	addPathToTree(t, tree, "/images/*path")
 	addPathToTree(t, tree, "/ima")
@@ -56,13 +57,13 @@ func TestVizTree(t *testing.T) {
 		t.Error("/ should match")
 		return
 	}
-	testChildren(t, vizTree,  []string {"i", "ima", "images", "images1", "images2", "apples",  "apples1",  "appeasement","appealing", "app", "plaster"})
+	testChildren(t, vizTree,  []string {"i", "ima", "images", "images1", "images2", "apples",  "apples1",  "appeasement","appealing", "app", "date", "plaster", "post", "users"})
 	testIfChildMatch(t, vizTree, "images")
-	testChildren(t, vizTree.child("images"),  []string {"abc.jpg", "*path"})
+	testChildren(t, vizTree.child("images"), []string{"abc.jpg", "*path"})
 	testIfChildMatch(t, vizTree, "images1")
-	testChildren(t, vizTree.child("images1"),  []string {"*path1"})
+	testChildren(t, vizTree.child("images1"), []string{"*path1"})
 	testIfChildMatch(t, vizTree, "app")
-	testChildren(t, vizTree.child("app"),  []string {"les"})
+	testChildren(t, vizTree.child("app"), []string{"les"})
 }
 
 func testChildren(t *testing.T, tree *vizNode, expectedChildren []string) {
@@ -75,8 +76,10 @@ func testChildren(t *testing.T, tree *vizNode, expectedChildren []string) {
 		t.Errorf("No children found")
 		return
 	}
+	sort.Strings(expectedChildren)
+	sort.Strings(children)
 	if !reflect.DeepEqual(children, expectedChildren) {
-		t.Errorf("Children  %v are different from expected children %v", children, expectedChildren)
+		t.Errorf("Children  %v are different \n from expected children %v", children, expectedChildren)
 		return
 	}
 }

--- a/pathmux/viztree_test.go
+++ b/pathmux/viztree_test.go
@@ -3,29 +3,27 @@ package pathmux
 import (
 	"testing"
 	"reflect"
-	"fmt"
 	"sort"
 )
 
-func addPathToTree(t *testing.T, tree *node, path string) {
+func addPathToTree(t *testing.T, tree *Tree, path string) {
 	t.Logf("Adding path %s", path)
-	n, err := tree.addPath(path[1:], nil)
+	err := tree.Add(path, true)
 	if err != nil {
 		t.Error(err)
 	}
-	n.leafValue = true // To make sure it is properly marked as a used node
 }
 
 func TestVizTree(t *testing.T) {
-	tree := &node{path: "/"}
+	tree := &Tree{path: "/"}
 
 	addPathToTree(t, tree, "/")
 	addPathToTree(t, tree, "/i")
 	addPathToTree(t, tree, "/i/:aaa")
-	addPathToTree(t, tree, "/images")
 	addPathToTree(t, tree, "/images/abc.jpg")
 	addPathToTree(t, tree, "/images/abc.jpg/:size")
 	addPathToTree(t, tree, "/images/:imgname")
+	addPathToTree(t, tree, "/images")
 	addPathToTree(t, tree, "/images/*path")
 	addPathToTree(t, tree, "/ima")
 	addPathToTree(t, tree, "/ima/:par")
@@ -51,19 +49,29 @@ func TestVizTree(t *testing.T) {
 	addPathToTree(t, tree, "/:something/abc")
 	addPathToTree(t, tree, "/:something/def")
 
-	vizTree := MakeVizTree(tree)
-	printVizTree(vizTree)
+	vizTree := (*vizNode)(NewVizTree(tree))
 	if !vizTree.canMatch {
 		t.Error("/ should match")
 		return
 	}
-	testChildren(t, vizTree,  []string {"i", "ima", "images", "images1", "images2", "apples",  "apples1",  "appeasement","appealing", "app", "date", "plaster", "post", "users"})
+	testChildren(t, vizTree, []string{"i", "ima", "images", "images1", "images2", "apples", "apples1", "appeasement", "appealing", "app", "date", "plaster", ":page", "post", "users", ":something"})
+	testIfChildMatch(t, vizTree, "i")
+	testChildren(t, vizTree.child("i"), []string{":aaa"})
 	testIfChildMatch(t, vizTree, "images")
-	testChildren(t, vizTree.child("images"), []string{"abc.jpg", "*path"})
+	testChildren(t, vizTree.child("images"), []string{"abc.jpg", "*path", ":imgname"})
+	testChildren(t, vizTree.child("images").child("abc.jpg"), []string{":size"})
 	testIfChildMatch(t, vizTree, "images1")
 	testChildren(t, vizTree.child("images1"), []string{"*path1"})
 	testIfChildMatch(t, vizTree, "app")
 	testChildren(t, vizTree.child("app"), []string{"les"})
+	testChildren(t, vizTree.child(":something"), []string{"abc", "def"})
+	testChildren(t, vizTree.child("users"), []string{":pk", ":id"})
+	testChildren(t, vizTree.child("users").child(":pk"), []string{":related"})
+	testChildren(t, vizTree.child("users").child(":id"), []string{"updatePassword"})
+	testChildren(t, vizTree.child("post").child(":post").child("page"), []string{":page"})
+	testChildren(t, vizTree.child("date"), []string{":year"})
+	testChildren(t, vizTree.child("date").child(":year"), []string{":month", "month"})
+	testChildren(t, vizTree.child("date").child(":year").child(":month"), []string{":post", "abc", "*post"})
 }
 
 func testChildren(t *testing.T, tree *vizNode, expectedChildren []string) {
@@ -75,6 +83,13 @@ func testChildren(t *testing.T, tree *vizNode, expectedChildren []string) {
 	if err != nil || children == nil {
 		t.Errorf("No children found")
 		return
+	}
+
+	for i := 0; i < len(tree.children); i++ {
+		if tree.children[i].leafWildcardNames != nil {
+			t.Errorf("leafWildcardNames different from nil")
+			return
+		}
 	}
 	sort.Strings(expectedChildren)
 	sort.Strings(children)
@@ -99,18 +114,4 @@ func childrenString(n *vizNode) (children []string, err error) {
 		children = append(children, n.children[i].path)
 	}
 	return
-}
-
-func printVizTree(vizTree *vizNode) {
-	if len(vizTree.children) > 0 {
-		fmt.Println("printing vizsubtree ", vizTree.path)
-	}
-	for i := 0; i < len(vizTree.children); i++ {
-		child := vizTree.children[i]
-		fmt.Println("path ", child.path)
-	}
-	for i := 0; i < len(vizTree.children); i++ {
-		child := vizTree.children[i]
-		printVizTree(child)
-	}
 }

--- a/pathmux/viztree_test.go
+++ b/pathmux/viztree_test.go
@@ -1,9 +1,9 @@
 package pathmux
 
 import (
-	"testing"
 	"reflect"
 	"sort"
+	"testing"
 )
 
 func addPathToTree(t *testing.T, tree *Tree, path string) {

--- a/pathmux/viztree_test.go
+++ b/pathmux/viztree_test.go
@@ -49,69 +49,119 @@ func TestVizTree(t *testing.T) {
 	addPathToTree(t, tree, "/:something/abc")
 	addPathToTree(t, tree, "/:something/def")
 
-	vizTree := (*VizTree)(NewVizTree(tree))
-	if !vizTree.canMatch {
-		t.Error("/ should match")
-		return
+	vizTree := NewVizTree(tree)
+	if !vizTree.CanMatch {
+		t.Fatalf("/ should match")
 	}
-	testChildren(t, vizTree, []string{"i", "ima", "images", "images1", "images2", "apples", "apples1", "appeasement", "appealing", "app", "date", "plaster", ":page", "post", "users", ":something"})
-	testIfChildMatch(t, vizTree, "i")
-	testChildren(t, vizTree.Child("i"), []string{":aaa"})
-	testIfChildMatch(t, vizTree, "images")
-	testChildren(t, vizTree.Child("images"), []string{"abc.jpg", "*path", ":imgname"})
-	testChildren(t, vizTree.Child("images").Child("abc.jpg"), []string{":size"})
-	testIfChildMatch(t, vizTree, "images1")
-	testChildren(t, vizTree.Child("images1"), []string{"*path1"})
-	testIfChildMatch(t, vizTree, "app")
-	testChildren(t, vizTree.Child("app"), []string{"les"})
-	testChildren(t, vizTree.Child(":something"), []string{"abc", "def"})
-	testChildren(t, vizTree.Child("users"), []string{":pk", ":id"})
-	testChildren(t, vizTree.Child("users").Child(":pk"), []string{":related"})
-	testChildren(t, vizTree.Child("users").Child(":id"), []string{"updatePassword"})
-	testChildren(t, vizTree.Child("post").Child(":post").Child("page"), []string{":page"})
-	testChildren(t, vizTree.Child("date"), []string{":year"})
-	testChildren(t, vizTree.Child("date").Child(":year"), []string{":month", "month"})
-	testChildren(t, vizTree.Child("date").Child(":year").Child(":month"), []string{":post", "abc", "*post"})
+	testChildren(t, vizTree, "i", "ima", "images", "images1", "images2", "apples", "apples1", "appeasement", "appealing", "app", "date", "plaster", ":page", "post", "users", ":something")
+	testIfChildMatches(t, vizTree, "i")
+	testChildren(t, vizTree.child("i"), ":aaa")
+	testIfChildMatches(t, vizTree.child("i"), ":aaa")
+	testIfChildMatches(t, vizTree, "images")
+	testChildren(t, vizTree.child("images"), "abc.jpg", "*path", ":imgname")
+	testIfChildMatches(t, vizTree.child("images"), "abc.jpg")
+	testIfChildMatches(t, vizTree.child("images"), ":imgname")
+	testIfChildMatches(t, vizTree.child("images"), "*path")
+	testChildren(t, vizTree.child("images").child("abc.jpg"), ":size")
+	testIfChildMatches(t, vizTree.child("images").child("abc.jpg"), ":size")
+	testIfChildMatches(t, vizTree, "ima")
+	testChildren(t, vizTree.child("ima"), ":par")
+	testIfChildMatches(t, vizTree.child("ima"), ":par")
+	testIfChildMatches(t, vizTree, "images1")
+	testIfChildMatches(t, vizTree, "images2")
+	testChildren(t, vizTree.child("images1"), "*path1")
+	testIfChildMatches(t, vizTree.child("images1"), "*path1")
+	testIfChildDoesNotMatches(t, vizTree, "app")
+	testChildren(t, vizTree.child("app"), "les")
+	testIfChildMatches(t, vizTree.child("app"), "les")
+	testIfChildMatches(t, vizTree, "apples")
+	testIfChildMatches(t, vizTree, "apples1")
+	testIfChildMatches(t, vizTree, "appeasement")
+	testIfChildMatches(t, vizTree, "appealing")
+	testIfChildDoesNotMatches(t, vizTree, "date")
+	testChildren(t, vizTree.child("date"), ":year")
+	testIfChildDoesNotMatches(t, vizTree.child("date"), ":year")
+	testChildren(t, vizTree.child("date").child(":year"), ":month", "month")
+	testIfChildMatches(t, vizTree.child("date").child(":year"), ":month")
+	testIfChildMatches(t, vizTree.child("date").child(":year"), "month")
+	testChildren(t, vizTree.child("date").child(":year").child(":month"), ":post", "abc", "*post")
+	testIfChildMatches(t, vizTree.child("date").child(":year").child(":month"), ":post")
+	testIfChildMatches(t, vizTree.child("date").child(":year").child(":month"), "*post")
+	testIfChildMatches(t, vizTree.child("date").child(":year").child(":month"), "abc")
+	testIfChildMatches(t, vizTree, ":page")
+	testChildren(t, vizTree.child(":page"), ":index")
+	testIfChildMatches(t, vizTree.child(":page"), ":index")
+	testIfChildDoesNotMatches(t, vizTree, "post")
+	testChildren(t, vizTree.child("post"), ":post")
+	testIfChildDoesNotMatches(t, vizTree.child("post"), ":post")
+	testChildren(t, vizTree.child("post").child(":post"), "page")
+	testIfChildDoesNotMatches(t, vizTree.child("post").child(":post"), "page")
+	testChildren(t, vizTree.child("post").child(":post").child("page"), ":page")
+	testIfChildMatches(t, vizTree.child("post").child(":post").child("page"), ":page")
+	testIfChildMatches(t, vizTree, "plaster")
+	testIfChildDoesNotMatches(t, vizTree, ":something")
+	testChildren(t, vizTree.child(":something"), "abc", "def")
+	testIfChildMatches(t, vizTree.child(":something"), "abc")
+	testIfChildMatches(t, vizTree.child(":something"), "def")
+	testIfChildDoesNotMatches(t, vizTree, "users")
+	testChildren(t, vizTree.child("users"), ":pk", ":id")
+	testIfChildDoesNotMatches(t, vizTree.child("users"), ":pk")
+	testIfChildDoesNotMatches(t, vizTree.child("users"), ":id")
+	testChildren(t, vizTree.child("users").child(":pk"), ":related")
+	testChildren(t, vizTree.child("users").child(":id"), "updatePassword")
+	testIfChildMatches(t, vizTree.child("users").child(":pk"), ":related")
+	testIfChildMatches(t, vizTree.child("users").child(":id"), "updatePassword")
 }
 
-func testChildren(t *testing.T, tree *VizTree, expectedChildren []string) {
-	if t.Failed() {
-		t.FailNow()
-	}
+func testChildren(t *testing.T, tree *VizTree, expectedChildren ...string) {
 	t.Log("Testing children of", tree.Path)
 	children, err := childrenString(tree)
 	if err != nil || children == nil {
-		t.Errorf("No children found")
+		t.Fatalf("No children found")
 		return
 	}
 
-	for i := 0; i < len(tree.children); i++ {
-		if tree.children[i].leafWildcardNames != nil {
-			t.Errorf("leafWildcardNames different from nil")
+	for _, child := range tree.Children {
+		if len(child.leafWildcardNames) != 0 {
+			t.Fatalf("leafWildcardNames different from nil")
 			return
 		}
 	}
 	sort.Strings(expectedChildren)
 	sort.Strings(children)
 	if !reflect.DeepEqual(children, expectedChildren) {
-		t.Errorf("Children  %v are different \n from expected children %v", children, expectedChildren)
-		return
+		t.Fatalf("Children  %v are different \n from expected children %v", children, expectedChildren)
 	}
 }
-func testIfChildMatch(t *testing.T, tree *VizTree, childPath string) {
-	if t.Failed() {
-		t.FailNow()
+func testIfChildMatches(t *testing.T, tree *VizTree, childPath string) {
+	t.Logf("Checking if child %v of %v has a matcher", childPath, tree.Path)
+	child := tree.child(childPath)
+	if child == nil {
+		t.Fatalf("No children %v found in %v", childPath, tree.Path)
 	}
-	t.Logf("Looking for child %v of %v", childPath, tree.Path)
-	if tree.Child(childPath) == nil {
-		t.Errorf("No children %v found in %v", childPath, tree.Path)
-		return
+	if !child.CanMatch {
+		t.Fatalf("Child %v has no matcher", child.Path)
 	}
 }
 
+func testIfChildDoesNotMatches(t *testing.T, tree *VizTree, childPath string) {
+	t.Logf("Checking if child %v of %v has no matcher", childPath, tree.Path)
+	child := tree.child(childPath)
+	if child == nil {
+		t.Fatalf("No children %v found in %v", childPath, tree.Path)
+	}
+	if child.CanMatch {
+		t.Fatalf("Child %v should have no matcher", child.Path)
+	}
+}
+
+func (n *VizTree) child(path string) *VizTree {
+	return findNode(n.Children, path)
+}
+
 func childrenString(n *VizTree) (children []string, err error) {
-	for i := 0; i < len(n.children); i++ {
-		children = append(children, n.children[i].Path)
+	for _, child := range n.Children {
+		children = append(children, child.Path)
 	}
 	return
 }


### PR DESCRIPTION
The visualization tree is basically an explosion of the radix tree used in pathmux.

It looks like a tree representation of a path broken down by its slashes. However, it is built from the original pathmux Tree.

It is included in the pathmux so it can access the inner representation of the tree.