### PR TITLE
unverifiedAuditLog - fix #631 

### DIFF
--- a/filters/auth/oauth.go
+++ b/filters/auth/oauth.go
@@ -40,6 +40,7 @@ const (
 	AuthUnknown                = "authUnknown"
 
 	authHeaderName      = "Authorization"
+	authHeaderPrefix    = "Bearer "
 	accessTokenQueryKey = "access_token"
 	scopeKey            = "scope"
 	uidKey              = "uid"
@@ -76,13 +77,12 @@ func getToken(r *http.Request) (string, error) {
 		return tok, nil
 	}
 
-	const b = "Bearer "
 	h := r.Header.Get(authHeaderName)
-	if !strings.HasPrefix(h, b) {
+	if !strings.HasPrefix(h, authHeaderPrefix) {
 		return "", errInvalidAuthorizationHeader
 	}
 
-	return h[len(b):], nil
+	return h[len(authHeaderPrefix):], nil
 }
 
 func unauthorized(ctx filters.FilterContext, uname string, reason rejectReason, hostname string) {

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zalando/skipper/filters/cors"
 	"github.com/zalando/skipper/filters/diag"
 	"github.com/zalando/skipper/filters/flowid"
+	logfilter "github.com/zalando/skipper/filters/log"
 	"github.com/zalando/skipper/filters/ratelimit"
 	"github.com/zalando/skipper/filters/tee"
 	"github.com/zalando/skipper/loadbalancer"
@@ -103,6 +104,7 @@ func MakeRegistry() filters.Registry {
 		loadbalancer.NewDecide(),
 		script.NewLuaScript(),
 		cors.NewOrigin(),
+		logfilter.NewUnverifiedAuditLog(),
 	} {
 		r.Register(s)
 	}

--- a/filters/log/log.go
+++ b/filters/log/log.go
@@ -32,9 +32,10 @@ const (
 	// UnverifiedAuditLogName is th filtername seend by the user
 	UnverifiedAuditLogName = "unverifiedAuditLog"
 
-	authHeaderName      = "Authorization"
-	authHeaderPrefix    = "Bearer "
-	accessTokenQueryKey = "access_token"
+	UnverifiedAuditHeader = "X-Unverified-Audit"
+	authHeaderName        = "Authorization"
+	authHeaderPrefix      = "Bearer "
+	accessTokenQueryKey   = "access_token"
 )
 
 type auditLog struct {
@@ -166,12 +167,10 @@ func (al *auditLog) Response(ctx filters.FilterContext) {
 	}
 }
 
-type unverifiedAuditLog struct {
-	writer io.Writer
-}
+type unverifiedAuditLog struct{}
 
 // NewUnverifiedAuditLog logs "Sub" of the middle part of a JWT Token.
-func NewUnverifiedAuditLog() filters.Spec { return &unverifiedAuditLog{writer: os.Stderr} }
+func NewUnverifiedAuditLog() filters.Spec { return &unverifiedAuditLog{} }
 
 func (ual *unverifiedAuditLog) Name() string { return UnverifiedAuditLogName }
 
@@ -209,7 +208,7 @@ func (ual *unverifiedAuditLog) Request(ctx filters.FilterContext) {
 		if err != nil {
 			return
 		}
-		ual.writer.Write([]byte("Audit sub: " + j.Sub + " "))
+		req.Header.Add(UnverifiedAuditHeader, j.Sub)
 	}
 }
 

--- a/filters/log/log.go
+++ b/filters/log/log.go
@@ -7,9 +7,11 @@ package log
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -27,6 +29,12 @@ const (
 	// reject reason information into the state bag to pass the
 	// information to the auditLog filter.
 	AuthRejectReasonKey = "auth-reject-reason"
+	// UnverifiedAuditLogName is th filtername seend by the user
+	UnverifiedAuditLogName = "unverifiedAuditLog"
+
+	authHeaderName      = "Authorization"
+	authHeaderPrefix    = "Bearer "
+	accessTokenQueryKey = "access_token"
 )
 
 type auditLog struct {
@@ -157,3 +165,52 @@ func (al *auditLog) Response(ctx filters.FilterContext) {
 		log.Errorf("Failed to json encode auditDoc: %v", err)
 	}
 }
+
+type unverifiedAuditLog struct {
+	writer io.Writer
+}
+
+// NewUnverifiedAuditLog logs "Sub" of the middle part of a JWT Token.
+func NewUnverifiedAuditLog() filters.Spec { return &unverifiedAuditLog{writer: os.Stderr} }
+
+func (ual *unverifiedAuditLog) Name() string { return UnverifiedAuditLogName }
+
+// CreateFilter has no arguments. It creates the filter if the user
+// specifies unverifiedAuditLog() in their route.
+func (ual *unverifiedAuditLog) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 0 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+	return ual, nil
+}
+
+type jwtMidPart struct {
+	Sub string `json:"sub"`
+}
+
+func (ual *unverifiedAuditLog) Request(ctx filters.FilterContext) {
+	req := ctx.Request()
+	ahead := req.Header.Get(authHeaderName)
+	if !strings.HasPrefix(ahead, authHeaderPrefix) {
+		return
+	}
+
+	fields := strings.FieldsFunc(ahead, func(r rune) bool {
+		return r == []rune(".")[0]
+	})
+	if len(fields) == 3 {
+		sDec, err := base64.RawStdEncoding.DecodeString(fields[1])
+		if err != nil {
+			return
+		}
+
+		var j jwtMidPart
+		err = json.Unmarshal(sDec, &j)
+		if err != nil {
+			return
+		}
+		ual.writer.Write([]byte("Audit sub: " + j.Sub + " "))
+	}
+}
+
+func (*unverifiedAuditLog) Response(filters.FilterContext) {}

--- a/filters/log/log_test.go
+++ b/filters/log/log_test.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"bytes"
 	"net/http"
 	"testing"
 
@@ -17,7 +16,7 @@ func TestRequest(t *testing.T) {
 		{
 			msg:      "request with token",
 			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJjNGRkZmU5ZC1hMGQzLTRhZmItYmYyNi0yNGI5NTg4NzMxYTAiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
-			expected: "Audit sub: c4ddfe9d-a0d3-4afb-bf26-24b9588731a0 ",
+			expected: "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0",
 		},
 		{
 			msg:      "request with empty token",
@@ -31,9 +30,7 @@ func TestRequest(t *testing.T) {
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
-			buf := bytes.NewBufferString("")
-
-			spec := &unverifiedAuditLog{writer: buf}
+			spec := &unverifiedAuditLog{}
 
 			fltr, err := spec.CreateFilter([]interface{}{})
 			if err != nil {
@@ -55,7 +52,7 @@ func TestRequest(t *testing.T) {
 
 			fltr.Request(ctx)
 
-			s := buf.String()
+			s := ctx.Request().Header.Get(UnverifiedAuditHeader)
 			if s != ti.expected {
 				t.Errorf("Unexpected result: %s != %s", s, ti.expected)
 				return

--- a/filters/log/log_test.go
+++ b/filters/log/log_test.go
@@ -1,0 +1,66 @@
+package log
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func TestRequest(t *testing.T) {
+	for _, ti := range []struct {
+		msg      string
+		tok      string
+		expected string
+	}{
+		{
+			msg:      "request with token",
+			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJjNGRkZmU5ZC1hMGQzLTRhZmItYmYyNi0yNGI5NTg4NzMxYTAiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
+			expected: "Audit sub: c4ddfe9d-a0d3-4afb-bf26-24b9588731a0 ",
+		},
+		{
+			msg:      "request with empty token",
+			tok:      "",
+			expected: "",
+		},
+		{
+			msg:      "request with wrong token",
+			tok:      "foo.bar.baz",
+			expected: "",
+		},
+	} {
+		t.Run(ti.msg, func(t *testing.T) {
+			buf := bytes.NewBufferString("")
+
+			spec := &unverifiedAuditLog{writer: buf}
+
+			fltr, err := spec.CreateFilter([]interface{}{})
+			if err != nil {
+				t.Errorf("Failed to create filter: %v", err)
+				return
+			}
+
+			req, err := http.NewRequest("GET", "http://localhost/", nil)
+			if err != nil {
+				t.Errorf("Failed to create request: %v", err)
+				return
+			}
+
+			ctx := &filtertest.Context{
+				FStateBag: make(map[string]interface{}),
+				FRequest:  req,
+			}
+			ctx.FRequest.Header.Add(authHeaderName, authHeaderPrefix+ti.tok)
+
+			fltr.Request(ctx)
+
+			s := buf.String()
+			if s != ti.expected {
+				t.Errorf("Unexpected result: %s != %s", s, ti.expected)
+				return
+			}
+
+		})
+	}
+}

--- a/logging/access.go
+++ b/logging/access.go
@@ -18,8 +18,8 @@ const (
 	// format:
 	// remote_host - - [date] "method uri protocol" status response_size "referer" "user_agent"
 	combinedLogFormat = commonLogFormat + ` "%s" "%s"`
-	// We add the duration in ms, a requested host and a flow id and audit log
-	accessLogFormat = combinedLogFormat + " %d %s %s %s\n"
+	// We add the duration in ms, a requested host and a flow id and optional audit log
+	accessLogFormat = combinedLogFormat + " %d %s %s%s\n"
 )
 
 type accessLogFormatter struct {
@@ -123,6 +123,9 @@ func LogAccess(entry *AccessEntry) {
 		requestedHost = entry.Request.Host
 		flowId = entry.Request.Header.Get(flowidFilter.HeaderName)
 		auditHeader = entry.Request.Header.Get(logFilter.UnverifiedAuditHeader)
+		if auditHeader != "" {
+			auditHeader = " " + auditHeader
+		}
 	}
 
 	accessLog.WithFields(logrus.Fields{

--- a/logging/access.go
+++ b/logging/access.go
@@ -18,8 +18,8 @@ const (
 	// format:
 	// remote_host - - [date] "method uri protocol" status response_size "referer" "user_agent"
 	combinedLogFormat = commonLogFormat + ` "%s" "%s"`
-	// We add the duration in ms, a requested host and a flow id and optional audit log
-	accessLogFormat = combinedLogFormat + " %d %s %s%s\n"
+	// We add the duration in ms, a requested host and a flow id and audit log
+	accessLogFormat = combinedLogFormat + " %d %s %s %s\n"
 )
 
 type accessLogFormatter struct {
@@ -123,9 +123,6 @@ func LogAccess(entry *AccessEntry) {
 		requestedHost = entry.Request.Host
 		flowId = entry.Request.Header.Get(flowidFilter.HeaderName)
 		auditHeader = entry.Request.Header.Get(logFilter.UnverifiedAuditHeader)
-		if auditHeader != "" {
-			auditHeader = " " + auditHeader
-		}
 	}
 
 	accessLog.WithFields(logrus.Fields{

--- a/logging/access.go
+++ b/logging/access.go
@@ -70,10 +70,13 @@ func remoteAddr(r *http.Request) string {
 func remoteHost(r *http.Request) string {
 	a := remoteAddr(r)
 	h := stripPort(a)
+	return omitWhitespace(h)
+}
+
+func omitWhitespace(h string) string {
 	if h != "" {
 		return h
 	}
-
 	return "-"
 }
 
@@ -121,8 +124,8 @@ func LogAccess(entry *AccessEntry) {
 		referer = entry.Request.Referer()
 		userAgent = entry.Request.UserAgent()
 		requestedHost = entry.Request.Host
-		flowId = entry.Request.Header.Get(flowidFilter.HeaderName)
-		auditHeader = entry.Request.Header.Get(logFilter.UnverifiedAuditHeader)
+		flowId = omitWhitespace(entry.Request.Header.Get(flowidFilter.HeaderName))
+		auditHeader = omitWhitespace(entry.Request.Header.Get(logFilter.UnverifiedAuditHeader))
 	}
 
 	accessLog.WithFields(logrus.Fields{

--- a/logging/access_test.go
+++ b/logging/access_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const logOutput = `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `
-const logJSONOutput = `{"audit":"","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`
+const logJSONOutput = `{"audit":"-","duration":42,"flow-id":"-","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`
 
 func testRequest() *http.Request {
 	r, _ := http.NewRequest("GET", "http://frank@example.com", nil)
@@ -50,7 +50,7 @@ func testAccessLog(t *testing.T, entry *AccessEntry, expectedOutput string, acce
 }
 
 func TestAccessLogFormatFull(t *testing.T) {
-	testAccessLog(t, testAccessEntry(), logOutput, false)
+	testAccessLog(t, testAccessEntry(), logOutput+"- -", false)
 }
 
 func TestAccessLogFormatJSON(t *testing.T) {
@@ -64,65 +64,71 @@ func TestAccessLogIgnoresEmptyEntry(t *testing.T) {
 func TestNoPanicOnMissingRequest(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request = nil
-	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "  " 418 2326 "" "" 42  `, false)
+	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "  " 418 2326 "" "" 42   `, false)
 }
 
 func TestUseXForwarded(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3")
-	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `, false)
+	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
 }
 
 func TestUseXForwardedJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3")
-	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"-","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestStripPortFwd4(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:6969")
-	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `, false)
+	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
 }
 
 func TestStripPortFwd4JSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:6969")
-	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"-","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestStripPortNoFwd4(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.RemoteAddr = "192.168.3.3:6969"
-	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `, false)
+	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
 }
 
 func TestMissingHostFallback(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.RemoteAddr = ""
-	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `, false)
+	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
 }
 
 func TestMissingHostFallbackJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.RemoteAddr = ""
-	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"-","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"-","host":"-","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestPresentFlowId(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Flow-Id", "sometestflowid")
-	testAccessLog(t, entry, `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com sometestflowid`, false)
+	testAccessLog(t, entry, `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com sometestflowid -`, false)
 }
 
 func TestPresentFlowIdJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Flow-Id", "sometestflowid")
-	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+}
+
+func TestPresentAudit(t *testing.T) {
+	entry := testAccessEntry()
+	entry.Request.Header.Set(logFilter.UnverifiedAuditHeader, "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0")
+	testAccessLog(t, entry, `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - c4ddfe9d-a0d3-4afb-bf26-24b9588731a0`, false)
 }
 
 func TestPresentAuditJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set(logFilter.UnverifiedAuditHeader, "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0")
-	testAccessLog(t, entry, `{"audit":"c4ddfe9d-a0d3-4afb-bf26-24b9588731a0","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"c4ddfe9d-a0d3-4afb-bf26-24b9588731a0","duration":42,"flow-id":"-","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }

--- a/logging/access_test.go
+++ b/logging/access_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	logFilter "github.com/zalando/skipper/filters/log"
 )
 
 const logOutput = `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `
@@ -117,4 +119,10 @@ func TestPresentFlowIdJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Flow-Id", "sometestflowid")
 	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+}
+
+func TestPresentAuditJSON(t *testing.T) {
+	entry := testAccessEntry()
+	entry.Request.Header.Set(logFilter.UnverifiedAuditHeader, "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0")
+	testAccessLog(t, entry, `{"audit":"c4ddfe9d-a0d3-4afb-bf26-24b9588731a0","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }

--- a/logging/access_test.go
+++ b/logging/access_test.go
@@ -9,8 +9,8 @@ import (
 	logFilter "github.com/zalando/skipper/filters/log"
 )
 
-const logOutput = `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `
-const logJSONOutput = `{"audit":"-","duration":42,"flow-id":"-","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`
+const logOutput = `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com `
+const logJSONOutput = `{"audit":"","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`
 
 func testRequest() *http.Request {
 	r, _ := http.NewRequest("GET", "http://frank@example.com", nil)
@@ -64,71 +64,71 @@ func TestAccessLogIgnoresEmptyEntry(t *testing.T) {
 func TestNoPanicOnMissingRequest(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request = nil
-	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "  " 418 2326 "" "" 42   `, false)
+	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "- - -" 418 2326 "-" "-" 42 - - -`, false)
 }
 
 func TestUseXForwarded(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3")
-	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
+	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`, false)
 }
 
 func TestUseXForwardedJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3")
-	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"-","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestStripPortFwd4(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:6969")
-	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
+	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`, false)
 }
 
 func TestStripPortFwd4JSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:6969")
-	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"-","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestStripPortNoFwd4(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.RemoteAddr = "192.168.3.3:6969"
-	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
+	testAccessLog(t, entry, `192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`, false)
 }
 
 func TestMissingHostFallback(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.RemoteAddr = ""
-	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - -`, false)
+	testAccessLog(t, entry, `- - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`, false)
 }
 
 func TestMissingHostFallbackJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.RemoteAddr = ""
-	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"-","host":"-","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestPresentFlowId(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Flow-Id", "sometestflowid")
-	testAccessLog(t, entry, `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com sometestflowid -`, false)
+	testAccessLog(t, entry, `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com sometestflowid -`, false)
 }
 
 func TestPresentFlowIdJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Flow-Id", "sometestflowid")
-	testAccessLog(t, entry, `{"audit":"-","duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestPresentAudit(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set(logFilter.UnverifiedAuditHeader, "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0")
-	testAccessLog(t, entry, `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com - c4ddfe9d-a0d3-4afb-bf26-24b9588731a0`, false)
+	testAccessLog(t, entry, `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - c4ddfe9d-a0d3-4afb-bf26-24b9588731a0`, false)
 }
 
 func TestPresentAuditJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set(logFilter.UnverifiedAuditHeader, "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0")
-	testAccessLog(t, entry, `{"audit":"c4ddfe9d-a0d3-4afb-bf26-24b9588731a0","duration":42,"flow-id":"-","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"c4ddfe9d-a0d3-4afb-bf26-24b9588731a0","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }

--- a/logging/access_test.go
+++ b/logging/access_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const logOutput = `127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "" "" 42 example.com `
-const logJSONOutput = `{"duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`
+const logJSONOutput = `{"audit":"","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`
 
 func testRequest() *http.Request {
 	r, _ := http.NewRequest("GET", "http://frank@example.com", nil)
@@ -74,7 +74,7 @@ func TestUseXForwarded(t *testing.T) {
 func TestUseXForwardedJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3")
-	testAccessLog(t, entry, `{"duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestStripPortFwd4(t *testing.T) {
@@ -86,7 +86,7 @@ func TestStripPortFwd4(t *testing.T) {
 func TestStripPortFwd4JSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:6969")
-	testAccessLog(t, entry, `{"duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestStripPortNoFwd4(t *testing.T) {
@@ -104,7 +104,7 @@ func TestMissingHostFallback(t *testing.T) {
 func TestMissingHostFallbackJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.RemoteAddr = ""
-	testAccessLog(t, entry, `{"duration":42,"flow-id":"","host":"-","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"","host":"-","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }
 
 func TestPresentFlowId(t *testing.T) {
@@ -116,5 +116,5 @@ func TestPresentFlowId(t *testing.T) {
 func TestPresentFlowIdJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Flow-Id", "sometestflowid")
-	testAccessLog(t, entry, `{"duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
+	testAccessLog(t, entry, `{"audit":"","duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`, true)
 }


### PR DESCRIPTION
implement #631 unverifiedAuditLog logs "sub" from 2nd part of decoded base64 jwt token if possible.

@hjacobs this is what you meant? Any idea for the prefix? I just did "Audit sub: " for now but I guess we want something else.

    Audit sub: c4ddfe9d-a0d3-4afb-bf26-24b9588731a0 ::1 - - [30/Apr/2018:09:39:59 +0200] "GET /ffff09 HTTP/1.1" 200 0 "" "curl/7.49.0" 0 localhost:9999
    Audit sub: c4ddfe9d-a0d3-4afb-bf26-24b9588731a0 ::1 - - [30/Apr/2018:09:39:59 +0200] "GET /ffff10 HTTP/1.1" 200 0 "" "curl/7.49.0" 2 localhost:9999
