### PR TITLE
Allow non-TTY applications to execute eskip commands

### DIFF
--- a/cmd/eskip/args.go
+++ b/cmd/eskip/args.go
@@ -17,10 +17,11 @@ package main
 import (
 	"errors"
 	"flag"
-	"golang.org/x/crypto/ssh/terminal"
 	"net/url"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -37,6 +38,7 @@ const (
 	appendFileFlag     = "append-file"
 	prettyFlag         = "pretty"
 	jsonFlag           = "json"
+	hasNoTTYFlag       = "no-tty"
 
 	defaultEtcdUrls     = "http://127.0.0.1:2379,http://127.0.0.1:4001"
 	defaultEtcdPrefix   = "/skipper"
@@ -70,6 +72,7 @@ var (
 	appendFileArg     string
 	pretty            bool
 	printJson         bool
+	hasNoTTY          bool
 )
 
 var (
@@ -103,6 +106,7 @@ func initFlags() {
 
 	flags.BoolVar(&pretty, prettyFlag, false, prettyUsage)
 	flags.BoolVar(&printJson, jsonFlag, false, jsonUsage)
+	flags.BoolVar(&hasNoTTY, hasNoTTYFlag, false, hasNoTTYUsage)
 }
 
 func init() {
@@ -205,7 +209,7 @@ func processStdin() *medium {
 	// what can go wrong
 	fdint := int(os.Stdin.Fd())
 
-	if isTest || terminal.IsTerminal(fdint) {
+	if isTest || terminal.IsTerminal(fdint) || hasNoTTY {
 		return nil
 	}
 

--- a/cmd/eskip/args.go
+++ b/cmd/eskip/args.go
@@ -38,7 +38,6 @@ const (
 	appendFileFlag     = "append-file"
 	prettyFlag         = "pretty"
 	jsonFlag           = "json"
-	hasNoTTYFlag       = "no-tty"
 
 	defaultEtcdUrls     = "http://127.0.0.1:2379,http://127.0.0.1:4001"
 	defaultEtcdPrefix   = "/skipper"
@@ -72,7 +71,6 @@ var (
 	appendFileArg     string
 	pretty            bool
 	printJson         bool
-	hasNoTTY          bool
 )
 
 var (
@@ -106,7 +104,6 @@ func initFlags() {
 
 	flags.BoolVar(&pretty, prettyFlag, false, prettyUsage)
 	flags.BoolVar(&printJson, jsonFlag, false, jsonUsage)
-	flags.BoolVar(&hasNoTTY, hasNoTTYFlag, false, hasNoTTYUsage)
 }
 
 func init() {
@@ -285,12 +282,12 @@ func processArgs() ([]*medium, error) {
 
 	if fileArg != nil {
 		media = append(media, fileArg)
-	}
+	} else {
+		stdinArg := processStdin()
 
-	stdinArg := processStdin()
-
-	if stdinArg != nil {
-		media = append(media, stdinArg)
+		if stdinArg != nil {
+			media = append(media, stdinArg)
+		}
 	}
 
 	patchMedia := processPatchArgs(

--- a/cmd/eskip/args.go
+++ b/cmd/eskip/args.go
@@ -206,7 +206,7 @@ func processStdin() *medium {
 	// what can go wrong
 	fdint := int(os.Stdin.Fd())
 
-	if isTest || terminal.IsTerminal(fdint) || hasNoTTY {
+	if isTest || terminal.IsTerminal(fdint) {
 		return nil
 	}
 

--- a/cmd/eskip/doc.go
+++ b/cmd/eskip/doc.go
@@ -83,6 +83,7 @@ const (
 	appendFileUsage     = "append filters from a file to each patched route"
 	prettyUsage         = "prints routes in a more readable format"
 	jsonUsage           = "prints routes as JSON"
+	hasNoTTYUsage       = "allows non-terminal applications to execute eskip commands"
 
 	// command line help (1):
 	help1 = `Usage: eskip <command> [media flags] [--] [file]

--- a/cmd/eskip/doc.go
+++ b/cmd/eskip/doc.go
@@ -83,7 +83,6 @@ const (
 	appendFileUsage     = "append filters from a file to each patched route"
 	prettyUsage         = "prints routes in a more readable format"
 	jsonUsage           = "prints routes as JSON"
-	hasNoTTYUsage       = "allows non-terminal applications to execute eskip commands"
 
 	// command line help (1):
 	help1 = `Usage: eskip <command> [media flags] [--] [file]
@@ -97,7 +96,7 @@ innkeeper     endpoint of an innkeeper server. See more about innkeeper:
               https://github.com/zalando/innkeeper
 etcd          endpoint(s) of an etcd cluster. See more about etcd:
               https://github.com/coreos/etcd
-stdin         standard input when not tty, expecting routes
+stdin         standard input when not tty, expecting routes but ignored if a file is provided
 file          a file containing routes
 inline        routes as command line parameter
 inline ids    a list of route ids (only for delete)


### PR DESCRIPTION
ref: https://github.com/zalando/skipper/issues/449

Introduce new flag: -no-tty