### PR TITLE
Fix/groupsize check in lb filter

### DIFF
--- a/loadbalancer/filter.go
+++ b/loadbalancer/filter.go
@@ -66,6 +66,10 @@ func (s *decideSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 		size = int(fsize)
 	}
 
+	if size < 1 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
 	return &decideFilter{
 		group:   group,
 		size:    size,

--- a/loadbalancer/filter.go
+++ b/loadbalancer/filter.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/zalando/skipper/filters"
-	"github.com/zalando/skipper/predicates"
 )
 
 const DecideFilterName = "lbDecide"
@@ -48,19 +47,19 @@ func (s *decideSpec) Name() string { return DecideFilterName }
 
 func (s *decideSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 	if len(args) != 2 {
-		return nil, predicates.ErrInvalidPredicateParameters
+		return nil, filters.ErrInvalidFilterParameters
 	}
 
 	group, ok := args[0].(string)
 	if !ok {
-		return nil, predicates.ErrInvalidPredicateParameters
+		return nil, filters.ErrInvalidFilterParameters
 	}
 
 	size, ok := args[1].(int)
 	if !ok {
 		fsize, ok := args[1].(float64)
 		if !ok {
-			return nil, predicates.ErrInvalidPredicateParameters
+			return nil, filters.ErrInvalidFilterParameters
 		}
 
 		size = int(fsize)

--- a/loadbalancer/routes_test.go
+++ b/loadbalancer/routes_test.go
@@ -1,0 +1,15 @@
+package loadbalancer
+
+import "testing"
+
+func TestInvalidGroupSize(t *testing.T) {
+	spec := NewDecide()
+
+	if _, err := spec.CreateFilter([]interface{}{"foo-group", 0}); err == nil {
+		t.Error("failed to fail with group size 0")
+	}
+
+	if _, err := spec.CreateFilter([]interface{}{"foo-group", -3}); err == nil {
+		t.Error("failed to fail with negative group size")
+	}
+}


### PR DESCRIPTION
adds check for non-positive group size in the lbDecide() filter

partially fixes: #566 
related PR: #567 