### PR TITLE
wire in missing connection, timeout parameters

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -497,16 +497,21 @@ func main() {
 		OAuthTokeninfoURL:   oauth2TokeninfoURL,
 
 		// connections, timeouts:
-		IdleConnectionsPerHost:  idleConnsPerHost,
-		CloseIdleConnsPeriod:    time.Duration(clsic) * time.Second,
-		BackendFlushInterval:    backendFlushInterval,
-		ExperimentalUpgrade:     experimentalUpgrade,
-		ReadTimeoutServer:       readTimeoutServer,
-		ReadHeaderTimeoutServer: readHeaderTimeoutServer,
-		WriteTimeoutServer:      writeTimeoutServer,
-		IdleTimeoutServer:       idleTimeoutServer,
-		MaxHeaderBytes:          maxHeaderBytes,
-		EnableConnMetricsServer: enableConnMetricsServer,
+		IdleConnectionsPerHost:     idleConnsPerHost,
+		CloseIdleConnsPeriod:       time.Duration(clsic) * time.Second,
+		BackendFlushInterval:       backendFlushInterval,
+		ExperimentalUpgrade:        experimentalUpgrade,
+		ReadTimeoutServer:          readTimeoutServer,
+		ReadHeaderTimeoutServer:    readHeaderTimeoutServer,
+		WriteTimeoutServer:         writeTimeoutServer,
+		IdleTimeoutServer:          idleTimeoutServer,
+		MaxHeaderBytes:             maxHeaderBytes,
+		EnableConnMetricsServer:    enableConnMetricsServer,
+		TimeoutBackend:             timeoutBackend,
+		KeepAliveBackend:           keepaliveBackend,
+		DualStackBackend:           enableDualstackBackend,
+		TLSHandshakeTimeoutBackend: tlsHandshakeTimeoutBackend,
+		MaxIdleConnsBackend:        maxIdleConnsBackend,
 	}
 
 	if pluginDir != "" {


### PR DESCRIPTION
(#677) Just forwarding the parameters from cmd to skipper:
```
timeoutBackend
keepaliveBackend
enableDualstackBackend
tlsHandshakeTimeoutBackend
maxIdleConnsBackend
```