### PR TITLE
Add internal ip whitelist option to healthcheck to be appended to the default

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -129,6 +129,7 @@ const (
 	enableHopHeadersRemovalUsage         = "enables removal of Hop-Headers according to RFC-2616"
 	oauth2TokeninfoURLUsage              = "sets the default tokeninfo URL to query information about an incoming OAuth2 token in oauth2Tokeninfo filters"
 	maxAuditBodyUsage                    = "sets the max body to read to log inthe audit log body"
+	whitelistedHealthCheckCIDRUsage      = "sets the iprange/CIDRS to be whitelisted during healthcheck"
 )
 
 var (
@@ -219,6 +220,7 @@ var (
 	oauth2TokeninfoURL              string
 	maxAuditBody                    int
 	multiPlugins                    pluginFlags
+	whitelistedHealthCheckCIDR  	string
 )
 
 func init() {
@@ -307,7 +309,7 @@ func init() {
 	flag.StringVar(&oauth2TokeninfoURL, "oauth2-tokeninfo-url", "", oauth2TokeninfoURLUsage)
 	flag.IntVar(&maxAuditBody, "max-audit-body", defaultMaxAuditBody, maxAuditBodyUsage)
 	flag.Var(&multiPlugins, "multi-plugin", multiPluginUsage)
-
+	flag.StringVar(&whitelistedHealthCheckCIDR, "whitelisted-healthcheck-cidr", "", whitelistedHealthCheckCIDRUsage)
 	flag.Parse()
 
 	// check if arguments were correctly parsed.
@@ -357,7 +359,13 @@ func main() {
 		os.Exit(2)
 	}
 
+	var whitelistCIDRS []string
+	if len(whitelistedHealthCheckCIDR) > 0 {
+		whitelistCIDRS = strings.Split(whitelistedHealthCheckCIDR, ",")
+	}
+
 	options := skipper.Options{
+		WhitelistedHealthCheckCIDR:          whitelistCIDRS,
 		Address:                             address,
 		EtcdUrls:                            eus,
 		EtcdPrefix:                          etcdPrefix,
@@ -433,6 +441,7 @@ func main() {
 		OAuthTokeninfoURL:                   oauth2TokeninfoURL,
 		MaxAuditBody:                        maxAuditBody,
 		Plugins:                             multiPlugins.Get(),
+		
 	}
 
 	if pluginDir != "" {

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -176,7 +176,7 @@ func New(o Options) (*Client, error) {
 
 	if len(o.WhitelistedHealthCheckCIDR) > 0 {
 		whitelistCIDRS := make([]interface{}, len(o.WhitelistedHealthCheckCIDR))
-		for i, v := range t {
+		for i, v := range o.WhitelistedHealthCheckCIDR {
 			whitelistCIDRS[i] = v
 		}
 		internalIPs = append(internalIPs , whitelistCIDRS...);

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -109,6 +109,9 @@ type Options struct {
 
 	// Noop, WIP.
 	ForceFullUpdatePeriod time.Duration
+
+	// WhitelistedHealthcheckCIDR to be appended to the default iprange
+	WhitelistedHealthCheckCIDR []string
 }
 
 // Client is a Skipper DataClient implementation used to create routes based on Kubernetes Ingress settings.
@@ -169,6 +172,15 @@ func New(o Options) (*Client, error) {
 		log.Info("register sigterm handler")
 		sigs = make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGTERM)
+	}
+
+	if len(o.WhitelistedHealthCheckCIDR) > 0 {
+		whitelistCIDRS := make([]interface{}, len(o.WhitelistedHealthCheckCIDR))
+		for i, v := range t {
+			whitelistCIDRS[i] = v
+		}
+		internalIPs = append(internalIPs , whitelistCIDRS...);
+		log.Debugf("new internal ips are: %s", internalIPs)
 	}
 
 	return &Client{

--- a/skipper.go
+++ b/skipper.go
@@ -46,6 +46,9 @@ const DefaultPluginDir = "./plugins"
 // Options to start skipper.
 type Options struct {
 
+	// WhitelistedHealthcheckCIDR appends the whitelisted IP Range to the inernalIPS range for healthcheck purposes
+	WhitelistedHealthCheckCIDR []string
+
 	// Network address that skipper should listen on.
 	Address string
 
@@ -476,7 +479,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 
 		clients = append(clients, etcdClient)
 	}
-
+    
 	if o.Kubernetes {
 		kubernetesClient, err := kubernetes.New(kubernetes.Options{
 			KubernetesInCluster:    o.KubernetesInCluster,
@@ -485,6 +488,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 			ProvideHTTPSRedirect:   o.KubernetesHTTPSRedirect,
 			IngressClass:           o.KubernetesIngressClass,
 			ReverseSourcePredicate: o.ReverseSourcePredicate,
+			WhitelistedHealthCheckCIDR: o.WhitelistedHealthCheckCIDR,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Added WhitelistedHealthCheckCIDR option to main.go skipper.go and kube.go as string array
append WhitelistedHealthCheckCIDR to internalIps in kube.go
tested on docker kubernetes, healthcheck working fine