### PR TITLE
create filter for setting custom span name for distributed tracing

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -107,7 +107,6 @@ const (
 	experimentalUpgradeUsage       = "enable experimental feature to handle upgrade protocol requests"
 	versionUsage                   = "print Skipper version"
 	maxLoopbacksUsage              = "maximum number of loopbacks for an incoming request, set to -1 to disable loopbacks"
-	opentracingUsage               = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
 	defaultHTTPStatusUsage         = "default HTTP status used when no route is found for a request"
 	pluginDirUsage                 = "set the directory to load plugins from, default is ./"
 	suppressRouteUpdateLogsUsage   = "print only summaries on route updates/deletes"
@@ -129,6 +128,9 @@ const (
 	enableHopHeadersRemovalUsage         = "enables removal of Hop-Headers according to RFC-2616"
 	oauth2TokeninfoURLUsage              = "sets the default tokeninfo URL to query information about an incoming OAuth2 token in oauth2Tokeninfo filters"
 	maxAuditBodyUsage                    = "sets the max body to read to log inthe audit log body"
+
+	opentracingUsage           = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
+	opentracingIngressSpanName = "set the name of the initial, pre-routing, tracing span"
 )
 
 var (
@@ -195,6 +197,7 @@ var (
 	enableRatelimiters              bool
 	ratelimits                      ratelimitFlags
 	openTracing                     string
+	openTracingInitialSpan          string
 	defaultHTTPStatus               int
 	pluginDir                       string
 	suppressRouteUpdateLogs         bool
@@ -283,6 +286,7 @@ func init() {
 	flag.BoolVar(&enableRatelimiters, "enable-ratelimits", false, enableRatelimitUsage)
 	flag.Var(&ratelimits, "ratelimits", ratelimitUsage)
 	flag.StringVar(&openTracing, "opentracing", "noop", opentracingUsage)
+	flag.StringVar(&openTracingInitialSpan, "opentracing-initial-span", "ingress", opentracingIngressSpanName)
 	flag.StringVar(&pluginDir, "plugindir", "", pluginDirUsage)
 	flag.IntVar(&defaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
 	flag.BoolVar(&suppressRouteUpdateLogs, "suppress-route-update-logs", false, suppressRouteUpdateLogsUsage)
@@ -414,6 +418,7 @@ func main() {
 		EnableRatelimiters:                  enableRatelimiters,
 		RatelimitSettings:                   ratelimits,
 		OpenTracing:                         strings.Split(openTracing, " "),
+		OpenTracingInitialSpan:              openTracingInitialSpan,
 		PluginDirs:                          []string{skipper.DefaultPluginDir},
 		DefaultHTTPStatus:                   defaultHTTPStatus,
 		SuppressRouteUpdateLogs:             suppressRouteUpdateLogs,

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -14,6 +14,7 @@ import (
 	logfilter "github.com/zalando/skipper/filters/log"
 	"github.com/zalando/skipper/filters/ratelimit"
 	"github.com/zalando/skipper/filters/tee"
+	"github.com/zalando/skipper/filters/tracing"
 	"github.com/zalando/skipper/loadbalancer"
 	"github.com/zalando/skipper/script"
 )
@@ -105,6 +106,7 @@ func MakeRegistry() filters.Registry {
 		script.NewLuaScript(),
 		cors.NewOrigin(),
 		logfilter.NewUnverifiedAuditLog(),
+		tracing.NewSpanName(),
 	} {
 		r.Register(s)
 	}

--- a/filters/tracing/spanname.go
+++ b/filters/tracing/spanname.go
@@ -2,10 +2,12 @@ package tracing
 
 import (
 	"github.com/zalando/skipper/filters"
-	"github.com/zalando/skipper/proxy"
 )
 
-const SpanNameFilterName = "tracingSpanName"
+const (
+	SpanNameFilterName      = "tracingSpanName"
+	OpenTracingProxySpanKey = "statebag:opentracing:proxy:span"
+)
 
 type spec struct{}
 
@@ -13,7 +15,7 @@ type filter struct {
 	spanName string
 }
 
-func New() filters.Spec {
+func NewSpanName() filters.Spec {
 	return &spec{}
 }
 
@@ -34,7 +36,7 @@ func (s *spec) CreateFilter(args []interface{}) (filters.Filter, error) {
 
 func (f *filter) Request(ctx filters.FilterContext) {
 	bag := ctx.StateBag()
-	bag[proxy.OpenTracingProxySpanKey] = f.spanName
+	bag[OpenTracingProxySpanKey] = f.spanName
 }
 
 func (f *filter) Response(filters.FilterContext) {}

--- a/filters/tracing/spanname.go
+++ b/filters/tracing/spanname.go
@@ -1,0 +1,40 @@
+package tracing
+
+import (
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/proxy"
+)
+
+const SpanNameFilterName = "tracingSpanName"
+
+type spec struct{}
+
+type filter struct {
+	spanName string
+}
+
+func New() filters.Spec {
+	return &spec{}
+}
+
+func (s *spec) Name() string { return SpanNameFilterName }
+
+func (s *spec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 1 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	name, ok := args[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	return &filter{spanName: name}, nil
+}
+
+func (f *filter) Request(ctx filters.FilterContext) {
+	bag := ctx.StateBag()
+	bag[proxy.OpenTracingProxySpanKey] = f.spanName
+}
+
+func (f *filter) Response(filters.FilterContext) {}

--- a/filters/tracing/spanname.go
+++ b/filters/tracing/spanname.go
@@ -1,3 +1,6 @@
+/*
+Package tracing provides filters to instrument distributed tracing.
+*/
 package tracing
 
 import (
@@ -5,7 +8,10 @@ import (
 )
 
 const (
-	SpanNameFilterName      = "tracingSpanName"
+	// SpanNameFilterName is the name of the filter in eskip.
+	SpanNameFilterName = "tracingSpanName"
+
+	// OpenTracingProxySpanKey is the key used in the state bag to pass the span name to the proxy.
 	OpenTracingProxySpanKey = "statebag:opentracing:proxy:span"
 )
 
@@ -15,6 +21,11 @@ type filter struct {
 	spanName string
 }
 
+// NewSpanName creates a filter spec for setting the name of the outgoing span. (By default "proxy".)
+//
+// 	tracingSpanName("example-operation")
+//
+// WARNING: this filter is experimental, and the name and the arguments can change until marked as stable.
 func NewSpanName() filters.Spec {
 	return &spec{}
 }

--- a/filters/tracing/spanname.go
+++ b/filters/tracing/spanname.go
@@ -25,7 +25,7 @@ type filter struct {
 //
 // 	tracingSpanName("example-operation")
 //
-// WARNING: this filter is experimental, and the name and the arguments can change until marked as stable.
+// EXPERIMENTAL: this filter is experimental, and the name and the arguments can change until marked as stable.
 func NewSpanName() filters.Spec {
 	return &spec{}
 }

--- a/filters/tracing/spanname_test.go
+++ b/filters/tracing/spanname_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 
 	"github.com/zalando/skipper/filters/filtertest"
-	"github.com/zalando/skipper/proxy"
 )
 
 func Test(t *testing.T) {
 	const spanName = "test-span"
 
-	f, err := New().CreateFilter([]interface{}{spanName})
+	f, err := NewSpanName().CreateFilter([]interface{}{spanName})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -20,7 +19,7 @@ func Test(t *testing.T) {
 
 	f.Request(&ctx)
 	bag := ctx.StateBag()
-	if bag[proxy.OpenTracingProxySpanKey] != spanName {
+	if bag[OpenTracingProxySpanKey] != spanName {
 		t.Error("failed to set the span name")
 	}
 }

--- a/filters/tracing/spanname_test.go
+++ b/filters/tracing/spanname_test.go
@@ -1,0 +1,26 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/proxy"
+)
+
+func Test(t *testing.T) {
+	const spanName = "test-span"
+
+	f, err := New().CreateFilter([]interface{}{spanName})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ctx filtertest.Context
+	ctx.FStateBag = make(map[string]interface{})
+
+	f.Request(&ctx)
+	bag := ctx.StateBag()
+	if bag[proxy.OpenTracingProxySpanKey] != spanName {
+		t.Error("failed to set the span name")
+	}
+}

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -14,8 +14,6 @@ import (
 	"github.com/zalando/skipper/routing"
 )
 
-const OpenTracingProxySpanKey = "statebag:opentracing:proxy:span"
-
 const unknownHost = "_unknownhost_"
 
 type context struct {

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -14,6 +14,8 @@ import (
 	"github.com/zalando/skipper/routing"
 )
 
+const OpenTracingProxySpanKey = "statebag:opentracing:proxy:span"
+
 const unknownHost = "_unknownhost_"
 
 type context struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -143,6 +143,8 @@ type Params struct {
 	// OpenTracer holds the tracer enabled for this proxy instance
 	OpenTracer ot.Tracer
 
+	// OpenTracingInitialSpan can override the default initial, pre-routing, span name.
+	// Default: "ingress".
 	OpenTracingInitialSpan string
 
 	// Loadbalancer to report unhealthy or dead backends to

--- a/skipper.go
+++ b/skipper.go
@@ -360,6 +360,8 @@ type Options struct {
 	// OpenTracing enables opentracing
 	OpenTracing []string
 
+	// OpenTracingInitialSpan can override the default initial, pre-routing, span name.
+	// Default: "ingress".
 	OpenTracingInitialSpan string
 
 	// PluginDir defines the directory to load plugins from, DEPRECATED, use PluginDirs

--- a/skipper.go
+++ b/skipper.go
@@ -360,6 +360,8 @@ type Options struct {
 	// OpenTracing enables opentracing
 	OpenTracing []string
 
+	OpenTracingInitialSpan string
+
 	// PluginDir defines the directory to load plugins from, DEPRECATED, use PluginDirs
 	PluginDir string
 	// PluginDirs defines the directories to load plugins from
@@ -792,10 +794,15 @@ func Run(o Options) error {
 			return err
 		}
 		proxyParams.OpenTracer = tracer
+		proxyParams.OpenTracingInitialSpan = o.OpenTracingInitialSpan
 	} else {
 		// always have a tracer available, so filter authors can rely on the
 		// existence of a tracer
 		proxyParams.OpenTracer, _ = tracing.LoadTracingPlugin(o.PluginDirs, []string{"noop"})
+	}
+
+	if proxyParams.OpenTracingInitialSpan != "" {
+		proxyParams.OpenTracingInitialSpan = o.OpenTracingInitialSpan
 	}
 
 	// create the proxy


### PR DESCRIPTION
Creating a filter to set the name of the proxy span for distributed tracing.

- [x] Create a filter
- [x] Apply the span name in the proxy
- [x] Add a parameter to override the initial span name (currently "ingress")
- [x] docs, mark the filter experimental