### PR TITLE
fix prepared wrong garbage in unverified auditlog

### DIFF
--- a/filters/log/log.go
+++ b/filters/log/log.go
@@ -37,11 +37,11 @@ const (
 	authHeaderName        = "Authorization"
 	authHeaderPrefix      = "Bearer "
 	accessTokenQueryKey   = "access_token"
-	defaultSub            = "clean-sub-not-matched"
+	defaultSub            = "<invalid-sub>"
 )
 
 var (
-	re = regexp.MustCompile("^[a-zA-z0-9_-]*$")
+	re = regexp.MustCompile("^[a-zA-z0-9_/:?=&%@.#-]*$")
 )
 
 type auditLog struct {

--- a/filters/log/log.go
+++ b/filters/log/log.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -36,6 +37,11 @@ const (
 	authHeaderName        = "Authorization"
 	authHeaderPrefix      = "Bearer "
 	accessTokenQueryKey   = "access_token"
+	defaultSub            = "clean-sub-not-matched"
+)
+
+var (
+	re = regexp.MustCompile("^[a-zA-z0-9_-]*$")
 )
 
 type auditLog struct {
@@ -208,8 +214,15 @@ func (ual *unverifiedAuditLog) Request(ctx filters.FilterContext) {
 		if err != nil {
 			return
 		}
-		req.Header.Add(UnverifiedAuditHeader, j.Sub)
+		req.Header.Add(UnverifiedAuditHeader, cleanSub(j.Sub))
 	}
 }
 
 func (*unverifiedAuditLog) Response(filters.FilterContext) {}
+
+func cleanSub(s string) string {
+	if re.MatchString(s) {
+		return s
+	}
+	return defaultSub
+}

--- a/filters/log/log_test.go
+++ b/filters/log/log_test.go
@@ -28,6 +28,11 @@ func TestRequest(t *testing.T) {
 			tok:      "foo.bar.baz",
 			expected: "",
 		},
+		{
+			msg:      "request with prepared Sub in token, which does not contain valid data",
+			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIweK3e774iLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0K.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
+			expected: defaultSub,
+		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
 			spec := &unverifiedAuditLog{}

--- a/filters/log/log_test.go
+++ b/filters/log/log_test.go
@@ -33,6 +33,11 @@ func TestRequest(t *testing.T) {
 			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIweK3e774iLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0K.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
 			expected: defaultSub,
 		},
+		{
+			msg:      "request with prepared Sub in token, which does contain valid URI data",
+			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJodHRwOi8vZm9vLm9yZy9wMT9hPWIjNSIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vcmVhbG0iOiJ1c2VycyIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vdG9rZW4iOiJCZWFyZXIiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL21hbmFnZWQtaWQiOiJzc3p1ZWNzIiwiYXpwIjoienRva2VuIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9icCI6IjgxMGQxZDAwLTQzMTItNDNlNS1iZDMxLWQ4MzczZmRkMjRjNyIsImF1dGhfdGltZSI6MTUyMzI1OTQ2OCwiaXNzIjoiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbSIsImV4cCI6MTUyNTAyNDI4NSwiaWF0IjoxNTI1MDIwNjc1fQo.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
+			expected: "http://foo.org/p1?a=b#5",
+		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
 			spec := &unverifiedAuditLog{}


### PR DESCRIPTION
To not log user specified random data this proofs that Sub claim contains "valid" string information and not random data chosen by the user sending the request.

@aermakov-zalando thanks for the hint!