### PR TITLE
prevent startup failure when default plugin dir is missing

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -402,7 +402,7 @@ func main() {
 		EnableRatelimiters:                  enableRatelimiters,
 		RatelimitSettings:                   ratelimits,
 		OpenTracing:                         strings.Split(openTracing, " "),
-		PluginDirs:                          []string{"./plugins"},
+		PluginDirs:                          []string{skipper.DefaultPluginDir},
 		DefaultHTTPStatus:                   defaultHTTPStatus,
 		SuppressRouteUpdateLogs:             suppressRouteUpdateLogs,
 		EnablePrometheusMetrics:             enablePrometheusMetrics,

--- a/plugins.go
+++ b/plugins.go
@@ -18,6 +18,11 @@ func findAndLoadPlugins(o *Options) error {
 	for _, dir := range o.PluginDirs {
 		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
+				// don't fail when default plugin dir is missing
+				if _, ok := err.(*os.PathError); ok && dir == DefaultPluginDir {
+					return err
+				}
+
 				log.Fatalf("failed to search for plugins: %s", err)
 			}
 			if info.IsDir() {

--- a/skipper.go
+++ b/skipper.go
@@ -37,6 +37,8 @@ const (
 	defaultRoutingUpdateBuffer = 1 << 5
 )
 
+const DefaultPluginDir = "./plugins"
+
 // Options to start skipper.
 type Options struct {
 


### PR DESCRIPTION
skipper currently cannot be started if the plugin dir is missing. This is fine if an explicit plugin dir is specified, but not when plugins are not intended to be used, and breaks compatibility this way.

The fix is a cheap one: ignore if the error is a path error and the dirname is the default. Open for better suggestions.

This is related to: https://github.com/zalando/skipper/pull/598