### PR TITLE
create a flag to disable detailed route update logging

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -98,6 +98,7 @@ const (
 	opentracingUsage               = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
 	defaultHTTPStatusUsage         = "default HTTP status used when no route is found for a request"
 	pluginDirUsage                 = "set the directory to load plugins from, default is ./"
+	suppressRouteUpdateLogsUsage   = "print only summaries on route updates/deletes"
 )
 
 var (
@@ -166,6 +167,7 @@ var (
 	openTracing               string
 	defaultHTTPStatus         int
 	pluginDir                 string
+	suppressRouteUpdateLogs   bool
 )
 
 func init() {
@@ -229,6 +231,7 @@ func init() {
 	flag.StringVar(&openTracing, "opentracing", "noop", opentracingUsage)
 	flag.StringVar(&pluginDir, "plugindir", ".", pluginDirUsage)
 	flag.IntVar(&defaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
+	flag.BoolVar(&suppressRouteUpdateLogs, "suppress-route-update-logs", false, suppressRouteUpdateLogsUsage)
 	flag.Parse()
 
 	// check if arguments were correctly parsed.
@@ -336,6 +339,7 @@ func main() {
 		OpenTracing:                         strings.Split(openTracing, " "),
 		PluginDir:                           pluginDir,
 		DefaultHTTPStatus:                   defaultHTTPStatus,
+		SuppressRouteUpdateLogs:             suppressRouteUpdateLogs,
 	}
 
 	if insecure {

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -172,7 +172,7 @@ func receiveRouteDefs(o Options, quit <-chan struct{}) <-chan []*eskip.Route {
 				return
 			}
 
-			incoming.log(o.Log, o.SupressLogs)
+			incoming.log(o.Log, o.SuppressLogs)
 			c := incoming.client
 			defsByClient[c] = applyIncoming(defsByClient[c], incoming)
 

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -38,7 +38,13 @@ type incomingData struct {
 	deletedIds     []string
 }
 
-func (d *incomingData) log(l logging.Logger) {
+func (d *incomingData) log(l logging.Logger, supress bool) {
+	if supress {
+		l.Infof("route settings, %v, upsert count: %v", d.typ, len(d.upsertedRoutes))
+		l.Infof("route settings, %v, delete count: %v", d.typ, len(d.deletedIds))
+		return
+	}
+
 	for _, r := range d.upsertedRoutes {
 		l.Infof("route settings, %v, route: %v: %v", d.typ, r.Id, r)
 	}
@@ -166,7 +172,7 @@ func receiveRouteDefs(o Options, quit <-chan struct{}) <-chan []*eskip.Route {
 				return
 			}
 
-			incoming.log(o.Log)
+			incoming.log(o.Log, o.SupressLogs)
 			c := incoming.client
 			defsByClient[c] = applyIncoming(defsByClient[c], incoming)
 

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -81,9 +81,9 @@ func TestLogging(t *testing.T) {
 
 	init := func(l logging.Logger, client DataClient, supress bool) *Routing {
 		return New(Options{
-			DataClients: []DataClient{client},
-			Log:         l,
-			SupressLogs: supress,
+			DataClients:  []DataClient{client},
+			Log:          l,
+			SuppressLogs: supress,
 		})
 	}
 

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -2,9 +2,12 @@ package routing
 
 import (
 	"testing"
+	"time"
 
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/routing/testdataclient"
+	"github.com/zalando/skipper/logging"
+	"github.com/zalando/skipper/logging/loggingtest"
 )
 
 func TestNoMultipleTreePredicates(t *testing.T) {
@@ -61,4 +64,102 @@ func TestNoMultipleTreePredicates(t *testing.T) {
 			}
 		}()
 	}
+}
+
+func TestLogging(t *testing.T) {
+	const r1 = `
+		r1_1: Path("/foo") -> "https://foo.example.org";
+		r1_2: Path("/bar") -> "https://bar.example.org";
+		r1_3: Path("/baz") -> "https://baz.example.org";
+	`
+
+	const r2 = `
+		r2_1: Path("/qux") -> "https://qux.example.org";
+		r2_2: Path("/quux") -> "https://quux.example.org";
+	`
+
+	const r3 = ""
+
+	createClients := func() ([]DataClient, error) {
+		dc1, err := testdataclient.NewDoc(r1)
+		if err != nil {
+			return nil, err
+		}
+
+		dc2, err := testdataclient.NewDoc(r2)
+		if err != nil {
+			return nil, err
+		}
+
+		dc3, err := testdataclient.NewDoc(r3)
+		if err != nil {
+			return nil, err
+		}
+
+		return []DataClient{dc1, dc2, dc3}, nil
+	}
+
+	init := func(l logging.Logger, clients []DataClient) *Routing {
+		return New(Options{
+			DataClients: clients,
+			Log: l,
+		})
+	}
+
+	testInitial := func(t *testing.T, logCount int) {
+		c, err := createClients()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		testLog := loggingtest.New()
+		rt := init(testLog, c)
+		defer rt.Close()
+
+		if err := testLog.WaitForN("route settings", logCount, 120 * time.Millisecond); err != nil {
+			t.Error(err)
+		}
+	}
+
+	testUpdate := func(t *testing.T, logCountInit int, logCountUpdate int) {
+		c, err := createClients()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		testLog := loggingtest.New()
+		rt := init(testLog, c)
+		defer rt.Close()
+
+		if err := testLog.WaitForN("route settings", logCountInit, 120 * time.Millisecond); err != nil {
+			t.Error(err)
+		}
+
+		testLog.Reset()
+
+		c[0].(*testdataclient.Client).UpdateDoc(
+			`r1_1: Path("/foo_mod") -> "https://foo.example.org"`,
+			[]string{"r1_2"},
+		)
+		c[1].(*testdataclient.Client).UpdateDoc(
+			`r2_1: Path("/qux_mod") -> "https://qux.example.org"`,
+			nil,
+		)
+
+		if err := testLog.WaitForN("route settings", logCountUpdate, 120 * time.Millisecond); err != nil {
+			t.Error(err)
+		}
+	}
+
+	t.Run("full", func(t *testing.T) {
+		t.Run("initial", func(t *testing.T) {
+			testInitial(t, 5)
+		})
+
+		t.Run("update", func(t *testing.T) {
+			testUpdate(t, 5, 3)
+		})
+	})
 }

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -113,8 +113,8 @@ type Options struct {
 	// Set a custom logger if necessary.
 	Log logging.Logger
 
-	// SupressLogs indicates whether to log only a summary of the route changes.
-	SupressLogs bool
+	// SuppressLogs indicates whether to log only a summary of the route changes.
+	SuppressLogs bool
 }
 
 // RouteFilter contains extensions to generic filter

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -112,6 +112,9 @@ type Options struct {
 
 	// Set a custom logger if necessary.
 	Log logging.Logger
+
+	// SupressLogs indicates whether to log only a summary of the route changes.
+	SupressLogs bool
 }
 
 // RouteFilter contains extensions to generic filter

--- a/skipper.go
+++ b/skipper.go
@@ -151,6 +151,10 @@ type Options struct {
 	// Custom data clients to be used together with the default etcd and Innkeeper.
 	CustomDataClients []routing.DataClient
 
+	// SuppressRouteUpdateLogs indicates to log only summaries of the routing updates
+	// instead of full details of the updated/deleted routes.
+	SuppressRouteUpdateLogs bool
+
 	// Dev mode. Currently this flag disables prioritization of the
 	// consumer side over the feeding side during the routing updates to
 	// populate the updated routes faster.
@@ -499,7 +503,9 @@ func Run(o Options) error {
 		PollTimeout:     o.SourcePollTimeout,
 		DataClients:     dataClients,
 		Predicates:      o.CustomPredicates,
-		UpdateBuffer:    updateBuffer})
+		UpdateBuffer:    updateBuffer,
+		SuppressLogs:    o.SuppressRouteUpdateLogs,
+	})
 	defer routing.Close()
 
 	proxyFlags := proxy.Flags(o.ProxyOptions) | o.ProxyFlags


### PR DESCRIPTION
when the -suppress-route-update-logs is set, only a summary of the rout changes will be logged