### PR TITLE
Feature/service ratelimit

### DIFF
--- a/cmd/skipper/ratelimiterflags.go
+++ b/cmd/skipper/ratelimiterflags.go
@@ -10,8 +10,8 @@ import (
 
 const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=local,max-hits=20,time-window=60
 	possible ratelimit properties:
-	type: local/disabled (defaults to local)
-	max-hits: the number of hits a local (meaning per instance) ratelimiter can get
+	type: local/service/disabled (defaults to disabled)
+	max-hits: the number of hits a ratelimiter can get
 	time-window: the duration of the sliding window for the rate limiter
 	(see also: https://godoc.org/github.com/zalando/skipper/ratelimit)`
 
@@ -45,6 +45,8 @@ func (r *ratelimitFlags) Set(value string) error {
 			switch kv[1] {
 			case "local":
 				s.Type = ratelimit.LocalRatelimit
+			case "service":
+				s.Type = ratelimit.ServiceRatelimit
 			case "disabled":
 				s.Type = ratelimit.DisableRatelimit
 			default:

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -41,6 +41,26 @@ Example - Ingress
 
 Example - Ingress with ratelimiting
 
+The example shows 50 calls per minute are allowed to each skipper
+instance for the given ingress.
+
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      annotations:
+        zalando.org/ratelimit: ratelimit(50, "1m")
+      name: app
+    spec:
+      rules:
+      - host: app-default.example.org
+        http:
+          paths:
+          - backend:
+              serviceName: app-svc
+              servicePort: 80
+
+Example - Ingress with client based ratelimiting
+
 The example shows 3 calls per minute per client, based on
 X-Forwarded-For header or IP incase there is no X-Forwarded-For header
 set, are allowed to each skipper instance for the given ingress.

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -91,6 +91,7 @@ func MakeRegistry() filters.Registry {
 		circuit.NewRateBreaker(),
 		circuit.NewDisableBreaker(),
 		ratelimit.NewLocalRatelimit(),
+		ratelimit.NewRatelimit(),
 		ratelimit.NewDisableRatelimit(),
 	} {
 		r.Register(s)

--- a/filters/ratelimit/ratelimit_test.go
+++ b/filters/ratelimit/ratelimit_test.go
@@ -68,11 +68,23 @@ func TestRateLimit(t *testing.T) {
 
 			if settings != expect {
 				t.Error("invalid settings")
-				t.Log("got", settings)
+				t.Log("got     ", settings)
 				t.Log("expected", expect)
 			}
 		}
 	}
+
+	t.Run("ratelimit service", test(
+		NewRatelimit,
+		ratelimit.Settings{
+			Type:       ratelimit.ServiceRatelimit,
+			MaxHits:    3,
+			TimeWindow: 1 * time.Second,
+			Lookuper:   ratelimit.NewSameBucketLookuper(),
+		},
+		3,
+		"1s",
+	))
 
 	t.Run("ratelimit local", test(
 		NewLocalRatelimit,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ce54e6c1b180407f563a8b45ddb724ef6247731412229814c2799a9c2a176f5c
-updated: 2017-09-20T15:32:09.381911487+02:00
+hash: 3a752320e676a837db5f77cbd70ebdc0a8d90b13e7539b614c68df092eb2efd3
+updated: 2017-10-31T19:35:10.727940916+01:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: efc9484eee77263a11f158ef4f30fcc30298a942
@@ -15,7 +15,7 @@ imports:
 - name: github.com/oklog/ulid
   version: d311cb43c92434ec4072dfbbda3400741d0a6337
 - name: github.com/opentracing/opentracing-go
-  version: 8ebe5d4e236eed9fd88e593c288bfb804d630b8c
+  version: 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
   subpackages:
   - ext
   - log
@@ -26,22 +26,21 @@ imports:
 - name: github.com/sony/gobreaker
   version: e9556a45379ef1da12e54847edb2fb3d7d566f36
 - name: github.com/szuecs/rate-limit-buffer
-  version: 585b0c9c230415b668ed4d42ef18f7a32c061702
+  version: 1a179ab26baf3b8450aaaa662e3120155fadb39d
 - name: golang.org/x/crypto
-  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
+  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
   - bcrypt
   - blowfish
   - ssh/terminal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
 - name: golang.org/x/sys
   version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
-  - windows
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
@@ -51,6 +50,8 @@ testImports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/sanity-io/litter
+  version: 74aad7f5a675c9103cbc98548c7711e3de027208
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/zalando/skipper
 import:
 - package: github.com/szuecs/rate-limit-buffer
-  version: ~0.1.0
+  version: ~0.2.0
 - package: github.com/abbot/go-http-auth
   version: ~0.3.0
 - package: github.com/dimfeld/httppath

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -616,6 +616,7 @@ func (p *Proxy) do(ctx *context) error {
 
 	ctx.loopCounter++
 
+	// proxy global setting
 	if settings, ok := p.limiters.Check(ctx.request); !ok {
 		p.log.Debugf("proxy.go limiter settings: %s", settings)
 		rerr := ratelimitError(settings)
@@ -638,6 +639,7 @@ func (p *Proxy) do(ctx *context) error {
 	ctx.applyRoute(route, params, p.flags.PreserveHost())
 
 	processedFilters := p.applyFiltersToRequest(ctx.route.Filters, ctx)
+	// per route rate limit
 	if settings, allow := p.checkRatelimit(ctx); !allow {
 		rerr := ratelimitError(settings)
 		return rerr

--- a/proxy/ratelimit_test.go
+++ b/proxy/ratelimit_test.go
@@ -126,7 +126,7 @@ func TestCheckDisableRateLimit(t *testing.T) {
 
 }
 
-func TestCheckRateLimit(t *testing.T) {
+func TestCheckLocalRateLimit(t *testing.T) {
 	fr := builtin.MakeRegistry()
 	backend := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	defer backend.Close()
@@ -202,6 +202,93 @@ func TestCheckRateLimit(t *testing.T) {
 		}
 		if i != expected {
 			t.Fatalf("should calculateratelimit header correctly: %d expected: %d", i, expected)
+		}
+	}
+	time.Sleep(timeWindow)
+	for i := 0; i < 10; i++ {
+		d0 := doc(128)
+		code, _ := request(d0)
+		if code == http.StatusTooManyRequests {
+			t.Fatal("should not be ratelimitted")
+		}
+	}
+}
+
+func TestCheckServiceRateLimit(t *testing.T) {
+	fr := builtin.MakeRegistry()
+	backend := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer backend.Close()
+	r := []*eskip.Route{&eskip.Route{Backend: backend.URL}}
+	timeWindow := 1 * time.Second
+	ratelimitSettings := ratelimit.Settings{
+		Type:       ratelimit.ServiceRatelimit,
+		MaxHits:    10,
+		TimeWindow: timeWindow,
+	}
+	p := proxytest.WithParams(fr, proxy.Params{
+		CloseIdleConnsPeriod: -time.Second,
+		RateLimiters:         ratelimit.NewRegistry(ratelimitSettings),
+	}, r...)
+	defer p.Close()
+
+	doc := func(l int) []byte {
+		b := make([]byte, l)
+		n, err := rand.Read(b)
+		if err != nil || n != l {
+			t.Fatal("failed to generate doc", err, n, l)
+		}
+
+		return b
+	}
+
+	request := func(doc []byte) (int, http.Header) {
+		req, err := http.NewRequest("GET", p.URL+"/", nil)
+		if err != nil {
+			t.Fatal("foo", "failed to create request", err)
+			return -1, nil
+		}
+
+		req.Close = true
+
+		rsp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatal("Do req", "failed to make request", err)
+			return -1, nil
+		}
+
+		defer rsp.Body.Close()
+		_, err = ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			t.Fatal("read", "failed to read response", err)
+		}
+
+		return rsp.StatusCode, rsp.Header
+	}
+
+	for i := 0; i < 10; i++ {
+		d0 := doc(128)
+		code, _ := request(d0)
+		if code == http.StatusTooManyRequests {
+			t.Fatal("should not be ratelimitted")
+		}
+	}
+	for i := 0; i < 10; i++ {
+		d0 := doc(128)
+		code, header := request(d0)
+		if code != http.StatusTooManyRequests {
+			t.Fatal("should be ratelimitted")
+		}
+		v := header.Get(ratelimit.Header)
+		if v == "" {
+			t.Fatalf("should set ratelimit header %s", ratelimit.Header)
+		}
+		expected := ratelimitSettings.MaxHits * int(time.Hour/ratelimitSettings.TimeWindow)
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("failed to convert string number %s to number: %v", v, err)
+		}
+		if i != expected {
+			t.Fatalf("should calculate ratelimit header correctly: %d expected: %d", i, expected)
 		}
 	}
 	time.Sleep(timeWindow)

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -16,6 +16,8 @@ type Type int
 const (
 	// Header is
 	Header = "X-Rate-Limit"
+	// ServiceRatelimitName is the name of the Ratelimit filter, which will be shown in log
+	ServiceRatelimitName = "serviceRatelimit"
 	// LocalRatelimitName is the name of the LocalRatelimit filter, which will be shown in log
 	LocalRatelimitName = "localRatelimit"
 	// DisableRatelimitName is the name of the DisableRatelimit, which will be shown in log
@@ -25,8 +27,13 @@ const (
 const (
 	// NoRatelimit is not used
 	NoRatelimit Type = iota
-	// LocalRatelimit is used to have a simple local rate limit,
-	// which is calculated and measured within each instance
+	// ServiceRatelimit is used to have a simple rate limit for a
+	// backend service, which is calculated and measured within
+	// each instance
+	ServiceRatelimit
+	// LocalRatelimit is used to have a simple local rate limit
+	// per user for a backend, which is calculated and measured
+	// within each instance
 	LocalRatelimit
 	// DisableRatelimit is used to disable rate limit
 	DisableRatelimit
@@ -43,22 +50,45 @@ type Lookuper interface {
 	Lookup(*http.Request) string
 }
 
+// SameBucketLookuper implements Lookuper interface and will always
+// match to the same bucket.
+type SameBucketLookuper struct{}
+
+// NewSameBucketLookuper returns a SameBucketLookuper.
+func NewSameBucketLookuper() SameBucketLookuper {
+	return SameBucketLookuper{}
+}
+
+// Lookup will always return "s" to select the same bucket.
+func (_ SameBucketLookuper) Lookup(req *http.Request) string {
+	return "s"
+}
+
+// XForwardedForLookuper implements Lookuper interface and will
+// select a bucket by X-Forwarded-For header or clientIP.
 type XForwardedForLookuper struct{}
 
+// NewXForwardedForLookuper returns an empty XForwardedForLookuper
 func NewXForwardedForLookuper() XForwardedForLookuper {
 	return XForwardedForLookuper{}
 }
 
+// Lookup returns the content of the X-Forwarded-For header or the
+// clientIP if not set.
 func (_ XForwardedForLookuper) Lookup(req *http.Request) string {
 	return net.RemoteHost(req).String()
 }
 
+// AuthLookuper implements Lookuper interface and will select a bucket
+// by Authorization header.
 type AuthLookuper struct{}
 
+// NewAuthLookuper returns an empty AuthLookuper
 func NewAuthLookuper() AuthLookuper {
 	return AuthLookuper{}
 }
 
+// Lookup returns the content of the Authorization header.
 func (_ AuthLookuper) Lookup(req *http.Request) string {
 	return req.Header.Get("Authorization")
 }
@@ -97,6 +127,8 @@ func (s Settings) String() string {
 	switch s.Type {
 	case DisableRatelimit:
 		return "disable"
+	case ServiceRatelimit:
+		return fmt.Sprintf("ratelimit(type=service,max-hits=%d,time-window=%s)", s.MaxHits, s.TimeWindow)
 	case LocalRatelimit:
 		return fmt.Sprintf("ratelimit(type=local,max-hits=%d,time-window=%s)", s.MaxHits, s.TimeWindow)
 	default:
@@ -145,8 +177,10 @@ func (l voidRatelimit) Close() {
 func newRatelimit(s Settings) *Ratelimit {
 	var impl implementation
 	switch s.Type {
+	case ServiceRatelimit:
+		impl = circularbuffer.NewRateLimiter(s.MaxHits, s.TimeWindow)
 	case LocalRatelimit:
-		impl = circularbuffer.NewRateLimiter(s.MaxHits, s.TimeWindow, s.CleanInterval)
+		impl = circularbuffer.NewClientRateLimiter(s.MaxHits, s.TimeWindow, s.CleanInterval)
 	default:
 		impl = voidRatelimit{}
 	}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -17,7 +17,7 @@ const (
 	// Header is
 	Header = "X-Rate-Limit"
 	// ServiceRatelimitName is the name of the Ratelimit filter, which will be shown in log
-	ServiceRatelimitName = "serviceRatelimit"
+	ServiceRatelimitName = "ratelimit"
 	// LocalRatelimitName is the name of the LocalRatelimit filter, which will be shown in log
 	LocalRatelimitName = "localRatelimit"
 	// DisableRatelimitName is the name of the DisableRatelimit, which will be shown in log

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -15,6 +16,45 @@ func checkNotRatelimitted(t *testing.T, rl *Ratelimit, client string) {
 	if !rl.Allow(client) {
 		t.Errorf("request is rate limitted for %s, but expected to be allowed", client)
 	}
+}
+
+func TestServiceRatelimit(t *testing.T) {
+	s := Settings{
+		Type:          ServiceRatelimit,
+		MaxHits:       3,
+		TimeWindow:    3 * time.Second,
+		CleanInterval: 4 * time.Second,
+	}
+	client1 := "foo"
+	client2 := "bar"
+
+	waitClean := func() {
+		time.Sleep(s.TimeWindow)
+	}
+
+	t.Run("new service ratelimitter", func(t *testing.T) {
+		rl := newRatelimit(s)
+		checkNotRatelimitted(t, rl, client1)
+	})
+
+	t.Run("does not rate limit unless we have enough calls, all clients are ratelimitted", func(t *testing.T) {
+		rl := newRatelimit(s)
+		for i := 0; i < s.MaxHits; i++ {
+			checkNotRatelimitted(t, rl, client1)
+		}
+
+		checkRatelimitted(t, rl, client1)
+		checkRatelimitted(t, rl, client2)
+	})
+
+	t.Run("does not rate limit if TimeWindow is over", func(t *testing.T) {
+		rl := newRatelimit(s)
+		for i := 0; i < s.MaxHits-1; i++ {
+			checkNotRatelimitted(t, rl, client1)
+		}
+		waitClean()
+		checkNotRatelimitted(t, rl, client1)
+	})
 }
 
 func TestLocalRatelimit(t *testing.T) {
@@ -78,4 +118,91 @@ func TestDisableRatelimit(t *testing.T) {
 		}
 		checkNotRatelimitted(t, rl, client1)
 	})
+}
+
+func BenchmarkServiceRatelimit(b *testing.B) {
+	maxint := 1 << 21
+	s := Settings{
+		Type:       ServiceRatelimit,
+		MaxHits:    maxint,
+		TimeWindow: 1 * time.Second,
+	}
+
+	rl := newRatelimit(s)
+	for i := 0; i < b.N; i++ {
+		rl.Allow("")
+	}
+}
+
+func BenchmarkLocalRatelimit(b *testing.B) {
+	maxint := 1 << 21
+	s := Settings{
+		Type:          LocalRatelimit,
+		MaxHits:       maxint,
+		TimeWindow:    1 * time.Second,
+		CleanInterval: 30 * time.Second,
+	}
+	client := "foo"
+
+	rl := newRatelimit(s)
+	for i := 0; i < b.N; i++ {
+		rl.Allow(client)
+	}
+}
+
+func BenchmarkLocalRatelimitWithCleaner(b *testing.B) {
+	maxint := 100
+	s := Settings{
+		Type:          LocalRatelimit,
+		MaxHits:       maxint,
+		TimeWindow:    100 * time.Millisecond,
+		CleanInterval: 300 * time.Millisecond,
+	}
+	client := "foo"
+
+	rl := newRatelimit(s)
+	for i := 0; i < b.N; i++ {
+		rl.Allow(client)
+	}
+}
+
+func BenchmarkLocalRatelimitClients1000(b *testing.B) {
+	s := Settings{
+		Type:          LocalRatelimit,
+		MaxHits:       100,
+		TimeWindow:    1 * time.Second,
+		CleanInterval: 30 * time.Second,
+	}
+	client := "foo"
+	count := 1000
+	clients := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		clients = append(clients, fmt.Sprintf("%s-%d", client, i))
+	}
+
+	rl := newRatelimit(s)
+	for i := 0; i < b.N; i++ {
+		rl.Allow(clients[i%count])
+	}
+}
+
+func BenchmarkLocalRatelimitWithCleanerClients1000(b *testing.B) {
+	maxint := 100
+	s := Settings{
+		Type:          LocalRatelimit,
+		MaxHits:       maxint,
+		TimeWindow:    100 * time.Millisecond,
+		CleanInterval: 300 * time.Millisecond,
+	}
+	client := "foo"
+	count := 1000
+	clients := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		clients = append(clients, fmt.Sprintf("%s-%d", client, i))
+	}
+
+	rl := newRatelimit(s)
+	for i := 0; i < b.N; i++ {
+		rl.Allow(clients[i%count])
+	}
 }

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -76,11 +76,17 @@ func (r *Registry) Check(req *http.Request) (Settings, bool) {
 		return Settings{}, true
 	}
 
-	ip := net.RemoteHost(req)
+	s := r.global
+	switch s.Type {
+	case ServiceRatelimit:
+		return s, r.Get(s).Allow("")
 
-	if !r.Get(r.global).Allow(ip.String()) {
-		return r.global, false
+	case LocalRatelimit:
+		ip := net.RemoteHost(req)
+		if !r.Get(s).Allow(ip.String()) {
+			return s, false
+		}
 	}
-	return Settings{}, true
 
+	return Settings{}, true
 }


### PR DESCRIPTION
Rate limit type service implements #470 a backend protection. 

It allows the definition of a maximum amount of requests that are passed to the backend without considering data from the client. It would be used like this:

    ratelimit(200, "1s")

The naming ratelimit() and not serviceRatelimit() indicates, that this is likely the default behaviour a user wants to have. Instead of the more complex localRatelimit(), which allows rate limiting based on client data.