### PR TITLE
fix proper nouns

### DIFF
--- a/docs/dataclients/eskip-file.md
+++ b/docs/dataclients/eskip-file.md
@@ -7,7 +7,7 @@ shows your route definitions in a clear way:
     % cat example.eskip
     hello: Path("/hello") -> "https://www.example.org"'
 
-The [skipper project](https://github.com/zalando/skipper) has two
+The [Skipper project](https://github.com/zalando/skipper) has two
 binaries, one is `skipper`, the other is `eskip`.
 [Eskip](https://godoc.org/github.com/zalando/skipper/cmd/eskip)
 can be used to validate the syntax of your routes file before
@@ -15,7 +15,7 @@ reloading a production server:
 
     % eskip check example.eskip
 
-To run skipper serving routes from an `eskip` file you have to use
+To run Skipper serving routes from an `eskip` file you have to use
 `-routes-file <file>` parameter:
 
     % skipper -routes-file example.eskip

--- a/docs/dataclients/kubernetes.md
+++ b/docs/dataclients/kubernetes.md
@@ -8,7 +8,7 @@ Detailed information you find in our [godoc for dataclient kubernetes](https://g
 
 ## Kubernetes Ingress Controller deployment
 
-How to [install skipper ingress-controller](../kubernetes/ingress-controller.md) for cluster operators.
+How to [install Skipper ingress-controller](../kubernetes/ingress-controller.md) for cluster operators.
 
 ## Kubernetes Ingress Usage
 

--- a/docs/dataclients/kubernetes.md
+++ b/docs/dataclients/kubernetes.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-Skipper's Kubernetes dataclient can be used, if you want to run skipper as
+Skipper's Kubernetes dataclient can be used, if you want to run Skipper as
 [kubernetes-ingress-controller](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-controllers).
 It will get it's route information from provisioned
 [Ingress Objects](https://kubernetes.io/docs/concepts/services-networking/ingress).
@@ -12,7 +12,7 @@ How to [install skipper ingress-controller](../kubernetes/ingress-controller.md)
 
 ## Kubernetes Ingress Usage
 
-Find out more [how to use skipper ingress features](../kubernetes/ingress-usage.md) for deployers.
+Find out more [how to use Skipper ingress features](../kubernetes/ingress-usage.md) for deployers.
 
 ## Why to choose Skipper?
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -29,11 +29,11 @@ defined. Skipper supports this scenario with the
 production since end of 2016.
 
 Skipper as ingress controller does not need to have any file
-configuration or anything external which configures skipper. Skipper
+configuration or anything external which configures Skipper. Skipper
 automatically finds Ingress objects and configures routes
 automatically, without reloading. The only requirement is to target
 all traffic you want to serve with Kubernetes to a loadbalancer pool
-of skippers. This is a clear advantage over other ingress controllers
+of Skippers. This is a clear advantage over other ingress controllers
 like nginx, haproxy or envoy.
 
 Read more about [Skipper's kubernetes dataclient](dataclients/kubernetes.md).

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -25,7 +25,7 @@ component responsible to route traffic into your
 As deployer you can define an ingress object and an ingress controller
 will make sure incoming traffic gets routed to her backend service as
 defined. Skipper supports this scenario with the
-[kubernetes dataclient](dataclients/kubernetes.md) and is used in
+[Kubernetes dataclient](dataclients/kubernetes.md) and is used in
 production since end of 2016.
 
 Skipper as ingress controller does not need to have any file
@@ -36,7 +36,7 @@ all traffic you want to serve with Kubernetes to a loadbalancer pool
 of Skippers. This is a clear advantage over other ingress controllers
 like nginx, haproxy or envoy.
 
-Read more about [Skipper's kubernetes dataclient](dataclients/kubernetes.md).
+Read more about [Skipper's Kubernetes dataclient](dataclients/kubernetes.md).
 
 ## Inkeeper Routes API
 

--- a/docs/kubernetes/ingress-backends.md
+++ b/docs/kubernetes/ingress-backends.md
@@ -3,12 +3,12 @@
 ## Kubernetes Race Condition problem
 
 As described in [#652](https://github.com/zalando/skipper/issues/652),
-there is a problem that exists in kubernetes, while terminating Pods.
+there is a problem that exists in Kubernetes, while terminating Pods.
 Terminating Pods could be graceful, but the nature of distributed
 environments will show failures, because not all components in the
 distributed system changed already their state. When a Pod terminates,
-the controller-manager has to update the `endpoints` of the kubernetes
-`service`.  Additionally skipper has to get this endpoints
+the controller-manager has to update the `endpoints` of the Kubernetes
+`service`.  Additionally Skipper has to get this endpoints
 list. Skipper polls the kube-apiserver every `-source-poll-timeout=<ms>`,
 which defaults to 3000.
 Reducing this interval or implementing watch will only reduce the
@@ -43,14 +43,14 @@ lifecycle:
 ```
 
 20 seconds should be enough to fade your Pod out of the endpoints list
-and skipper's routing table.
+and Skipper's routing table.
 
 ### SIGTERM handling in Containers
 
 An application can implement a SIGTERM handler, that changes the
 `readinessProbe` target to unhealthy for the application
 instance. This will make sure it will be deleted from the endpoints
-list and from skipper's routing table. Similar to [Pod Lifecycle
+list and from Skipper's routing table. Similar to [Pod Lifecycle
 Hooks](#pod-lifecycle-hooks) you could sleep 20 seconds and after that
 terminate your application or you just wait until SIGKILL will cleanup
 the instance after 60s.

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -1,7 +1,7 @@
 # Skipper Ingress Controller
 
 This documentation is meant for for cluster operators and describes
-how to install skipper as Ingress-Controller into your Kubernetes
+how to install Skipper as Ingress-Controller into your Kubernetes
 Cluster.
 
 ## Why you should use skipper as ingress controller?
@@ -44,7 +44,7 @@ traffic to the pods. Instead it uses the Endpoints API to bypass
 kube-proxy created iptables to remove overhead like conntrack entries
 for iptables DNAT. Skipper can also reuse connections to Pods, such
 that you have no overhead in establishing connections all the time. To
-prevent errors on node failures, skipper also does automatically
+prevent errors on node failures, Skipper also does automatically
 retries to another endpoint in case it gets a connection refused or
 TLS handshake error to the endpoint.  Other reasons are future support
 of features like session affinity, different loadbalancer
@@ -60,7 +60,7 @@ A logical overview of the traffic flow in AWS is shown in this picture:
 
 ![logical ingress-traffic-flow](../img/ingress-traffic-flow-aws.svg)
 
-We described that skipper bypasses Kubernetes Service and use directly
+We described that Skipper bypasses Kubernetes Service and use directly
 endpoints for [good reasons](https://opensource.zalando.com/skipper/kubernetes/ingress-controller/#why-skipper-uses-endpoints-and-not-services),
 therefore the real traffic flow is shown in the next picture.
 ![technical ingress-traffic-flow](../img/ingress-traffic-flow-aws-technical.svg)

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -8,7 +8,7 @@ Cluster.
 
 Baremetal loadbalancer perform really well, but the configuration is
 not updated frequently and most of these installations are not meant
-to rapidly change. With introducing kubernetes this will change and
+to rapidly change. With introducing Kubernetes this will change and
 there is a need of rapid changing http routers. Skipper is designed
 for rapidly changing it's routing tree.
 
@@ -20,10 +20,10 @@ and [more](ingress-usage.md).
 
 ## What is an Ingress-Controller?
 
-Ingress-controllers are serving http requests into a kubernetes
+Ingress-controllers are serving http requests into a Kubernetes
 cluster. Most of the time traffic will pass ingress got to a
-kubernetes service IP which will forward the packets to kubernetes Pods
-selected by the kubernetes service.
+Kubernetes service IP which will forward the packets to Kubernetes Pods
+selected by the Kubernetes service.
 For having a successful ingress, you need to have a DNS name pointing
 to some stable IP addresses that act as a loadbalancer.
 

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -24,7 +24,7 @@ Service type | supported | workaround
 ClusterIP | yes | ---
 NodePort | yes | ---
 ExternalName | no, [related issue](https://github.com/zalando/skipper/issues/549) | [use deployment with routestring](../dataclients/route-string/#proxy-to-a-given-url)
-LoadBalancer | no | it should not, because kubernetes cloud-controller-manager will maintain it
+LoadBalancer | no | it should not, because Kubernetes cloud-controller-manager will maintain it
 
 # Basics
 
@@ -49,7 +49,7 @@ endpoints selected by the Kubernetes service `app-svc` on port `80`.
 
 To have 2 routes with different `Host` headers serving the same
 backends, you have to specify 2 entries in the rules section, as
-kubernetes defined the ingress spec. This is often used in cases of
+Kubernetes defined the ingress spec. This is often used in cases of
 migrations from one domain to another one or migrations to or from
 bare metal datacenters to cloud providers or inter cloud or intra
 cloud providers migrations. Examples are AWS account migration, AWS to
@@ -337,7 +337,7 @@ you know how much calls per duration your backend is able to handle.
 Ratelimits are enforced per route.
 
 More details you will find in [ratelimit package](https://godoc.org/github.com/zalando/skipper/filters/ratelimit)
-and [kubernetes dataclient](https://godoc.org/github.com/zalando/skipper/dataclients/kubernetes) documentation.
+and [Kubernetes dataclient](https://godoc.org/github.com/zalando/skipper/dataclients/kubernetes) documentation.
 
 ### Client Ratelimits
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -353,7 +353,7 @@ are exposed from skipper to the metrics endpoint, default listener
 
 Dataclients poll some kind of data source for routes. To change the
 timeout for calls that polls a dataclient, which could be the
-kubernetes API, use the following option:
+Kubernetes API, use the following option:
 
     -source-poll-timeout int
         polling timeout of the routing data sources, in milliseconds (default 3000)

--- a/docs/videos.md
+++ b/docs/videos.md
@@ -1,18 +1,18 @@
-## How to build skipper
+## How to build Skipper
 
 We expect you to have [Go](https://golang.org/dl) and [glide](https://github.com/Masterminds/glide) installed.
 
-### How to build skipper without plugins
+### How to build Skipper without plugins
 
 <script src="https://asciinema.org/a/5eenqvXBDqjQAB2ZcV6mQ7OGj.js" id="asciicast-5eenqvXBDqjQAB2ZcV6mQ7OGj" data-rows="30" async></script>
 
 
-### How to build skipper with plugins
+### How to build Skipper with plugins
 
 __TODO__
 
 ## How to run Skipper
 
-We expect you to have already built skipper.
+We expect you to have already built Skipper.
 
 __TODO__


### PR DESCRIPTION
Make "Skipper" and "Kubernetes" more consistent in the docs.