### PR TITLE
Document how to deploy with enabled RBAC

### DIFF
--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -309,7 +309,7 @@ ClusterRole:
     apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRole
     metadata:
-      name: aws-ingress-controller
+      name: skipper-ingress 
     rules:
     - apiGroups: ["extensions"]
       resources: ["ingresses", ]
@@ -332,14 +332,14 @@ ClusterRoleBinding:
     apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRoleBinding
     metadata:
-      name: aws-ingress-controller
+      name: skipper-ingress 
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: aws-ingress-controller
+      name: skipper-ingress 
     subjects:
     - kind: ServiceAccount
-      name: aws-ingress-controller
+      name: skipper-ingress 
       namespace: kube-system
 
 Last but not least the `ServiceAccount` has to be assigned to the Skipper daemonset.

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -194,7 +194,7 @@ We deploy a service type ClusterIP that we will select from ingress:
     apiVersion: v1
     kind: Service
     metadata:
-      name: sszuecs-demo
+      name: skipper-demo
       labels:
         application: skipper-demo
     spec:
@@ -205,7 +205,7 @@ We deploy a service type ClusterIP that we will select from ingress:
           targetPort: 9090
           name: external
       selector:
-        application: sszuecs-demo
+        application: skipper-demo
 
 To deploy both, you have to run:
 

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -300,7 +300,7 @@ First create a new `ServiceAccount` which will be assigned to the Skipper pods:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
-      name: skipper-ingress 
+      name: skipper-ingress
       namespace: kube-system
 
 the required permissions are defined within a `ClusterRole` resource.
@@ -312,20 +312,16 @@ ClusterRole:
     apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRole
     metadata:
-      name: skipper-ingress 
+      name: skipper-ingress
     rules:
     - apiGroups: ["extensions"]
       resources: ["ingresses", ]
       verbs: ["get", "list"]
-    - apiGroups: ["extensions"]
-      resources: ["ingresses/status", ]
-      verbs: ["get", "list", "patch"]
     - apiGroups: [""]
       resources: ["namespaces", "services", "endpoints"]
       verbs: ["get", "list"]
 
 This `ClusterRole` defines access to `get` and `list` all created ingresses, namespaces, services and endpoints.
-Furthermore it enables Skipper to `patch` the state of an ingress (like updating the endpoint of an ingress).
 
 To assign the defined `ClusterRole` to the previously created `ServiceAccount`
 a `ClusterRoleBinding` has to be created:
@@ -335,14 +331,14 @@ ClusterRoleBinding:
     apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRoleBinding
     metadata:
-      name: skipper-ingress 
+      name: skipper-ingress
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: skipper-ingress 
+      name: skipper-ingress
     subjects:
     - kind: ServiceAccount
-      name: skipper-ingress 
+      name: skipper-ingress
       namespace: kube-system
 
 Last but not least the `ServiceAccount` has to be assigned to the Skipper daemonset.
@@ -370,7 +366,7 @@ daemonset:
             application: skipper
         spec:
           hostNetwork: true
-          serviceAccountName: skipper-ingress 
+          serviceAccountName: skipper-ingress
           containers:
           - name: skipper-ingress
             image: registry.opensource.zalan.do/pathfinder/skipper:latest

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -297,7 +297,7 @@ First create a new `ServiceAccount` which will be assigned to the Skipper pods:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
-      name:  aws-ingress-controller
+      name: skipper-ingress 
       namespace: kube-system
 
 the required permissions are defined within a `ClusterRole` resource.

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -367,7 +367,7 @@ daemonset:
             application: skipper
         spec:
           hostNetwork: true
-          serviceAccountName: aws-ingress-controller
+          serviceAccountName: skipper-ingress 
           containers:
           - name: skipper-ingress
             image: registry.opensource.zalan.do/pathfinder/skipper:latest
@@ -387,6 +387,9 @@ daemonset:
               - "-enable-ratelimits"
               - "-experimental-upgrade"
               - "-metrics-exp-decay-sample"
+	      - "-lb-healthcheck-interval=3s"
+	      - "-metrics-flavour=codahale,prometheus"
+	      - "-enable-connection-metrics"
             resources:
               limits:
                 cpu: 200m

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -146,9 +146,9 @@ traffic.
               - "-enable-ratelimits"
               - "-experimental-upgrade"
               - "-metrics-exp-decay-sample"
-	      - "-lb-healthcheck-interval=3s"
-	      - "-metrics-flavour=codahale,prometheus"
-	      - "-enable-connection-metrics"
+              - "-lb-healthcheck-interval=3s"
+              - "-metrics-flavour=codahale,prometheus"
+              - "-enable-connection-metrics"
             resources:
               limits:
                 cpu: 200m
@@ -390,9 +390,9 @@ daemonset:
               - "-enable-ratelimits"
               - "-experimental-upgrade"
               - "-metrics-exp-decay-sample"
-	      - "-lb-healthcheck-interval=3s"
-	      - "-metrics-flavour=codahale,prometheus"
-	      - "-enable-connection-metrics"
+              - "-lb-healthcheck-interval=3s"
+              - "-metrics-flavour=codahale,prometheus"
+              - "-enable-connection-metrics"
             resources:
               limits:
                 cpu: 200m

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -146,6 +146,9 @@ traffic.
               - "-enable-ratelimits"
               - "-experimental-upgrade"
               - "-metrics-exp-decay-sample"
+	      - "-lb-healthcheck-interval=3s"
+	      - "-metrics-flavour=codahale,prometheus"
+	      - "-enable-connection-metrics"
             resources:
               limits:
                 cpu: 200m

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -319,7 +319,7 @@ ClusterRole:
       verbs: ["get", "list"]
     - apiGroups: [""]
       resources: ["namespaces", "services", "endpoints"]
-      verbs: ["get", "list"]
+      verbs: ["get"]
 
 This `ClusterRole` defines access to `get` and `list` all created ingresses, namespaces, services and endpoints.
 


### PR DESCRIPTION
Added sample manifests for:

* ServiceAccount
* ClusterRole
* ClusterRoleBinding
* adopted DaemonSet

see issue in [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/153)