### PR TITLE
all: drop underscore if param or receiver is unused

### DIFF
--- a/dataclients/routestring/string.go
+++ b/dataclients/routestring/string.go
@@ -31,6 +31,6 @@ func (r *routes) LoadAll() ([]*eskip.Route, error) {
 	return r.parsed, nil
 }
 
-func (_ *routes) LoadUpdate() ([]*eskip.Route, []string, error) {
+func (*routes) LoadUpdate() ([]*eskip.Route, []string, error) {
 	return nil, nil, nil
 }

--- a/filters/builtin/path.go
+++ b/filters/builtin/path.go
@@ -123,4 +123,4 @@ func (f *modPath) Request(ctx filters.FilterContext) {
 }
 
 // Noop.
-func (_ *modPath) Response(_ filters.FilterContext) {}
+func (*modPath) Response(filters.FilterContext) {}

--- a/filters/builtin/query.go
+++ b/filters/builtin/query.go
@@ -129,4 +129,4 @@ func (f *modQuery) Request(ctx filters.FilterContext) {
 }
 
 // Noop.
-func (_ *modQuery) Response(_ filters.FilterContext) {}
+func (*modQuery) Response(filters.FilterContext) {}

--- a/filters/flowid/filter.go
+++ b/filters/flowid/filter.go
@@ -2,9 +2,10 @@ package flowid
 
 import (
 	"fmt"
-	"github.com/zalando/skipper/filters"
 	"log"
 	"strings"
+
+	"github.com/zalando/skipper/filters"
 )
 
 const (
@@ -82,7 +83,7 @@ func (f *flowId) Request(fc filters.FilterContext) {
 }
 
 // Response is No-Op in this filter
-func (_ *flowId) Response(filters.FilterContext) {}
+func (*flowId) Response(filters.FilterContext) {}
 
 // CreateFilter will return a new flowId filter from the spec
 // If at least 1 argument is present and it contains the value "reuse", the filter instance is configured to accept
@@ -104,4 +105,4 @@ func (spec *flowIdSpec) CreateFilter(fc []interface{}) (filters.Filter, error) {
 }
 
 // Name returns the canonical filter name
-func (_ *flowIdSpec) Name() string { return Name }
+func (*flowIdSpec) Name() string { return Name }

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -167,7 +167,7 @@ func (t *tracer) Extract(format interface{}, carrier interface{}) (ot.SpanContex
 }
 
 // SpanContext interface
-func (s *span) ForeachBaggageItem(_ func(k, v string) bool) {}
+func (s *span) ForeachBaggageItem(func(k, v string) bool) {}
 
 // Span interface
 func (s *span) Finish() {
@@ -192,15 +192,15 @@ func (s *span) SetTag(key string, value interface{}) ot.Span {
 	return s
 }
 
-func (_ *span) LogFields(_ ...log.Field) {}
+func (*span) LogFields(...log.Field) {}
 
-func (_ *span) LogKV(_ ...interface{}) {}
+func (*span) LogKV(...interface{}) {}
 
 func (s *span) SetBaggageItem(restrictedKey, value string) ot.Span {
 	return s
 }
 
-func (_ *span) BaggageItem(_ string) string {
+func (*span) BaggageItem(string) string {
 	return ""
 }
 
@@ -208,8 +208,8 @@ func (s *span) Tracer() ot.Tracer {
 	return s.tracer
 }
 
-func (_ *span) LogEvent(_ string) {}
+func (*span) LogEvent(string) {}
 
-func (_ *span) LogEventWithPayload(_ string, _ interface{}) {}
+func (*span) LogEventWithPayload(string, interface{}) {}
 
-func (_ *span) Log(_ ot.LogData) {}
+func (*span) Log(ot.LogData) {}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -60,7 +60,7 @@ func NewSameBucketLookuper() SameBucketLookuper {
 }
 
 // Lookup will always return "s" to select the same bucket.
-func (_ SameBucketLookuper) Lookup(req *http.Request) string {
+func (SameBucketLookuper) Lookup(*http.Request) string {
 	return "s"
 }
 
@@ -75,7 +75,7 @@ func NewXForwardedForLookuper() XForwardedForLookuper {
 
 // Lookup returns the content of the X-Forwarded-For header or the
 // clientIP if not set.
-func (_ XForwardedForLookuper) Lookup(req *http.Request) string {
+func (XForwardedForLookuper) Lookup(req *http.Request) string {
 	return net.RemoteHost(req).String()
 }
 
@@ -89,7 +89,7 @@ func NewAuthLookuper() AuthLookuper {
 }
 
 // Lookup returns the content of the Authorization header.
-func (_ AuthLookuper) Lookup(req *http.Request) string {
+func (AuthLookuper) Lookup(req *http.Request) string {
 	return req.Header.Get("Authorization")
 }
 


### PR DESCRIPTION
 - this satisfies golint and also a follow up on
https://github.com/zalando/skipper/pull/521#discussion_r158845373