### PR TITLE
initial tests that are based on the filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install: $(SOURCES)
 	go install -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 	go install -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/eskip
 
-check: build convert-testfiles
+check: build
 	# go test $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -42,7 +42,7 @@ check: build convert-testfiles
 	#
 	for p in $(PACKAGES); do go test $$p || break; done
 
-shortcheck: build convert-testfiles
+shortcheck: build
 	# go test -test.short -run ^Test $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -96,7 +96,7 @@ precommit: check-imports fmt build shortcheck vet
 
 check-precommit: check-imports check-fmt build shortcheck vet
 
-.coverprofile-all: convert-testfiles $(SOURCES)
+.coverprofile-all: $(SOURCES)
 	# go list -f \
 	# 	'{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' \
 	# 	$(PACKAGES) | xargs -i sh -c {}

--- a/dataclients/kubernetes/definitions.go
+++ b/dataclients/kubernetes/definitions.go
@@ -132,7 +132,7 @@ type service struct {
 
 func (s service) GetTargetPort(svcPort backendPort) (string, error) {
 	for _, sp := range s.Spec.Ports {
-		if sp.MatchingPort(svcPort) {
+		if sp.MatchingPort(svcPort) && sp.TargetPort != nil {
 			return sp.TargetPort.String(), nil
 		}
 	}

--- a/dataclients/kubernetes/definitions.go
+++ b/dataclients/kubernetes/definitions.go
@@ -105,8 +105,9 @@ type ingressList struct {
 }
 
 type servicePort struct {
-	Name string `json:"name"`
-	Port int    `json:"port"`
+	Name       string `json:"name"`
+	Port       int    `json:"port"`
+	TargetPort int    `json:"targetPort"`
 }
 
 type serviceSpec struct {
@@ -115,6 +116,7 @@ type serviceSpec struct {
 }
 
 type service struct {
+	Meta *metadata    `json:"metadata"`
 	Spec *serviceSpec `json:"spec"`
 }
 
@@ -122,12 +124,11 @@ type endpoint struct {
 	Subsets []*subset `json:"subsets"`
 }
 
-func (ep endpoint) Targets(ingSvcPort string) []string {
-	epPort, _ := strconv.Atoi(ingSvcPort)
+func (ep endpoint) Targets(svcPortName string, svcPortTarget int) []string {
 	result := make([]string, 0)
 	for _, s := range ep.Subsets {
 		for _, port := range s.Ports {
-			if port.Name == ingSvcPort || port.Port == epPort {
+			if port.Name == svcPortName || port.Port == svcPortTarget {
 				for _, addr := range s.Addresses {
 					result = append(result, fmt.Sprintf("http://%s:%d", addr.IP, port.Port))
 				}

--- a/dataclients/kubernetes/definitions_test.go
+++ b/dataclients/kubernetes/definitions_test.go
@@ -10,6 +10,7 @@ func Test_endpoint_Targets(t *testing.T) {
 		name       string
 		Subsets    []*subset
 		ingSvcPort string
+		targetPort *backendPort
 		want       []string
 	}{
 		{
@@ -32,6 +33,7 @@ func Test_endpoint_Targets(t *testing.T) {
 				},
 			},
 			ingSvcPort: "http",
+			targetPort: &backendPort{value: 80},
 			want:       []string{"http://1.2.3.4:80"},
 		},
 		{
@@ -54,6 +56,7 @@ func Test_endpoint_Targets(t *testing.T) {
 				},
 			},
 			ingSvcPort: "80",
+			targetPort: &backendPort{value: 80},
 			want:       []string{"http://1.2.3.4:80"},
 		},
 		{
@@ -81,6 +84,7 @@ func Test_endpoint_Targets(t *testing.T) {
 				},
 			},
 			ingSvcPort: "http",
+			targetPort: &backendPort{value: 80},
 			want:       []string{"http://1.2.3.4:80"},
 		},
 		{
@@ -108,6 +112,7 @@ func Test_endpoint_Targets(t *testing.T) {
 				},
 			},
 			ingSvcPort: "80",
+			targetPort: &backendPort{value: 80},
 			want:       []string{"http://1.2.3.4:80"},
 		},
 	}
@@ -116,7 +121,7 @@ func Test_endpoint_Targets(t *testing.T) {
 			ep := endpoint{
 				Subsets: tt.Subsets,
 			}
-			if got := ep.Targets(tt.ingSvcPort); !reflect.DeepEqual(got, tt.want) {
+			if got := ep.Targets(tt.ingSvcPort, tt.targetPort.String()); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("endpoint.Targets() = %v, want %v", got, tt.want)
 			}
 		})

--- a/dataclients/kubernetes/definitions_test.go
+++ b/dataclients/kubernetes/definitions_test.go
@@ -5,6 +5,53 @@ import (
 	"testing"
 )
 
+func TestGetTargetPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		svc         *service
+		svcPort     backendPort
+		expected    string
+		errExpected bool
+	}{
+		{
+			name: "svc1",
+			svc: &service{
+				Spec: &serviceSpec{
+					Ports: []*servicePort{
+						&servicePort{
+							Port:       80,
+							TargetPort: &backendPort{value: 5000},
+						},
+					},
+				}},
+			svcPort:     backendPort{value: 80},
+			expected:    "80",
+			errExpected: false,
+		},
+		{
+			name: "svc without targetport",
+			svc: &service{
+				Spec: &serviceSpec{
+					Ports: []*servicePort{
+						&servicePort{
+							Port: 80,
+						},
+					},
+				}},
+			svcPort:     backendPort{value: 80},
+			expected:    "",
+			errExpected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := tt.svc.GetTargetPort(tt.svcPort); got != tt.expected && (err != nil && !tt.errExpected) {
+				t.Errorf("GetTargetPort: %v, expected: %v, err: %v", got, tt.expected, err)
+			}
+		})
+	}
+}
+
 func TestMatchingPort(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/dataclients/kubernetes/definitions_test.go
+++ b/dataclients/kubernetes/definitions_test.go
@@ -5,6 +5,42 @@ import (
 	"testing"
 )
 
+func TestMatchingPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		sp         *servicePort
+		targetPort backendPort
+		expected   bool
+	}{
+		{
+			name: "svc-port",
+			sp: &servicePort{
+				Port:       80,
+				TargetPort: &backendPort{value: 5000},
+			},
+			targetPort: backendPort{value: 80},
+			expected:   true,
+		},
+		{
+			name: "svc-name",
+			sp: &servicePort{
+				Name:       "web",
+				Port:       80,
+				TargetPort: &backendPort{value: 5000},
+			},
+			targetPort: backendPort{value: "web"},
+			expected:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sp.MatchingPort(tt.targetPort); got != tt.expected {
+				t.Errorf("MatchingPort: %v, expected: %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func Test_endpoint_Targets(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -356,6 +356,7 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 		err     error
 		routes  []*eskip.Route
 		ns      = i.Metadata.Namespace
+		name    = i.Metadata.Name
 		svcName = i.Spec.DefaultBackend.ServiceName
 		svcPort = i.Spec.DefaultBackend.ServicePort
 	)
@@ -393,7 +394,7 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 		}
 
 		r := &eskip.Route{
-			Id:      routeID(ns, svcName, "", "", ""),
+			Id:      routeID(ns, name, "", "", ""),
 			Backend: address,
 		}
 		routes = append(routes, r)
@@ -401,7 +402,7 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 		return nil, false, err
 	}
 
-	group := routeID(ns, svcName, "", "", "")
+	group := routeID(ns, name, "", "", "")
 
 	// TODO:
 	// - don't do load balancing if there's only a single endpoint
@@ -410,7 +411,7 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 
 	for idx, ep := range eps {
 		r := &eskip.Route{
-			Id:      routeID(ns, svcName, "", "", string(idx)),
+			Id:      routeID(ns, name, "", "", string(idx)),
 			Backend: ep,
 			Predicates: []*eskip.Predicate{{
 				Name: loadbalancer.MemberPredicateName,
@@ -424,7 +425,7 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 	}
 
 	decisionRoute := &eskip.Route{
-		Id:          routeID(ns, svcName, "", "", "") + "__lb_group",
+		Id:          routeID(ns, name, "", "", "") + "__lb_group",
 		BackendType: eskip.LoopBackend,
 		Predicates: []*eskip.Predicate{{
 			Name: loadbalancer.GroupPredicateName,

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -438,7 +438,11 @@ func (c *Client) getEndpoints(ns, name, port string) ([]string, error) {
 		return nil, errEndpointNotFound
 	}
 
-	return ep.Targets(port), nil
+	targets := ep.Targets(port)
+	if len(targets) == 0 {
+		return nil, errEndpointNotFound
+	}
+	return targets, nil
 }
 
 func (c *Client) convertPathRule(ns, name, host string, prule *pathRule, endpointsURLs map[string][]string) ([]*eskip.Route, error) {

--- a/dataclients/kubernetes/kube2_test.go
+++ b/dataclients/kubernetes/kube2_test.go
@@ -1,0 +1,408 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type testFileAPI struct {
+	test         *testing.T
+	testbasepath string
+	server       *httptest.Server
+	ingresses    *ingressList
+	failNext     bool
+}
+
+func newTestFileAPI(t *testing.T) *testFileAPI {
+	api := &testFileAPI{
+		test:         t,
+		testbasepath: "testdata/kube",
+		ingresses:    &ingressList{},
+	}
+
+	api.server = httptest.NewServer(api)
+	return api
+}
+
+func readFile(fpath string) ([]byte, error) {
+	fd, err := os.OpenFile(fpath, os.O_RDONLY, 0444)
+	if err != nil {
+		return []byte(""), err
+	}
+	bts, err := ioutil.ReadAll(fd)
+	if err != nil && err != io.EOF {
+		return []byte(""), err
+	}
+	err = fd.Close()
+	return bts, err
+}
+
+func (api *testFileAPI) getFilenames(basepath, ns string) []string {
+	pattern := fmt.Sprintf("../../%s/%s/*.json", basepath, ns)
+	filenames, err := filepath.Glob(pattern)
+	if err != nil {
+		api.test.Fatalf("Failed to glob files: %v", err)
+	}
+	return filenames
+}
+
+func (api *testFileAPI) getTestService(fpath string) (*service, bool) {
+
+	fpath = "../../" + fpath + ".json"
+	log.Debugf("getTestService: %s", fpath)
+
+	b, err := readFile(fpath)
+	if err != nil {
+		log.Errorf("Failed to read file: %v", err)
+		return nil, false
+	}
+
+	var result service
+	err = json.Unmarshal(b, &result)
+	if err != nil {
+		log.Errorf("Failed to unmarshal: %v", err)
+		return nil, false
+	}
+
+	if result.Meta.Namespace == "" {
+		result.Meta.Namespace = "default"
+	}
+
+	// if log.GetLevel() == log.DebugLevel {
+	// 	spew.Dump(result)
+	// }
+
+	return &result, true
+}
+
+func (api *testFileAPI) getTestIngresses(urlpath string) *ingressList {
+	filenames := api.getFilenames(urlpath, "default")
+	filenames = append(filenames, api.getFilenames(urlpath, "ns2")...)
+
+	result := ingressList{Items: []*ingressItem{}}
+	for _, fpath := range filenames {
+		b, err := readFile(fpath)
+		if err != nil {
+			api.test.Fatalf("failed to readfile: %v", err)
+		}
+
+		var item ingressItem
+		err = json.Unmarshal(b, &item)
+		if err != nil {
+			api.test.Fatalf("failed to unmarshal ingressItem: %s\n: %v", string(b), err)
+		}
+		if item.Metadata.Namespace == "" {
+			item.Metadata.Namespace = "default"
+		}
+		result.Items = append(result.Items, &item)
+	}
+	log.Debugf("Found %d ingress definitions", len(result.Items))
+	// if log.GetLevel() == log.DebugLevel {
+	// 	spew.Dump(result)
+	// }
+
+	return &result
+}
+
+func (api *testFileAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if api.failNext {
+		api.failNext = false
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	urlpath := api.testbasepath + r.URL.Path
+	if r.URL.Path == ingressesURI {
+		ingresses := api.getTestIngresses(urlpath)
+
+		if err := respondJSON(w, ingresses); err != nil {
+			api.test.Error(err)
+		}
+
+		return
+	}
+
+	s, ok := api.getTestService(urlpath)
+	if !ok {
+		s = &service{}
+	}
+
+	if err := respondJSON(w, s); err != nil {
+		api.test.Error(err)
+	}
+}
+
+func (api *testFileAPI) Close() {
+	api.server.Close()
+}
+
+func TestMyIngress(t *testing.T) {
+	api := newTestFileAPI(t)
+	defer api.Close()
+	dc, err := New(Options{KubernetesURL: api.server.URL})
+	if err != nil {
+		t.Error(err)
+	}
+
+	r, err := dc.LoadAll()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	checkRoutes(t, r, map[string]string{
+		"kube_default__app1__app_default_example_org____app1_svc":                                 "http://10.3.0.2:80",
+		"kube_default__app1__app_default_example_org____app1_svc__lb_group":                       "",
+		"kube_default__app_namedport_1__app_default_named_example_org____app_svc_named":           "http://10.3.0.3:80",
+		"kube_default__app_namedport_1__app_default_named_example_org____app_svc_named__lb_group": "",
+		"kube_ns2__app1__app1_ns2_example_org____app1_svc":                                        "http://10.3.1.3:80",
+		"kube_ns2__app1__app1_ns2_example_org____app1_svc__lb_group":                              "",
+	})
+}
+
+// ------------------------------------------------------------------
+
+func TestMyHealthcheckInitial(t *testing.T) {
+	api := newTestFileAPI(t)
+	defer api.Close()
+
+	t.Run("no healthcheck, empty", func(t *testing.T) {
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
+
+		r, err := dc.LoadAll()
+		if err != nil {
+			t.Error(err)
+		}
+
+		checkHealthcheck(t, r, false, false, false)
+	})
+
+	t.Run("no healthcheck", func(t *testing.T) {
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
+
+		r, err := dc.LoadAll()
+		if err != nil {
+			t.Error(err)
+		}
+
+		checkHealthcheck(t, r, false, false, false)
+	})
+
+	t.Run("no healthcheck, fail", func(t *testing.T) {
+		api.failNext = true
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
+
+		_, err = dc.LoadAll()
+		if err == nil {
+			t.Error("failed to fail")
+		}
+	})
+
+	t.Run("use healthcheck, empty", func(t *testing.T) {
+		dc, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		r, err := dc.LoadAll()
+		if err != nil {
+			t.Error(err)
+		}
+
+		checkHealthcheck(t, r, true, true, false)
+	})
+
+	t.Run("use healthcheck", func(t *testing.T) {
+		dc, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		r, err := dc.LoadAll()
+		if err != nil {
+			t.Error(err)
+		}
+
+		checkHealthcheck(t, r, true, true, false)
+	})
+
+	t.Run("use reverse healthcheck", func(t *testing.T) {
+		dc, err := New(Options{
+			KubernetesURL:          api.server.URL,
+			ProvideHealthcheck:     true,
+			ReverseSourcePredicate: true,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		r, err := dc.LoadAll()
+		if err != nil {
+			t.Error(err)
+		}
+
+		checkHealthcheck(t, r, true, true, true)
+	})
+}
+
+func TestMyHealthcheckUpdate(t *testing.T) {
+	api := newTestFileAPI(t)
+	defer api.Close()
+
+	t.Run("no healthcheck, update fail", func(t *testing.T) {
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
+
+		dc.LoadAll()
+		api.failNext = true
+
+		r, d, err := dc.LoadUpdate()
+		if err == nil {
+			t.Error("failed to fail")
+		}
+
+		checkHealthcheck(t, r, false, false, false)
+		if len(d) != 0 {
+			t.Error("unexpected delete")
+		}
+	})
+
+	t.Run("use healthcheck, update fail", func(t *testing.T) {
+		dc, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		dc.LoadAll()
+		api.failNext = true
+
+		if _, _, err := dc.LoadUpdate(); err == nil {
+			t.Error("failed to fail")
+		}
+	})
+
+	t.Run("use healthcheck, update succeeds", func(t *testing.T) {
+		dc, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		dc.LoadAll()
+
+		r, d, err := dc.LoadUpdate()
+		if err != nil {
+			t.Error("failed to fail")
+		}
+
+		checkHealthcheck(t, r, true, true, false)
+		if len(d) != 0 {
+			t.Error("unexpected delete")
+		}
+	})
+
+	t.Run("use healthcheck, update fails, gets fixed", func(t *testing.T) {
+		dc, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		dc.LoadAll()
+
+		api.failNext = true
+		dc.LoadUpdate()
+
+		r, d, err := dc.LoadUpdate()
+		if err != nil {
+			t.Error("failed to fail")
+		}
+
+		checkHealthcheck(t, r, true, true, false)
+		if len(d) != 0 {
+			t.Error("unexpected delete")
+		}
+	})
+}
+
+func TestMyHealthcheckReload(t *testing.T) {
+	api := newTestFileAPI(t)
+	defer api.Close()
+
+	t.Run("no healthcheck, reload fail", func(t *testing.T) {
+		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
+
+		dc.LoadAll()
+		api.failNext = true
+
+		r, err := dc.LoadAll()
+		if err == nil {
+			t.Error("failed to fail")
+		}
+
+		checkHealthcheck(t, r, false, false, false)
+	})
+
+	t.Run("use healthcheck, reload succeeds", func(t *testing.T) {
+		dc, err := New(Options{
+			KubernetesURL:      api.server.URL,
+			ProvideHealthcheck: true,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		dc.LoadAll()
+
+		r, err := dc.LoadAll()
+		if err != nil {
+			t.Error("failed to fail")
+		}
+
+		checkHealthcheck(t, r, true, true, false)
+		checkRoutes(t, r, map[string]string{
+			healthcheckRouteID:                                                                        "",
+			"kube_default__app1__app_default_example_org____app1_svc":                                 "http://10.3.0.2:80",
+			"kube_default__app1__app_default_example_org____app1_svc__lb_group":                       "",
+			"kube_default__app_namedport_1__app_default_named_example_org____app_svc_named":           "http://10.3.0.3:80",
+			"kube_default__app_namedport_1__app_default_named_example_org____app_svc_named__lb_group": "",
+			"kube_ns2__app1__app1_ns2_example_org____app1_svc":                                        "http://10.3.1.3:80",
+			"kube_ns2__app1__app1_ns2_example_org____app1_svc__lb_group":                              "",
+		})
+	})
+}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -18,15 +18,18 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"syscall"
 	"testing"
 	"time"
 
+	"testing/quick"
+
+	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/predicates/source"
-	"testing/quick"
 )
 
 type services map[string]map[string]*service
@@ -128,6 +131,7 @@ func testServices() services {
 		},
 		"namespace2": map[string]*service{
 			"service3": testService("9.0.1.2", map[string]int{"port3": 7272}),
+			"service4": testService("10.0.1.2", map[string]int{"port4": 4444, "port5": 5555}),
 		},
 	}
 }
@@ -171,12 +175,25 @@ func testIngresses() []*ingressItem {
 		),
 		testIngress("namespace1", "ratelimit", "service1", "localRatelimit(20,\"1m\")", "", "", backendPort{8080}, 1.0),
 		testIngress("namespace1", "ratelimitAndBreaker", "service1", "", "localRatelimit(20,\"1m\") -> consecutiveBreaker(15)", "", backendPort{8080}, 1.0),
+		testIngress("namespace2", "svcwith2ports", "service4", "", "", "", backendPort{4444}, 1.0),
 	}
 }
 
 func checkRoutes(t *testing.T, r []*eskip.Route, expected map[string]string) {
 	if len(r) != len(expected) {
-		t.Error("number of routes doesn't match expected", len(r), len(expected))
+		curIDs := make([]string, len(r))
+		expectedIDs := make([]string, len(expected))
+		for i := range r {
+			curIDs[i] = r[i].Id
+		}
+		j := 0
+		for k := range expected {
+			expectedIDs[j] = k
+			j++
+		}
+		sort.Strings(expectedIDs)
+		sort.Strings(curIDs)
+		t.Errorf("number of routes %d doesn't match expected %d: %v", len(r), len(expected), cmp.Diff(curIDs, expectedIDs))
 		return
 	}
 
@@ -185,7 +202,7 @@ func checkRoutes(t *testing.T, r []*eskip.Route, expected map[string]string) {
 		for _, ri := range r {
 			if ri.Id == id {
 				if ri.Backend != backend {
-					t.Error("invalid backend", ri.Backend, backend)
+					t.Errorf("invalid backend %v", cmp.Diff(ri.Backend, backend))
 					return
 				}
 
@@ -202,7 +219,7 @@ func checkRoutes(t *testing.T, r []*eskip.Route, expected map[string]string) {
 
 func checkIDs(t *testing.T, got []string, expected ...string) {
 	if len(got) != len(expected) {
-		t.Error("number of IDs doesn't match expected", len(got), len(expected))
+		t.Errorf("number of IDs %d doesn't match expected %d", len(got), len(expected))
 		return
 	}
 
@@ -765,6 +782,8 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__ratelimit________lb_group":                              "",
 			"kube_namespace1__ratelimitAndBreaker______":                              "http://1.2.3.4:8080",
 			"kube_namespace1__ratelimitAndBreaker________lb_group":                    "",
+			"kube_namespace2__svcwith2ports______":                                    "http://10.0.1.2:4444",
+			"kube_namespace2__svcwith2ports________lb_group":                          "",
 		})
 	})
 
@@ -831,6 +850,8 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__ratelimit________lb_group":                              "",
 			"kube_namespace1__ratelimitAndBreaker______":                              "http://1.2.3.4:8080",
 			"kube_namespace1__ratelimitAndBreaker________lb_group":                    "",
+			"kube_namespace2__svcwith2ports________lb_group":                          "",
+			"kube_namespace2__svcwith2ports______":                                    "http://10.0.1.2:4444",
 		})
 	})
 
@@ -935,6 +956,8 @@ func TestIngress(t *testing.T) {
 			"kube_namespace1__ratelimit________lb_group",
 			"kube_namespace1__ratelimitAndBreaker______",
 			"kube_namespace1__ratelimitAndBreaker________lb_group",
+			"kube_namespace2__svcwith2ports______",
+			"kube_namespace2__svcwith2ports________lb_group",
 		)
 	})
 
@@ -1335,6 +1358,9 @@ func TestHealthcheckInitial(t *testing.T) {
 		api.services = testServices()
 		api.ingresses.Items = testIngresses()
 		dc, err := New(Options{KubernetesURL: api.server.URL})
+		if err != nil {
+			t.Error(err)
+		}
 
 		r, err := dc.LoadAll()
 		if err != nil {
@@ -1582,6 +1608,8 @@ func TestHealthcheckReload(t *testing.T) {
 			"kube_namespace1__ratelimit________lb_group":                              "",
 			"kube_namespace1__ratelimitAndBreaker______":                              "http://1.2.3.4:8080",
 			"kube_namespace1__ratelimitAndBreaker________lb_group":                    "",
+			"kube_namespace2__svcwith2ports______":                                    "http://10.0.1.2:4444",
+			"kube_namespace2__svcwith2ports________lb_group":                          "",
 		})
 	})
 }

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -193,7 +193,7 @@ func checkRoutes(t *testing.T, r []*eskip.Route, expected map[string]string) {
 		}
 		sort.Strings(expectedIDs)
 		sort.Strings(curIDs)
-		t.Errorf("number of routes %d doesn't match expected %d: %v", len(r), len(expected), cmp.Diff(curIDs, expectedIDs))
+		t.Errorf("number of routes %d doesn't match expected %d: %v", len(r), len(expected), cmp.Diff(expectedIDs, curIDs))
 		return
 	}
 

--- a/testdata/kube/api/v1/namespaces/default/services/app-svc-named.json
+++ b/testdata/kube/api/v1/namespaces/default/services/app-svc-named.json
@@ -1,0 +1,1 @@
+{"kind":"Service","apiVersion":"v1","metadata":{"name":"app-svc-named"},"spec":{"clusterIP":"10.3.0.3","type":"ClusterIP","ports":[{"port":80,"targetPort":9999,"protocol":"TCP","name":"http"}],"selector":{"application":"app1"}}}

--- a/testdata/kube/api/v1/namespaces/default/services/app-svc-named.yaml
+++ b/testdata/kube/api/v1/namespaces/default/services/app-svc-named.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: app-svc-named
+spec:
+  clusterIP: 10.3.0.3
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9999
+      protocol: TCP
+      name: http
+  selector:
+    application: app1

--- a/testdata/kube/api/v1/namespaces/default/services/app1-svc.json
+++ b/testdata/kube/api/v1/namespaces/default/services/app1-svc.json
@@ -1,0 +1,1 @@
+{"kind":"Service","apiVersion":"v1","metadata":{"name":"app1-svc"},"spec":{"clusterIP":"10.3.0.2","type":"ClusterIP","ports":[{"port":80,"targetPort":9999,"protocol":"TCP"}],"selector":{"application":"app1"}}}

--- a/testdata/kube/api/v1/namespaces/default/services/app1-svc.yaml
+++ b/testdata/kube/api/v1/namespaces/default/services/app1-svc.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: app1-svc
+spec:
+  clusterIP: 10.3.0.2
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9999
+      protocol: TCP
+  selector:
+    application: app1

--- a/testdata/kube/api/v1/namespaces/ns2/services/app1-svc.json
+++ b/testdata/kube/api/v1/namespaces/ns2/services/app1-svc.json
@@ -1,0 +1,1 @@
+{"kind":"Service","apiVersion":"v1","metadata":{"name":"app1-svc","namespace":"ns2","labels":{"application":"app1"}},"spec":{"clusterIP":"10.3.1.3","type":"ClusterIP","ports":[{"port":80,"targetPort":9999,"protocol":"TCP"}],"selector":{"application":"app1"}}}

--- a/testdata/kube/api/v1/namespaces/ns2/services/app1-svc.yaml
+++ b/testdata/kube/api/v1/namespaces/ns2/services/app1-svc.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: app1-svc
+  namespace: ns2
+  labels:
+    application: app1
+spec:
+  clusterIP: 10.3.1.3
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9999
+      protocol: TCP
+  selector:
+    application: app1

--- a/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-default.json
+++ b/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-default.json
@@ -1,0 +1,1 @@
+{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"app1"},"spec":{"rules":[{"host":"app-default.example.org","http":{"paths":[{"backend":{"serviceName":"app1-svc","servicePort":80}}]}}]}}

--- a/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-default.yaml
+++ b/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-default.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: app1
+spec:
+  rules:
+  - host: app-default.example.org
+    http:
+      paths:
+      - backend:
+          serviceName: app1-svc
+          servicePort: 80

--- a/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-named-svc-port.json
+++ b/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-named-svc-port.json
@@ -1,0 +1,1 @@
+{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"app-namedport-1"},"spec":{"rules":[{"host":"app-default-named.example.org","http":{"paths":[{"backend":{"serviceName":"app-svc-named","servicePort":"http"}}]}}]}}

--- a/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-named-svc-port.yaml
+++ b/testdata/kube/apis/extensions/v1beta1/ingresses/default/app-named-svc-port.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: app-namedport-1
+spec:
+  rules:
+  - host: app-default-named.example.org
+    http:
+      paths:
+      - backend:
+          serviceName: app-svc-named
+          servicePort: http

--- a/testdata/kube/apis/extensions/v1beta1/ingresses/ns2/app-ns2.json
+++ b/testdata/kube/apis/extensions/v1beta1/ingresses/ns2/app-ns2.json
@@ -1,0 +1,1 @@
+{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"app1","namespace":"ns2"},"spec":{"rules":[{"host":"app1-ns2.example.org","http":{"paths":[{"backend":{"serviceName":"app1-svc","servicePort":80}}]}}]}}

--- a/testdata/kube/apis/extensions/v1beta1/ingresses/ns2/app-ns2.yaml
+++ b/testdata/kube/apis/extensions/v1beta1/ingresses/ns2/app-ns2.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: app1
+  namespace: ns2
+spec:
+  rules:
+  - host: app1-ns2.example.org
+    http:
+      paths:
+      - backend:
+          serviceName: app1-svc
+          servicePort: 80


### PR DESCRIPTION
This implements basic test infrastructure to test kubernetes objects defined as yaml files, which are automatically converted to json and then served by ServeHTTP within kube2_test.go.

needed a rebase to fix/566-kube-dc-part, because of a dependency of the data structure change

What do you think?