### PR TITLE
Multi plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor
 linter.log
 site/
 plugins/
+_test_plugins/*.so

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCES            = $(shell find . -name '*.go' -not -path "./vendor/*")
+SOURCES            = $(shell find . -name '*.go' -not -path "./vendor/*" -and -not -path "./_test_plugins" )
 PACKAGES           = $(shell glide novendor || echo -n "./...")
 CURRENT_VERSION    = $(shell git describe --tags --always --dirty)
 VERSION           ?= $(CURRENT_VERSION)
@@ -7,6 +7,9 @@ NEXT_MINOR         = $(shell go run packaging/version/version.go minor $(CURRENT
 NEXT_PATCH         = $(shell go run packaging/version/version.go patch $(CURRENT_VERSION))
 COMMIT_HASH        = $(shell git rev-parse --short HEAD)
 TEST_ETCD_VERSION ?= v2.3.8
+TEST_PLUGINS       = _test_plugins/filter_noop.so \
+		     _test_plugins/predicate_match_none.so \
+		     _test_plugins/dataclient_noop.so
 
 default: build
 
@@ -34,7 +37,7 @@ install: $(SOURCES)
 	go install -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 	go install -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/eskip
 
-check: build
+check: build check-plugins
 	# go test $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -50,6 +53,12 @@ shortcheck: build
 	#
 	for p in $(PACKAGES); do go test -test.short -run ^Test $$p || break -1; done
 
+check-plugins: $(TEST_PLUGINS)
+	go test -run LoadPlugins
+
+_test_plugins/%.so: _test_plugins/%.go
+	go build -buildmode=plugin -o $@ $<
+
 bench: build
 	# go test -bench . $(PACKAGES)
 	#
@@ -64,6 +73,7 @@ lint: build
 clean:
 	go clean -i ./...
 	rm -rf .coverprofile-all .cover
+	rm ./_test_plugins/*.so
 
 deps:
 	go get -t github.com/zalando/skipper/...

--- a/Makefile
+++ b/Makefile
@@ -166,5 +166,5 @@ else ifeq ($(TRAVIS_BRANCH)_$(TRAVIS_PULL_REQUEST), master_false)
 else ifeq ($(TRAVIS_BRANCH), master)
 	make deps check-precommit
 else
-	make deps shortcheck
+	make deps shortcheck check-plugins
 endif

--- a/_test_plugins/dataclient_noop.go
+++ b/_test_plugins/dataclient_noop.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/routing"
+)
+
+type DataClient string
+
+func InitDataClient([]string) (routing.DataClient, error) {
+	var dc DataClient = ""
+	return dc, nil
+}
+
+func (dc DataClient) LoadAll() ([]*eskip.Route, error) {
+	return eskip.Parse(string(dc))
+}
+
+func (dc DataClient) LoadUpdate() ([]*eskip.Route, []string, error) {
+	return nil, nil, nil
+}

--- a/_test_plugins/filter_noop.go
+++ b/_test_plugins/filter_noop.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/zalando/skipper/filters"
+)
+
+type noopSpec struct{}
+
+func InitFilter(opts []string) (filters.Spec, error) {
+	return noopSpec{}, nil
+}
+
+func (s noopSpec) Name() string {
+	return "noop"
+}
+func (s noopSpec) CreateFilter(config []interface{}) (filters.Filter, error) {
+	return noopFilter{}, nil
+}
+
+type noopFilter struct{}
+
+func (f noopFilter) Request(filters.FilterContext)  {}
+func (f noopFilter) Response(filters.FilterContext) {}

--- a/_test_plugins/predicate_match_none.go
+++ b/_test_plugins/predicate_match_none.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/zalando/skipper/routing"
+)
+
+type noneSpec struct{}
+
+func InitPredicate(opts []string) (routing.PredicateSpec, error) {
+	return noneSpec{}, nil
+}
+
+func (s noneSpec) Name() string {
+	return "None"
+}
+func (s noneSpec) Create(config []interface{}) (routing.Predicate, error) {
+	return nonePredicate{}, nil
+}
+
+type nonePredicate struct{}
+
+func (p nonePredicate) Match(*http.Request) bool {
+	return false
+}

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -211,6 +211,7 @@ var (
 	filterPlugins                   filterFlags
 	predicatePlugins                predicateFlags
 	dataclientPlugins               dataclientFlags
+	multiPlugins                    multiPluginFlags
 )
 
 func init() {
@@ -295,6 +296,7 @@ func init() {
 	flag.Var(&filterPlugins, "filter-plugin", filterPluginUsage)
 	flag.Var(&predicatePlugins, "predicate-plugin", predicatePluginUsage)
 	flag.Var(&dataclientPlugins, "dataclient-plugin", dataclientPluginUsage)
+	flag.Var(&multiPlugins, "multi-plugin", multiPluginUsage)
 
 	flag.Parse()
 
@@ -418,6 +420,7 @@ func main() {
 		FilterPlugins:                       filterPlugins.Get(),
 		PredicatePlugins:                    predicatePlugins.Get(),
 		DataClientPlugins:                   dataclientPlugins.Get(),
+		MultiPlugins:                        multiPlugins.Get(),
 	}
 
 	if pluginDir != "" {

--- a/cmd/skipper/pluginFlags.go
+++ b/cmd/skipper/pluginFlags.go
@@ -87,3 +87,31 @@ func (f *dataclientFlags) Set(value string) error {
 func (f *dataclientFlags) Get() [][]string {
 	return f.values
 }
+
+const multiPluginUsage = "set a custom multitype plugins to load, a comma separated list of name and arguments"
+
+type multiPluginFlags struct {
+	values [][]string
+}
+
+func (f *multiPluginFlags) String() string {
+	var ret []string
+	for _, val := range f.values {
+		ret = append(ret, strings.Join(val, ","))
+	}
+	return strings.Join(ret, " ")
+}
+
+func (f *multiPluginFlags) Set(value string) error {
+	if f == nil {
+		f = &multiPluginFlags{}
+	}
+	for _, v := range strings.Split(value, " ") {
+		f.values = append(f.values, strings.Split(v, ","))
+	}
+	return nil
+}
+
+func (f *multiPluginFlags) Get() [][]string {
+	return f.values
+}

--- a/cmd/skipper/pluginFlags.go
+++ b/cmd/skipper/pluginFlags.go
@@ -8,6 +8,7 @@ const (
 	filterPluginUsage     = "set a custom filter plugins to load, a comma separated list of name and arguments"
 	predicatePluginUsage  = "set a custom predicate plugins to load, a comma separated list of name and arguments"
 	dataclientPluginUsage = "set a custom dataclient plugins to load, a comma separated list of name and arguments"
+	multiPluginUsage      = "set a custom multitype plugins to load, a comma separated list of name and arguments"
 )
 
 type pluginFlags struct {
@@ -30,33 +31,5 @@ func (f *pluginFlags) Set(value string) error {
 }
 
 func (f *pluginFlags) Get() [][]string {
-	return f.values
-}
-
-const multiPluginUsage = "set a custom multitype plugins to load, a comma separated list of name and arguments"
-
-type multiPluginFlags struct {
-	values [][]string
-}
-
-func (f *multiPluginFlags) String() string {
-	var ret []string
-	for _, val := range f.values {
-		ret = append(ret, strings.Join(val, ","))
-	}
-	return strings.Join(ret, " ")
-}
-
-func (f *multiPluginFlags) Set(value string) error {
-	if f == nil {
-		f = &multiPluginFlags{}
-	}
-	for _, v := range strings.Split(value, " ") {
-		f.values = append(f.values, strings.Split(v, ","))
-	}
-	return nil
-}
-
-func (f *multiPluginFlags) Get() [][]string {
 	return f.values
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -178,6 +178,20 @@ func (dc DataClient) LoadUpdate() ([]*eskip.Route, []string, error) {
 }
 ```
 
+## MultiType plugins
+
+Sometimes it is necessary to combine multiple plugin types into one module. This can
+be done with this kind of plugin.
+
+The module must have a `InitPlugin` function with the signature
+
+    func([]string) (filters.Spec, routing.PredicateSpec, routing.DataClient, error)
+
+Any of the returned types may be nil, so you can have e.g. a combined filter / data client
+plugin or share a filter and a predicate, e.g. like
+
+
+
 ## OpenTracing plugins
 
 The tracers, except for "noop", are built as Go Plugins. A tracing plugin can

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -181,7 +181,8 @@ func (dc DataClient) LoadUpdate() ([]*eskip.Route, []string, error) {
 ## MultiType plugins
 
 Sometimes it is necessary to combine multiple plugin types into one module. This can
-be done with this kind of plugin.
+be done with this kind of plugin. Note that these modules are not auto loaded, these
+need an explicit `-multi-plugin name,arg1,arg2` command line switch for skipper.
 
 The module must have a `InitPlugin` function with the signature
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,7 +40,7 @@ There are some pitfalls:
 
 ## Filter plugins
 
-All plugins must have a function named "InitFilter" with the following signature
+All plugins must have a function named `InitFilter` with the following signature
 
     func([]string) (filters.Spec, error)
 
@@ -48,9 +48,9 @@ The parameters passed are all arguments for the plugin, i.e. everything after th
 word from skipper's `-filter-plugin` parameter. E.g. when the `-filter-plugin` 
 parameter is
 
-    "myfilter,datafile=/path/to/file,foo=bar"
+    myfilter,datafile=/path/to/file,foo=bar
 
-the "myfilter" plugin will receive
+the `myfilter` plugin will receive
 
     []string{"datafile=/path/to/file", "foo=bar"}
 
@@ -62,7 +62,7 @@ Filter plugins can be found in the [filter repo](https://github.com/skipper-plug
 
 ### Example filter plugin
 
-An example "noop" plugin looks like
+An example `noop` plugin looks like
 
 ```go
 package main
@@ -92,7 +92,7 @@ func (f noopFilter) Response(filters.FilterContext) {}
 
 ## Predicate plugins
 
-All plugins must have a function named "InitPredicate" with the following signature
+All plugins must have a function named `InitPredicate` with the following signature
 
     func([]string) (routing.PredicateSpec, error)
 
@@ -100,9 +100,9 @@ The parameters passed are all arguments for the plugin, i.e. everything after th
 word from skipper's `-predicate-plugin` parameter. E.g. when the `-predicate-plugin` 
 parameter is
 
-    "mypred,datafile=/path/to/file,foo=bar"
+    mypred,datafile=/path/to/file,foo=bar
 
-the "mypred" plugin will receive
+the `mypred` plugin will receive
 
     []string{"datafile=/path/to/file", "foo=bar"}
 
@@ -114,7 +114,7 @@ Predicate plugins can be found in the [predicate repo](https://github.com/skippe
 
 ### Example predicate plugin
 
-An example "MatchAll" plugin looks like
+An example `MatchAll` plugin looks like
 
 ```go
 package main
@@ -152,7 +152,7 @@ function with the signature
 
     func([]string) (routing.DataClient, error)
 
-A "noop" data client looks like
+A `noop` data client looks like
 
 ```go
 package main
@@ -337,13 +337,13 @@ func (g *geoip) Match(r *http.Request) bool {
 
 ## OpenTracing plugins
 
-The tracers, except for "noop", are built as Go Plugins. A tracing plugin can
+The tracers, except for `noop`, are built as Go Plugins. A tracing plugin can
 be loaded with `-opentracing NAME` as parameter to skipper.
 
 Implementations of OpenTracing API can be found in the
 https://github.com/skipper-plugins/opentracing repository.
 
-All plugins must have a function named "InitTracer" with the following signature
+All plugins must have a function named `InitTracer` with the following signature
 
     func([]string) (opentracing.Tracer, error)
 

--- a/skipper.go
+++ b/skipper.go
@@ -366,6 +366,10 @@ type Options struct {
 	// what the []string should contain.
 	DataClientPlugins [][]string
 
+	// MultiPlugins combine multiple types of the above plugin types in one plugin (where
+	// necessary because of shared data between e.g. a filter and a data client).
+	MultiPlugins [][]string
+
 	// DefaultHTTPStatus is the HTTP status used when no routes are found
 	// for a request.
 	DefaultHTTPStatus int

--- a/skipper.go
+++ b/skipper.go
@@ -571,7 +571,7 @@ func Run(o Options) error {
 		lbInstance = loadbalancer.New(o.LoadBalancerHealthCheckInterval)
 	}
 
-	if err := findAndLoadPlugins(&o); err != nil {
+	if err := o.findAndLoadPlugins(); err != nil {
 		return err
 	}
 

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -208,3 +208,12 @@ func TestHTTPServer(t *testing.T) {
 		t.Fatalf("Failed to stream response body: %v", err)
 	}
 }
+
+func TestLoadPlugins(t *testing.T) {
+	o := Options{
+		PluginDirs: []string{"./_test_plugins"},
+	}
+	if err := o.findAndLoadPlugins(); err != nil {
+		t.Fatalf("Failed to load plugins: %s", err)
+	}
+}


### PR DESCRIPTION
so https://github.com/aryszka/configfilter could be converted to a plugin ;-)

*  when loading a `.so` file, it is checked if there is also a `.conf` file
  with the same base, e.g. for `./plugins/noop.so` a config of
  `./plugins/noop.conf` is attempted to open. If it exists, each line
  in this file is passed as argument to the plugin loader function
  (leading and trailing spaces stripped, lines beginning with a `#`
  after space stripping are ignored).
* add support for multitype plugins complete auto detection and `.conf`
 file support
* add some noop plugins in _test_plugins and add a make target to build
  and try loading as test
