### PR TITLE
Add annotation for specifying custom routes on ingress

### DIFF
--- a/dataclients/kubernetes/doc.go
+++ b/dataclients/kubernetes/doc.go
@@ -141,6 +141,31 @@ defined route in ingress.
               serviceName: app-svc
               servicePort: 80
 
+Example - Ingress with custom skipper Routes configuration
+
+The example shows the use of custom skipper routes which be additional to the
+routes generated for the ingress.
+
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      annotations:
+        zalando.org/skipper-routes: |
+          Method("OPTIONS") ->
+          setResponseHeader("Access-Control-Allow-Origin", "*") ->
+          setResponseHeader("Access-Control-Allow-Methods", "GET, OPTIONS") ->
+          setResponseHeader("Access-Control-Allow-Headers", "Authorization") ->
+          status(200) -> <shunt>
+      name: app
+    spec:
+      rules:
+      - host: app-default.example.org
+        http:
+          paths:
+          - backend:
+              serviceName: app-svc
+              servicePort: 80
+
 Example - Ingress with shadow traffic
 
 This will send production traffic to app-default.example.org and

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -340,6 +340,13 @@ func routeID(namespace, name, host, path, backend string) string {
 	return fmt.Sprintf("kube_%s__%s__%s__%s__%s", namespace, name, host, path, backend)
 }
 
+// routeIDForCustom generates a route id for a custom route of an ingress
+// resource.
+func routeIDForCustom(namespace, name, id, host string, index int) string {
+	name = name + "_" + id + "_" + strconv.Itoa(index)
+	return routeID(namespace, name, host, "", "")
+}
+
 // converts the default backend if any
 func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, error) {
 	// the usage of the default backend depends on what we want
@@ -709,9 +716,9 @@ func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 			host := []string{"^" + strings.Replace(rule.Host, ".", "[.]", -1) + "$"}
 
 			// add extra routes from optional annotation
-			for _, route := range extraRoutes {
+			for idx, route := range extraRoutes {
 				route.HostRegexps = host
-				route.Id = routeID("", route.Id, rule.Host, "", "")
+				route.Id = routeIDForCustom(i.Metadata.Namespace, i.Metadata.Name, route.Id, rule.Host, idx)
 				hostRoutes[rule.Host] = append(hostRoutes[rule.Host], route)
 			}
 

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -639,14 +639,15 @@ func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 	routes := make([]*eskip.Route, 0, len(items))
 	hostRoutes := make(map[string][]*eskip.Route)
 	for _, i := range items {
+		if i.Metadata == nil || i.Metadata.Namespace == "" || i.Metadata.Name == "" ||
+			i.Spec == nil {
+			log.Warn("invalid ingress item: missing metadata")
+			continue
+		}
+
 		logger := log.WithFields(log.Fields{
 			"ingress": fmt.Sprintf("%s/%s", i.Metadata.Namespace, i.Metadata.Name),
 		})
-		if i.Metadata == nil || i.Metadata.Namespace == "" || i.Metadata.Name == "" ||
-			i.Spec == nil {
-			logger.Warn("invalid ingress item: missing metadata")
-			continue
-		}
 
 		if r, ok, err := c.convertDefaultBackend(i); ok {
 			routes = append(routes, r...)

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -200,9 +199,6 @@ func testIngresses() []*ingressItem {
 }
 
 func checkRoutes(t *testing.T, r []*eskip.Route, expected map[string]string) {
-	for _, route := range r {
-		fmt.Println(route.Id)
-	}
 	if len(r) != len(expected) {
 		curIDs := make([]string, len(r))
 		expectedIDs := make([]string, len(expected))
@@ -638,7 +634,7 @@ func TestIngressData(t *testing.T) {
 		)},
 		map[string]string{
 			"kube_foo__qux__www_example_org_____bar": "http://1.2.3.4:8181",
-			"kube_____www_example_org____":           "",
+			"kube_foo__qux__0__www_example_org____":  "",
 		},
 	}} {
 		t.Run(ti.msg, func(t *testing.T) {

--- a/dataclients/kubernetes/lbtarget_test.go
+++ b/dataclients/kubernetes/lbtarget_test.go
@@ -39,6 +39,7 @@ func testSingleIngressWithTargets(t *testing.T, targets []string, expectedRoutes
 		"",
 		"",
 		"",
+		"",
 		backendPort{"port1"},
 		1.0,
 		testRule(

--- a/docs/dataclients/kubernetes.md
+++ b/docs/dataclients/kubernetes.md
@@ -47,6 +47,7 @@ Skipper's main features:
   - All Filters and Predicates can be used with 2 annotations
     - Predicates: `zalando.org/skipper-predicate`
     - Filters: `zalando.org/skipper-filter`
+  - Custom routes can be defined with the annotation `zalando.org/skipper-routes`
   - [metrics](https://godoc.org/github.com/zalando/skipper/metrics)
   - access logs
   - Blue-Green deployments, with another Ingress annotation `zalando.org/backend-weights`

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -100,7 +100,7 @@ This example shows how to add predicates and filters:
 
 ## Custom Routes
 
-Custom routes is a way of extending the default routes configured for your
+Custom routes is a way of extending the default routes configured for an
 ingress resource.
 
 This example shows how to add a custom route for handling `OPTIONS` requests.

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -8,10 +8,11 @@ features Skipper provides
 
 Annotation | example data | usage
 --- | --- | ---
-zalando.org/backend-weights | {"my-app-1": 80, "my-app-2": 20} | blue-green deployments
-zalando.org/skipper-filter | consecutiveBreaker(15) | arbitrary filters
-zalando.org/skipper-predicate | QueryParam("version", "^alpha$") | arbitrary predicates
-zalando.org/ratelimit | ratelimit(50, "1m") | deprecated, use zalando.org/skipper-filter instead
+zalando.org/backend-weights | `{"my-app-1": 80, "my-app-2": 20}` | blue-green deployments
+zalando.org/skipper-filter | `consecutiveBreaker(15)` | arbitrary filters
+zalando.org/skipper-predicate | `QueryParam("version", "^alpha$")` | arbitrary predicates
+zalando.org/skipper-routes | `Method("OPTIONS") -> stauts(200) -> <shunt>` | extra custom routes
+zalando.org/ratelimit | `ratelimit(50, "1m")` | deprecated, use zalando.org/skipper-filter instead
 
 ## Supported Service types
 
@@ -97,6 +98,44 @@ This example shows how to add predicates and filters:
               serviceName: app-svc
               servicePort: 80
 
+## Custom Routes
+
+Custom routes is a way of extending the default routes configured for your
+ingress resource.
+
+This example shows how to add a custom route for handling `OPTIONS` requests.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    zalando.org/skipper-routes: |
+      Method("OPTIONS") ->
+      setResponseHeader("Access-Control-Allow-Origin", "*") ->
+      setResponseHeader("Access-Control-Allow-Methods", "GET, OPTIONS") ->
+      setResponseHeader("Access-Control-Allow-Headers", "Authorization") ->
+      status(200) -> <shunt>
+  name: app
+spec:
+  rules:
+  - host: app-default.example.org
+    http:
+      paths:
+      - backend:
+          serviceName: app-svc
+          servicePort: 80
+```
+
+This will generate a custom route for the ingress which looks like this:
+
+```
+Host(/^app-default[.]example[.]org$/) && Method("OPTIONS") ->
+  setResponseHeader("Access-Control-Allow-Origin", "*") ->
+  setResponseHeader("Access-Control-Allow-Methods", "GET, OPTIONS") ->
+  setResponseHeader("Access-Control-Allow-Headers", "Authorization") ->
+  status(200) -> <shunt>
+```
 
 # Filters - Basic HTTP manipulations
 


### PR DESCRIPTION
This is an idea of how we could allow specifying custom routes on an ingress resource, to make it very simple to extend the application at the ingress layer.

My use case is that I have a REST API which is now called by a client-side application so I need to respond with the correct `Access-Control-Allow-Origin` headers. Instead of extending my application, with this I can just add an annotation (`zalando.org/skipper-routes`) to my ingress and quickly extend the API to send the right headers. The filter or predicate annotations are not enough because I need to respond with just the headers for the `OPTIONS` request and I can't proxy to my backend because it doesn't handle the `OPTIONS` request.

This is not yet tested, I just wanted to show a PoC for you to see before I go further with the idea.