### PR TITLE
fixing routing config recovery after differential update errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ lint: build
 
 clean:
 	go clean -i ./...
+	rm -rf .coverprofile-all .cover
 
 deps:
 	go get -t github.com/zalando/skipper/...

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -94,8 +94,6 @@ func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <
 			initial = true
 			to = 0
 		case initial || len(routes) > 0 || len(deletedIDs) > 0:
-			initial = false
-
 			var incoming *incomingData
 			if initial {
 				incoming = &incomingData{incomingReset, c, routes, nil}
@@ -103,6 +101,7 @@ func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <
 				incoming = &incomingData{incomingUpdate, c, routes, deletedIDs}
 			}
 
+			initial = false
 			select {
 			case out <- incoming:
 			case <-quit:

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -101,7 +101,7 @@ func TestLogging(t *testing.T) {
 
 		testLog := loggingtest.New()
 		defer testLog.Close()
-		testLog.Unmute()
+		// testLog.Unmute()
 
 		rt := init(testLog, client, suppress)
 		defer rt.Close()
@@ -114,6 +114,8 @@ func TestLogging(t *testing.T) {
 		count := testLog.Count(initQuery)
 		if count != initCount {
 			t.Error("unexpected count of log entries", count)
+			t.Log("expected", initCount, initQuery)
+			t.Log("got     ", count)
 			return
 		}
 
@@ -146,7 +148,7 @@ func TestLogging(t *testing.T) {
 	t.Run("full", func(t *testing.T) {
 		testUpdate(
 			t, false,
-			"route settings, update", 5,
+			"route settings, reset", 5,
 			"route settings, update, route:", 2,
 			"route settings, update, deleted", 1,
 		)
@@ -155,7 +157,7 @@ func TestLogging(t *testing.T) {
 	t.Run("suppressed", func(t *testing.T) {
 		testUpdate(
 			t, true,
-			"route settings, update", 2,
+			"route settings, reset", 2,
 			"route settings, update, upsert count:", 1,
 			"route settings, update, delete count:", 1,
 		)

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -101,7 +101,6 @@ func TestLogging(t *testing.T) {
 
 		testLog := loggingtest.New()
 		defer testLog.Close()
-		// testLog.Unmute()
 
 		rt := init(testLog, client, suppress)
 		defer rt.Close()

--- a/routing/routing_test.go
+++ b/routing/routing_test.go
@@ -738,7 +738,6 @@ func TestRoutingHandlerHEAD(t *testing.T) {
 
 func TestUpdateFailsRecovers(t *testing.T) {
 	l := loggingtest.New()
-	// l.Unmute()
 	defer l.Close()
 
 	dc, err := testdataclient.NewDoc(`

--- a/routing/routing_test.go
+++ b/routing/routing_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -733,4 +734,71 @@ func TestRoutingHandlerHEAD(t *testing.T) {
 	if rsp.Header.Get("X-Count") != "3" {
 		t.Error("invalid count header")
 	}
+}
+
+func TestUpdateFailsRecovers(t *testing.T) {
+	l := loggingtest.New()
+	// l.Unmute()
+	defer l.Close()
+
+	dc, err := testdataclient.NewDoc(`
+		foo: Path("/foo") -> setPath("/") -> "https://foo.example.org";
+		bar: Path("/bar") -> setPath("/") -> "https://bar.example.org";
+		baz: Path("/baz") -> setPath("/") -> "https://baz.example.org";
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rt := routing.New(routing.Options{
+		FilterRegistry: builtin.MakeRegistry(),
+		DataClients:    []routing.DataClient{dc},
+		PollTimeout:    12 * time.Millisecond,
+		Log:            l,
+	})
+	defer rt.Close()
+
+	check := func(id, path, backend string, match bool) {
+		if t.Failed() {
+			return
+		}
+
+		if r, _ := rt.Route(&http.Request{URL: &url.URL{Path: path}}); r == nil && match {
+			t.Error("route not found:", id)
+		} else if r == nil && !match {
+			return
+		} else if !match {
+			t.Error("unexpected route found:", id, path)
+		} else if r.Id != id || r.Backend != backend {
+			t.Error("invalid route matched")
+			t.Log("got:     ", r.Id, r.Backend)
+			t.Log("expected:", id, backend)
+		}
+	}
+
+	if err := l.WaitFor("route settings applied", 120*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	check("foo", "/foo", "https://foo.example.org", true)
+	check("bar", "/bar", "https://bar.example.org", true)
+	check("baz", "/baz", "https://baz.example.org", true)
+
+	l.Reset()
+	dc.FailNext()
+
+	if err := dc.UpdateDoc(`
+		foo: Path("/foo") -> setPath("/") -> "https://foo.example.org";
+		baz: Path("/baz") -> setPath("/") -> "https://baz-new.example.org";
+	`, []string{"bar"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := l.WaitFor("route settings applied", 120*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	check("foo", "/foo", "https://foo.example.org", true)
+	check("bar", "", "", false)
+	check("baz", "/baz", "https://baz-new.example.org", true)
 }


### PR DESCRIPTION
Fixing a bug where on route config updates, the recovery request for the full route config from a data client is not handled correctly, causing that routes that were deleted during the failing period are not removed from the active configuration.