### PR TITLE
Add documentation for `compress()` to usage

### DIFF
--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -158,6 +158,14 @@ Add a HTTP header in the response path of your clients.
 
     setResponseHeader("X-Foo", "bar")
 
+## Enable gzip
+
+Compress responses with gzip.
+
+    compress() // compress all valid MIME types
+    compress("text/html") // only compress HTML files
+    compress(9, "text/html") // control the level of compression, 1 = fastest, 9 = best compression, 0 = no compression
+
 ## Set the Path
 
 Change the path in the request path to your backend to `/newPath/`.


### PR DESCRIPTION
I was trying to find information on enabling gzip with Skipper and couldn't find any documentation on it. A search led me to https://github.com/zalando/skipper/issues/87 which shows the feature implemented in https://github.com/zalando/skipper/pull/161 without any documentation update.