### PR TITLE
compatibility fix to the public builtin.Redirect() function

### DIFF
--- a/filters/builtin/redirect.go
+++ b/filters/builtin/redirect.go
@@ -149,12 +149,16 @@ func getLocation(ctx filters.FilterContext, location *url.URL, typ redirectType)
 	return u.String()
 }
 
-// Redirect implements the redirect logic as a standalone function.
-func Redirect(ctx filters.FilterContext, code int, location *url.URL, typ redirectType) {
+func redirectWithType(ctx filters.FilterContext, code int, location *url.URL, typ redirectType) {
 	u := getLocation(ctx, location, typ)
 	ctx.Serve(&http.Response{
 		StatusCode: code,
 		Header:     http.Header{"Location": []string{u}}})
+}
+
+// Redirect implements the redirect logic as a standalone function.
+func Redirect(ctx filters.FilterContext, code int, location *url.URL) {
+	redirectWithType(ctx, code, location, redTo)
 }
 
 func (spec *redirect) Request(ctx filters.FilterContext) {
@@ -163,7 +167,7 @@ func (spec *redirect) Request(ctx filters.FilterContext) {
 		return
 	}
 
-	Redirect(ctx, spec.code, spec.location, spec.typ)
+	redirectWithType(ctx, spec.code, spec.location, spec.typ)
 }
 
 // Sets the status code and the location header of the response. Marks the


### PR DESCRIPTION
fixing the builtin.Redirect() function to avoid using the package internal redirectType type