### PR TITLE
remove concurrent test specs from https redirect test

### DIFF
--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -19,7 +19,7 @@ type redirectTest struct {
 	backend         string
 	fallbackBackend string
 	t               *testing.T
-	l *loggingtest.Logger
+	l               *loggingtest.Logger
 }
 
 func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) {
@@ -93,7 +93,7 @@ func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) 
 		backend:         backend,
 		fallbackBackend: fallbackBackend,
 		t:               t,
-		l: l,
+		l:               l,
 	}, nil
 }
 

--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -19,11 +19,39 @@ type redirectTest struct {
 	backend         string
 	fallbackBackend string
 	t               *testing.T
+	l *loggingtest.Logger
 }
 
 func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) {
-	s := testServices()
-	i := &ingressList{Items: testIngresses()}
+	s := services{
+		"namespace1": map[string]*service{
+			"service1": testService("1.2.3.4", map[string]int{"port1": 8080}),
+		},
+	}
+	i := &ingressList{Items: []*ingressItem{
+		testIngress(
+			"namespace1",
+			"mega",
+			"service1",
+			"",
+			"",
+			"",
+			"",
+			backendPort{"port1"},
+			1.0,
+			testRule(
+				"foo.example.org",
+				testPathRule("/test1", "service1", backendPort{"port1"}),
+				testPathRule("/test2", "service2", backendPort{"port2"}),
+			),
+			testRule(
+				"bar.example.org",
+				testPathRule("/test1", "service1", backendPort{"port1"}),
+				testPathRule("/test2", "service2", backendPort{"port2"}),
+			),
+		),
+	}}
+
 	api := newTestAPI(t, s, i)
 
 	dc, err := New(Options{
@@ -51,7 +79,7 @@ func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) 
 		return nil, err
 	}
 
-	ingress := i.Items[1]
+	ingress := i.Items[0]
 	rule := ingress.Spec.Rules[0]
 	service := s[ingress.Metadata.Namespace][rule.Http.Paths[0].Backend.ServiceName].Spec
 	fallbackService := s[i.Items[0].Metadata.Namespace][i.Items[0].Spec.DefaultBackend.ServiceName].Spec
@@ -65,20 +93,31 @@ func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) 
 		backend:         backend,
 		fallbackBackend: fallbackBackend,
 		t:               t,
+		l: l,
 	}, nil
 }
 
-func (rt *redirectTest) testRedirectRoute(req *http.Request, expectedID, expectedBackend string) bool {
+func (rt *redirectTest) testRedirectRoute(testCase string, req *http.Request, expectedID, expectedBackend string) {
+	if rt.t.Failed() {
+		return
+	}
+
 	route, _ := rt.router.Route(req)
-	switch {
-	case expectedID != "" && route.Id != expectedID:
-		return false
-	case expectedBackend != "" && route.Backend != expectedBackend:
-		return false
-	case expectedID == "" && expectedBackend == "" && route != nil:
-		return false
-	default:
-		return true
+	rt.t.Log("got:     ", route.Id, route.Backend)
+	if expectedID != "" && route.Id != expectedID {
+		rt.t.Error(testCase, "failed to match the id")
+		rt.t.Log("got:     ", route.Id, route.Backend)
+		rt.t.Log("expected:", expectedID, expectedBackend)
+	}
+
+	if expectedBackend != "" && route.Backend != expectedBackend {
+		rt.t.Error(testCase, "failed to match the backend")
+		rt.t.Log("got:     ", route.Id, route.Backend)
+		rt.t.Log("expected:", expectedID, expectedBackend)
+	}
+
+	if expectedID == "" && expectedBackend == "" && route != nil {
+		rt.t.Error(testCase, "unexpected route matched")
 	}
 }
 
@@ -91,9 +130,7 @@ func (rt *redirectTest) testNormalHTTPS(expectedID, expectedBackend string) {
 		},
 	}
 
-	if !rt.testRedirectRoute(httpsRequest, expectedID, expectedBackend) {
-		rt.t.Error("failed to match the right route when checking normal request")
-	}
+	rt.testRedirectRoute("normal", httpsRequest, expectedID, expectedBackend)
 }
 
 func (rt *redirectTest) testRedirectHTTP(expectedID, expectedBackend string) {
@@ -107,9 +144,7 @@ func (rt *redirectTest) testRedirectHTTP(expectedID, expectedBackend string) {
 		},
 	}
 
-	if !rt.testRedirectRoute(httpRequest, expectedID, expectedBackend) {
-		rt.t.Error("failed to match the right route when checking redirect request")
-	}
+	rt.testRedirectRoute("redirect", httpRequest, expectedID, expectedBackend)
 }
 
 func (rt *redirectTest) testRedirectNotFound(expectedID, expectedBackend string) {
@@ -123,14 +158,13 @@ func (rt *redirectTest) testRedirectNotFound(expectedID, expectedBackend string)
 		},
 	}
 
-	if !rt.testRedirectRoute(nonExistingHTTP, expectedID, expectedBackend) {
-		rt.t.Error("failed to match the right route when checking unmatched redirect")
-	}
+	rt.testRedirectRoute("unmatched", nonExistingHTTP, expectedID, expectedBackend)
 }
 
 func (rt *redirectTest) close() {
 	rt.router.Close()
 	rt.api.Close()
+	rt.l.Close()
 }
 
 func TestHTTPSRedirect(t *testing.T) {


### PR DESCRIPTION
Fixes: #585 

This PR only fixes the tests but not the root cause.

As it turns out, the failing tests were not caused here due to a concurrency race condition, but because of the current ingress client accepts multiple default backends from different ingress specs, therefore there are multiple default routes that can match a request that doesn't match any host and path rules.

The problem is referenced here: https://github.com/zalando/skipper/blob/master/dataclients/kubernetes/kube.go#L352

The reason, why the test only occasionally fails, is that the routing package uses maps internally during processing the routes, and this introducses a certain level of randomness.

This PR removes the competing ingress specs from the https redirect tests.