### PR TITLE
Feature/add migration path for metrics

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -51,66 +51,66 @@ const (
 	defaultMaxIdleConnsBackend             = 0
 	defaultLoadBalancerHealthCheckInterval = 0 // disabled
 
-	addressUsage                         = "network address that skipper should listen on"
-	etcdUrlsUsage                        = "urls of nodes in an etcd cluster, storing route definitions"
-	etcdPrefixUsage                      = "path prefix for skipper related data in etcd"
-	kubernetesUsage                      = "enables skipper to generate routes for ingress resources in kubernetes cluster"
-	kubernetesInClusterUsage             = "specify if skipper is running inside kubernetes cluster"
-	kubernetesURLUsage                   = "kubernetes API base URL for the ingress data client; requires kubectl proxy running; omit if kubernetes-in-cluster is set to true"
-	kubernetesHealthcheckUsage           = "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes"
-	kubernetesHTTPSRedirectUsage         = "automatic HTTP->HTTPS redirect route; valid only with kubernetes"
-	kubernetesIngressClassUsage          = "ingress class regular expression used to filter ingress resources for kubernetes"
-	innkeeperURLUsage                    = "API endpoint of the Innkeeper service, storing route definitions"
-	innkeeperAuthTokenUsage              = "fixed token for innkeeper authentication"
-	innkeeperPreRouteFiltersUsage        = "filters to be prepended to each route loaded from Innkeeper"
-	innkeeperPostRouteFiltersUsage       = "filters to be appended to each route loaded from Innkeeper"
-	oauthURLUsage                        = "OAuth2 URL for Innkeeper authentication"
-	oauthCredentialsDirUsage             = "directory where oauth credentials are stored: client.json and user.json"
-	oauthScopeUsage                      = "the whitespace separated list of oauth scopes"
-	routesFileUsage                      = "file containing static route definitions"
-	inlineRoutesUsage                    = "inline routes in eskip format"
-	sourcePollTimeoutUsage               = "polling timeout of the routing data sources, in milliseconds"
-	insecureUsage                        = "flag indicating to ignore the verification of the TLS certificates of the backend services"
-	proxyPreserveHostUsage               = "flag indicating to preserve the incoming request 'Host' header in the outgoing requests"
-	idleConnsPerHostUsage                = "maximum idle connections per backend host"
-	closeIdleConnsPeriodUsage            = "period of closing all idle connections in seconds or as a duration string. Not closing when less than 0"
-	devModeUsage                         = "enables developer time behavior, like ubuffered routing updates"
-	supportListenerUsage                 = "network address used for exposing the /metrics endpoint. An empty value disables support endpoint."
-	metricsListenerUsage                 = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
-	metricsPrefixUsage                   = "allows setting a custom path prefix for metrics export"
-	enableProfileUsage                   = "enable profile information on the metrics endpoint with path /pprof"
-	debugGcMetricsUsage                  = "enables reporting of the Go garbage collector statistics exported in debug.GCStats"
-	runtimeMetricsUsage                  = "enables reporting of the Go runtime statistics exported in runtime and specifically runtime.MemStats"
-	serveRouteMetricsUsage               = "enables reporting total serve time metrics for each route"
-	serveHostMetricsUsage                = "enables reporting total serve time metrics for each host"
-	backendHostMetricsUsage              = "enables reporting total serve time metrics for each backend"
-	allFiltersMetricsUsage               = "enables reporting combined filter metrics for each route"
-	combinedResponseMetricsUsage         = "enables reporting combined response time metrics"
-	routeResponseMetricsUsage            = "enables reporting response time metrics for each route"
-	routeBackendErrorCountersUsage       = "enables counting backend errors for each route"
-	routeStreamErrorCountersUsage        = "enables counting streaming errors for each route"
-	routeBackendMetricsUsage             = "enables reporting backend response time metrics for each route"
-	metricsUseExpDecaySampleUsage        = "use exponentially decaying sample in metrics"
-	disableMetricsCompatsUsage           = "disables the default true value for all-filters-metrics, route-response-metrics, route-backend-errorCounters and route-stream-error-counters"
-	applicationLogUsage                  = "output file for the application log. When not set, /dev/stderr is used"
-	applicationLogLevelUsage             = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
-	applicationLogPrefixUsage            = "prefix for each log entry"
-	accessLogUsage                       = "output file for the access log, When not set, /dev/stderr is used"
-	accessLogDisabledUsage               = "when this flag is set, no access log is printed"
-	accessLogJSONEnabledUsage            = "when this flag is set, log in JSON format is used"
-	debugEndpointUsage                   = "when this address is set, skipper starts an additional listener returning the original and transformed requests"
-	certPathTLSUsage                     = "the path on the local filesystem to the certificate file (including any intermediates)"
-	keyPathTLSUsage                      = "the path on the local filesystem to the certificate's private key file"
-	backendFlushIntervalUsage            = "flush interval for upgraded proxy connections"
-	experimentalUpgradeUsage             = "enable experimental feature to handle upgrade protocol requests"
-	versionUsage                         = "print Skipper version"
-	maxLoopbacksUsage                    = "maximum number of loopbacks for an incoming request, set to -1 to disable loopbacks"
-	opentracingUsage                     = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
-	defaultHTTPStatusUsage               = "default HTTP status used when no route is found for a request"
-	pluginDirUsage                       = "set the directory to load plugins from, default is ./"
-	suppressRouteUpdateLogsUsage         = "print only summaries on route updates/deletes"
-	enablePrometheusMetricsUsage         = "use Prometheus metrics format to expose metrics"
-	enableCodahaleMetricsUsage           = "use Codahale metrics format to expose metrics (enabled by default, but you have to select in case you want to have both)"
+	addressUsage                   = "network address that skipper should listen on"
+	etcdUrlsUsage                  = "urls of nodes in an etcd cluster, storing route definitions"
+	etcdPrefixUsage                = "path prefix for skipper related data in etcd"
+	kubernetesUsage                = "enables skipper to generate routes for ingress resources in kubernetes cluster"
+	kubernetesInClusterUsage       = "specify if skipper is running inside kubernetes cluster"
+	kubernetesURLUsage             = "kubernetes API base URL for the ingress data client; requires kubectl proxy running; omit if kubernetes-in-cluster is set to true"
+	kubernetesHealthcheckUsage     = "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes"
+	kubernetesHTTPSRedirectUsage   = "automatic HTTP->HTTPS redirect route; valid only with kubernetes"
+	kubernetesIngressClassUsage    = "ingress class regular expression used to filter ingress resources for kubernetes"
+	innkeeperURLUsage              = "API endpoint of the Innkeeper service, storing route definitions"
+	innkeeperAuthTokenUsage        = "fixed token for innkeeper authentication"
+	innkeeperPreRouteFiltersUsage  = "filters to be prepended to each route loaded from Innkeeper"
+	innkeeperPostRouteFiltersUsage = "filters to be appended to each route loaded from Innkeeper"
+	oauthURLUsage                  = "OAuth2 URL for Innkeeper authentication"
+	oauthCredentialsDirUsage       = "directory where oauth credentials are stored: client.json and user.json"
+	oauthScopeUsage                = "the whitespace separated list of oauth scopes"
+	routesFileUsage                = "file containing static route definitions"
+	inlineRoutesUsage              = "inline routes in eskip format"
+	sourcePollTimeoutUsage         = "polling timeout of the routing data sources, in milliseconds"
+	insecureUsage                  = "flag indicating to ignore the verification of the TLS certificates of the backend services"
+	proxyPreserveHostUsage         = "flag indicating to preserve the incoming request 'Host' header in the outgoing requests"
+	idleConnsPerHostUsage          = "maximum idle connections per backend host"
+	closeIdleConnsPeriodUsage      = "period of closing all idle connections in seconds or as a duration string. Not closing when less than 0"
+	devModeUsage                   = "enables developer time behavior, like ubuffered routing updates"
+	supportListenerUsage           = "network address used for exposing the /metrics endpoint. An empty value disables support endpoint."
+	metricsListenerUsage           = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
+	metricsPrefixUsage             = "allows setting a custom path prefix for metrics export"
+	enableProfileUsage             = "enable profile information on the metrics endpoint with path /pprof"
+	debugGcMetricsUsage            = "enables reporting of the Go garbage collector statistics exported in debug.GCStats"
+	runtimeMetricsUsage            = "enables reporting of the Go runtime statistics exported in runtime and specifically runtime.MemStats"
+	serveRouteMetricsUsage         = "enables reporting total serve time metrics for each route"
+	serveHostMetricsUsage          = "enables reporting total serve time metrics for each host"
+	backendHostMetricsUsage        = "enables reporting total serve time metrics for each backend"
+	allFiltersMetricsUsage         = "enables reporting combined filter metrics for each route"
+	combinedResponseMetricsUsage   = "enables reporting combined response time metrics"
+	routeResponseMetricsUsage      = "enables reporting response time metrics for each route"
+	routeBackendErrorCountersUsage = "enables counting backend errors for each route"
+	routeStreamErrorCountersUsage  = "enables counting streaming errors for each route"
+	routeBackendMetricsUsage       = "enables reporting backend response time metrics for each route"
+	metricsUseExpDecaySampleUsage  = "use exponentially decaying sample in metrics"
+	disableMetricsCompatsUsage     = "disables the default true value for all-filters-metrics, route-response-metrics, route-backend-errorCounters and route-stream-error-counters"
+	applicationLogUsage            = "output file for the application log. When not set, /dev/stderr is used"
+	applicationLogLevelUsage       = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
+	applicationLogPrefixUsage      = "prefix for each log entry"
+	accessLogUsage                 = "output file for the access log, When not set, /dev/stderr is used"
+	accessLogDisabledUsage         = "when this flag is set, no access log is printed"
+	accessLogJSONEnabledUsage      = "when this flag is set, log in JSON format is used"
+	debugEndpointUsage             = "when this address is set, skipper starts an additional listener returning the original and transformed requests"
+	certPathTLSUsage               = "the path on the local filesystem to the certificate file (including any intermediates)"
+	keyPathTLSUsage                = "the path on the local filesystem to the certificate's private key file"
+	backendFlushIntervalUsage      = "flush interval for upgraded proxy connections"
+	experimentalUpgradeUsage       = "enable experimental feature to handle upgrade protocol requests"
+	versionUsage                   = "print Skipper version"
+	maxLoopbacksUsage              = "maximum number of loopbacks for an incoming request, set to -1 to disable loopbacks"
+	opentracingUsage               = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
+	defaultHTTPStatusUsage         = "default HTTP status used when no route is found for a request"
+	pluginDirUsage                 = "set the directory to load plugins from, default is ./"
+	suppressRouteUpdateLogsUsage   = "print only summaries on route updates/deletes"
+	enablePrometheusMetricsUsage   = "*deprecated* use Prometheus metrics format to expose metrics"
+
 	loadBalancerHealthCheckIntervalUsage = "use to set the health checker interval to check healthiness of former dead or unhealthy routes"
 	reverseSourcePredicateUsage          = "reverse the order of finding the client IP from X-Forwarded-For header"
 	readTimeoutServerUsage               = "set ReadTimeout for http server connections"
@@ -194,7 +194,7 @@ var (
 	pluginDir                       string
 	suppressRouteUpdateLogs         bool
 	enablePrometheusMetrics         bool
-	enableCodahaleMetrics           bool
+	metricsFlavour                  metricsFlags
 	loadBalancerHealthCheckInterval time.Duration
 	reverseSourcePredicate          bool
 	readTimeoutServer               time.Duration
@@ -275,7 +275,7 @@ func init() {
 	flag.IntVar(&defaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
 	flag.BoolVar(&suppressRouteUpdateLogs, "suppress-route-update-logs", false, suppressRouteUpdateLogsUsage)
 	flag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", false, enablePrometheusMetricsUsage)
-	flag.BoolVar(&enableCodahaleMetrics, "enable-codahale-metrics", false, enableCodahaleMetricsUsage)
+	flag.Var(&metricsFlavour, "metrics-flavour", metricsFlavourUsage)
 	flag.DurationVar(&loadBalancerHealthCheckInterval, "lb-healthcheck-interval", defaultLoadBalancerHealthCheckInterval, loadBalancerHealthCheckIntervalUsage)
 	flag.BoolVar(&reverseSourcePredicate, "reverse-source-predicate", false, reverseSourcePredicateUsage)
 	flag.DurationVar(&readTimeoutServer, "read-timeout-server", defaultReadTimeoutServer, readTimeoutServerUsage)
@@ -400,7 +400,7 @@ func main() {
 		DefaultHTTPStatus:                   defaultHTTPStatus,
 		SuppressRouteUpdateLogs:             suppressRouteUpdateLogs,
 		EnablePrometheusMetrics:             enablePrometheusMetrics,
-		EnableCodahaleMetrics:               enableCodahaleMetrics,
+		MetricsFlavours:                     metricsFlavour.Get(),
 		LoadBalancerHealthCheckInterval:     loadBalancerHealthCheckInterval,
 		ReverseSourcePredicate:              reverseSourcePredicate,
 		ReadTimeoutServer:                   readTimeoutServer,

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -109,7 +109,7 @@ const (
 	defaultHTTPStatusUsage         = "default HTTP status used when no route is found for a request"
 	pluginDirUsage                 = "set the directory to load plugins from, default is ./"
 	suppressRouteUpdateLogsUsage   = "print only summaries on route updates/deletes"
-	enablePrometheusMetricsUsage   = "*deprecated* use Prometheus metrics format to expose metrics"
+	enablePrometheusMetricsUsage   = "siwtch to Prometheus metrics format to expose metrics. *Deprecated*: use metrics-flavour"
 
 	loadBalancerHealthCheckIntervalUsage = "use to set the health checker interval to check healthiness of former dead or unhealthy routes"
 	reverseSourcePredicateUsage          = "reverse the order of finding the client IP from X-Forwarded-For header"

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -110,6 +110,7 @@ const (
 	pluginDirUsage                       = "set the directory to load plugins from, default is ./"
 	suppressRouteUpdateLogsUsage         = "print only summaries on route updates/deletes"
 	enablePrometheusMetricsUsage         = "use Prometheus metrics format to expose metrics"
+	enableCodahaleMetricsUsage           = "use Codahale metrics format to expose metrics (enabled by default, but you have to select in case you want to have both)"
 	loadBalancerHealthCheckIntervalUsage = "use to set the health checker interval to check healthiness of former dead or unhealthy routes"
 	reverseSourcePredicateUsage          = "reverse the order of finding the client IP from X-Forwarded-For header"
 	readTimeoutServerUsage               = "set ReadTimeout for http server connections"
@@ -193,6 +194,7 @@ var (
 	pluginDir                       string
 	suppressRouteUpdateLogs         bool
 	enablePrometheusMetrics         bool
+	enableCodahaleMetrics           bool
 	loadBalancerHealthCheckInterval time.Duration
 	reverseSourcePredicate          bool
 	readTimeoutServer               time.Duration
@@ -273,6 +275,7 @@ func init() {
 	flag.IntVar(&defaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
 	flag.BoolVar(&suppressRouteUpdateLogs, "suppress-route-update-logs", false, suppressRouteUpdateLogsUsage)
 	flag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", false, enablePrometheusMetricsUsage)
+	flag.BoolVar(&enableCodahaleMetrics, "enable-codahale-metrics", false, enableCodahaleMetricsUsage)
 	flag.DurationVar(&loadBalancerHealthCheckInterval, "lb-healthcheck-interval", defaultLoadBalancerHealthCheckInterval, loadBalancerHealthCheckIntervalUsage)
 	flag.BoolVar(&reverseSourcePredicate, "reverse-source-predicate", false, reverseSourcePredicateUsage)
 	flag.DurationVar(&readTimeoutServer, "read-timeout-server", defaultReadTimeoutServer, readTimeoutServerUsage)
@@ -397,6 +400,7 @@ func main() {
 		DefaultHTTPStatus:                   defaultHTTPStatus,
 		SuppressRouteUpdateLogs:             suppressRouteUpdateLogs,
 		EnablePrometheusMetrics:             enablePrometheusMetrics,
+		EnableCodahaleMetrics:               enableCodahaleMetrics,
 		LoadBalancerHealthCheckInterval:     loadBalancerHealthCheckInterval,
 		ReverseSourcePredicate:              reverseSourcePredicate,
 		ReadTimeoutServer:                   readTimeoutServer,

--- a/cmd/skipper/metricsFlags.go
+++ b/cmd/skipper/metricsFlags.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"strings"
+)
+
+const metricsFlavourUsage = "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale' and 'prometheus', you can select both of them"
+
+type metricsFlags struct {
+	values []string
+}
+
+var (
+	errInvalidMetricsFlag = errors.New("invalid metrics flavour, valid ones are 'codahale' and 'prometheus'")
+	allowed               = map[string]bool{
+		"codahale":   true,
+		"prometheus": true,
+	}
+)
+
+func (m *metricsFlags) String() string {
+	return strings.Join(m.values, ",")
+}
+
+func (m *metricsFlags) Set(value string) error {
+	if m == nil {
+		m = &metricsFlags{}
+	}
+	m.values = strings.Split(value, ",")
+
+	for _, s := range m.values {
+		if _, ok := allowed[s]; !ok {
+			return errInvalidMetricsFlag
+		}
+	}
+	return nil
+}
+
+func (m *metricsFlags) Get() []string {
+	return m.values
+}

--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -92,7 +91,6 @@ func (a *All) RegisterHandler(path string, handler *http.ServeMux) {
 func (a *All) newHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Header.Get("Accept") == "application/codahale+json" {
-			req.URL.Path = strings.TrimPrefix(req.URL.Path, "/metrics")
 			a.codaHaleHandler.ServeHTTP(w, req)
 		} else {
 			a.prometheusHandler.ServeHTTP(w, req)

--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -6,10 +6,10 @@ import (
 )
 
 type All struct {
-	prometheus      *Prometheus
-	codaHale        *CodaHale
-	prommHandler    http.Handler
-	codaHaleHandler http.Handler
+	prometheus        *Prometheus
+	codaHale          *CodaHale
+	prometheusHandler http.Handler
+	codaHaleHandler   http.Handler
 }
 
 func NewAll(o Options) *All {
@@ -83,7 +83,7 @@ func (a *All) IncErrorsStreaming(routeId string) {
 
 }
 func (a *All) RegisterHandler(path string, handler *http.ServeMux) {
-	a.prommHandler = a.prometheus.CreateHandler()
+	a.prometheusHandler = a.prometheus.CreateHandler()
 	a.codaHaleHandler = a.codaHale.CreateHandler(path)
 	handler.Handle(path, a.newHandler())
 }
@@ -93,7 +93,7 @@ func (a *All) newHandler() http.Handler {
 		if req.Header.Get("Accept") == "application/json" {
 			a.codaHaleHandler.ServeHTTP(w, req)
 		} else {
-			a.prommHandler.ServeHTTP(w, req)
+			a.prometheusHandler.ServeHTTP(w, req)
 		}
 	})
 }

--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -1,0 +1,99 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+)
+
+type All struct {
+	prometheus      *Prometheus
+	codaHale        *CodaHale
+	prommHandler    http.Handler
+	codaHaleHandler http.Handler
+}
+
+func NewAll(o Options) *All {
+	return &All{
+		prometheus: NewPrometheus(o),
+		codaHale:   NewCodaHale(o),
+	}
+}
+
+func (a *All) MeasureSince(key string, start time.Time) {
+	a.prometheus.MeasureSince(key, start)
+	a.codaHale.MeasureSince(key, start)
+}
+func (a *All) IncCounter(key string) {
+	a.prometheus.IncCounter(key)
+	a.codaHale.IncCounter(key)
+
+}
+func (a *All) MeasureRouteLookup(start time.Time) {
+	a.prometheus.MeasureRouteLookup(start)
+	a.codaHale.MeasureRouteLookup(start)
+}
+func (a *All) MeasureFilterRequest(filterName string, start time.Time) {
+	a.prometheus.MeasureFilterRequest(filterName, start)
+	a.codaHale.MeasureFilterRequest(filterName, start)
+}
+func (a *All) MeasureAllFiltersRequest(routeId string, start time.Time) {
+	a.prometheus.MeasureAllFiltersRequest(routeId, start)
+	a.codaHale.MeasureAllFiltersRequest(routeId, start)
+}
+func (a *All) MeasureBackend(routeId string, start time.Time) {
+	a.prometheus.MeasureBackend(routeId, start)
+	a.codaHale.MeasureBackend(routeId, start)
+}
+func (a *All) MeasureBackendHost(routeBackendHost string, start time.Time) {
+	a.prometheus.MeasureBackendHost(routeBackendHost, start)
+	a.codaHale.MeasureBackendHost(routeBackendHost, start)
+}
+func (a *All) MeasureFilterResponse(filterName string, start time.Time) {
+	a.prometheus.MeasureFilterResponse(filterName, start)
+	a.codaHale.MeasureFilterResponse(filterName, start)
+}
+func (a *All) MeasureAllFiltersResponse(routeId string, start time.Time) {
+	a.prometheus.MeasureAllFiltersResponse(routeId, start)
+	a.codaHale.MeasureAllFiltersResponse(routeId, start)
+}
+func (a *All) MeasureResponse(code int, method string, routeId string, start time.Time) {
+	a.prometheus.MeasureResponse(code, method, routeId, start)
+	a.codaHale.MeasureResponse(code, method, routeId, start)
+}
+func (a *All) MeasureServe(routeId, host, method string, code int, start time.Time) {
+	a.prometheus.MeasureServe(routeId, host, method, code, start)
+	a.codaHale.MeasureServe(routeId, host, method, code, start)
+}
+func (a *All) IncRoutingFailures() {
+	a.prometheus.IncRoutingFailures()
+	a.codaHale.IncRoutingFailures()
+}
+func (a *All) IncErrorsBackend(routeId string) {
+	a.prometheus.IncErrorsBackend(routeId)
+	a.codaHale.IncErrorsBackend(routeId)
+}
+func (a *All) MeasureBackend5xx(t time.Time) {
+	a.prometheus.MeasureBackend5xx(t)
+	a.codaHale.MeasureBackend5xx(t)
+
+}
+func (a *All) IncErrorsStreaming(routeId string) {
+	a.prometheus.IncErrorsStreaming(routeId)
+	a.codaHale.IncErrorsStreaming(routeId)
+
+}
+func (a *All) RegisterHandler(path string, handler *http.ServeMux) {
+	a.prommHandler = a.prometheus.CreateHandler()
+	a.codaHaleHandler = a.codaHale.CreateHandler(path)
+	handler.Handle(path, a.newHandler())
+}
+
+func (a *All) newHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Accept") == "application/json" {
+			a.codaHaleHandler.ServeHTTP(w, req)
+		} else {
+			a.prommHandler.ServeHTTP(w, req)
+		}
+	})
+}

--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"net/http"
 	"time"
+
+	"github.com/prometheus/common/log"
 )
 
 type All struct {
@@ -90,7 +92,8 @@ func (a *All) RegisterHandler(path string, handler *http.ServeMux) {
 
 func (a *All) newHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Header.Get("Accept") == "application/json" {
+		if req.Header.Get("Accept") == "application/codahale+json" {
+			log.Infof("got accepted header with path %s", req.URL)
 			a.codaHaleHandler.ServeHTTP(w, req)
 		} else {
 			a.prometheusHandler.ServeHTTP(w, req)

--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -85,8 +85,8 @@ func (a *All) IncErrorsStreaming(routeId string) {
 
 }
 func (a *All) RegisterHandler(path string, handler *http.ServeMux) {
-	a.prometheusHandler = a.prometheus.CreateHandler()
-	a.codaHaleHandler = a.codaHale.CreateHandler(path)
+	a.prometheusHandler = a.prometheus.getHandler()
+	a.codaHaleHandler = a.codaHale.getHandler(path)
 	handler.Handle(path, a.newHandler())
 }
 

--- a/metrics/codahale.go
+++ b/metrics/codahale.go
@@ -204,8 +204,12 @@ func (c *CodaHale) IncErrorsStreaming(routeId string) {
 }
 
 func (c *CodaHale) RegisterHandler(path string, handler *http.ServeMux) {
-	h := &codaHaleMetricsHandler{path: path, registry: c.reg, options: c.options}
+	h := c.CreateHandler(path)
 	handler.Handle(path, h)
+}
+
+func (c *CodaHale) CreateHandler(path string) http.Handler {
+	return &codaHaleMetricsHandler{path: path, registry: c.reg, options: c.options}
 }
 
 type codaHaleMetricsHandler struct {

--- a/metrics/codahale.go
+++ b/metrics/codahale.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	metrics "github.com/rcrowley/go-metrics"
 )
 
@@ -229,6 +230,7 @@ func (c *codaHaleMetricsHandler) sendMetrics(w http.ResponseWriter, p string) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(metrics)
 	} else {
+		logrus.Errorf("metrics for path %s not found", p)
 		http.NotFound(w, nil)
 	}
 }

--- a/metrics/codahale.go
+++ b/metrics/codahale.go
@@ -257,7 +257,6 @@ func filterMetrics(reg metrics.Registry, prefix, key string) skipperMetrics {
 			}
 		})
 	}
-
 	return metrics
 }
 

--- a/metrics/codahale.go
+++ b/metrics/codahale.go
@@ -46,6 +46,7 @@ type CodaHale struct {
 	createTimer   func() metrics.Timer
 	createCounter func() metrics.Counter
 	options       Options
+	handler       http.Handler
 }
 
 // NewCodaHale returns a new CodaHale backend of metrics.
@@ -205,12 +206,21 @@ func (c *CodaHale) IncErrorsStreaming(routeId string) {
 }
 
 func (c *CodaHale) RegisterHandler(path string, handler *http.ServeMux) {
-	h := c.CreateHandler(path)
+	h := c.getHandler(path)
 	handler.Handle(path, h)
 }
 
 func (c *CodaHale) CreateHandler(path string) http.Handler {
 	return &codaHaleMetricsHandler{path: path, registry: c.reg, options: c.options}
+}
+
+func (c *CodaHale) getHandler(path string) http.Handler {
+	if c.handler != nil {
+		return c.handler
+	}
+
+	c.handler = c.CreateHandler(path)
+	return c.handler
 }
 
 type codaHaleMetricsHandler struct {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,6 +19,7 @@ const (
 	UnkownKind Kind = iota
 	CodaHaleKind
 	PrometheusKind
+	AllKind
 )
 
 func (k Kind) String() string {
@@ -27,6 +28,8 @@ func (k Kind) String() string {
 		return "codahale"
 	case PrometheusKind:
 		return "prometheus"
+	case AllKind:
+		return "all"
 	default:
 		return "unknown"
 	}
@@ -40,6 +43,8 @@ func ParseMetricsKind(t string) Kind {
 		return CodaHaleKind
 	case "prometheus":
 		return PrometheusKind
+	case "all":
+		return AllKind
 	default:
 		return UnkownKind
 	}
@@ -155,6 +160,8 @@ func NewDefaultHandler(o Options) http.Handler {
 	var m Metrics
 
 	switch o.Format {
+	case AllKind:
+		m = NewAllKind(o)
 	case PrometheusKind:
 		m = NewPrometheus(o)
 	default:

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -161,7 +161,7 @@ func NewDefaultHandler(o Options) http.Handler {
 
 	switch o.Format {
 	case AllKind:
-		m = NewAllKind(o)
+		m = NewAll(o)
 	case PrometheusKind:
 		m = NewPrometheus(o)
 	default:

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -6,6 +6,8 @@ import (
 	"net/http/pprof"
 	"strings"
 	"time"
+
+	"github.com/prometheus/common/log"
 )
 
 const (
@@ -16,10 +18,10 @@ const (
 type Kind int
 
 const (
-	UnkownKind Kind = iota
-	CodaHaleKind
+	UnkownKind   Kind = 0
+	CodaHaleKind Kind = 1 << iota
 	PrometheusKind
-	AllKind
+	AllKind = CodaHaleKind | PrometheusKind
 )
 
 func (k Kind) String() string {
@@ -186,6 +188,7 @@ func NewHandler(o Options, m Metrics) http.Handler {
 
 	// Root path should return 404.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Infof("root handler")
 		w.WriteHeader(http.StatusNotFound)
 	})
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -46,6 +46,7 @@ type Prometheus struct {
 
 	opts     Options
 	registry *prometheus.Registry
+	handler  http.Handler
 }
 
 // NewPrometheus returns a new Prometheus metric backend.
@@ -243,9 +244,18 @@ func (p *Prometheus) CreateHandler() http.Handler {
 	return promhttp.HandlerFor(p.registry, promhttp.HandlerOpts{})
 }
 
+func (p *Prometheus) getHandler() http.Handler {
+	if p.handler != nil {
+		return p.handler
+	}
+
+	p.handler = p.CreateHandler()
+	return p.handler
+}
+
 // RegisterHandler satisfies Metrics interface.
 func (p *Prometheus) RegisterHandler(path string, mux *http.ServeMux) {
-	promHandler := p.CreateHandler()
+	promHandler := p.getHandler()
 	mux.Handle(path, promHandler)
 }
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -239,10 +239,14 @@ func (p *Prometheus) registerMetrics() {
 	}
 }
 
+func (p *Prometheus) CreateHandler() http.Handler {
+	return promhttp.HandlerFor(p.registry, promhttp.HandlerOpts{})
+}
+
 // RegisterHandler satisfies Metrics interface.
 func (p *Prometheus) RegisterHandler(path string, mux *http.ServeMux) {
-	memHandler := promhttp.HandlerFor(p.registry, promhttp.HandlerOpts{})
-	mux.Handle(path, memHandler)
+	promHandler := p.CreateHandler()
+	mux.Handle(path, promHandler)
 }
 
 // MeasureSince satisfies Metrics interface.

--- a/skipper.go
+++ b/skipper.go
@@ -359,6 +359,9 @@ type Options struct {
 	// EnablePrometheusMetrics enables Prometheus format metrics.
 	EnablePrometheusMetrics bool
 
+	// EnableCodahaleMetrics enables Codahale json format metrics.
+	EnableCodahaleMetrics bool
+
 	// LoadBalancerHealthCheckInterval enables and sets the
 	// interval when to schedule health checks for dead or
 	// unhealthy routes
@@ -659,7 +662,9 @@ func Run(o Options) error {
 		mux.Handle("/routes/", routing)
 
 		metricsKind := metrics.CodaHaleKind
-		if o.EnablePrometheusMetrics {
+		if o.EnablePrometheusMetrics && o.EnableCodahaleMetrics {
+			metricsKind = metrics.AllKind
+		} else if o.EnablePrometheusMetrics {
 			metricsKind = metrics.PrometheusKind
 		}
 

--- a/skipper.go
+++ b/skipper.go
@@ -356,7 +356,10 @@ type Options struct {
 	// for a request.
 	DefaultHTTPStatus int
 
-	// EnablePrometheusMetrics (*deprecated*) enables Prometheus format metrics.
+	// EnablePrometheusMetrics enables Prometheus format metrics.
+	//
+	// This option is *deprecated*. The recommended way to enable prometheus metrics is to
+	// use the MetricsFlavours option.
 	EnablePrometheusMetrics bool
 
 	// MetricsFlavours sets the metrics storage and exposed format
@@ -669,17 +672,9 @@ func Run(o Options) error {
 		for _, s := range o.MetricsFlavours {
 			switch s {
 			case "codahale":
-				if metricsKind == metrics.PrometheusKind {
-					metricsKind = metrics.AllKind
-				} else {
-					metricsKind = metrics.CodaHaleKind
-				}
+				metricsKind |= metrics.CodaHaleKind
 			case "prometheus":
-				if metricsKind == metrics.CodaHaleKind {
-					metricsKind = metrics.AllKind
-				} else {
-					metricsKind = metrics.PrometheusKind
-				}
+				metricsKind |= metrics.PrometheusKind
 			}
 		}
 		// set default if unset


### PR DESCRIPTION
This change will make it possible to serve prometheus and codahale metrics.
To get codahale metrics you have to send an "Accept" header "application/json", else skipper will serve prometheus metrics.