### PR TITLE
provide path modes for Kubernetes ingress paths

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -123,7 +123,7 @@ const (
 	kubernetesHTTPSRedirectUsage    = "automatic HTTP->HTTPS redirect route; valid only with kubernetes"
 	kubernetesIngressClassUsage     = "ingress class regular expression used to filter ingress resources for kubernetes"
 	whitelistedHealthCheckCIDRUsage = "sets the iprange/CIDRS to be whitelisted during healthcheck"
-	kubernetesPathModeUsage         = "controls the default interpretation of Kubernetes ingress paths: kubernetes-ingress/path-regexp/path-prefix/exact-path"
+	kubernetesPathModeUsage         = "controls the default interpretation of Kubernetes ingress paths: kubernetes-ingress/path-regexp/path-prefix"
 
 	// OAuth2:
 	oauthURLUsage            = "OAuth2 URL for Innkeeper authentication"

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -56,7 +56,7 @@ const (
 type PathMode int
 
 const (
-	DefaultPathMode PathMode = iota
+	KubernetesIngressMode PathMode = iota
 	PathRegexp
 	PathPrefix
 	ExactPath
@@ -238,7 +238,7 @@ func (m PathMode) String() string {
 func ParsePathMode(s string) (PathMode, error) {
 	switch s {
 	case defaultPathModeString:
-		return DefaultPathMode, nil
+		return KubernetesIngressMode, nil
 	case pathRegexpString:
 		return PathRegexp, nil
 	case pathPrefixString:
@@ -622,7 +622,7 @@ func (c *Client) convertPathRule(
 	)
 
 	pathExpression := prule.Path
-	if pathExpression != "" && pathMode == DefaultPathMode {
+	if pathExpression != "" && pathMode == KubernetesIngressMode {
 		pathExpression = "^" + pathExpression
 	}
 

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -598,8 +598,10 @@ func setPath(m PathMode, r *eskip.Route, p string) {
 			Name: "Path",
 			Args: []interface{}{p},
 		})
-	default:
+	case PathRegexp:
 		r.PathRegexps = []string{p}
+	default:
+		r.PathRegexps = []string{"^" + p}
 	}
 }
 
@@ -620,11 +622,6 @@ func (c *Client) convertPathRule(
 		routes []*eskip.Route
 		svc    *service
 	)
-
-	pathExpression := prule.Path
-	if pathExpression != "" && pathMode == KubernetesIngressMode {
-		pathExpression = "^" + pathExpression
-	}
 
 	svcPort := prule.Backend.ServicePort
 	svcName := prule.Backend.ServiceName
@@ -664,7 +661,7 @@ func (c *Client) convertPathRule(
 				Backend: address,
 			}
 
-			setPath(pathMode, r, pathExpression)
+			setPath(pathMode, r, prule.Path)
 
 			if 0.0 < prule.Backend.Traffic && prule.Backend.Traffic < 1.0 {
 				r.Predicates = append([]*eskip.Predicate{{
@@ -691,7 +688,7 @@ func (c *Client) convertPathRule(
 			Backend: eps[0],
 		}
 
-		setPath(pathMode, r, pathExpression)
+		setPath(pathMode, r, prule.Path)
 
 		// add traffic predicate if traffic weight is between 0.0 and 1.0
 		if 0.0 < prule.Backend.Traffic && prule.Backend.Traffic < 1.0 {
@@ -729,7 +726,7 @@ func (c *Client) convertPathRule(
 			}},
 		}
 
-		setPath(pathMode, r, pathExpression)
+		setPath(pathMode, r, prule.Path)
 
 		// add traffic predicate if traffic weight is between 0.0 and 1.0
 		if 0.0 < prule.Backend.Traffic && prule.Backend.Traffic < 1.0 {
@@ -760,7 +757,7 @@ func (c *Client) convertPathRule(
 		}},
 	}
 
-	setPath(pathMode, decisionRoute, pathExpression)
+	setPath(pathMode, decisionRoute, prule.Path)
 
 	routes = append(routes, decisionRoute)
 	return routes, nil

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -63,10 +63,10 @@ const (
 )
 
 const (
-	defaultPathModeString = "default"
-	pathRegexpString      = "path-regexp"
-	pathPrefixString      = "path-prefix"
-	exactPathString       = "exact-path"
+	kubernetesIngressModeString = "kubernetes-ingress"
+	pathRegexpString            = "path-regexp"
+	pathPrefixString            = "path-prefix"
+	exactPathString             = "exact-path"
 )
 
 var internalIPs = []interface{}{
@@ -231,13 +231,13 @@ func (m PathMode) String() string {
 	case ExactPath:
 		return exactPathString
 	default:
-		return defaultPathModeString
+		return kubernetesIngressModeString
 	}
 }
 
 func ParsePathMode(s string) (PathMode, error) {
 	switch s {
-	case defaultPathModeString:
+	case kubernetesIngressModeString:
 		return KubernetesIngressMode, nil
 	case pathRegexpString:
 		return PathRegexp, nil

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -58,6 +58,9 @@ const (
 // rules using the zalando.org/skipper-ingress-path-mode annotation. When path mode is not
 // set, the Kubernetes ingress specification is used, accepting regular expressions with a
 // mandatory leading "/", automatically prepended by the "^" control character.
+//
+// When PathPrefix or ExactPath are used, the path matching becomes deterministic when
+// a request could match more than one ingress routes otherwise.
 type PathMode int
 
 const (
@@ -71,11 +74,17 @@ const (
 	PathRegexp
 
 	// PathPrefix is like the PathSubtree predicate. E.g. "/foo/bar" will match
-	// "/foo/bar" or "/foo/bar/baz", but won't match "/foo/baroo".
+	// "/foo/bar" or "/foo/bar/baz", but won't match "/foo/barooz".
+	//
+	// In this mode, when a Path or a PathSubtree predicate is set in an annotation,
+	// the value from the annotation has precedence over the standard ingress path.
 	PathPrefix
 
 	// ExactPath is like the Path predicate. E.g. "/foo/bar" will only match
 	// "/foo/bar".
+	//
+	// In this mode, when a Path or a PathSubtree predicate is set in an annotation,
+	// the value from the annotation has precedence over the standard ingress path.
 	ExactPath
 )
 

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -53,12 +53,29 @@ const (
 	pathModeAnnotationKey         = "zalando.org/skipper-ingress-path-mode"
 )
 
+// PathMode values are used to control the ingress path interpretation. The path mode can
+// be set globally for all ingress paths, and it can be overruled by the individual ingress
+// rules using the zalando.org/skipper-ingress-path-mode annotation. When path mode is not
+// set, the Kubernetes ingress specification is used, accepting regular expressions with a
+// mandatory leading "/", automatically prepended by the "^" control character.
 type PathMode int
 
 const (
+	// KubernetesIngressMode is the default path mode. Expects regular expressions
+	// with a mandatory leading "/". The expressions are automatically prepended by
+	// the "^" control character.
 	KubernetesIngressMode PathMode = iota
+
+	// PathRegexp is like KubernetesIngressMode but is not prepended by the "^"
+	// control character.
 	PathRegexp
+
+	// PathPrefix is like the PathSubtree predicate. E.g. "/foo/bar" will match
+	// "/foo/bar" or "/foo/bar/baz", but won't match "/foo/baroo".
 	PathPrefix
+
+	// ExactPath is like the Path predicate. E.g. "/foo/bar" will only match
+	// "/foo/bar".
 	ExactPath
 )
 
@@ -130,8 +147,8 @@ type Options struct {
 	// WhitelistedHealthcheckCIDR to be appended to the default iprange
 	WhitelistedHealthCheckCIDR []string
 
-	// PathMode controls the default handling of ingress paths in cases when the ingress doesn't specify it
-	// with an annotation.
+	// PathMode controls the default interpretation of ingress paths in cases when the ingress doesn't
+	// specify it with an annotation.
 	PathMode PathMode
 }
 
@@ -222,6 +239,8 @@ func New(o Options) (*Client, error) {
 	}, nil
 }
 
+// String returns the string representation of the path mode, the same
+// values that are used in the path mode annotation.
 func (m PathMode) String() string {
 	switch m {
 	case PathRegexp:
@@ -235,6 +254,8 @@ func (m PathMode) String() string {
 	}
 }
 
+// ParsePathMode parses the string representations of the different
+// path modes.
 func ParsePathMode(s string) (PathMode, error) {
 	switch s {
 	case kubernetesIngressModeString:

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -108,28 +108,21 @@ func testIngress(ns, name, defaultService, ratelimitCfg, filterString, predicate
 	}
 
 	meta := metadata{
-		Namespace: ns,
-		Name:      name,
+		Namespace:   ns,
+		Name:        name,
+		Annotations: make(map[string]string),
 	}
 	if ratelimitCfg != "" {
-		meta.Annotations = map[string]string{
-			ratelimitAnnotationKey: ratelimitCfg,
-		}
+		meta.Annotations[ratelimitAnnotationKey] = ratelimitCfg
 	}
 	if filterString != "" {
-		meta.Annotations = map[string]string{
-			skipperfilterAnnotationKey: filterString,
-		}
+		meta.Annotations[skipperfilterAnnotationKey] = filterString
 	}
 	if predicateString != "" {
-		meta.Annotations = map[string]string{
-			skipperpredicateAnnotationKey: predicateString,
-		}
+		meta.Annotations[skipperpredicateAnnotationKey] = predicateString
 	}
 	if routesString != "" {
-		meta.Annotations = map[string]string{
-			skipperRoutesAnnotationKey: routesString,
-		}
+		meta.Annotations[skipperRoutesAnnotationKey] = routesString
 	}
 	return &ingressItem{
 		Metadata: &meta,

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1416,7 +1416,7 @@ func TestConvertPathRuleTraffic(t *testing.T) {
 				return
 			}
 
-			route, err := dc.convertPathRule("namespace1", "", "", tc.rule, DefaultPathMode, map[string][]string{})
+			route, err := dc.convertPathRule("namespace1", "", "", tc.rule, KubernetesIngressMode, map[string][]string{})
 			if err != nil {
 				t.Errorf("should not fail: %v", err)
 			}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1416,7 +1416,7 @@ func TestConvertPathRuleTraffic(t *testing.T) {
 				return
 			}
 
-			route, err := dc.convertPathRule("namespace1", "", "", tc.rule, map[string][]string{})
+			route, err := dc.convertPathRule("namespace1", "", "", tc.rule, DefaultPathMode, map[string][]string{})
 			if err != nil {
 				t.Errorf("should not fail: %v", err)
 			}

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -110,7 +110,7 @@ func TestPathMatchingModes(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		setIngressWithPath("/foo")
-		r, err := loadRoutes(DefaultPathMode)
+		r, err := loadRoutes(KubernetesIngressMode)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -195,7 +195,7 @@ func TestPathMatchingModes(t *testing.T) {
 	})
 
 	t.Run("additional exact path from annotation", func(t *testing.T) {
-		extendableModes := []PathMode{DefaultPathMode, PathRegexp}
+		extendableModes := []PathMode{KubernetesIngressMode, PathRegexp}
 
 		for _, mode := range extendableModes {
 			t.Run(mode.String(), func(t *testing.T) {
@@ -232,7 +232,7 @@ func TestPathMatchingModes(t *testing.T) {
 	})
 
 	t.Run("additional path prefix from annotation", func(t *testing.T) {
-		extendableModes := []PathMode{DefaultPathMode, PathRegexp}
+		extendableModes := []PathMode{KubernetesIngressMode, PathRegexp}
 
 		for _, mode := range extendableModes {
 			t.Run(mode.String(), func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestPathModeParsing(t *testing.T) {
 		fail: true,
 	}, {
 		str:  defaultPathModeString,
-		mode: DefaultPathMode,
+		mode: KubernetesIngressMode,
 	}, {
 		str:  pathRegexpString,
 		mode: PathRegexp,

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -164,32 +164,6 @@ func TestPathMatchingModes(t *testing.T) {
 		}
 	})
 
-	t.Run("exact path", func(t *testing.T) {
-		setIngressWithPath("/foo")
-		r, err := loadRoutes(ExactPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		routeWithExactPath, err := findRouteWithExactPath(r)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if routeWithExactPath == nil {
-			t.Fatal("route with path regexp not found")
-		}
-
-		p, err := findPathPredicate(routeWithExactPath, "Path")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if p == nil || p.Args[0] != "/foo" {
-			t.Error("invalid path prefix value", routeWithExactPath.Path)
-		}
-	})
-
 	t.Run("additional exact path from annotation", func(t *testing.T) {
 		extendableModes := []PathMode{KubernetesIngressMode, PathRegexp}
 
@@ -265,66 +239,54 @@ func TestPathMatchingModes(t *testing.T) {
 	})
 
 	t.Run("overriding with exact path from annotation", func(t *testing.T) {
-		overridableModes := []PathMode{PathPrefix, ExactPath}
+		setIngressWithPath("/foo", "Path(\"/bar\")")
+		r, err := loadRoutes(PathPrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-		for _, mode := range overridableModes {
-			t.Run(mode.String(), func(t *testing.T) {
-				setIngressWithPath("/foo", "Path(\"/bar\")")
-				r, err := loadRoutes(mode)
-				if err != nil {
-					t.Fatal(err)
-				}
+		routeWithExactPath, err := findRouteWithExactPath(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-				routeWithExactPath, err := findRouteWithExactPath(r)
-				if err != nil {
-					t.Fatal(err)
-				}
+		if routeWithExactPath == nil {
+			t.Fatal("route with path regexp not found")
+		}
 
-				if routeWithExactPath == nil {
-					t.Fatal("route with path regexp not found")
-				}
+		p, err := findPathPredicate(routeWithExactPath, "Path")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-				p, err := findPathPredicate(routeWithExactPath, "Path")
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				if p == nil || p.Args[0] != "/bar" {
-					t.Error("missing or invalid exact path value")
-				}
-			})
+		if p == nil || p.Args[0] != "/bar" {
+			t.Error("missing or invalid exact path value")
 		}
 	})
 
 	t.Run("overriding with path prefix from annotation", func(t *testing.T) {
-		overridableModes := []PathMode{PathPrefix, ExactPath}
+		setIngressWithPath("/foo", "PathSubtree(\"/bar\")")
+		r, err := loadRoutes(PathPrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-		for _, mode := range overridableModes {
-			t.Run(mode.String(), func(t *testing.T) {
-				setIngressWithPath("/foo", "PathSubtree(\"/bar\")")
-				r, err := loadRoutes(mode)
-				if err != nil {
-					t.Fatal(err)
-				}
+		routeWithPathPrefix, err := findRouteWithPathPrefix(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-				routeWithPathPrefix, err := findRouteWithPathPrefix(r)
-				if err != nil {
-					t.Fatal(err)
-				}
+		if routeWithPathPrefix == nil {
+			t.Fatal("route with path regexp not found")
+		}
 
-				if routeWithPathPrefix == nil {
-					t.Fatal("route with path regexp not found")
-				}
+		p, err := findPathPredicate(routeWithPathPrefix, "PathSubtree")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-				p, err := findPathPredicate(routeWithPathPrefix, "PathSubtree")
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				if p == nil || p.Args[0] != "/bar" {
-					t.Error("missing or invalid exact path value")
-				}
-			})
+		if p == nil || p.Args[0] != "/bar" {
+			t.Error("missing or invalid exact path value")
 		}
 	})
 }
@@ -343,9 +305,6 @@ func TestPathModeParsing(t *testing.T) {
 	}, {
 		str:  pathRegexpString,
 		mode: PathRegexp,
-	}, {
-		str:  exactPathString,
-		mode: ExactPath,
 	}, {
 		str:  pathPrefixString,
 		mode: PathPrefix,

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -1,0 +1,334 @@
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/zalando/skipper/eskip"
+)
+
+func findPathPredicate(r *eskip.Route, name string) (*eskip.Predicate, error) {
+	var preds []*eskip.Predicate
+	for _, p := range r.Predicates {
+		if p.Name == name {
+			preds = append(preds, p)
+		}
+	}
+
+	if len(preds) > 1 {
+		return nil, fmt.Errorf("multiple predicates of the same name: %d %s", len(preds), name)
+	}
+
+	if len(preds) == 1 {
+		return preds[0], nil
+	}
+
+	return nil, nil
+}
+
+func findRouteWithRx(r []*eskip.Route) *eskip.Route {
+	for _, ri := range r {
+		if len(ri.PathRegexps) == 1 {
+			return ri
+		}
+	}
+
+	return nil
+}
+
+func findRouteWithPathPrefix(r []*eskip.Route) (*eskip.Route, error) {
+	for _, ri := range r {
+		p, err := findPathPredicate(ri, "PathSubtree")
+		if err != nil {
+			return nil, err
+		}
+
+		if p != nil {
+			return ri, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func findRouteWithExactPath(r []*eskip.Route) (*eskip.Route, error) {
+	for _, ri := range r {
+		if ri.Path != "" {
+			return ri, nil
+		}
+
+		p, err := findPathPredicate(ri, "Path")
+		if err != nil {
+			return nil, err
+		}
+
+		if p != nil && ri.Path != "" {
+			return nil, errors.New("route with duplicate path predicate found")
+		}
+
+		if p != nil || ri.Path != "" {
+			return ri, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func TestPathMatchingModes(t *testing.T) {
+	s := testServices()
+	api := newTestAPI(t, s, &ingressList{})
+	defer api.Close()
+
+	setIngressWithPath := func(p string, annotations ...string) {
+		i := testIngress(
+			"namespace1", "ingress1", "service1", "", "", "", "", backendPort{8080}, 1.0,
+			testRule("www.example.org", testPathRule(p, "service1", backendPort{8080})),
+		)
+
+		annotation := strings.Join(annotations, " && ")
+		if len(annotations) > 0 {
+			i.Metadata.Annotations[skipperpredicateAnnotationKey] = annotation
+		}
+
+		api.ingresses.Items = []*ingressItem{i}
+	}
+
+	loadRoutes := func(m PathMode) ([]*eskip.Route, error) {
+		c, err := New(Options{
+			KubernetesURL: api.server.URL,
+			PathMode:      m,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		defer c.Close()
+		return c.LoadAll()
+	}
+
+	t.Run("default", func(t *testing.T) {
+		setIngressWithPath("/foo")
+		r, err := loadRoutes(DefaultPathMode)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		routeWithRx := findRouteWithRx(r)
+		if routeWithRx == nil {
+			t.Fatal("route with path regexp not found")
+		}
+
+		if routeWithRx.PathRegexps[0] != "^/foo" {
+			t.Error("invalid path regexp value", routeWithRx.PathRegexps[0])
+		}
+	})
+
+	t.Run("regexp", func(t *testing.T) {
+		setIngressWithPath("^/foo")
+		r, err := loadRoutes(PathRegexp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		routeWithRx := findRouteWithRx(r)
+		if routeWithRx == nil {
+			t.Fatal("route with path regexp not found")
+		}
+
+		if routeWithRx.PathRegexps[0] != "^/foo" {
+			t.Error("invalid path regexp value", routeWithRx.PathRegexps[0])
+		}
+	})
+
+	t.Run("path prefix", func(t *testing.T) {
+		setIngressWithPath("/foo")
+		r, err := loadRoutes(PathPrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		routeWithPathPrefix, err := findRouteWithPathPrefix(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if routeWithPathPrefix == nil {
+			t.Fatal("route with path prefix not found")
+		}
+
+		p, err := findPathPredicate(routeWithPathPrefix, "PathSubtree")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if p.Args[0] != "/foo" {
+			t.Error("invalid path prefix value", p.Args[0])
+		}
+	})
+
+	t.Run("exact path", func(t *testing.T) {
+		setIngressWithPath("/foo")
+		r, err := loadRoutes(ExactPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		routeWithExactPath, err := findRouteWithExactPath(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if routeWithExactPath == nil {
+			t.Fatal("route with path regexp not found")
+		}
+
+		p, err := findPathPredicate(routeWithExactPath, "Path")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if p == nil || p.Args[0] != "/foo" {
+			t.Error("invalid path prefix value", routeWithExactPath.Path)
+		}
+	})
+
+	t.Run("additional exact path from annotation", func(t *testing.T) {
+		extendableModes := []PathMode{DefaultPathMode, PathRegexp}
+
+		for _, mode := range extendableModes {
+			t.Run(mode.String(), func(t *testing.T) {
+				prx := "/foo"
+				if mode == PathRegexp {
+					prx = "^/foo"
+				}
+
+				setIngressWithPath(prx, "Path(\"/bar\")")
+				r, err := loadRoutes(mode)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				routeWithRx := findRouteWithRx(r)
+				if routeWithRx == nil {
+					t.Fatal("route with path regexp not found")
+				}
+
+				if routeWithRx.PathRegexps[0] != "^/foo" {
+					t.Error("invalid path regexp value", routeWithRx.PathRegexps[0])
+				}
+
+				p, err := findPathPredicate(routeWithRx, "Path")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if p == nil || p.Args[0] != "/bar" {
+					t.Error("missing or invalid exact path value")
+				}
+			})
+		}
+	})
+
+	t.Run("additional path prefix from annotation", func(t *testing.T) {
+		extendableModes := []PathMode{DefaultPathMode, PathRegexp}
+
+		for _, mode := range extendableModes {
+			t.Run(mode.String(), func(t *testing.T) {
+				prx := "/foo"
+				if mode == PathRegexp {
+					prx = "^/foo"
+				}
+
+				setIngressWithPath(prx, "PathSubtree(\"/bar\")")
+				r, err := loadRoutes(mode)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				routeWithRx := findRouteWithRx(r)
+				if routeWithRx == nil {
+					t.Fatal("route with path regexp not found")
+				}
+
+				if routeWithRx.PathRegexps[0] != "^/foo" {
+					t.Error("invalid path regexp value", routeWithRx.PathRegexps[0])
+				}
+
+				p, err := findPathPredicate(routeWithRx, "PathSubtree")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if p == nil || p.Args[0] != "/bar" {
+					t.Error("missing or invalid path prefix value")
+				}
+			})
+		}
+	})
+
+	t.Run("overriding with exact path from annotation", func(t *testing.T) {
+		overridableModes := []PathMode{PathPrefix, ExactPath}
+
+		for _, mode := range overridableModes {
+			t.Run(mode.String(), func(t *testing.T) {
+				setIngressWithPath("/foo", "Path(\"/bar\")")
+				r, err := loadRoutes(mode)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				routeWithExactPath, err := findRouteWithExactPath(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if routeWithExactPath == nil {
+					t.Fatal("route with path regexp not found")
+				}
+
+				p, err := findPathPredicate(routeWithExactPath, "Path")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if p == nil || p.Args[0] != "/bar" {
+					t.Error("missing or invalid exact path value")
+				}
+			})
+		}
+	})
+
+	t.Run("overriding with path prefix from annotation", func(t *testing.T) {
+		overridableModes := []PathMode{PathPrefix, ExactPath}
+
+		for _, mode := range overridableModes {
+			t.Run(mode.String(), func(t *testing.T) {
+				setIngressWithPath("/foo", "PathSubtree(\"/bar\")")
+				r, err := loadRoutes(mode)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				routeWithPathPrefix, err := findRouteWithPathPrefix(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if routeWithPathPrefix == nil {
+					t.Fatal("route with path regexp not found")
+				}
+
+				p, err := findPathPredicate(routeWithPathPrefix, "PathSubtree")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if p == nil || p.Args[0] != "/bar" {
+					t.Error("missing or invalid exact path value")
+				}
+			})
+		}
+	})
+}

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -342,7 +342,7 @@ func TestPathModeParsing(t *testing.T) {
 		str:  "foo",
 		fail: true,
 	}, {
-		str:  defaultPathModeString,
+		str:  kubernetesIngressModeString,
 		mode: KubernetesIngressMode,
 	}, {
 		str:  pathRegexpString,

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -55,10 +55,6 @@ func findRouteWithPathPrefix(r []*eskip.Route) (*eskip.Route, error) {
 
 func findRouteWithExactPath(r []*eskip.Route) (*eskip.Route, error) {
 	for _, ri := range r {
-		if ri.Path != "" {
-			return ri, nil
-		}
-
 		p, err := findPathPredicate(ri, "Path")
 		if err != nil {
 			return nil, err

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -82,7 +82,6 @@ Ingress paths can be interpreted in four different modes:
 1. based on the kubernetes ingress specification
 2. as plain regular expression
 3. as a path prefix
-4. as an exact path
 
 The default is the kubernetes ingress mode. It can be changed by a startup option
 to any of the other modes, and the individual ingress rules can also override the
@@ -110,19 +109,14 @@ When the path mode is set to "path-prefix", the ingress path is not a regular
 expression. As an example, "/foo/bar" will match "/foo/bar" or "/foo/bar/baz", but
 won't match "/foo/barooz".
 
-### Exact path
+### Path prefix behavior
 
-ExactPath is like the Path predicate. As an example "/foo/bar" will only match
-"/foo/bar".
-
-### Path prefix and exact path behavior
-
-When PathPrefix or ExactPath are used, the path matching becomes deterministic when
+When PathPrefix is used, the path matching becomes deterministic when
 a request could match more than one ingress routes otherwise.
 
-### Path prefix and exact path with predicate annotations
+### Path prefix with predicate annotations
 
-In PathPrefix or ExactPath mode, when a Path or PathSubtree predicate is set in an
+In PathPrefix mode, when a Path or PathSubtree predicate is set in an
 annotation, the predicate in the annotation takes precedence over the normal ingress
 path.
 

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -109,12 +109,8 @@ When the path mode is set to "path-prefix", the ingress path is not a regular
 expression. As an example, "/foo/bar" will match "/foo/bar" or "/foo/bar/baz", but
 won't match "/foo/barooz".
 
-### Path prefix behavior
-
 When PathPrefix is used, the path matching becomes deterministic when
 a request could match more than one ingress routes otherwise.
-
-### Path prefix with predicate annotations
 
 In PathPrefix mode, when a Path or PathSubtree predicate is set in an
 annotation, the predicate in the annotation takes precedence over the normal ingress

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -75,6 +75,57 @@ Cloud migration.
               serviceName: app-svc
               servicePort: 80
 
+## Ingress path handling
+
+Ingress paths can be interpreted in four different modes:
+
+1. based on the kubernetes ingress specification
+2. as plain regular expression
+3. as a path prefix
+4. as an exact path
+
+The default is the kubernetes ingress mode. It can be changed by a startup option
+to any of the other modes, and the individual ingress rules can also override the
+default behavior with the zalando.org/skipper-ingress-path-mode annotation.
+
+E.g.:
+
+    zalando.org/skipper-ingress-path-mode: path-prefix
+
+### Kubernetes ingress specification base path
+
+By default, the ingress path is interpreted as a regular expression with a
+mandatory leading "/", and is automatically prepended by a "^" control character,
+enforcing that the path has to be at the start of the incoming request path.
+
+### Plain regular expression
+
+When the path mode is set to "path-regexp", the ingress path is interpreted similar
+to the default kubernetes ingress specification way, but is not prepended by the "^"
+control character.
+
+### Path prefix
+
+When the path mode is set to "path-prefix", the ingress path is not a regular
+expression. As an example, "/foo/bar" will match "/foo/bar" or "/foo/bar/baz", but
+won't match "/foo/barooz".
+
+### Exact path
+
+ExactPath is like the Path predicate. As an example "/foo/bar" will only match
+"/foo/bar".
+
+### Path prefix and exact path behavior
+
+When PathPrefix or ExactPath are used, the path matching becomes deterministic when
+a request could match more than one ingress routes otherwise.
+
+### Path prefix and exact path with predicate annotations
+
+In PathPrefix or ExactPath mode, when a Path or PathSubtree predicate is set in an
+annotation, the predicate in the annotation takes precedence over the normal ingress
+path.
+
 ## Filters and Predicates
 
 - **Filters** can manipulate http data, which is not possible in the ingress spec.

--- a/skipper.go
+++ b/skipper.go
@@ -103,6 +103,8 @@ type Options struct {
 	// be loaded, too.
 	KubernetesIngressClass string
 
+	KubernetesPathMode kubernetes.PathMode
+
 	// *DEPRECATED* API endpoint of the Innkeeper service, storing route definitions.
 	InnkeeperUrl string
 
@@ -493,6 +495,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 			IngressClass:               o.KubernetesIngressClass,
 			ReverseSourcePredicate:     o.ReverseSourcePredicate,
 			WhitelistedHealthCheckCIDR: o.WhitelistedHealthCheckCIDR,
+			PathMode:                   o.KubernetesPathMode,
 		})
 		if err != nil {
 			return nil, err

--- a/skipper.go
+++ b/skipper.go
@@ -103,6 +103,8 @@ type Options struct {
 	// be loaded, too.
 	KubernetesIngressClass string
 
+	// PathMode controls the default interpretation of ingress paths in cases
+	// when the ingress doesn't specify it with an annotation.
 	KubernetesPathMode kubernetes.PathMode
 
 	// *DEPRECATED* API endpoint of the Innkeeper service, storing route definitions.


### PR DESCRIPTION
fixes: #662 and #360

introducing path handling modes in order to allow control over how ingress paths are interpreted by default and per-ingress.

- [x] global path handling mode for the Kubernetes data client
- [x] ingress specific path handling mode
- [x] command line option for the global path handling mode
- [x] documentation
- [x] drop ExactPath