### PR TITLE
create a data client for inline routes

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -59,6 +59,7 @@ const (
 	oauthCredentialsDirUsage       = "directory where oauth credentials are stored: client.json and user.json"
 	oauthScopeUsage                = "the whitespace separated list of oauth scopes"
 	routesFileUsage                = "file containing static route definitions"
+	inlineRoutesUsage              = "inline routes in eskip format"
 	sourcePollTimeoutUsage         = "polling timeout of the routing data sources, in milliseconds"
 	insecureUsage                  = "flag indicating to ignore the verification of the TLS certificates of the backend services"
 	proxyPreserveHostUsage         = "flag indicating to preserve the incoming request 'Host' header in the outgoing requests"
@@ -123,6 +124,7 @@ var (
 	innkeeperURL              string
 	sourcePollTimeout         int64
 	routesFile                string
+	inlineRoutes              string
 	oauthURL                  string
 	oauthScope                string
 	oauthCredentialsDir       string
@@ -187,6 +189,7 @@ func init() {
 	flag.StringVar(&innkeeperURL, "innkeeper-url", "", innkeeperURLUsage)
 	flag.Int64Var(&sourcePollTimeout, "source-poll-timeout", defaultSourcePollTimeout, sourcePollTimeoutUsage)
 	flag.StringVar(&routesFile, "routes-file", "", routesFileUsage)
+	flag.StringVar(&inlineRoutes, "inline-routes", "", inlineRoutesUsage)
 	flag.StringVar(&oauthURL, "oauth-url", "", oauthURLUsage)
 	flag.StringVar(&oauthScope, "oauth-scope", "", oauthScopeUsage)
 	flag.StringVar(&oauthCredentialsDir, "oauth-credentials-dir", "", oauthCredentialsDirUsage)
@@ -294,6 +297,7 @@ func main() {
 		InnkeeperUrl:                        innkeeperURL,
 		SourcePollTimeout:                   time.Duration(sourcePollTimeout) * time.Millisecond,
 		RoutesFile:                          routesFile,
+		InlineRoutes:                        inlineRoutes,
 		IdleConnectionsPerHost:              idleConnsPerHost,
 		CloseIdleConnsPeriod:                time.Duration(clsic) * time.Second,
 		IgnoreTrailingSlash:                 false,

--- a/dataclients/routestring/string.go
+++ b/dataclients/routestring/string.go
@@ -1,0 +1,31 @@
+// Package routestring provides a DataClient implementation for
+// setting route configuration in form of simple eskip string.
+package routestring
+
+import (
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/routing"
+)
+
+type routes struct {
+	parsed []*eskip.Route
+}
+
+// New creates a data client that parses a string of eskip routes and
+// serves it for the routing package.
+func New(r string) (routing.DataClient, error) {
+	parsed, err := eskip.Parse(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &routes{parsed: parsed}, nil
+}
+
+func (r *routes) LoadAll() ([]*eskip.Route, error) {
+	return r.parsed, nil
+}
+
+func (_ *routes) LoadUpdate() ([]*eskip.Route, []string, error) {
+	return nil, nil, nil
+}

--- a/dataclients/routestring/string_test.go
+++ b/dataclients/routestring/string_test.go
@@ -1,0 +1,111 @@
+package routestring
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sanity-io/litter"
+	"github.com/zalando/skipper/eskip"
+)
+
+func TestRouteString(t *testing.T) {
+	for _, test := range []struct {
+		title    string
+		text     string
+		expected []*eskip.Route
+		fail     bool
+	}{{
+		title: "empty",
+	}, {
+		title: "invalid",
+		text:  "foo",
+		fail:  true,
+	}, {
+		title: "single expression",
+		text:  `* -> static("/", "/var/www") -> <shunt>`,
+		expected: []*eskip.Route{{
+			Filters: []*eskip.Filter{{
+				Name: "static",
+				Args: []interface{}{
+					"/",
+					"/var/www",
+				},
+			}},
+			BackendType: eskip.ShuntBackend,
+			Shunt:       true,
+		}},
+	}, {
+		title: "single definition",
+		text:  `static_content: * -> static("/", "/var/www") -> <shunt>`,
+		expected: []*eskip.Route{{
+			Id: "static_content",
+			Filters: []*eskip.Filter{{
+				Name: "static",
+				Args: []interface{}{
+					"/",
+					"/var/www",
+				},
+			}},
+			BackendType: eskip.ShuntBackend,
+			Shunt:       true,
+		}},
+	}, {
+		title: "multiple definitions",
+		text: `static_content: * -> static("/", "/var/www") -> <shunt>;
+			register: Method("POST") && Path("/register")
+				-> setPath("/")
+				-> "https://register.example.org"`,
+		expected: []*eskip.Route{{
+			Id: "static_content",
+			Filters: []*eskip.Filter{{
+				Name: "static",
+				Args: []interface{}{
+					"/",
+					"/var/www",
+				},
+			}},
+			BackendType: eskip.ShuntBackend,
+			Shunt:       true,
+		}, {
+			Id:     "register",
+			Method: "POST",
+			Path:   "/register",
+			Filters: []*eskip.Filter{{
+				Name: "setPath",
+				Args: []interface{}{
+					"/",
+				},
+			}},
+			Backend: "https://register.example.org",
+		}},
+	}} {
+		t.Run(test.title, func(t *testing.T) {
+			dc, err := New(test.text)
+			if err == nil && test.fail {
+				t.Error("failed to fail")
+				return
+			} else if err != nil && !test.fail {
+				t.Error(err)
+				return
+			} else if test.fail {
+				return
+			}
+
+			r, err := dc.LoadAll()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if len(r) == 0 {
+				r = nil
+			}
+
+			if !reflect.DeepEqual(r, test.expected) {
+				t.Error("invalid routes received")
+				t.Log("got:     ", litter.Sdump(r))
+				t.Log("expected:", litter.Sdump(test.expected))
+			}
+		})
+	}
+}

--- a/skipper.go
+++ b/skipper.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/circuit"
 	"github.com/zalando/skipper/dataclients/kubernetes"
+	"github.com/zalando/skipper/dataclients/routestring"
 	"github.com/zalando/skipper/eskipfile"
 	"github.com/zalando/skipper/etcd"
 	"github.com/zalando/skipper/filters"
@@ -118,6 +119,9 @@ type Options struct {
 
 	// File containing static route definitions.
 	RoutesFile string
+
+	// InlineRoutes can define routes as eskip text.
+	InlineRoutes string
 
 	// Polling timeout of the routing data sources.
 	SourcePollTimeout time.Duration
@@ -322,6 +326,16 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 		}
 
 		clients = append(clients, f)
+	}
+
+	if o.InlineRoutes != "" {
+		ir, err := routestring.New(o.InlineRoutes)
+		if err != nil {
+			log.Error("error while parsing inline routes", err)
+			return nil, err
+		}
+
+		clients = append(clients, ir)
 	}
 
 	if o.InnkeeperUrl != "" {


### PR DESCRIPTION
- creates a DataClient implementation for taking routes as in-memory strings
- adds an InlineRoutes option in the root package
- adds command a line flag to set inline routes