### PR TITLE
create a filter for inline content

### DIFF
--- a/eskip/doc.go
+++ b/eskip/doc.go
@@ -154,6 +154,8 @@ filters:
 
 	static("/images", "/var/www/images")
 
+	inlineContent("{\"foo\": 42}", "application/json")
+
 	stripQuery("true")
 
 	preserveHost()

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -43,6 +43,7 @@ const (
 	CompressName        = "compress"
 	SetQueryName        = "setQuery"
 	DropQueryName       = "dropQuery"
+	InlineContentName   = "inlineContent"
 )
 
 // Returns a Registry object initialized with the default set of filter
@@ -69,6 +70,7 @@ func MakeRegistry() filters.Registry {
 		NewRedirectTo(),
 		NewRedirectLower(),
 		NewStripQuery(),
+		NewInlineContent(),
 		flowid.New(),
 		PreserveHost(),
 		NewStatus(),

--- a/filters/builtin/inlinecontent.go
+++ b/filters/builtin/inlinecontent.go
@@ -14,6 +14,22 @@ type inlineContent struct {
 	mime string
 }
 
+// Creates a filter spec for the inlineContent() filter.
+//
+// Usage of the filter:
+//
+//     * -> status(420) -> inlineContent("Enhance Your Calm") -> <shunt>
+//
+// Or:
+//
+//     * -> inlineContent("{\"foo\": 42}", "application/json") -> <shunt>
+//
+// It accepts two arguments: the content and the optional content type.
+// When the content type is not set, it tries to detect it using
+// http.DetectContentType.
+//
+// The filter shunts the request with status code 200.
+//
 func NewInlineContent() filters.Spec {
 	return &inlineContent{}
 }

--- a/filters/builtin/inlinecontent_test.go
+++ b/filters/builtin/inlinecontent_test.go
@@ -1,0 +1,158 @@
+package builtin
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/proxy/proxytest"
+)
+
+func TestInlineContentArgs(t *testing.T) {
+	for _, test := range []struct {
+		title        string
+		args         []interface{}
+		expectedText string
+		expectedMime string
+		fail         bool
+	}{{
+		title: "no args",
+		fail:  true,
+	}, {
+		title: "too many args",
+		args:  []interface{}{"foo", "bar", "baz"},
+		fail:  true,
+	}, {
+		title: "not string for text",
+		args:  []interface{}{42, "bar"},
+		fail:  true,
+	}, {
+		title: "not string for mime",
+		args:  []interface{}{"foo", 42},
+		fail:  true,
+	}, {
+		title:        "text only",
+		args:         []interface{}{"foo"},
+		expectedText: "foo",
+		expectedMime: "text/plain",
+	}, {
+		title:        "html, detected",
+		args:         []interface{}{`<!doctype html><html>foo</html>`},
+		expectedText: `<!doctype html><html>foo</html>`,
+		expectedMime: "text/html",
+	}} {
+		t.Run(test.title, func(t *testing.T) {
+			f, err := (&inlineContent{}).CreateFilter(test.args)
+			if test.fail && err == nil {
+				t.Error("fail to fail")
+				return
+			} else if err != nil && !test.fail {
+				t.Error(err)
+				return
+			} else if test.fail {
+				return
+			}
+
+			c := f.(*inlineContent)
+
+			if c.text != test.expectedText {
+				t.Error("invalid content")
+				t.Log("got:     ", c.text)
+				t.Log("expected:", test.expectedText)
+			}
+
+			if !strings.HasPrefix(c.mime, test.expectedMime) {
+				t.Error("invalid mime")
+				t.Log("got:     ", c.mime)
+				t.Log("expected:", test.expectedMime)
+			}
+		})
+	}
+}
+
+func TestInlineContent(t *testing.T) {
+	for _, test := range []struct {
+		title               string
+		routes              string
+		expectedContent     string
+		expectedContentType string
+	}{{
+		title:  "empty",
+		routes: `* -> inlineContent("") -> <shunt>`,
+	}, {
+		title:               "some text, automatic",
+		routes:              `* -> inlineContent("foo bar baz") -> <shunt>`,
+		expectedContent:     "foo bar baz",
+		expectedContentType: "text/plain",
+	}, {
+		title: "some text, custom",
+		routes: `*
+			-> inlineContent("foo bar baz", "application/foo")
+			-> <shunt>`,
+		expectedContent:     "foo bar baz",
+		expectedContentType: "application/foo",
+	}, {
+		title: "some json",
+		routes: `*
+			-> inlineContent("{\"foo\": [\"bar\", \"baz\"]}", "application/json")
+			-> <shunt>`,
+		expectedContent:     "{\"foo\": [\"bar\", \"baz\"]}",
+		expectedContentType: "application/json",
+	}} {
+		t.Run(test.title, func(t *testing.T) {
+			r, err := eskip.Parse(test.routes)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			p := proxytest.New(MakeRegistry(), r...)
+			defer p.Close()
+
+			rsp, err := http.Get(p.URL)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			defer rsp.Body.Close()
+
+			if rsp.StatusCode != http.StatusOK {
+				t.Error("invalid status received")
+				t.Log("got:     ", rsp.StatusCode)
+				t.Log("expected:", http.StatusOK)
+			}
+
+			if !strings.HasPrefix(
+				rsp.Header.Get("Content-Type"),
+				test.expectedContentType,
+			) {
+				t.Error("invalid content type received")
+				t.Log("got:     ", rsp.Header.Get("Content-Type"))
+				t.Log("expected:", test.expectedContentType)
+			}
+
+			if rsp.Header.Get("Content-Length") !=
+				strconv.Itoa(len(test.expectedContent)) {
+				t.Error("invalid content length received")
+				t.Log("got:     ", rsp.Header.Get("Content-Length"))
+				t.Log("expected:", len(test.expectedContent))
+			}
+
+			b, err := ioutil.ReadAll(rsp.Body)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if string(b) != test.expectedContent {
+				t.Error("invalid content received")
+				t.Log("got:     ", string(b))
+				t.Log("expected:", test.expectedContent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
creates a filter that can be used to return static inline content, primarily for testing or demo