### PR TITLE
Expose default port 9090 in the Dockerfile

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -5,4 +5,6 @@ RUN mkdir -p /usr/bin
 ADD skipper eskip /usr/bin/
 ENV PATH $PATH:/usr/bin
 
+EXPOSE 9090
+
 CMD ["/usr/bin/skipper"]

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -5,6 +5,6 @@ RUN mkdir -p /usr/bin
 ADD skipper eskip /usr/bin/
 ENV PATH $PATH:/usr/bin
 
-EXPOSE 9090
+EXPOSE 9090 9911
 
 CMD ["/usr/bin/skipper"]


### PR DESCRIPTION
The default port of 9090 should be exposed in the Docker image.  Adding the EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime.