### PR TITLE
plugins dir does not exist

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -7,4 +7,5 @@ ENV PATH $PATH:/usr/bin
 
 EXPOSE 9090 9911
 
+RUN mkdir plugins
 CMD ["/usr/bin/skipper"]


### PR DESCRIPTION
fix: if not plugins are mounted as volume, skipper should have an empty plugins directory to not fail to start

```
% ./bin/skipper
2018/03/27 17:33:22 failed to search for plugins: lstat ./plugins: no such file or directory
```