### PR TITLE
eskip, filters: use `fmt.Errorf` directly

### DIFF
--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -318,7 +318,7 @@ func (l *eskipLex) Lex(lval *eskipSymType) int {
 }
 
 func (l *eskipLex) Error(err string) {
-	l.err = errors.New(fmt.Sprintf(
+	l.err = fmt.Errorf(
 		"parse failed after token %v, position %d: %s",
-		l.lastToken, l.initialLength-len(l.code), err))
+		l.lastToken, l.initialLength-len(l.code), err)
 }

--- a/filters/flowid/standard.go
+++ b/filters/flowid/standard.go
@@ -1,7 +1,6 @@
 package flowid
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"regexp"
@@ -16,7 +15,7 @@ const (
 )
 
 var (
-	ErrInvalidLen       = errors.New(fmt.Sprintf("Invalid length. Must be between %d and %d", MinLength, MaxLength))
+	ErrInvalidLen       = fmt.Errorf("Invalid length. Must be between %d and %d", MinLength, MaxLength)
 	standardFlowIDRegex = regexp.MustCompile(`^[0-9a-zA-Z+-]+$`)
 )
 


### PR DESCRIPTION
 - instead of `errors.New(fmt.Sprintf())`