### PR TITLE
Fix/unnecessary healthcheck updates

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -1065,7 +1065,8 @@ func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
 	if c.provideHealthcheck {
 		healthy := !c.hasReceivedTerm()
 		if healthy != c.healthy {
-			hc := healthcheckRoute(healthy, c.reverseSourcePredicate)
+			c.healthy = healthy
+			hc := healthcheckRoute(c.healthy, c.reverseSourcePredicate)
 			next[healthcheckRouteID] = hc
 			updatedRoutes = append(updatedRoutes, hc)
 		}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1576,7 +1576,7 @@ func TestHealthcheckUpdate(t *testing.T) {
 			t.Error("failed to fail")
 		}
 
-		checkHealthcheck(t, r, true, true, false)
+		checkHealthcheck(t, r, false, false, false)
 		if len(d) != 0 {
 			t.Error("unexpected delete")
 		}
@@ -1604,7 +1604,7 @@ func TestHealthcheckUpdate(t *testing.T) {
 			t.Error("failed to fail")
 		}
 
-		checkHealthcheck(t, r, true, true, false)
+		checkHealthcheck(t, r, false, false, false)
 		if len(d) != 0 {
 			t.Error("unexpected delete")
 		}

--- a/dataclients/kubernetes/update_test.go
+++ b/dataclients/kubernetes/update_test.go
@@ -1,0 +1,36 @@
+package kubernetes
+
+import "testing"
+
+func TestUpdateOnlyChangedRoutes(t *testing.T) {
+	api := newTestAPIWithEndpoints(t, make(services), &ingressList{}, make(endpoints))
+	defer api.Close()
+
+	k, err := New(Options{
+		KubernetesURL:      api.server.URL,
+		ProvideHealthcheck: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := k.LoadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(r) != 1 || r[0].Id != healthcheckRouteID {
+		t.Fatal("no healthcheck route received")
+	}
+
+	for i := 0; i < 3; i++ {
+		update, del, err := k.LoadUpdate()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(update) != 0 || len(del) != 0 {
+			t.Fatal("unexpected udpate received")
+		}
+	}
+}


### PR DESCRIPTION
- preserve health state
- in LoadUpdate, provide a healthcheck route only when it has changed