### PR TITLE
Using regex delimiter fails in character list in eskip #134

### DIFF
--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -151,8 +151,47 @@ func scanEscaped(delimiter byte, code string) ([]byte, string) {
 	return b, code
 }
 
+func scanRegexp(code string) ([]byte, string) {
+	var b []byte
+	escaped := false
+	var insideGroup = false
+	for len(code) > 0 {
+		c := code[0]
+		isDelimiter := c == '/'
+		isEscapeChar := c == escapeChar
+
+		//Check if starting [... or ending ...]. Ignore if group character is escaped i.e. \[ or \]
+		if !escaped && !insideGroup && c == '[' {
+			insideGroup = true
+		} else if !escaped && insideGroup && c == ']' {
+			insideGroup = false
+		}
+
+		if escaped {
+			//delimeter / is escaped in PathRegexp so that it means no end PathRegexp(/\//), but we don't
+			//want escape / in the Golang regexp
+			if !isDelimiter {
+				b = append(b, escapeChar)
+			}
+			b = append(b, c)
+			escaped = false
+		} else {
+			if isDelimiter && !insideGroup {
+				return b, code
+			}
+			if isEscapeChar {
+				escaped = true
+			} else {
+				b = append(b, c)
+			}
+		}
+		code = code[1:]
+	}
+	return b, code
+}
+
 func scanRegexpLiteral(code string) (t token, rest string, err error) {
-	b, rest := scanEscaped('/', code[1:])
+	b, rest := scanRegexp(code[1:])
 	if len(rest) == 0 {
 		err = incompleteToken
 		return

--- a/eskip/parser_test.go
+++ b/eskip/parser_test.go
@@ -29,15 +29,15 @@ const (
 
 	routingDocumentExample = `
         route0: ` + singleRouteExample + `;
-        
+
         route1: Path("/some/path") -> "https://backend-0.example.com";
         route2: Path("/some/other/path") -> fixPath() -> "https://backend-1.example.com";
-        
+
         route3:
             Method("POST") && Path("/api") ->
             requestHeader("X-Type", "ajax-post") ->
             "https://api.example.com";
-        
+
         catchAll: * -> "https://www.example.org";
         catchAllWithCustom: * && Custom() -> "https://www.example.org"`
 )
@@ -184,5 +184,29 @@ func TestNumber(t *testing.T) {
 	_, err := parse(`* -> number(3.14) -> <shunt>`)
 	if err != nil {
 		t.Error("failed to parse number", err)
+	}
+}
+
+func TestRegExp(t *testing.T) {
+	testRegExpOnce(t, `PathRegexp(/[/]/)-> <shunt>`, `[/]`)
+	testRegExpOnce(t, `PathRegexp(/[\[]/)-> <shunt>`, `[\[]`)
+	testRegExpOnce(t, `PathRegexp(/[\]]/)-> <shunt>`, `[\]]`)
+	testRegExpOnce(t, `PathRegexp(/[\\]/)-> <shunt>`, `[\\]`)
+	testRegExpOnce(t, `PathRegexp(/[\/]/)-> <shunt>`, `[/]`)
+	testRegExpOnce(t, `PathRegexp(/["]/)-> <shunt>`, `["]`)
+	testRegExpOnce(t, `PathRegexp(/[\"]/)-> <shunt>`, `[\"]`)
+	testRegExpOnce(t, `PathRegexp(/\//)-> <shunt>`, `/`)
+	testRegExpOnce(t, `PathRegexp(/[[:upper:]]/)-> <shunt>`, `[[:upper:]]`)
+}
+
+func testRegExpOnce(t *testing.T, regexpStr string, expectedRegExp string) {
+	routes, err := parse(regexpStr)
+	if err != nil {
+		t.Error("failed to parse PathRegexp:"+regexpStr, err)
+		return
+	}
+
+	if expectedRegExp != routes[0].matchers[0].args[0] {
+		t.Error("failed to parse PathRegexp:"+regexpStr+", expected regexp to be "+expectedRegExp, err)
 	}
 }


### PR DESCRIPTION
Modified scanning of regexp as it need to take into account special characters #134
Question 
from 
`PathRegexp(/\/\w+Id$/)` 
it seems that / is meant to be escaped. But inside [] I think / can be go without escaping? 

And master impl seems to parse `/\\/` as Go regexp `\` , I mean one cannot escape \ ? I removed this behaviour, in those cases, but I didn't see any issues.
