### PR TITLE
header copy filters 

### DIFF
--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -75,6 +75,8 @@ func MakeRegistry() filters.Registry {
 		PreserveHost(),
 		NewStatus(),
 		NewCompress(),
+		NewCopyRequestHeader(),
+		NewCopyResponseHeader(),
 		diag.NewRandom(),
 		diag.NewLatency(),
 		diag.NewBandwidth(),

--- a/filters/builtin/copy.go
+++ b/filters/builtin/copy.go
@@ -1,0 +1,91 @@
+package builtin
+
+import "github.com/zalando/skipper/filters"
+
+const (
+	requestCopyFilterName  = "requestCopyHeader"
+	responseCopyFilterName = "responseCopyHeader"
+	// CopyRequestHeader copies a request header to another proxy
+	// request header
+	CopyRequestHeader direction = iota
+	// CopyResponseHeader copies a proxied response header to the
+	// response header
+	CopyResponseHeader
+)
+
+type direction int
+
+type copySpec struct {
+	typ        direction
+	filterName string
+}
+type copyFilter struct {
+	typ      direction
+	src, dst string
+}
+
+// NewCopyRequestHeader creates a filter specification whose instances
+// copies a specified source Header to a defined destination Header
+// from the request to the proxy request.
+func NewCopyRequestHeader() filters.Spec {
+	return &copySpec{
+		typ:        CopyRequestHeader,
+		filterName: requestCopyFilterName,
+	}
+}
+
+// NewCopyResponseHeader creates a filter specification whose instances
+// copies a specified source Header to a defined destination Header
+// from the backend response to the proxy response.
+func NewCopyResponseHeader() filters.Spec {
+	return &copySpec{
+		typ:        CopyResponseHeader,
+		filterName: responseCopyFilterName,
+	}
+}
+
+func (s *copySpec) Name() string { return s.filterName }
+
+func (s *copySpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 2 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	f := &copyFilter{typ: s.typ}
+
+	if value, ok := args[0].(string); ok {
+		f.src = value
+	} else {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	if value, ok := args[1].(string); ok {
+		f.dst = value
+	} else {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	return f, nil
+}
+
+func (f copyFilter) Request(ctx filters.FilterContext) {
+	if f.typ != CopyRequestHeader {
+		return
+	}
+
+	h := ctx.Request().Header
+	if s := h.Get(f.src); s != "" {
+		h.Add(f.dst, s)
+	}
+}
+
+func (f copyFilter) Response(ctx filters.FilterContext) {
+	if f.typ != CopyResponseHeader {
+		return
+	}
+
+	h := ctx.Response().Header
+	if s := h.Get(f.src); s != "" {
+		h.Add(f.dst, s)
+	}
+}

--- a/filters/builtin/copy_test.go
+++ b/filters/builtin/copy_test.go
@@ -1,0 +1,283 @@
+package builtin
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func TestNewCopyRequestHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		want filters.Spec
+	}{
+		{
+			name: "test copy request header constructor",
+			want: &copySpec{
+				typ:        CopyRequestHeader,
+				filterName: requestCopyFilterName,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewCopyRequestHeader(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewCopyRequestHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewCopyResponseHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		want filters.Spec
+	}{
+		{
+			name: "test copy response header constructor",
+			want: &copySpec{
+				typ:        CopyResponseHeader,
+				filterName: responseCopyFilterName,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewCopyResponseHeader(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewCopyResponseHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_copySpec_Name(t *testing.T) {
+	type fields struct {
+		typ        direction
+		filterName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "test response copy filter name",
+			fields: fields{
+				typ:        CopyResponseHeader,
+				filterName: responseCopyFilterName,
+			},
+			want: responseCopyFilterName,
+		}, {
+			name: "test request copy filter name",
+			fields: fields{
+				typ:        CopyRequestHeader,
+				filterName: requestCopyFilterName,
+			},
+			want: requestCopyFilterName,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &copySpec{
+				typ:        tt.fields.typ,
+				filterName: tt.fields.filterName,
+			}
+			if got := s.Name(); got != tt.want {
+				t.Errorf("copySpec.Name() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_copySpec_CreateFilter(t *testing.T) {
+	type fields struct {
+		typ        direction
+		filterName string
+	}
+	type args struct {
+		args []interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    filters.Filter
+		wantErr bool
+	}{
+		{
+			name: "test request copy filter create filter",
+			fields: fields{
+				typ:        CopyRequestHeader,
+				filterName: requestCopyFilterName,
+			},
+			args: args{[]interface{}{"X-Src", "X-Dst"}},
+			want: &copyFilter{
+				typ: CopyRequestHeader,
+				src: "X-Src",
+				dst: "X-Dst",
+			},
+			wantErr: false,
+		}, {
+			name: "test response copy filter create filter",
+			fields: fields{
+				typ:        CopyResponseHeader,
+				filterName: responseCopyFilterName,
+			},
+			args: args{[]interface{}{"X-Src", "X-Dst"}},
+			want: &copyFilter{
+				typ: CopyResponseHeader,
+				src: "X-Src",
+				dst: "X-Dst",
+			},
+			wantErr: false,
+		}, {
+			name: "test wrong args create filter",
+			fields: fields{
+				typ:        CopyResponseHeader,
+				filterName: responseCopyFilterName,
+			},
+			args:    args{[]interface{}{5, "X-Dst"}},
+			want:    nil,
+			wantErr: true,
+		}, {
+			name: "test wrong args 2 create filter",
+			fields: fields{
+				typ:        CopyResponseHeader,
+				filterName: responseCopyFilterName,
+			},
+			args:    args{[]interface{}{"X-Dst", 5}},
+			want:    nil,
+			wantErr: true,
+		}, {
+			name: "test wrong args 3 create filter",
+			fields: fields{
+				typ:        CopyResponseHeader,
+				filterName: responseCopyFilterName,
+			},
+			args:    args{[]interface{}{"X-foo"}},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &copySpec{
+				typ:        tt.fields.typ,
+				filterName: tt.fields.filterName,
+			}
+			got, err := s.CreateFilter(tt.args.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("copySpec.CreateFilter() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("copySpec.CreateFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func buildfilterRequestContext() filters.FilterContext {
+	r, _ := http.NewRequest("GET", "http://example.org/api/v3", nil)
+	r.Header.Add("X-Src", "header src content")
+	return &filtertest.Context{FRequest: r}
+}
+
+func buildfilterResponseContext() filters.FilterContext {
+	r := &http.Response{Header: make(http.Header)}
+	r.Header.Add("X-Src", "header src content")
+	return &filtertest.Context{FResponse: r}
+}
+
+func Test_copyFilter_Request(t *testing.T) {
+	type fields struct {
+		typ direction
+		src string
+		dst string
+	}
+	type args struct {
+		ctx filters.FilterContext
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		expect string
+	}{
+		{
+			name: "request copy header",
+			fields: fields{
+				typ: CopyRequestHeader,
+				src: "X-Src",
+				dst: "X-Dst",
+			},
+			args: args{
+				ctx: buildfilterRequestContext(),
+			},
+			expect: "header src content",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := copyFilter{
+				typ: tt.fields.typ,
+				src: tt.fields.src,
+				dst: tt.fields.dst,
+			}
+			f.Request(tt.args.ctx)
+			got := tt.args.ctx.Request().Header.Get(f.dst)
+			if got != tt.expect {
+				t.Errorf("'%s' expected '%s'", got, tt.expect)
+			}
+		})
+	}
+}
+
+func Test_copyFilter_Response(t *testing.T) {
+	type fields struct {
+		typ direction
+		src string
+		dst string
+	}
+	type args struct {
+		ctx filters.FilterContext
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		expect string
+	}{
+		{
+			name: "response copy header",
+			fields: fields{
+				typ: CopyResponseHeader,
+				src: "X-Src",
+				dst: "X-Dst",
+			},
+			args: args{
+				ctx: buildfilterResponseContext(),
+			},
+			expect: "header src content",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := copyFilter{
+				typ: tt.fields.typ,
+				src: tt.fields.src,
+				dst: tt.fields.dst,
+			}
+			f.Response(tt.args.ctx)
+			got := tt.args.ctx.Response().Header.Get(f.dst)
+			if got != tt.expect {
+				t.Errorf("'%s' expected '%s'", got, tt.expect)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
requestCopyHeader() and responseCopyHeader() that can copy the content of header "src" to "dst" in the request or response pass of the proxy.

Closes #426 