### PR TITLE
fix test timeout in kubernetes http redirect

### DIFF
--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -42,8 +42,9 @@ func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) 
 	})
 
 	const to = 120 * time.Millisecond
-	l.WaitFor("all ingresses received", to)
-	l.WaitFor("route settings applied", to)
+	if err := l.WaitFor("route settings applied", to); err != nil {
+		t.Fatal("waiting for route settings", err)
+	}
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
- removing unnecessary wait (root cause for time sensitive test runs)
- handling the timeout for the effective wait