### PR TITLE
Fix/unverified auditlog base64 encoding

### DIFF
--- a/filters/log/log.go
+++ b/filters/log/log.go
@@ -204,7 +204,7 @@ func (ual *unverifiedAuditLog) Request(ctx filters.FilterContext) {
 		return r == []rune(".")[0]
 	})
 	if len(fields) == 3 {
-		sDec, err := base64.URLEncoding.DecodeString(fields[1])
+		sDec, err := base64.RawURLEncoding.DecodeString(fields[1])
 		if err != nil {
 			return
 		}

--- a/filters/log/log.go
+++ b/filters/log/log.go
@@ -204,7 +204,7 @@ func (ual *unverifiedAuditLog) Request(ctx filters.FilterContext) {
 		return r == []rune(".")[0]
 	})
 	if len(fields) == 3 {
-		sDec, err := base64.RawStdEncoding.DecodeString(fields[1])
+		sDec, err := base64.URLEncoding.DecodeString(fields[1])
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
It should use URL encoding as defined in RFC7519 and append padding automatically.