### PR TITLE
fix flaky tests relying on etcdtest

### DIFF
--- a/cmd/eskip/load_test.go
+++ b/cmd/eskip/load_test.go
@@ -17,10 +17,11 @@ package main
 import (
 	"bytes"
 	"errors"
-	"github.com/zalando/skipper/etcd/etcdtest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/zalando/skipper/etcd/etcdtest"
 )
 
 const testStdinName = "testStdin"
@@ -142,6 +143,9 @@ func TestCheckRepeatingRouteIds(t *testing.T) {
 }
 
 func TestCheckEtcdInvalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	urls, err := stringsToUrls(etcdtest.Urls...)
 	if err != nil {
 		t.Error(err)
@@ -160,6 +164,10 @@ func TestCheckEtcdInvalid(t *testing.T) {
 }
 
 func TestCheckEtcd(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	urls, err := stringsToUrls(etcdtest.Urls...)
 	if err != nil {
 		t.Error(err)

--- a/cmd/eskip/write_test.go
+++ b/cmd/eskip/write_test.go
@@ -27,7 +27,6 @@ var testEtcdUrls []*url.URL
 
 func TestMain(m *testing.M) {
 	for _, arg := range os.Args {
-		log.Printf("arg: %s", arg)
 		if arg == "-test.short=true" {
 			return
 		}

--- a/cmd/eskip/write_test.go
+++ b/cmd/eskip/write_test.go
@@ -15,16 +15,24 @@
 package main
 
 import (
-	"github.com/zalando/skipper/etcd/etcdtest"
 	"log"
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/zalando/skipper/etcd/etcdtest"
 )
 
 var testEtcdUrls []*url.URL
 
 func TestMain(m *testing.M) {
+	for _, arg := range os.Args {
+		log.Printf("arg: %s", arg)
+		if arg == "-test.short=true" {
+			return
+		}
+	}
+
 	err := etcdtest.Start()
 	if err != nil {
 		log.Fatal(err)
@@ -58,6 +66,9 @@ func TestUpsertLoadFail(t *testing.T) {
 }
 
 func TestUpsertGeneratesId(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	etcdtest.DeleteAllFrom(defaultEtcdPrefix)
 
 	in := &medium{typ: inline, eskip: `Method("POST") -> <shunt>`}
@@ -78,6 +89,9 @@ func TestUpsertGeneratesId(t *testing.T) {
 }
 
 func TestUpsertUsesId(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	etcdtest.DeleteAllFrom(defaultEtcdPrefix)
 
 	in := &medium{typ: inline, eskip: `route1: Method("POST") -> <shunt>`}
@@ -107,6 +121,9 @@ func TestResetLoadFail(t *testing.T) {
 }
 
 func TestResetLoadExistingFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	etcdtest.DeleteAllFrom(defaultEtcdPrefix)
 
 	in := &medium{typ: inline, eskip: `route2: Method("POST") -> <shunt>`}
@@ -133,6 +150,9 @@ func TestResetLoadExistingFails(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	etcdtest.DeleteAllFrom(defaultEtcdPrefix)
 
 	in := &medium{typ: inline, eskip: `route2: Method("PUT") -> <shunt>; route3: Method("HEAD") -> <shunt>`}
@@ -197,6 +217,9 @@ func TestDeleteLoadFails(t *testing.T) {
 }
 
 func TestDeleteFromIds(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	etcdtest.DeleteAllFrom(defaultEtcdPrefix)
 
 	in := &medium{typ: inline, eskip: `route1: Method("POST") -> <shunt>`}
@@ -223,6 +246,9 @@ func TestDeleteFromIds(t *testing.T) {
 }
 
 func TestDeleteFromRoutes(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	etcdtest.DeleteAllFrom(defaultEtcdPrefix)
 
 	in := &medium{typ: inline, eskip: `route1: Method("POST") -> <shunt>`}

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -16,8 +16,6 @@ package etcd
 
 import (
 	"errors"
-	"github.com/zalando/skipper/eskip"
-	"github.com/zalando/skipper/etcd/etcdtest"
 	"log"
 	"net"
 	"net/http"
@@ -26,9 +24,19 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/etcd/etcdtest"
 )
 
 func TestMain(m *testing.M) {
+	for _, arg := range os.Args {
+		log.Printf("arg: %s", arg)
+		if arg == "-test.short=true" {
+			return
+		}
+	}
+
 	err := etcdtest.Start()
 	if err != nil {
 		log.Fatal(err)
@@ -253,6 +261,10 @@ func TestValidatesDocument(t *testing.T) {
 }
 
 func TestReceivesInitial(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.ResetData(); err != nil {
 		t.Error(t)
 		return
@@ -282,6 +294,10 @@ func TestReceivesInitial(t *testing.T) {
 }
 
 func TestReceivesUpdates(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.ResetData(); err != nil {
 		t.Error(err)
 		return
@@ -312,6 +328,10 @@ func TestReceivesUpdates(t *testing.T) {
 }
 
 func TestReceiveInsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.ResetData(); err != nil {
 		t.Error(err)
 		return
@@ -345,6 +365,9 @@ func TestReceiveInsert(t *testing.T) {
 }
 
 func TestReceiveDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	if err := etcdtest.ResetData(); err != nil {
 		t.Error(err)
 		return
@@ -388,6 +411,10 @@ func TestUpsertNoId(t *testing.T) {
 }
 
 func TestUpsertNew(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.DeleteAll(); err != nil {
 		t.Error(err)
 		return
@@ -414,6 +441,10 @@ func TestUpsertNew(t *testing.T) {
 }
 
 func TestUpsertExisting(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.DeleteAll(); err != nil {
 		t.Error(err)
 		return
@@ -461,6 +492,10 @@ func TestDeleteNoId(t *testing.T) {
 }
 
 func TestDeleteNotExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.DeleteAll(); err != nil {
 		t.Error(err)
 		return
@@ -491,6 +526,10 @@ func TestDeleteNotExists(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.DeleteAll(); err != nil {
 		t.Error(err)
 		return
@@ -521,6 +560,10 @@ func TestDelete(t *testing.T) {
 }
 
 func TestLoadWithParseFailures(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	if err := etcdtest.DeleteAll(); err != nil {
 		t.Error(err)
 		return

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestMain(m *testing.M) {
 	for _, arg := range os.Args {
-		log.Printf("arg: %s", arg)
 		if arg == "-test.short=true" {
 			return
 		}


### PR DESCRIPTION
shortcheck should not rely on etcd tests, ignoring all of them and hack around testing.Main to return on running with shortcheck