### PR TITLE
Minor fixes for prometheus metrics

### DIFF
--- a/metrics/codahale.go
+++ b/metrics/codahale.go
@@ -232,7 +232,7 @@ func (c *codaHaleMetricsHandler) sendMetrics(w http.ResponseWriter, p string) {
 // This listener is only used to expose the metrics
 func (c *codaHaleMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
 	p := r.URL.Path

--- a/metrics/doc.go
+++ b/metrics/doc.go
@@ -11,7 +11,7 @@ For CodaHale format it uses the Go implementation of the Go Coda Hale metrics li
 https://github.com/dropwizard/metrics
 https://github.com/rcrowley/go-metrics
 
-For Prometheus format is will use Prometheus Go  official client library:
+For Prometheus format, it uses Prometheus Go official client library:
 
 https://github.com/prometheus/client_golang
 
@@ -34,7 +34,7 @@ REST API
 
 This listener accepts GET requests on the /metrics endpoint like any other REST api. A request to "/metrics" should
 return a JSON response including all the collected metrics if CodaHale format is used, or in Plain text if Prometheus
-format is use . Please note that a lot of metrics are created lazily whenever a request triggers them. This means that
+format is used. Please note that a lot of metrics are created lazily whenever a request triggers them. This means that
 the API response will depend on the current routes and the filters used. In the case there are no metrics due to inactivity,
 the API will return 404 if CodaHale is used or 200 if Prometheus is used.
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -179,7 +179,7 @@ func NewHandler(o Options, m Metrics) http.Handler {
 
 	// Root path should return 404.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusNotFound)
 	})
 
 	Default = m

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -21,7 +21,7 @@ func TestHandlerPrometheusBadRequests(t *testing.T) {
 	rw := httptest.NewRecorder()
 
 	mh.ServeHTTP(rw, r)
-	if rw.Code != http.StatusBadRequest {
+	if rw.Code != http.StatusNotFound {
 		t.Error("The root resource should not provide a valid response")
 	}
 }
@@ -57,14 +57,14 @@ func TestHandlerCodaHaleBadRequests(t *testing.T) {
 	rw1 := httptest.NewRecorder()
 
 	mh.ServeHTTP(rw1, r1)
-	if rw1.Code != http.StatusBadRequest {
+	if rw1.Code != http.StatusNotFound {
 		t.Error("The root resource should not provide a valid response")
 	}
 
 	r2, _ := http.NewRequest("POST", "/metrics", nil)
 	rw2 := httptest.NewRecorder()
 	mh.ServeHTTP(rw2, r2)
-	if rw2.Code != http.StatusBadRequest {
+	if rw2.Code != http.StatusMethodNotAllowed {
 		t.Error("POST method should not provide a valid response")
 	}
 }


### PR DESCRIPTION
Minor fixes pointed out on #507 PR that's already merged.

* Typos on doc
* Set better status code on not allowed path for metrics endpoint `/`: `400` -> `404`
* Set better status code on not allowed method `POST` on codaHale format metrics enpoint: `400` -> `405`