### PR TITLE
Enable eskip to handle OAuth when working with etcd

### DIFF
--- a/cmd/eskip/args.go
+++ b/cmd/eskip/args.go
@@ -27,7 +27,7 @@ import (
 const (
 	etcdUrlsFlag       = "etcd-urls"
 	etcdPrefixFlag     = "etcd-prefix"
-	etcdOAuthTokenFlag = "oauth-token-etcd"
+	etcdOAuthTokenFlag = "etcd-oauth-token"
 	innkeeperUrlFlag   = "innkeeper-url"
 	oauthTokenFlag     = "oauth-token"
 	inlineRoutesFlag   = "routes"

--- a/cmd/eskip/args.go
+++ b/cmd/eskip/args.go
@@ -27,6 +27,7 @@ import (
 const (
 	etcdUrlsFlag       = "etcd-urls"
 	etcdPrefixFlag     = "etcd-prefix"
+	etcdOAuthTokenFlag = "oauth-token-etcd"
 	innkeeperUrlFlag   = "innkeeper-url"
 	oauthTokenFlag     = "oauth-token"
 	inlineRoutesFlag   = "routes"
@@ -62,6 +63,7 @@ var (
 	etcdPrefix        string
 	innkeeperUrl      string
 	oauthToken        string
+	etcdOAuthToken    string
 	inlineRoutes      string
 	inlineRouteIds    string
 	insecure          bool
@@ -88,6 +90,7 @@ func initFlags() {
 	// the default value not used here, because it depends on the command
 	flags.StringVar(&etcdUrls, etcdUrlsFlag, "", etcdUrlsUsage)
 	flags.StringVar(&etcdPrefix, etcdPrefixFlag, "", etcdPrefixUsage)
+	flags.StringVar(&etcdOAuthToken, etcdOAuthTokenFlag, "", etcdOAuthTokenUsage)
 
 	flags.StringVar(&innkeeperUrl, innkeeperUrlFlag, "", innkeeperUrlUsage)
 	flags.StringVar(&oauthToken, oauthTokenFlag, "", oauthTokenUsage)
@@ -135,7 +138,7 @@ func stringsToUrls(strs ...string) ([]*url.URL, error) {
 
 // returns etcd type medium if any of '-etcd-urls' or '-etcd-prefix'
 // are defined.
-func processEtcdArgs(etcdUrls, etcdPrefix string) (*medium, error) {
+func processEtcdArgs(etcdUrls, etcdPrefix, oauthToken string) (*medium, error) {
 	if etcdUrls == "" && etcdPrefix == "" {
 		return nil, nil
 	}
@@ -157,7 +160,8 @@ func processEtcdArgs(etcdUrls, etcdPrefix string) (*medium, error) {
 	return &medium{
 		typ:  etcd,
 		urls: urls,
-		path: etcdPrefix}, nil
+		path: etcdPrefix,
+		oauthToken: oauthToken}, nil
 }
 
 func processInnkeeperArgs(innkeeperUrl, oauthToken string) (*medium, error) {
@@ -254,7 +258,7 @@ func processArgs() ([]*medium, error) {
 		media = append(media, innkeeperArg)
 	}
 
-	etcdArg, err := processEtcdArgs(etcdUrls, etcdPrefix)
+	etcdArg, err := processEtcdArgs(etcdUrls, etcdPrefix, etcdOAuthToken)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/eskip/args.go
+++ b/cmd/eskip/args.go
@@ -158,9 +158,9 @@ func processEtcdArgs(etcdUrls, etcdPrefix, oauthToken string) (*medium, error) {
 	}
 
 	return &medium{
-		typ:  etcd,
-		urls: urls,
-		path: etcdPrefix,
+		typ:        etcd,
+		urls:       urls,
+		path:       etcdPrefix,
 		oauthToken: oauthToken}, nil
 }
 

--- a/cmd/eskip/args_test.go
+++ b/cmd/eskip/args_test.go
@@ -84,7 +84,7 @@ func TestProcessArgs(t *testing.T) {
 		false,
 		nil,
 		[]*medium{{
-			typ: etcd,
+			typ:        etcd,
 			oauthToken: "example",
 			urls: []*url.URL{
 				{Scheme: "https", Host: "etcd1.example.org:4242"},

--- a/cmd/eskip/args_test.go
+++ b/cmd/eskip/args_test.go
@@ -80,6 +80,19 @@ func TestProcessArgs(t *testing.T) {
 	}, {
 
 		// etcd-urls
+		[]string{"-etcd-urls", "https://etcd1.example.org:4242,https://etcd2.example.org:4545", "-etcd-oauth-token", "example"},
+		false,
+		nil,
+		[]*medium{{
+			typ: etcd,
+			oauthToken: "example",
+			urls: []*url.URL{
+				{Scheme: "https", Host: "etcd1.example.org:4242"},
+				{Scheme: "https", Host: "etcd2.example.org:4545"}},
+			path: "/skipper"}},
+	}, {
+
+		// etcd-urls
 		[]string{"-etcd-urls", "https://etcd1.example.org:4242,https://etcd2.example.org:4545"},
 		false,
 		nil,

--- a/cmd/eskip/doc.go
+++ b/cmd/eskip/doc.go
@@ -74,6 +74,7 @@ const (
 	etcdPrefixUsage     = "path prefix for routes in etcd"
 	innkeeperUrlUsage   = "url for the innkeeper service"
 	oauthTokenUsage     = "oauth token used to authenticate to innkeeper"
+	etcdOAuthTokenUsage = "oauth token used to authenticate to etcd"
 	inlineRoutesUsage   = "inline: routes in eskip format"
 	inlineIdsUsage      = "inline ids: comma separated route ids"
 	insecureUsage       = "skip TLS certificate verification"

--- a/cmd/eskip/media.go
+++ b/cmd/eskip/media.go
@@ -73,7 +73,7 @@ func validateSelectRead(media []*medium) (a cmdArgs, err error) {
 	}
 
 	if len(media) == 0 {
-		a.in, err = processEtcdArgs(defaultEtcdUrls, defaultEtcdPrefix)
+		a.in, err = processEtcdArgs(defaultEtcdUrls, defaultEtcdPrefix, "")
 		return
 	}
 

--- a/cmd/eskip/media_test.go
+++ b/cmd/eskip/media_test.go
@@ -30,6 +30,7 @@ func checkMedium(t *testing.T, left, right *medium, testIndex, itemIndex int) {
 
 	if left.typ != right.typ ||
 		left.path != right.path ||
+		left.oauthToken != right.oauthToken ||
 		left.eskip != right.eskip {
 		t.Error("failed to parse medium", testIndex, itemIndex)
 	}

--- a/cmd/eskip/mediadefaults.go
+++ b/cmd/eskip/mediadefaults.go
@@ -14,7 +14,7 @@ var commandToDefaultMediums = map[command]defaultFunc{
 func defaultRead(a cmdArgs) (aa cmdArgs, err error) {
 	aa = a
 	if aa.in == nil {
-		aa.in, err = processEtcdArgs(defaultEtcdUrls, defaultEtcdPrefix)
+		aa.in, err = processEtcdArgs(defaultEtcdUrls, defaultEtcdPrefix, "")
 	}
 	return
 }
@@ -22,7 +22,7 @@ func defaultRead(a cmdArgs) (aa cmdArgs, err error) {
 func defaultWrite(a cmdArgs) (aa cmdArgs, err error) {
 	aa = a
 	if aa.out == nil {
-		aa.out, err = processEtcdArgs(defaultEtcdUrls, defaultEtcdPrefix)
+		aa.out, err = processEtcdArgs(defaultEtcdUrls, defaultEtcdPrefix, "")
 	}
 
 	return

--- a/cmd/eskip/mediadefaults_test.go
+++ b/cmd/eskip/mediadefaults_test.go
@@ -53,6 +53,7 @@ func TestAddDefaultMedia(t *testing.T) {
 		err: nil,
 		inResult: &medium{
 			typ: etcd,
+			oauthToken: "",
 			urls: []*url.URL{
 				{Scheme: "https", Host: "etcd1.example.org:2379"},
 				{Scheme: "https", Host: "etcd2.example.org:4001"}},
@@ -71,6 +72,7 @@ func TestAddDefaultMedia(t *testing.T) {
 		},
 		outResult: &medium{
 			typ: etcd,
+			oauthToken: "",
 			urls: []*url.URL{
 				{Scheme: "http", Host: "127.0.0.1:2379"},
 				{Scheme: "http", Host: "127.0.0.1:4001"}},
@@ -93,6 +95,7 @@ func TestAddDefaultMedia(t *testing.T) {
 		},
 		outResult: &medium{
 			typ: etcd,
+			oauthToken: "",
 			urls: []*url.URL{
 				{Scheme: "https", Host: "etcd1.example.org:2379"},
 				{Scheme: "https", Host: "etcd2.example.org:4001"}},

--- a/cmd/eskip/mediadefaults_test.go
+++ b/cmd/eskip/mediadefaults_test.go
@@ -52,7 +52,7 @@ func TestAddDefaultMedia(t *testing.T) {
 		out: nil,
 		err: nil,
 		inResult: &medium{
-			typ: etcd,
+			typ:        etcd,
 			oauthToken: "",
 			urls: []*url.URL{
 				{Scheme: "https", Host: "etcd1.example.org:2379"},
@@ -71,7 +71,7 @@ func TestAddDefaultMedia(t *testing.T) {
 			typ: stdin,
 		},
 		outResult: &medium{
-			typ: etcd,
+			typ:        etcd,
 			oauthToken: "",
 			urls: []*url.URL{
 				{Scheme: "http", Host: "127.0.0.1:2379"},
@@ -94,7 +94,7 @@ func TestAddDefaultMedia(t *testing.T) {
 			typ: stdin,
 		},
 		outResult: &medium{
-			typ: etcd,
+			typ:        etcd,
 			oauthToken: "",
 			urls: []*url.URL{
 				{Scheme: "https", Host: "etcd1.example.org:2379"},

--- a/cmd/eskip/readclient.go
+++ b/cmd/eskip/readclient.go
@@ -38,9 +38,9 @@ func createReadClient(m *medium) (readClient, error) {
 
 	case etcd:
 		return etcdclient.New(etcdclient.Options{
-			Endpoints: urlsToStrings(m.urls),
-			Prefix:    m.path,
-			Insecure:  insecure,
+			Endpoints:  urlsToStrings(m.urls),
+			Prefix:     m.path,
+			Insecure:   insecure,
 			OAuthToken: m.oauthToken})
 
 	case stdin:

--- a/cmd/eskip/readclient.go
+++ b/cmd/eskip/readclient.go
@@ -40,7 +40,8 @@ func createReadClient(m *medium) (readClient, error) {
 		return etcdclient.New(etcdclient.Options{
 			Endpoints: urlsToStrings(m.urls),
 			Prefix:    m.path,
-			Insecure:  insecure})
+			Insecure:  insecure,
+			OAuthToken: m.oauthToken})
 
 	case stdin:
 		return &stdinReader{reader: os.Stdin}, nil

--- a/cmd/eskip/writeclient.go
+++ b/cmd/eskip/writeclient.go
@@ -25,9 +25,9 @@ func createWriteClient(out *medium) (writeClient, error) {
 		return createInnkeeperClient(out)
 	case etcd:
 		return etcdclient.New(etcdclient.Options{
-			Endpoints: urlsToStrings(out.urls),
-			Prefix:    out.path,
-			Insecure:  insecure,
+			Endpoints:  urlsToStrings(out.urls),
+			Prefix:     out.path,
+			Insecure:   insecure,
 			OAuthToken: out.oauthToken})
 	}
 	return nil, invalidOutput

--- a/cmd/eskip/writeclient.go
+++ b/cmd/eskip/writeclient.go
@@ -27,7 +27,8 @@ func createWriteClient(out *medium) (writeClient, error) {
 		return etcdclient.New(etcdclient.Options{
 			Endpoints: urlsToStrings(out.urls),
 			Prefix:    out.path,
-			Insecure:  insecure})
+			Insecure:  insecure,
+			OAuthToken: out.oauthToken})
 	}
 	return nil, invalidOutput
 }

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -106,6 +106,9 @@ type Options struct {
 
 	// Skip TLS certificate check.
 	Insecure bool
+
+	// Optional OAuth-Token
+	OAuthToken string
 }
 
 // A Client is used to load the whole set of routes and the updates from an
@@ -115,6 +118,7 @@ type Client struct {
 	routesRoot string
 	client     *http.Client
 	etcdIndex  uint64
+	oauthToken string
 }
 
 var (
@@ -154,7 +158,8 @@ func New(o Options) (*Client, error) {
 		endpoints:  o.Endpoints,
 		routesRoot: o.Prefix + routesPath,
 		client:     httpClient,
-		etcdIndex:  0}, nil
+		etcdIndex:  0,
+		oauthToken: o.OAuthToken}, nil
 }
 
 func isTimeout(err error) bool {
@@ -262,6 +267,11 @@ func (c *Client) etcdRequest(method, path, data string) (*response, error) {
 		}
 
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		if c.oauthToken != "" {
+			r.Header.Set("Authorization", "Bearer " + c.oauthToken)
+		}
+
 		return r, nil
 	})
 

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -269,7 +269,7 @@ func (c *Client) etcdRequest(method, path, data string) (*response, error) {
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		if c.oauthToken != "" {
-			r.Header.Set("Authorization", "Bearer " + c.oauthToken)
+			r.Header.Set("Authorization", "Bearer "+c.oauthToken)
 		}
 
 		return r, nil

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -260,7 +260,7 @@ func TestReceivesInitial(t *testing.T) {
 
 	expectedEndpoints := strings.Join(etcdtest.Urls, ";")
 
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -287,7 +287,7 @@ func TestReceivesUpdates(t *testing.T) {
 		return
 	}
 
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -317,7 +317,7 @@ func TestReceiveInsert(t *testing.T) {
 		return
 	}
 
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -350,7 +350,7 @@ func TestReceiveDelete(t *testing.T) {
 		return
 	}
 
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -375,7 +375,7 @@ func TestReceiveDelete(t *testing.T) {
 }
 
 func TestUpsertNoId(t *testing.T) {
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -393,7 +393,7 @@ func TestUpsertNew(t *testing.T) {
 		return
 	}
 
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -419,7 +419,7 @@ func TestUpsertExisting(t *testing.T) {
 		return
 	}
 
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -448,7 +448,7 @@ func TestUpsertExisting(t *testing.T) {
 }
 
 func TestDeleteNoId(t *testing.T) {
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -465,7 +465,7 @@ func TestDeleteNotExists(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -495,7 +495,7 @@ func TestDelete(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return
@@ -529,7 +529,7 @@ func TestLoadWithParseFailures(t *testing.T) {
 	etcdtest.PutData("catalog", `Path("/pdp") -> "https://catalog.example.org"`)
 	etcdtest.PutData("cms", "invalid expression")
 
-	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false})
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, ""})
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
This is a first draft with missing new tests to enable eskip to handle oauth. Just did it straight forward and added it to the client.

Also introduced a new `oauth-token-etcd` argument to have no collisions with current innkeeper implementation.