### PR TITLE
include the response streaming duration in the proxy span

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -35,6 +35,7 @@ type context struct {
 	startServe            time.Time
 	metrics               *filterMetrics
 	tracer                opentracing.Tracer
+	proxySpan             opentracing.Span
 
 	routeLookup *routing.RouteLookup
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/loadbalancer"
 	"github.com/zalando/skipper/logging/loggingtest"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/routing/testdataclient"
@@ -135,7 +136,12 @@ func newTestProxyWithFiltersAndParams(fr filters.Registry, doc string, params Pa
 		FilterRegistry: fr,
 		PollTimeout:    sourcePollTimeout,
 		DataClients:    []routing.DataClient{dc},
-		Log:            tl})
+		Predicates: []routing.PredicateSpec{
+			loadbalancer.NewGroup(),
+			loadbalancer.NewMember(),
+		},
+		Log: tl,
+	})
 	params.Routing = rt
 	p := WithParams(params)
 	p.log = tl

--- a/proxy/testtracer_test.go
+++ b/proxy/testtracer_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"net/http"
+	"time"
 
 	ot "github.com/opentracing/opentracing-go"
 	log "github.com/opentracing/opentracing-go/log"
@@ -18,6 +19,8 @@ type span struct {
 	tags          map[string]interface{}
 	tracer        *tracer
 	refs          []ot.SpanReference
+	start         time.Time
+	finish        time.Time
 }
 
 func (t *tracer) findAllSpans(operationName string) []*span {
@@ -40,11 +43,17 @@ func (t *tracer) findSpan(operationName string) (*span, bool) {
 	return nil, false
 }
 
+func (t *tracer) reset(traceContent string) {
+	t.traceContent = traceContent
+	t.recordedSpans = nil
+}
+
 func (t *tracer) createSpanBase() *span {
 	return &span{
 		tracer: t,
 		trace:  t.traceContent,
 		tags:   make(map[string]interface{}),
+		start:  time.Now(),
 	}
 }
 
@@ -89,6 +98,7 @@ func (s *span) Finish() {
 }
 
 func (s *span) FinishWithOptions(opts ot.FinishOptions) {
+	s.finish = time.Now()
 	s.tracer.recordedSpans = append(s.tracer.recordedSpans, s)
 }
 


### PR DESCRIPTION
Currently, we set two spans in the proxy for opentracing:

- server span ("ingress")
- client span ("proxy")

The proxy span starts before making the backend request. However it is closed as soon as the response headers are parsed, or the request failed. After discussing it with @lmineiro, I believe the proxy span should include the duration while the response content is fully copied onto the incoming connection. This PR moves finishing the proxy span after the stream copying is done or aborted.