### PR TITLE
return proxyError after retry of a loadbalanced route 

### DIFF
--- a/proxy/lb_failingbackend_test.go
+++ b/proxy/lb_failingbackend_test.go
@@ -153,7 +153,7 @@ func TestConnectionRefused(t *testing.T) {
 		if msg, ok := requestEndpoint("/c", "group-C/BE-1"); !ok {
 			t.Errorf("failed to receive the right response for '/c': %s", msg)
 		}
-		if msg, ok := requestEndpoint("/d", "Internal Server Error"); !ok {
+		if msg, ok := requestEndpoint("/d", "Bad Gateway"); !ok {
 			t.Errorf("failed to receive the right response for '/d': %s", msg)
 		}
 	})
@@ -192,7 +192,7 @@ func TestConnectionRefused(t *testing.T) {
 			msg:          "Groups with only failing members should  fail on multiple calls d",
 			path:         "/d",
 			nTimes:       150,
-			expectedCode: 500,
+			expectedCode: http.StatusBadGateway,
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -850,7 +850,7 @@ func (p *Proxy) do(ctx *context) error {
 					if perr2.code >= http.StatusInternalServerError {
 						p.metrics.MeasureBackend5xx(backendStart)
 					}
-					return perr2.err
+					return perr2
 				}
 				p.log.Infof("Successfully retry to %v, orig %v, code: %d", ctx.route.Backend, origRoute.Backend, rsp.StatusCode)
 			} else {

--- a/routing/fallbackgroup_test.go
+++ b/routing/fallbackgroup_test.go
@@ -140,7 +140,7 @@ func TestFallbackGroupLB(t *testing.T) {
 
 		// group A responds two times with failure:
 		if !request("/", "non-grouped") ||
-			!request("/a", "Internal Server Error", "Internal Server Error") ||
+			!request("/a", "Bad Gateway", "Bad Gateway") ||
 			!request("/b", "group-B/BE-1", "group-B/BE-2") {
 			t.Error("failed to receive the right response")
 		}


### PR DESCRIPTION
one part of the fix for #654 is to make sure we return a 502 in case of "No route to host".

Reply also with proxyError after retry of a loadbalanced route to make sure we create a 502 and not a 500. We have to be consistent in returning proxyError.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>