### PR TITLE
Fix: empty group when no target endpoints + fix: id formatting for default backends with target endpoints + small improvements

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -425,6 +425,10 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 		routes = append(routes, r)
 	}
 
+	if len(eps) == 0 {
+		return routes, true, nil
+	}
+
 	decisionRoute := &eskip.Route{
 		Id:          routeID(ns, name, "", "", "") + "__lb_group",
 		BackendType: eskip.LoopBackend,
@@ -565,6 +569,10 @@ func (c *Client) convertPathRule(ns, name, host string, prule *pathRule, endpoin
 			log.Debugf("Traffic weight %.2f for backend '%s'", prule.Backend.Traffic, svcName)
 		}
 		routes = append(routes, r)
+	}
+
+	if len(eps) == 0 {
+		return routes, nil
 	}
 
 	decisionRoute := &eskip.Route{

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -413,7 +414,7 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 
 	for idx, ep := range eps {
 		r := &eskip.Route{
-			Id:      routeID(ns, name, "", "", string(idx)),
+			Id:      routeID(ns, name, "", "", strconv.Itoa(idx)),
 			Backend: ep,
 			Predicates: []*eskip.Predicate{{
 				Name: loadbalancer.MemberPredicateName,

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -824,15 +824,6 @@ func mapRoutes(r []*eskip.Route) map[string]*eskip.Route {
 	return m
 }
 
-func (c *Client) listRoutes() []*eskip.Route {
-	l := make([]*eskip.Route, 0, len(c.current))
-	for _, r := range c.current {
-		l = append(l, r)
-	}
-
-	return l
-}
-
 // filterIngressesByClass will filter only the ingresses that have the valid class, these are
 // the defined one, empty string class or not class at all
 func (c *Client) filterIngressesByClass(items []*ingressItem) []*ingressItem {

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -371,6 +371,7 @@ func (c *Client) convertDefaultBackend(i *ingressItem) ([]*eskip.Route, bool, er
 		err = nil
 		log.Errorf("Failed to find target port %v, %s, fallback to service", svc.Spec.Ports, svcPort)
 	} else {
+		// TODO(aryszka): check docs that service name is always good for requesting the endpoints
 		log.Infof("Found target port %v, for service %s", targetPort, svcName)
 		eps, err = c.getEndpoints(
 			ns,

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -256,7 +256,7 @@ func checkRoutesExact(t *testing.T, r []*eskip.Route, expect []*eskip.Route) {
 		}
 
 		if !found {
-			t.Errorf("route not found: %v", r[i])
+			t.Errorf("route not found: %s: %v", r[i].Id, r[i])
 			return
 		}
 	}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -394,8 +394,7 @@ func TestIngressData(t *testing.T) {
 		},
 		[]*ingressItem{testIngress("foo", "baz", "bar", "", "", "", backendPort{8080}, 1.0)},
 		map[string]string{
-			"kube_foo__baz______":           "http://1.2.3.4:8080",
-			"kube_foo__baz________lb_group": "",
+			"kube_foo__baz______": "http://1.2.3.4:8080",
 		},
 	}, {
 		"service backend from ingress and service, path rule",
@@ -423,8 +422,7 @@ func TestIngressData(t *testing.T) {
 			),
 		)},
 		map[string]string{
-			"kube_foo__baz__www_example_org_____bar":           "http://1.2.3.4:8181",
-			"kube_foo__baz__www_example_org_____bar__lb_group": "",
+			"kube_foo__baz__www_example_org_____bar": "http://1.2.3.4:8181",
 		},
 	}, {
 		"service backend from ingress and service, default and path rule",
@@ -453,10 +451,8 @@ func TestIngressData(t *testing.T) {
 			),
 		)},
 		map[string]string{
-			"kube_foo__qux______":                              "http://1.2.3.4:8080",
-			"kube_foo__qux________lb_group":                    "",
-			"kube_foo__qux__www_example_org_____baz":           "http://5.6.7.8:8181",
-			"kube_foo__qux__www_example_org_____baz__lb_group": "",
+			"kube_foo__qux______":                    "http://1.2.3.4:8080",
+			"kube_foo__qux__www_example_org_____baz": "http://5.6.7.8:8181",
 		},
 	}, {
 		"service backend from ingress and service, with port name",
@@ -484,8 +480,7 @@ func TestIngressData(t *testing.T) {
 			),
 		)},
 		map[string]string{
-			"kube_foo__qux__www_example_org_____bar":           "http://1.2.3.4:8181",
-			"kube_foo__qux__www_example_org_____bar__lb_group": "",
+			"kube_foo__qux__www_example_org_____bar": "http://1.2.3.4:8181",
 		},
 	}, {
 		"ignore ingress entries with missing metadata",
@@ -529,8 +524,7 @@ func TestIngressData(t *testing.T) {
 			},
 		},
 		map[string]string{
-			"kube_foo__qux__www_example_org_____bar":           "http://1.2.3.4:8181",
-			"kube_foo__qux__www_example_org_____bar__lb_group": "",
+			"kube_foo__qux__www_example_org_____bar": "http://1.2.3.4:8181",
 		},
 	}} {
 		t.Run(ti.msg, func(t *testing.T) {
@@ -762,28 +756,18 @@ func TestIngress(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__default_only______":                                     "http://1.2.3.4:8080",
-			"kube_namespace1__default_only________lb_group":                           "",
-			"kube_namespace2__path_rule_only__www_example_org_____service3":           "http://9.0.1.2:7272",
-			"kube_namespace2__path_rule_only__www_example_org_____service3__lb_group": "",
-			"kube_namespace1__mega______":                                             "http://1.2.3.4:8080",
-			"kube_namespace1__mega________lb_group":                                   "",
-			"kube_namespace1__mega__foo_example_org___test1__service1":                "http://1.2.3.4:8080",
-			"kube_namespace1__mega__foo_example_org___test1__service1__lb_group":      "",
-			"kube_namespace1__mega__foo_example_org___test2__service2":                "http://5.6.7.8:8181",
-			"kube_namespace1__mega__foo_example_org___test2__service2__lb_group":      "",
-			"kube___catchall__foo_example_org____":                                    "",
-			"kube_namespace1__mega__bar_example_org___test1__service1":                "http://1.2.3.4:8080",
-			"kube_namespace1__mega__bar_example_org___test1__service1__lb_group":      "",
-			"kube_namespace1__mega__bar_example_org___test2__service2":                "http://5.6.7.8:8181",
-			"kube_namespace1__mega__bar_example_org___test2__service2__lb_group":      "",
-			"kube___catchall__bar_example_org____":                                    "",
-			"kube_namespace1__ratelimit______":                                        "http://1.2.3.4:8080",
-			"kube_namespace1__ratelimit________lb_group":                              "",
-			"kube_namespace1__ratelimitAndBreaker______":                              "http://1.2.3.4:8080",
-			"kube_namespace1__ratelimitAndBreaker________lb_group":                    "",
-			"kube_namespace2__svcwith2ports______":                                    "http://10.0.1.2:4444",
-			"kube_namespace2__svcwith2ports________lb_group":                          "",
+			"kube_namespace1__default_only______":                           "http://1.2.3.4:8080",
+			"kube_namespace2__path_rule_only__www_example_org_____service3": "http://9.0.1.2:7272",
+			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube___catchall__foo_example_org____":                          "",
+			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube___catchall__bar_example_org____":                          "",
+			"kube_namespace1__ratelimit______":                              "http://1.2.3.4:8080",
+			"kube_namespace1__ratelimitAndBreaker______":                    "http://1.2.3.4:8080",
+			"kube_namespace2__svcwith2ports______":                          "http://10.0.1.2:4444",
 		})
 	})
 
@@ -810,8 +794,7 @@ func TestIngress(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__mega__foo_example_org___test1__service1":           "http://1.2.3.4:8080",
-			"kube_namespace1__mega__foo_example_org___test1__service1__lb_group": "",
+			"kube_namespace1__mega__foo_example_org___test1__service1": "http://1.2.3.4:8080",
 		})
 	})
 
@@ -830,28 +813,18 @@ func TestIngress(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__default_only______":                                     "http://1.2.3.4:8080",
-			"kube_namespace1__default_only________lb_group":                           "",
-			"kube_namespace2__path_rule_only__www_example_org_____service3":           "http://9.0.1.2:7272",
-			"kube_namespace2__path_rule_only__www_example_org_____service3__lb_group": "",
-			"kube_namespace1__mega______":                                             "http://1.2.3.4:8080",
-			"kube_namespace1__mega________lb_group":                                   "",
-			"kube_namespace1__mega__foo_example_org___test1__service1":                "http://1.2.3.4:8080",
-			"kube_namespace1__mega__foo_example_org___test1__service1__lb_group":      "",
-			"kube_namespace1__mega__foo_example_org___test2__service2":                "http://5.6.7.8:8181",
-			"kube_namespace1__mega__foo_example_org___test2__service2__lb_group":      "",
-			"kube___catchall__foo_example_org____":                                    "",
-			"kube_namespace1__mega__bar_example_org___test1__service1":                "http://1.2.3.4:8080",
-			"kube_namespace1__mega__bar_example_org___test1__service1__lb_group":      "",
-			"kube_namespace1__mega__bar_example_org___test2__service2":                "http://5.6.7.8:8181",
-			"kube_namespace1__mega__bar_example_org___test2__service2__lb_group":      "",
-			"kube___catchall__bar_example_org____":                                    "",
-			"kube_namespace1__ratelimit______":                                        "http://1.2.3.4:8080",
-			"kube_namespace1__ratelimit________lb_group":                              "",
-			"kube_namespace1__ratelimitAndBreaker______":                              "http://1.2.3.4:8080",
-			"kube_namespace1__ratelimitAndBreaker________lb_group":                    "",
-			"kube_namespace2__svcwith2ports________lb_group":                          "",
-			"kube_namespace2__svcwith2ports______":                                    "http://10.0.1.2:4444",
+			"kube_namespace1__default_only______":                           "http://1.2.3.4:8080",
+			"kube_namespace2__path_rule_only__www_example_org_____service3": "http://9.0.1.2:7272",
+			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube___catchall__foo_example_org____":                          "",
+			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube___catchall__bar_example_org____":                          "",
+			"kube_namespace1__ratelimit______":                              "http://1.2.3.4:8080",
+			"kube_namespace1__ratelimitAndBreaker______":                    "http://1.2.3.4:8080",
+			"kube_namespace2__svcwith2ports______":                          "http://10.0.1.2:4444",
 		})
 	})
 
@@ -908,9 +881,7 @@ func TestIngress(t *testing.T) {
 			t,
 			d,
 			"kube_namespace1__mega__foo_example_org___test2__service2",
-			"kube_namespace1__mega__foo_example_org___test2__service2__lb_group",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org___test2__service2__lb_group",
 		)
 	})
 
@@ -939,25 +910,16 @@ func TestIngress(t *testing.T) {
 			t,
 			d,
 			"kube_namespace2__path_rule_only__www_example_org_____service3",
-			"kube_namespace2__path_rule_only__www_example_org_____service3__lb_group",
 			"kube_namespace1__mega______",
-			"kube_namespace1__mega________lb_group",
 			"kube_namespace1__mega__foo_example_org___test1__service1",
-			"kube_namespace1__mega__foo_example_org___test1__service1__lb_group",
 			"kube_namespace1__mega__foo_example_org___test2__service2",
-			"kube_namespace1__mega__foo_example_org___test2__service2__lb_group",
 			"kube___catchall__foo_example_org____",
 			"kube_namespace1__mega__bar_example_org___test1__service1",
-			"kube_namespace1__mega__bar_example_org___test1__service1__lb_group",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org___test2__service2__lb_group",
 			"kube___catchall__bar_example_org____",
 			"kube_namespace1__ratelimit______",
-			"kube_namespace1__ratelimit________lb_group",
 			"kube_namespace1__ratelimitAndBreaker______",
-			"kube_namespace1__ratelimitAndBreaker________lb_group",
 			"kube_namespace2__svcwith2ports______",
-			"kube_namespace2__svcwith2ports________lb_group",
 		)
 	})
 
@@ -986,9 +948,7 @@ func TestIngress(t *testing.T) {
 			t,
 			d,
 			"kube_namespace1__mega__bar_example_org___test1__service1",
-			"kube_namespace1__mega__bar_example_org___test1__service1__lb_group",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org___test2__service2__lb_group",
 			"kube___catchall__bar_example_org____",
 		)
 	})
@@ -1046,10 +1006,8 @@ func TestIngress(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__new1__new1_example_org_____service1":           "http://1.2.3.4:8080",
-			"kube_namespace1__new1__new1_example_org_____service1__lb_group": "",
-			"kube_namespace1__new2__new2_example_org_____service2":           "http://5.6.7.8:8181",
-			"kube_namespace1__new2__new2_example_org_____service2__lb_group": "",
+			"kube_namespace1__new1__new1_example_org_____service1": "http://1.2.3.4:8080",
+			"kube_namespace1__new2__new2_example_org_____service2": "http://5.6.7.8:8181",
 		})
 	})
 
@@ -1109,20 +1067,16 @@ func TestIngress(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__new1__new1_example_org_____service1":           "http://1.2.3.4:8080",
-			"kube_namespace1__new1__new1_example_org_____service1__lb_group": "",
-			"kube_namespace1__new2__new2_example_org_____service2":           "http://5.6.7.8:8181",
-			"kube_namespace1__new2__new2_example_org_____service2__lb_group": "",
-			"kube_namespace2__path_rule_only__www_example_org_____service3":  "http://9.0.1.2:9999",
+			"kube_namespace1__new1__new1_example_org_____service1":          "http://1.2.3.4:8080",
+			"kube_namespace1__new2__new2_example_org_____service2":          "http://5.6.7.8:8181",
+			"kube_namespace2__path_rule_only__www_example_org_____service3": "http://9.0.1.2:9999",
 		})
 
 		checkIDs(
 			t,
 			d,
 			"kube_namespace1__mega__bar_example_org___test1__service1",
-			"kube_namespace1__mega__bar_example_org___test1__service1__lb_group",
 			"kube_namespace1__mega__bar_example_org___test2__service2",
-			"kube_namespace1__mega__bar_example_org___test2__service2__lb_group",
 			"kube___catchall__bar_example_org____",
 		)
 	})
@@ -1180,8 +1134,7 @@ func TestIngress(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__new1__new1_example_org_____service1":           "http://1.2.3.4:8080",
-			"kube_namespace1__new1__new1_example_org_____service1__lb_group": "",
+			"kube_namespace1__new1__new1_example_org_____service1": "http://1.2.3.4:8080",
 		})
 	})
 }
@@ -1243,11 +1196,9 @@ func TestConvertPathRule(t *testing.T) {
 		}
 
 		checkRoutes(t, r, map[string]string{
-			"kube_namespace1__new1__new1_example_org___test1__service1":           "http://1.2.3.4:8080",
-			"kube_namespace1__new1__new1_example_org___test1__service1__lb_group": "",
-			"kube___catchall__new1_example_org____":                               "",
-			"kube_namespace1__new1__new1_example_org___test2__service1":           "http://1.2.3.4:8080",
-			"kube_namespace1__new1__new1_example_org___test2__service1__lb_group": "",
+			"kube_namespace1__new1__new1_example_org___test1__service1": "http://1.2.3.4:8080",
+			"kube___catchall__new1_example_org____":                     "",
+			"kube_namespace1__new1__new1_example_org___test2__service1": "http://1.2.3.4:8080",
 		})
 	})
 }
@@ -1587,29 +1538,19 @@ func TestHealthcheckReload(t *testing.T) {
 
 		checkHealthcheck(t, r, true, true, false)
 		checkRoutes(t, r, map[string]string{
-			healthcheckRouteID:                                                        "",
-			"kube_namespace1__default_only______":                                     "http://1.2.3.4:8080",
-			"kube_namespace1__default_only________lb_group":                           "",
-			"kube_namespace2__path_rule_only__www_example_org_____service3":           "http://9.0.1.2:7272",
-			"kube_namespace2__path_rule_only__www_example_org_____service3__lb_group": "",
-			"kube_namespace1__mega______":                                             "http://1.2.3.4:8080",
-			"kube_namespace1__mega________lb_group":                                   "",
-			"kube_namespace1__mega__foo_example_org___test1__service1":                "http://1.2.3.4:8080",
-			"kube_namespace1__mega__foo_example_org___test1__service1__lb_group":      "",
-			"kube_namespace1__mega__foo_example_org___test2__service2":                "http://5.6.7.8:8181",
-			"kube_namespace1__mega__foo_example_org___test2__service2__lb_group":      "",
-			"kube___catchall__foo_example_org____":                                    "",
-			"kube_namespace1__mega__bar_example_org___test1__service1":                "http://1.2.3.4:8080",
-			"kube_namespace1__mega__bar_example_org___test1__service1__lb_group":      "",
-			"kube_namespace1__mega__bar_example_org___test2__service2":                "http://5.6.7.8:8181",
-			"kube_namespace1__mega__bar_example_org___test2__service2__lb_group":      "",
-			"kube___catchall__bar_example_org____":                                    "",
-			"kube_namespace1__ratelimit______":                                        "http://1.2.3.4:8080",
-			"kube_namespace1__ratelimit________lb_group":                              "",
-			"kube_namespace1__ratelimitAndBreaker______":                              "http://1.2.3.4:8080",
-			"kube_namespace1__ratelimitAndBreaker________lb_group":                    "",
-			"kube_namespace2__svcwith2ports______":                                    "http://10.0.1.2:4444",
-			"kube_namespace2__svcwith2ports________lb_group":                          "",
+			healthcheckRouteID:                                              "",
+			"kube_namespace1__default_only______":                           "http://1.2.3.4:8080",
+			"kube_namespace2__path_rule_only__www_example_org_____service3": "http://9.0.1.2:7272",
+			"kube_namespace1__mega______":                                   "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__foo_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube___catchall__foo_example_org____":                          "",
+			"kube_namespace1__mega__bar_example_org___test1__service1":      "http://1.2.3.4:8080",
+			"kube_namespace1__mega__bar_example_org___test2__service2":      "http://5.6.7.8:8181",
+			"kube___catchall__bar_example_org____":                          "",
+			"kube_namespace1__ratelimit______":                              "http://1.2.3.4:8080",
+			"kube_namespace1__ratelimitAndBreaker______":                    "http://1.2.3.4:8080",
+			"kube_namespace2__svcwith2ports______":                          "http://10.0.1.2:4444",
 		})
 	})
 }

--- a/dataclients/kubernetes/lbtarget_test.go
+++ b/dataclients/kubernetes/lbtarget_test.go
@@ -1,0 +1,114 @@
+package kubernetes
+
+import "testing"
+
+func TestLBTargets(t *testing.T) {
+	const expectedRoutes = `
+
+		// default backend, target 1:
+		kube_namespace1__ingress1_______:
+		  LBMember("kube_namespace1__ingress1______", 0)
+		  -> "http://42.0.1.2:8080";
+
+		// default backend, target 2:
+		kube_namespace1__ingress1_______:
+		  LBMember("kube_namespace1__ingress1______", 1)
+		  -> "http://42.0.1.3:8080";
+
+		// default group:
+		kube_namespace1__ingress1________lb_group:
+		  LBGroup("kube_namespace1__ingress1______")
+		  -> lbDecide("kube_namespace1__ingress1______", 2) ->
+		  <loopback>;
+
+		// path rule, target 1:
+		kube_namespace1__ingress1__test_example_org___test1__service1_0:
+		  Host(/^test[.]example[.]org$/)
+		  && PathRegexp(/^\/test1/)
+		  && LBMember("kube_namespace1__ingress1__test_example_org___test1__service1", 0)
+		  -> "http://42.0.1.2:8080";
+
+		// path rule, target 2:
+		kube_namespace1__ingress1__test_example_org___test1__service1_1:
+		  Host(/^test[.]example[.]org$/)
+		  && PathRegexp(/^\/test1/)
+		  && LBMember("kube_namespace1__ingress1__test_example_org___test1__service1", 1)
+		  -> "http://42.0.1.3:8080";
+
+		// path rule group:
+		kube_namespace1__ingress1__test_example_org___test1__service1__lb_group:
+		  Host(/^test[.]example[.]org$/) && PathRegexp(/^\/test1/)
+		  && LBGroup("kube_namespace1__ingress1__test_example_org___test1__service1")
+		  -> lbDecide("kube_namespace1__ingress1__test_example_org___test1__service1", 2)
+		  -> <loopback>;
+
+		// catch all:
+		kube___catchall__test_example_org____:
+		  Host(/^test[.]example[.]org$/)
+		  -> <shunt>;
+	`
+
+	svc := testServiceWithTargetPort(
+		"1.2.3.4",
+		map[string]int{"port1": 8080},
+		map[int]*backendPort{8080: {8080}},
+	)
+
+	services := services{
+		"namespace1": map[string]*service{"service1": svc},
+	}
+
+	endpoints := endpoints{
+		"namespace1": map[string]endpoint{
+			"service1": {
+				Subsets: []*subset{{
+					Addresses: []*address{{
+						IP: "42.0.1.2",
+					}},
+					Ports: []*port{{
+						Name: "port1",
+						Port: 8080,
+					}},
+				}, {
+					Addresses: []*address{{
+						IP: "42.0.1.3",
+					}},
+					Ports: []*port{{
+						Name: "port1",
+						Port: 8080,
+					}},
+				}},
+			},
+		},
+	}
+
+	ingress := testIngress(
+		"namespace1",
+		"ingress1",
+		"service1",
+		"",
+		"",
+		"",
+		backendPort{"port1"},
+		1.0,
+		testRule(
+			"test.example.org",
+			testPathRule("/test1", "service1", backendPort{"port1"}),
+		),
+	)
+
+	api := newTestAPIWithEndpoints(t, services, &ingressList{Items: []*ingressItem{ingress}}, endpoints)
+	defer api.Close()
+
+	dc, err := New(Options{KubernetesURL: api.server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := dc.LoadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkRoutesDoc(t, r, expectedRoutes)
+}

--- a/dataclients/kubernetes/lbtarget_test.go
+++ b/dataclients/kubernetes/lbtarget_test.go
@@ -6,12 +6,12 @@ func TestLBTargets(t *testing.T) {
 	const expectedRoutes = `
 
 		// default backend, target 1:
-		kube_namespace1__ingress1_______:
+		kube_namespace1__ingress1______0:
 		  LBMember("kube_namespace1__ingress1______", 0)
 		  -> "http://42.0.1.2:8080";
 
 		// default backend, target 2:
-		kube_namespace1__ingress1_______:
+		kube_namespace1__ingress1______1:
 		  LBMember("kube_namespace1__ingress1______", 1)
 		  -> "http://42.0.1.3:8080";
 


### PR DESCRIPTION
- fix: remove load balancing when using service fallback, therefore removing invalid route with 0 size group
- fix: ID formatting, therefore remove duplicate IDs, therefore broken load balancing for default backends
- improve: remove unnecessary load balancing loopback when there's just a single target endpoint, but keep using the target endpoint
- refactor: remove unused method (listRoutes)
