### PR TITLE
all: simplifications

### DIFF
--- a/filters/diag/diag.go
+++ b/filters/diag/diag.go
@@ -321,7 +321,7 @@ func (t *throttle) goThrottle(in io.ReadCloser, close bool) io.ReadCloser {
 
 				switch t.typ {
 				case bandwidth, backendBandwidth:
-					delay -= time.Now().Sub(start)
+					delay -= time.Since(start)
 				}
 
 				time.Sleep(t.delay)

--- a/logging/handler.go
+++ b/logging/handler.go
@@ -10,7 +10,7 @@ type loggingHandler struct {
 	proxy http.Handler
 }
 
-// Creates an http.Handler that provides access log
+// NewHandler creates an http.Handler that provides access log
 // for the underlying handler.
 func NewHandler(next http.Handler) http.Handler {
 	return &loggingHandler{proxy: next}
@@ -22,7 +22,7 @@ func (lh *loggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	lw := &loggingWriter{writer: w}
 	lh.proxy.ServeHTTP(lw, r)
 
-	dur := time.Now().Sub(now)
+	dur := time.Since(now)
 
 	entry := &AccessEntry{
 		Request:      r,

--- a/logging/log_test.go
+++ b/logging/log_test.go
@@ -2,11 +2,12 @@ package logging
 
 import (
 	"bytes"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"strconv"
 	"strings"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func TestCustomOutputForApplicationLog(t *testing.T) {
@@ -27,7 +28,7 @@ func TestCustomPrefixForApplicationLog(t *testing.T) {
 		ApplicationLogPrefix: prefix})
 	log.Infof("Hello, world!")
 	got := buf.String()
-	if !strings.HasPrefix(got, "[TEST_PREFIX]") || strings.Index(got, "Hello, world!") < 0 {
+	if !strings.HasPrefix(got, "[TEST_PREFIX]") || !strings.Contains(got, "Hello, world!") {
 		t.Error("failed to use custom prefix")
 	}
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -209,7 +209,7 @@ func NewPrometheus(opts Options) *Prometheus {
 
 // sinceS returns the seconds passed since the start time until now.
 func (p *Prometheus) sinceS(start time.Time) float64 {
-	return time.Now().Sub(start).Seconds()
+	return time.Since(start).Seconds()
 }
 
 func (p *Prometheus) registerMetrics() {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -282,7 +282,7 @@ func TestGetRoundtrip(t *testing.T) {
 	}
 
 	if !bytes.Equal(w.Body.Bytes(), payload) {
-		t.Error("wrong content", string(w.Body.Bytes()))
+		t.Error("wrong content", w.Body.String())
 	}
 }
 
@@ -321,7 +321,7 @@ func TestPostRoundtrip(t *testing.T) {
 	}
 
 	if w.Body.Len() != 0 {
-		t.Error("wrong content", string(w.Body.Bytes()))
+		t.Error("wrong content", w.Body.String())
 	}
 }
 

--- a/routing/matcher_test.go
+++ b/routing/matcher_test.go
@@ -1114,9 +1114,7 @@ func BenchmarkConstructionMass(b *testing.B) {
 
 	const count = 10000
 	routes := make([]*Route, count)
-	for i, r := range randomRoutes[:count] {
-		routes[i] = r
-	}
+	copy(routes, randomRoutes[:count])
 
 	for i := 0; i < b.N; i++ {
 		_, errs := newMatcher(routes, IgnoreTrailingSlash)

--- a/routing/routing_test.go
+++ b/routing/routing_test.go
@@ -129,10 +129,7 @@ func stringsAreSame(xs, ys []string) bool {
 			delete(diff, y)
 		}
 	}
-	if len(diff) == 0 {
-		return true
-	}
-	return false
+	return len(diff) == 0
 }
 
 func TestKeepsReceivingInitialRouteDataUntilSucceeds(t *testing.T) {


### PR DESCRIPTION
 * `time.Since` instead of `time.Now().Sub`
 * `strings.Contains` instead of `strings.Index`
 * `bytes.Buffer.String` instead of `string(bytes.Buffer.Bytes())`
 * `copy` instead of for loop