### PR TITLE
Fix route printing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.8.1
+  - 1.x
 
 env:
   global:

--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -119,21 +119,13 @@ func printCmd(a cmdArgs) error {
 			return err
 		}
 	} else {
-		f := "%s: %s;\n"
-		for i, r := range lr.routes {
+		for _, r := range lr.routes {
 			if perr, hasError := lr.parseErrors[r.Id]; hasError {
 				printStderr(r.Id, perr)
-			} else {
-				if r.Id == "" {
-					fmt.Fprintln(stdout, r.String())
-				} else {
-					fmt.Fprintf(stdout, f, r.Id, r.Print(pretty))
-					if i == 0 {
-						f = "\n" + f
-					}
-				}
 			}
 		}
+
+		eskip.Fprint(stdout, pretty, lr.routes...)
 	}
 
 	if len(lr.parseErrors) > 0 {

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -193,7 +193,7 @@ func Fprint(w io.Writer, pretty bool, routes ...*Route) {
 		return
 	}
 
-	if len(routes) == 1 && routes[0].Id == "" {
+	if len(routes) == 1 && !isDefinition(routes[0]) {
 		fprintExpression(w, routes[0], pretty)
 		return
 	}

--- a/eskip/string_test.go
+++ b/eskip/string_test.go
@@ -225,14 +225,6 @@ func TestNumberString(t *testing.T) {
 }
 
 func TestPrintLines(t *testing.T) {
-	// single expression
-	// single def
-	// empty defs
-	// defs
-	// with pretty and with not
-	// package level
-	// route level
-
 	check := func(t *testing.T, got, expected string) {
 		if got != expected {
 			t.Error("invalid string result")
@@ -258,122 +250,141 @@ func TestPrintLines(t *testing.T) {
 			Backend: "https://www.example.org",
 		}
 
-		expected := `Path("/foo") -> setPath("/") -> "https://www.example.org"`
-		got := route.String()
-		check(t, got, expected)
+		t.Run("String()", func(t *testing.T) {
+			expected := `Path("/foo") -> setPath("/") -> "https://www.example.org"`
+			got := route.String()
+			check(t, got, expected)
+		})
+
+		t.Run("Print()", func(t *testing.T) {
+			t.Run("not pretty", func(t *testing.T) {
+				expected := `Path("/foo") -> setPath("/") -> "https://www.example.org"`
+				got := route.Print(false)
+				check(t, got, expected)
+			})
+
+			t.Run("pretty", func(t *testing.T) {
+				expected := `Path("/foo")
+  -> setPath("/")
+  -> "https://www.example.org"`
+				got := route.Print(true)
+				check(t, got, expected)
+			})
+		})
 	})
 
-	type packageLevelTest struct {
-		title    string
-		routes   []*Route
-		expected string
-	}
+	t.Run("package level", func(t *testing.T) {
+		type packageLevelTest struct {
+			title    string
+			routes   []*Route
+			expected string
+		}
 
-	testsBase := []packageLevelTest{{
-		title: "single expression (no ID)",
-		routes: []*Route{{
-			Predicates: []*Predicate{{
-				Name: "Path",
-				Args: []interface{}{
-					"/foo",
-				},
+		testsBase := []packageLevelTest{{
+			title: "single expression (no ID)",
+			routes: []*Route{{
+				Predicates: []*Predicate{{
+					Name: "Path",
+					Args: []interface{}{
+						"/foo",
+					},
+				}},
+				Filters: []*Filter{{
+					Name: "setPath",
+					Args: []interface{}{
+						"/",
+					},
+				}},
+				Backend: "https://www.example.org",
 			}},
-			Filters: []*Filter{{
-				Name: "setPath",
-				Args: []interface{}{
-					"/",
-				},
-			}},
-			Backend: "https://www.example.org",
-		}},
-	}, {
-		title: "single expression (no ID)",
-		routes: []*Route{{
-			Id: "testRoute1",
-			Predicates: []*Predicate{{
-				Name: "Path",
-				Args: []interface{}{
-					"/foo",
-				},
-			}},
-			Filters: []*Filter{{
-				Name: "setPath",
-				Args: []interface{}{
-					"/",
-				},
-			}},
-			Backend: "https://www.example.org",
-		}},
-	}, {
-		title: "empty",
-	}, {
-		title: "multiple routes",
-		routes: []*Route{{
-			Id: "testRoute1",
-			Predicates: []*Predicate{{
-				Name: "Path",
-				Args: []interface{}{
-					"/foo",
-				},
-			}},
-			Filters: []*Filter{{
-				Name: "setPath",
-				Args: []interface{}{
-					"/",
-				},
-			}},
-			Backend: "https://ww1.example.org",
 		}, {
-			Id: "testRoute2",
-			Predicates: []*Predicate{{
-				Name: "Path",
-				Args: []interface{}{
-					"/bar",
-				},
+			title: "single definition (with ID)",
+			routes: []*Route{{
+				Id: "testRoute1",
+				Predicates: []*Predicate{{
+					Name: "Path",
+					Args: []interface{}{
+						"/foo",
+					},
+				}},
+				Filters: []*Filter{{
+					Name: "setPath",
+					Args: []interface{}{
+						"/",
+					},
+				}},
+				Backend: "https://www.example.org",
 			}},
-			Filters: []*Filter{{
-				Name: "setPath",
-				Args: []interface{}{
-					"/",
-				},
-			}},
-			Backend: "https://ww2.example.org",
 		}, {
-			Id: "testRoute3",
-			Predicates: []*Predicate{{
-				Name: "Path",
-				Args: []interface{}{
-					"/baz",
-				},
+			title: "empty",
+		}, {
+			title: "multiple routes",
+			routes: []*Route{{
+				Id: "testRoute1",
+				Predicates: []*Predicate{{
+					Name: "Path",
+					Args: []interface{}{
+						"/foo",
+					},
+				}},
+				Filters: []*Filter{{
+					Name: "setPath",
+					Args: []interface{}{
+						"/",
+					},
+				}},
+				Backend: "https://ww1.example.org",
+			}, {
+				Id: "testRoute2",
+				Predicates: []*Predicate{{
+					Name: "Path",
+					Args: []interface{}{
+						"/bar",
+					},
+				}},
+				Filters: []*Filter{{
+					Name: "setPath",
+					Args: []interface{}{
+						"/",
+					},
+				}},
+				Backend: "https://ww2.example.org",
+			}, {
+				Id: "testRoute3",
+				Predicates: []*Predicate{{
+					Name: "Path",
+					Args: []interface{}{
+						"/baz",
+					},
+				}},
+				Filters: []*Filter{{
+					Name: "setPath",
+					Args: []interface{}{
+						"/",
+					},
+				}},
+				Backend: "https://ww3.example.org",
 			}},
-			Filters: []*Filter{{
-				Name: "setPath",
-				Args: []interface{}{
-					"/",
-				},
-			}},
-			Backend: "https://ww3.example.org",
-		}},
-	}}
+		}}
 
-	expectedFlat := []string{
-		`Path("/foo") -> setPath("/") -> "https://www.example.org"`,
-		`testRoute1: Path("/foo") -> setPath("/") -> "https://www.example.org"`,
-		``,
-		`testRoute1: Path("/foo") -> setPath("/") -> "https://ww1.example.org";
+		expectedFlat := []string{
+			`Path("/foo") -> setPath("/") -> "https://www.example.org"`,
+			`testRoute1: Path("/foo") -> setPath("/") -> "https://www.example.org";`,
+			``,
+			`testRoute1: Path("/foo") -> setPath("/") -> "https://ww1.example.org";
 testRoute2: Path("/bar") -> setPath("/") -> "https://ww2.example.org";
-testRoute3: Path("/baz") -> setPath("/") -> "https://ww3.example.org"`,
-	}
+testRoute3: Path("/baz") -> setPath("/") -> "https://ww3.example.org";`,
+		}
 
-	expectedPretty := []string{
-		`Path("/foo")
+		expectedPretty := []string{
+			`Path("/foo")
   -> setPath("/")
   -> "https://www.example.org"`,
-		`testRoute1: Path("/foo")
+			`testRoute1: Path("/foo")
   -> setPath("/")
-  -> "https://www.example.org"`,
-		``,
-		`testRoute1: Path("/foo")
+  -> "https://www.example.org";`,
+			``,
+			`testRoute1: Path("/foo")
   -> setPath("/")
   -> "https://ww1.example.org";
 
@@ -383,65 +394,66 @@ testRoute2: Path("/bar")
 
 testRoute3: Path("/baz")
   -> setPath("/")
-  -> "https://ww3.example.org"`,
-	}
-
-	makeTests := func(base []packageLevelTest, expected []string) []packageLevelTest {
-		tests := make([]packageLevelTest, len(base))
-		for i := range base {
-			tests[i] = base[i]
-			tests[i].expected = expected[i]
+  -> "https://ww3.example.org";`,
 		}
 
-		return tests
-	}
+		makeTests := func(base []packageLevelTest, expected []string) []packageLevelTest {
+			tests := make([]packageLevelTest, len(base))
+			for i := range base {
+				tests[i] = base[i]
+				tests[i].expected = expected[i]
+			}
 
-	testsFlat := makeTests(testsBase, expectedFlat)
-	testsPretty := makeTests(testsBase, expectedPretty)
+			return tests
+		}
 
-	runTests := func(t *testing.T, tests []packageLevelTest, print func(packageLevelTest) string) {
-		for _, test := range tests {
-			t.Run(test.title, func(t *testing.T) {
-				got := print(test)
-				check(t, got, test.expected)
+		testsFlat := makeTests(testsBase, expectedFlat)
+		testsPretty := makeTests(testsBase, expectedPretty)
+
+		runTests := func(t *testing.T, tests []packageLevelTest, print func(packageLevelTest) string) {
+			for _, test := range tests {
+				t.Run(test.title, func(t *testing.T) {
+					got := print(test)
+					check(t, got, test.expected)
+				})
+			}
+		}
+
+		t.Run("String()", func(t *testing.T) {
+			runTests(t, testsFlat, func(test packageLevelTest) string { return String(test.routes...) })
+		})
+
+		t.Run("Print()", func(t *testing.T) {
+			t.Run("not pretty", func(t *testing.T) {
+				runTests(t, testsFlat, func(test packageLevelTest) string {
+					return Print(false, test.routes...)
+				})
 			})
-		}
-	}
 
-	t.Run("String() package level", func(t *testing.T) {
-		runTests(t, testsFlat, func(test packageLevelTest) string { return String(test.routes...) })
-	})
-
-	t.Run("Print()", func(t *testing.T) {
-		t.Run("not pretty", func(t *testing.T) {
-			runTests(t, testsFlat, func(test packageLevelTest) string {
-				return Print(false, test.routes...)
+			t.Run("pretty", func(t *testing.T) {
+				runTests(t, testsPretty, func(test packageLevelTest) string {
+					return Print(true, test.routes...)
+				})
 			})
 		})
 
-		t.Run("pretty", func(t *testing.T) {
-			runTests(t, testsPretty, func(test packageLevelTest) string {
-				return Print(true, test.routes...)
+		t.Run("Fprint()", func(t *testing.T) {
+			fprint := func(pretty bool, routes []*Route) string {
+				var buf bytes.Buffer
+				Fprint(&buf, pretty, routes...)
+				return buf.String()
+			}
+
+			t.Run("not pretty", func(t *testing.T) {
+				runTests(t, testsFlat, func(test packageLevelTest) string {
+					return fprint(false, test.routes)
+				})
 			})
-		})
-	})
 
-	t.Run("Fprint()", func(t *testing.T) {
-		fprint := func(pretty bool, routes []*Route) string {
-			var buf bytes.Buffer
-			Fprint(&buf, pretty, routes...)
-			return buf.String()
-		}
-
-		t.Run("not pretty", func(t *testing.T) {
-			runTests(t, testsFlat, func(test packageLevelTest) string {
-				return fprint(false, test.routes)
-			})
-		})
-
-		t.Run("pretty", func(t *testing.T) {
-			runTests(t, testsPretty, func(test packageLevelTest) string {
-				return fprint(true, test.routes)
+			t.Run("pretty", func(t *testing.T) {
+				runTests(t, testsPretty, func(test packageLevelTest) string {
+					return fprint(true, test.routes)
+				})
 			})
 		})
 	})

--- a/eskip/string_test.go
+++ b/eskip/string_test.go
@@ -6,16 +6,23 @@ import (
 	"testing"
 )
 
-func findDiffPos(left, right string) int {
-	pos := 0
+func findDiffPos(left, right string) (pos int, leftOut, rightOut string) {
 	for i := 0; i < len(left); i++ {
+		if len(right) <= i {
+			pos = i
+			break
+		}
+
 		if left[i:i+1] != right[i:i+1] {
 			pos = i
 			break
 		}
 	}
 
-	return pos
+	leftOut = left[0:pos]
+	rightOut = right[0:pos]
+
+	return
 }
 
 func testDoc(t *testing.T, doc string) string {
@@ -26,7 +33,8 @@ func testDoc(t *testing.T, doc string) string {
 
 	docBack := String(routes...)
 	if docBack != doc {
-		t.Error("failed to serialize doc", findDiffPos(docBack, doc))
+		pos, _, _ := findDiffPos(docBack, doc)
+		t.Error("failed to serialize doc", pos)
 		t.Log(docBack)
 		t.Log(doc)
 	}
@@ -90,8 +98,8 @@ func TestRouteString(t *testing.T) {
 	}} {
 		rstring := item.route.String()
 		if rstring != item.string {
-			pos := findDiffPos(rstring, item.string)
-			t.Error(rstring, item.string, i, pos, rstring[pos:pos+1], item.string[pos:pos+1])
+			pos, rstringOut, itemOut := findDiffPos(rstring, item.string)
+			t.Error(rstring, item.string, i, pos, rstringOut, itemOut)
 		}
 	}
 }
@@ -105,7 +113,7 @@ func TestRouteExpression(t *testing.T) {
 
 func TestDocString(t *testing.T) {
 	testDoc(t, `route1: Method("GET") -> filter("expression") -> <shunt>;`+"\n"+
-		`route2: Path("/some/path") -> "https://www.example.org"`)
+		`route2: Path("/some/path") -> "https://www.example.org";`)
 }
 
 func TestPrintNonPretty(t *testing.T) {
@@ -151,7 +159,7 @@ func TestPrintMultiRoutePretty(t *testing.T) {
 			`  -> filter("expression")`+"\n"+
 			`  -> <shunt>;`+"\n\n"+
 			`route2: Path("/some/path")`+"\n"+
-			`  -> "https://www.example.org"`,
+			`  -> "https://www.example.org";`,
 		t, 0, true, true)
 }
 
@@ -159,7 +167,7 @@ func TestPrintMultiRouteNonPretty(t *testing.T) {
 	testPrinting(`route1: Method("GET") -> filter("expression") -> <shunt>;`+"\n"+
 		`route2: Path("/some/path") -> "https://www.example.org"`,
 		`route1: Method("GET") -> filter("expression") -> <shunt>;`+"\n"+
-			`route2: Path("/some/path") -> "https://www.example.org"`,
+			`route2: Path("/some/path") -> "https://www.example.org";`,
 		t, 0, false, true)
 }
 
@@ -177,14 +185,14 @@ func testPrinting(routestr string, expected string, t *testing.T, i int, pretty 
 	}
 
 	if printedRoute != expected {
-		pos := findDiffPos(printedRoute, expected)
-		t.Error(printedRoute, expected, i, pos, printedRoute[pos:pos+1], expected[pos:pos+1])
+		pos, printed, expected := findDiffPos(printedRoute, expected)
+		t.Error(printedRoute, expected, i, pos, printed, expected)
 	}
 }
 
 func TestParseAndStringAndParse(t *testing.T) {
 	doc := `route1: Method("GET") -> filter("expression") -> <shunt>;` + "\n" +
-		`route2: Path("/some/path") -> "https://www.example.org"`
+		`route2: Path("/some/path") -> "https://www.example.org";`
 	doc = testDoc(t, doc)
 	doc = testDoc(t, doc)
 	doc = testDoc(t, doc)


### PR DESCRIPTION
Fix route printing:
- Unify Fprint and Print
- Add semicolon to the last printing route line, too
- Fix Fprint adding extra lines in non-pretty mode