### PR TITLE
Allow using an exponentially decaying sample for histograms

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -80,6 +80,7 @@ const (
 	routeBackendErrorCountersUsage = "enables counting backend errors for each route"
 	routeStreamErrorCountersUsage  = "enables counting streaming errors for each route"
 	routeBackendMetricsUsage       = "enables reporting backend response time metrics for each route"
+	metricsUseExpDecaySampleUsage  = "use exponentially decaying sample in metrics"
 	disableMetricsCompatsUsage     = "disables the default true value for all-filters-metrics, route-response-metrics, route-backend-errorCounters and route-stream-error-counters"
 	applicationLogUsage            = "output file for the application log. When not set, /dev/stderr is used"
 	applicationLogLevelUsage       = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
@@ -143,6 +144,7 @@ var (
 	routeBackendErrorCounters bool
 	routeStreamErrorCounters  bool
 	routeBackendMetrics       bool
+	metricsUseExpDecaySample  bool
 	disableMetricsCompat      bool
 	applicationLog            string
 	applicationLogLevel       string
@@ -205,6 +207,7 @@ func init() {
 	flag.BoolVar(&routeBackendErrorCounters, "route-backend-error-counters", false, routeBackendErrorCountersUsage)
 	flag.BoolVar(&routeStreamErrorCounters, "route-stream-error-counters", false, routeStreamErrorCountersUsage)
 	flag.BoolVar(&routeBackendMetrics, "route-backend-metrics", false, routeBackendMetricsUsage)
+	flag.BoolVar(&metricsUseExpDecaySample, "metrics-exp-decay-sample", false, metricsUseExpDecaySampleUsage)
 	flag.BoolVar(&disableMetricsCompat, "disable-metrics-compat", false, disableMetricsCompatsUsage)
 	flag.StringVar(&applicationLog, "application-log", "", applicationLogUsage)
 	flag.StringVar(&applicationLogLevel, "application-log-level", defaultApplicationLogLevel, applicationLogLevelUsage)
@@ -313,6 +316,7 @@ func main() {
 		EnableRouteBackendErrorsCounters:    routeBackendErrorCounters,
 		EnableRouteStreamingErrorsCounters:  routeStreamErrorCounters,
 		EnableRouteBackendMetrics:           routeBackendMetrics,
+		MetricsUseExpDecaySample:            metricsUseExpDecaySample,
 		DisableMetricsCompatibilityDefaults: disableMetricsCompat,
 		ApplicationLogOutput:                applicationLog,
 		ApplicationLogPrefix:                applicationLogPrefix,

--- a/skipper.go
+++ b/skipper.go
@@ -217,6 +217,10 @@ type Options struct {
 	// enabled by default.
 	EnableRouteBackendMetrics bool
 
+	// When set, makes the histograms use an exponentially decaying sample
+	// instead of the default uniform one.
+	MetricsUseExpDecaySample bool
+
 	// The following options, for backwards compatibility, are true
 	// by default: EnableAllFiltersMetrics, EnableRouteResponseMetrics,
 	// EnableRouteBackendErrorsCounters, EnableRouteStreamingErrorsCounters,
@@ -554,6 +558,7 @@ func Run(o Options) error {
 			EnableRouteBackendErrorsCounters:   o.EnableRouteBackendErrorsCounters,
 			EnableRouteStreamingErrorsCounters: o.EnableRouteStreamingErrorsCounters,
 			EnableRouteBackendMetrics:          o.EnableRouteBackendMetrics,
+			UseExpDecaySample:                  o.MetricsUseExpDecaySample,
 			DisableCompatibilityDefaults:       o.DisableMetricsCompatibilityDefaults,
 		})
 		mux.Handle("/metrics", metricsHandler)


### PR DESCRIPTION
Add -metrics-exp-decay-sample option. If set, metrics will use an exponentially decaying sample for the histograms instead of the uniform one. Once we're satisfied with the results, we can switch the defaults.

Fix #428.
Fix #363.