### PR TITLE
Retry after

### DIFF
--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -12,6 +12,9 @@ import (
 	"github.com/zalando/skipper/ratelimit"
 )
 
+// RetryAfterKey is used as key in the context state bag
+const RetryAfterKey = "#ratelimitretryafter"
+
 // RouteSettingsKey is used as key in the context state bag
 const RouteSettingsKey = "#ratelimitsettings"
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ed4c9832f72de1aeb33488d81331aa379adc61ba07337c51e15bada9c8299b2d
-updated: 2018-01-04T08:00:57.348776525+01:00
+hash: 9553ba72abe52ef7ffb117fe347b1a8530cc0315d011f5b944e0035551511c67
+updated: 2018-03-22T23:34:00.457358076+01:00
 imports:
 - name: github.com/abbot/go-http-auth
   version: efc9484eee77263a11f158ef4f30fcc30298a942
@@ -57,11 +57,11 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/sony/gobreaker
   version: e9556a45379ef1da12e54847edb2fb3d7d566f36
 - name: github.com/szuecs/rate-limit-buffer
-  version: 1a179ab26baf3b8450aaaa662e3120155fadb39d
+  version: 5d55546321233ce69d1b8c9bdaaff2c7cde3479e
 - name: github.com/yuin/gopher-lua
   version: 478861c8ce6e8c2f16d5984d5ed30c4327c70437
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/zalando/skipper
 import:
 - package: github.com/szuecs/rate-limit-buffer
-  version: ~0.2.0
+  version: ~0.5.0
 - package: github.com/abbot/go-http-auth
   version: ~0.3.0
 - package: github.com/dimfeld/httppath

--- a/proxy/ratelimit_test.go
+++ b/proxy/ratelimit_test.go
@@ -300,3 +300,80 @@ func TestCheckServiceRateLimit(t *testing.T) {
 		}
 	}
 }
+
+func TestRetryAfterHeader(t *testing.T) {
+	fr := builtin.MakeRegistry()
+	backend := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer backend.Close()
+	r := []*eskip.Route{{Backend: backend.URL}}
+	limit := 5
+	timeWindow := time.Duration(limit) * time.Second
+	ratelimitSettings := ratelimit.Settings{
+		Type:       ratelimit.ServiceRatelimit,
+		MaxHits:    1,
+		TimeWindow: timeWindow,
+	}
+	p := proxytest.WithParams(fr, proxy.Params{
+		CloseIdleConnsPeriod: -time.Second,
+		RateLimiters:         ratelimit.NewRegistry(ratelimitSettings),
+	}, r...)
+	defer p.Close()
+
+	doc := func(l int) []byte {
+		b := make([]byte, l)
+		n, err := rand.Read(b)
+		if err != nil || n != l {
+			t.Fatal("failed to generate doc", err, n, l)
+		}
+
+		return b
+	}
+
+	request := func(doc []byte) (int, http.Header) {
+		req, err := http.NewRequest("GET", p.URL+"/", nil)
+		if err != nil {
+			t.Fatal("foo", "failed to create request", err)
+			return -1, nil
+		}
+
+		req.Close = true
+
+		rsp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatal("Do req", "failed to make request", err)
+			return -1, nil
+		}
+
+		defer rsp.Body.Close()
+		_, err = ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			t.Fatal("read", "failed to read response", err)
+		}
+
+		return rsp.StatusCode, rsp.Header
+	}
+
+	d0 := doc(128)
+	code, _ := request(d0)
+	if code == http.StatusTooManyRequests {
+		t.Fatal("should not be ratelimitted")
+	}
+
+	d1 := doc(128)
+	code, header := request(d1)
+	if code != http.StatusTooManyRequests {
+		t.Fatal("should be ratelimitted")
+	}
+	v := header.Get(ratelimit.RetryAfterHeader)
+	if v == "" {
+		t.Fatalf("should set retry header %s", ratelimit.RetryAfterHeader)
+	}
+	expected := limit
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		t.Fatalf("failed to convert string number %s to number: %v", v, err)
+	}
+	if i != expected {
+		t.Fatalf("should calculate ratelimit header correctly: %d expected: %d", i, expected)
+	}
+}

--- a/ratelimit/doc.go
+++ b/ratelimit/doc.go
@@ -75,10 +75,18 @@ used to group client requests. It accepts the default
 HTTP Response
 
 In case of rate limiting, the HTTP response status will be 429 Too
-Many Requests, and a header will be set which shows the maximum
-requests per hour (based on RFC 6585):
+Many Requests and two headers will be set.
 
-     X-Rate-Limit: 6000
+One which shows the maximum requests per hour:
+
+	X-Rate-Limit: 6000
+
+And another indicating how long (in seconds) to wait before making a new
+request:
+
+	Retry-After: 3600
+
+Both are based on RFC 6585.
 
 Registry
 


### PR DESCRIPTION
Hi,

I'm working on implementing the `Retry-After` header described on #438. This is what I get when I run some requests against the Skipper version in this PR:

```
(...)
[APP]INFO[0000] route settings, reset, route: foo: * -> ratelimit(1, "5s") -> "https://www.google.de/"
[APP]INFO[0000] route settings received
[APP]INFO[0000] route settings applied
::1 - - [23/Mar/2018:16:21:53 +0100] "HEAD / HTTP/1.1" 200 0 "" "curl/7.54.0" 222 localhost:9090
::1 - - [23/Mar/2018:16:21:54 +0100] "HEAD / HTTP/1.1" 429 18 "" "curl/7.54.0" 0 localhost:9090
```

In the client we can see the headers properly set:

```
$ curl -I localhost:9090
HTTP/1.1 200 OK
(...)

$ curl -I localhost:9090
HTTP/1.1 429 Too Many Requests
Content-Type: text/plain; charset=utf-8
Retry-After: 5
Server: Skipper
X-Content-Type-Options: nosniff
X-Rate-Limit: 720
Date: Fri, 23 Mar 2018 15:21:54 GMT
Content-Length: 18
```

The problem is that the test I wrote isn't passing, even when getting a `429` response:

```
$ go test -run TestRetryAfterHeader proxy/ratelimit_test.go
--- FAIL: TestRetryAfterHeader (0.00s)
        ratelimit_test.go:369: should set retry header Retry-After
FAIL
FAIL    command-line-arguments  0.018s
```

With @vetinari help, we realised that the coding is returning on the check after the line `settings, ok := ctx.stateBag[ratelimitfilters.RouteSettingsKey].(ratelimit.Settings)` of the `Proxy.checkRatelimit()` method.

I though that the only place where the rate limit was actually checked was at the end of the same method, where we have `return settings, rl.Allow(s)`, but there's also [the `Registry.Check()` method of the ratelimit][1] that does something similar.

So, what should we do here? Change the behaviour of the test, ensuring that `ratelimitfilters.RouteSettingsKey` is set, to mimic the behaviour of the manual test? Or the `Ratelimit.RetryAfter()` method should not be called on the `Proxy.checkRatelimit()` but on `Registry. Check()`?

Regards,
Tiago.

[1]: https://github.com/zalando/skipper/blob/62ad0f8/ratelimit/registry.go#L74