### PR TITLE
fix endpoint.Targets() to filter selected targets also by ports

### DIFF
--- a/dataclients/kubernetes/definitions.go
+++ b/dataclients/kubernetes/definitions.go
@@ -122,12 +122,15 @@ type endpoint struct {
 	Subsets []*subset `json:"subsets"`
 }
 
-func (ep endpoint) Targets() []string {
+func (ep endpoint) Targets(ingSvcPort string) []string {
+	epPort, _ := strconv.Atoi(ingSvcPort)
 	result := make([]string, 0)
 	for _, s := range ep.Subsets {
 		for _, port := range s.Ports {
-			for _, addr := range s.Addresses {
-				result = append(result, fmt.Sprintf("http://%s:%d", addr.IP, port.Port))
+			if port.Name == ingSvcPort || port.Port == epPort {
+				for _, addr := range s.Addresses {
+					result = append(result, fmt.Sprintf("http://%s:%d", addr.IP, port.Port))
+				}
 			}
 		}
 	}
@@ -145,6 +148,7 @@ type address struct {
 }
 
 type port struct {
+	Name     string `json:"name"`
 	Port     int    `json:"port"`
 	Protocol string `json:"protocol"`
 }

--- a/dataclients/kubernetes/definitions_test.go
+++ b/dataclients/kubernetes/definitions_test.go
@@ -1,0 +1,124 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_endpoint_Targets(t *testing.T) {
+	tests := []struct {
+		name       string
+		Subsets    []*subset
+		ingSvcPort string
+		want       []string
+	}{
+		{
+			name: "single node and port fully specified by name",
+			Subsets: []*subset{
+				&subset{
+					Addresses: []*address{
+						&address{
+							IP:   "1.2.3.4",
+							Node: "nodeA",
+						},
+					},
+					Ports: []*port{
+						&port{
+							Name:     "http",
+							Port:     80,
+							Protocol: "tcp",
+						},
+					},
+				},
+			},
+			ingSvcPort: "http",
+			want:       []string{"http://1.2.3.4:80"},
+		},
+		{
+			name: "single node and port fully specified by port number",
+			Subsets: []*subset{
+				&subset{
+					Addresses: []*address{
+						&address{
+							IP:   "1.2.3.4",
+							Node: "nodeA",
+						},
+					},
+					Ports: []*port{
+						&port{
+							Name:     "http",
+							Port:     80,
+							Protocol: "tcp",
+						},
+					},
+				},
+			},
+			ingSvcPort: "80",
+			want:       []string{"http://1.2.3.4:80"},
+		},
+		{
+			name: "single node and 2 ports fully specified by name",
+			Subsets: []*subset{
+				&subset{
+					Addresses: []*address{
+						&address{
+							IP:   "1.2.3.4",
+							Node: "nodeA",
+						},
+					},
+					Ports: []*port{
+						&port{
+							Name:     "http",
+							Port:     80,
+							Protocol: "tcp",
+						},
+						&port{
+							Name:     "metrics",
+							Port:     9911,
+							Protocol: "tcp",
+						},
+					},
+				},
+			},
+			ingSvcPort: "http",
+			want:       []string{"http://1.2.3.4:80"},
+		},
+		{
+			name: "single node and 2 ports fully specified by port number",
+			Subsets: []*subset{
+				&subset{
+					Addresses: []*address{
+						&address{
+							IP:   "1.2.3.4",
+							Node: "nodeA",
+						},
+					},
+					Ports: []*port{
+						&port{
+							Name:     "http",
+							Port:     80,
+							Protocol: "tcp",
+						},
+						&port{
+							Name:     "metrics",
+							Port:     9911,
+							Protocol: "tcp",
+						},
+					},
+				},
+			},
+			ingSvcPort: "80",
+			want:       []string{"http://1.2.3.4:80"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := endpoint{
+				Subsets: tt.Subsets,
+			}
+			if got := ep.Targets(tt.ingSvcPort); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("endpoint.Targets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will fix  #563

Given an ingress spec:

    spec:
      rules:
      - host: foo.example.org
        http:
          paths:
          - backend:
              serviceName: foo
              servicePort: http
            path: /

And a service definition:

    spec:
      ports:
      - name: http
        port: 80
        protocol: TCP
        targetPort: 9090
      - name: metrics
         port: 9911
        protocol: TCP
        targetPort: 9911
      selector:
        application: foo
      type: ClusterIP

would result in 2x the replica count one for each pod :80 and :9911. 

This PR will fix it and make sure only selected endpoints will be used (with port :80).