### PR TITLE
sort routing table output on support endpoint

### DIFF
--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/zalando/skipper/eskip"
@@ -515,6 +516,10 @@ func receiveRouteMatcher(o Options, out chan<- *routeTable, quit <-chan struct{}
 					validRoutes = append(validRoutes, &r.Route)
 				}
 			}
+
+			sort.SliceStable(validRoutes, func(i, j int) bool {
+				return validRoutes[i].Id < validRoutes[j].Id
+			})
 
 			rt = &routeTable{
 				m:             m,

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -268,10 +267,6 @@ func (r *Routing) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		return
 	}
-
-	sort.SliceStable(routes, func(i, j int) bool {
-		return routes[i].Id < routes[j].Id
-	})
 
 	w.Header().Set("Content-Type", "text/plain")
 	eskip.Fprint(w, extractPretty(req), routes...)

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -267,6 +268,10 @@ func (r *Routing) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		return
 	}
+
+	sort.SliceStable(routes, func(i, j int) bool {
+		return routes[i].Id < routes[j].Id
+	})
 
 	w.Header().Set("Content-Type", "text/plain")
 	eskip.Fprint(w, extractPretty(req), routes...)


### PR DESCRIPTION
sort routing table output to create simply diffs if you want to investigate differences of 2 routing tables