### PR TITLE
Support for Limiting Ingress Lookups to a Single Namespace

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -125,6 +125,7 @@ const (
 	kubernetesIngressClassUsage     = "ingress class regular expression used to filter ingress resources for kubernetes"
 	whitelistedHealthCheckCIDRUsage = "sets the iprange/CIDRS to be whitelisted during healthcheck"
 	kubernetesPathModeUsage         = "controls the default interpretation of Kubernetes ingress paths: kubernetes-ingress/path-regexp/path-prefix"
+	kubernetesNamespaceUsage        = "limit ingress monitoring to this namespace"
 
 	// OAuth2:
 	oauthURLUsage            = "OAuth2 URL for Innkeeper authentication"
@@ -231,6 +232,7 @@ var (
 	kubernetesIngressClass     string
 	whitelistedHealthCheckCIDR string
 	kubernetesPathModeString   string
+	kubernetesNamespace        string
 
 	// OAuth2:
 	oauthURL            string
@@ -335,6 +337,7 @@ func init() {
 	flag.StringVar(&kubernetesIngressClass, "kubernetes-ingress-class", "", kubernetesIngressClassUsage)
 	flag.StringVar(&whitelistedHealthCheckCIDR, "whitelisted-healthcheck-cidr", "", whitelistedHealthCheckCIDRUsage)
 	flag.StringVar(&kubernetesPathModeString, "kubernetes-path-mode", "kubernetes-ingress", kubernetesPathModeUsage)
+	flag.StringVar(&kubernetesNamespace, "kubernetes-namespace", "", kubernetesNamespaceUsage)
 
 	// OAuth2:
 	flag.StringVar(&oauthURL, "oauth-url", "", oauthURLUsage)
@@ -493,6 +496,7 @@ func main() {
 		KubernetesIngressClass:     kubernetesIngressClass,
 		WhitelistedHealthCheckCIDR: whitelistCIDRS,
 		KubernetesPathMode:         kubernetesPathMode,
+		KubernetesNamespace:        kubernetesNamespace,
 
 		// OAuth2:
 		OAuthUrl:            oauthURL,

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -125,7 +125,7 @@ const (
 	kubernetesIngressClassUsage     = "ingress class regular expression used to filter ingress resources for kubernetes"
 	whitelistedHealthCheckCIDRUsage = "sets the iprange/CIDRS to be whitelisted during healthcheck"
 	kubernetesPathModeUsage         = "controls the default interpretation of Kubernetes ingress paths: kubernetes-ingress/path-regexp/path-prefix"
-	kubernetesNamespaceUsage        = "limit ingress monitoring to this namespace"
+	kubernetesNamespaceUsage        = "watch only this namespace for ingresses"
 
 	// OAuth2:
 	oauthURLUsage            = "OAuth2 URL for Innkeeper authentication"

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -110,7 +110,7 @@ type Options struct {
 	// environment variables.)
 	KubernetesURL string
 
-	// KubernetesNamespace is used to switch between monitoring ingresses in the cluster-scope or limit
+	// KubernetesNamespace is used to switch between finding ingresses in the cluster-scope or limit
 	// the ingresses to only those in the specified namespace. Defaults to "" which means monitor ingresses
 	// in the cluster-scope.
 	KubernetesNamespace string
@@ -215,12 +215,10 @@ func New(o Options) (*Client, error) {
 		return nil, err
 	}
 
-	log.Debugf("running in-cluster: %t. api server url: %s. provide health check: %t. ingress.class filter: %s", o.KubernetesInCluster, apiURL, o.ProvideHealthcheck, ingCls)
-	if o.KubernetesNamespace == "" {
-		log.Debugf("monitoring ingresses across the cluster")
-	} else {
-		log.Debugf(fmt.Sprintf("monitoring ingresses within the \"%s\" namespace", o.KubernetesNamespace))
-	}
+	log.Debugf(
+		"running in-cluster: %t. api server url: %s. provide health check: %t. ingress.class filter: %s. namespace: %s",
+		o.KubernetesInCluster, apiURL, o.ProvideHealthcheck, ingCls, o.KubernetesNamespace,
+	)
 
 	var sigs chan os.Signal
 	if o.ProvideHealthcheck {

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -1108,14 +1108,16 @@ func (c *Client) filterIngressesByClass(items []*ingressItem) []*ingressItem {
 	return validIngs
 }
 
+func (c *Client) getIngressURI() string {
+	if c.namespace == "" {
+		return ingressesClusterURI
+	}
+	return fmt.Sprintf(ingressesNamespaceFmt, c.namespace)
+}
+
 func (c *Client) loadAndConvert() ([]*eskip.Route, error) {
 	var il ingressList
-	ingressesURI := ""
-	if c.namespace == "" {
-		ingressesURI = ingressesClusterURI
-	} else {
-		ingressesURI = fmt.Sprintf(ingressesNamespaceFmt, c.namespace)
-	}
+	ingressesURI := c.getIngressURI()
 	if err := c.getJSON(ingressesURI, &il); err != nil {
 		log.Debugf("requesting all ingresses failed: %v", err)
 		return nil, err

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -1108,7 +1108,7 @@ func (c *Client) filterIngressesByClass(items []*ingressItem) []*ingressItem {
 	return validIngs
 }
 
-func (c *Client) getIngressURI() string {
+func (c *Client) getIngressesURI() string {
 	if c.namespace == "" {
 		return ingressesClusterURI
 	}
@@ -1117,7 +1117,7 @@ func (c *Client) getIngressURI() string {
 
 func (c *Client) loadAndConvert() ([]*eskip.Route, error) {
 	var il ingressList
-	ingressesURI := c.getIngressURI()
+	ingressesURI := c.getIngressesURI()
 	if err := c.getJSON(ingressesURI, &il); err != nil {
 		log.Debugf("requesting all ingresses failed: %v", err)
 		return nil, err

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1895,6 +1895,24 @@ func TestReadServiceAccountToken(t *testing.T) {
 	}
 }
 
+func TestIngressScoping(t *testing.T) {
+	client := &Client{
+		namespace: "test",
+	}
+	expected := "/apis/extensions/v1beta1/namespaces/test/ingresses"
+	uri := client.getIngressURI()
+	if uri != expected {
+		t.Errorf("unexpected ingress uri returned: %s should be %s", uri, expected)
+	}
+
+	client.namespace = ""
+	expected = "/apis/extensions/v1beta1/ingresses"
+	uri = client.getIngressURI()
+	if uri != expected {
+		t.Errorf("unexpected ingress uri returned: %s should be %s", uri, expected)
+	}
+}
+
 // generateSSCert only for testing purposes
 func generateSSCert() []byte {
 	//create root CA

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1900,14 +1900,14 @@ func TestIngressScoping(t *testing.T) {
 		namespace: "test",
 	}
 	expected := "/apis/extensions/v1beta1/namespaces/test/ingresses"
-	uri := client.getIngressURI()
+	uri := client.getIngressesURI()
 	if uri != expected {
 		t.Errorf("unexpected ingress uri returned: %s should be %s", uri, expected)
 	}
 
 	client.namespace = ""
 	expected = "/apis/extensions/v1beta1/ingresses"
-	uri = client.getIngressURI()
+	uri = client.getIngressesURI()
 	if uri != expected {
 		t.Errorf("unexpected ingress uri returned: %s should be %s", uri, expected)
 	}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -417,7 +417,7 @@ func (api *testAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.URL.Path == ingressesURI {
+	if r.URL.Path == ingressesClusterURI {
 		if err := respondJSON(w, api.ingresses); err != nil {
 			api.test.Error(err)
 		}

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -306,6 +306,17 @@ Example ingress:
               serviceName: app-svc
               servicePort: 80
 
+## Scoping Skipper Deployments to a Single Namespace
+
+In some instances you might want skipper to only watch for ingress objects
+created in a single namespace. This can be achieved by using
+`kubernetes-namespace=<string>` where `<string>` is the Kubernetes namespace.
+Specifying this option forces Skipper to look at the namespace ingresses
+endpoint rather than the cluster-wide ingresses endpoint.
+
+By default this value is an empty string (`""`) and will scope the skipper
+instance to be cluster-wide, watching all `Ingress` objects across all namespaces.
+
 ## Install Skipper with enabled RBAC
 
 If Role-Based Access Control ("RBAC") is enabled you have to create some additional

--- a/skipper.go
+++ b/skipper.go
@@ -107,6 +107,11 @@ type Options struct {
 	// when the ingress doesn't specify it with an annotation.
 	KubernetesPathMode kubernetes.PathMode
 
+	// KubernetesNamespace is used to switch between monitoring ingresses in the cluster-scope or limit
+	// the ingresses to only those in the specified namespace. Defaults to "" which means monitor ingresses
+	// in the cluster-scope.
+	KubernetesNamespace string
+
 	// *DEPRECATED* API endpoint of the Innkeeper service, storing route definitions.
 	InnkeeperUrl string
 
@@ -502,6 +507,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 			ReverseSourcePredicate:     o.ReverseSourcePredicate,
 			WhitelistedHealthCheckCIDR: o.WhitelistedHealthCheckCIDR,
 			PathMode:                   o.KubernetesPathMode,
+			KubernetesNamespace:        o.KubernetesNamespace,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Issue Reference: https://github.com/zalando/skipper/issues/686

**Purpose**
We have a use-case where we deploy identical environments on the same cluster, segregating them by `Namespace`. To aid in configuration it'd be nice to use the same `ingress.class` in each namespace (e.g. `ingress.class: api`) without having to add the namepsace to the class.

This also has the added benefit of being able to further restrict RBAC permissions by combining a `ClusterRole` and `RoleBinding` to ensure that the associated `ServiceAccount` can't list ingresses in another namespace.

**Implementation**

I've added a `-kubernetes-namepsace` option that defaults to `""`.

* When the argument is omitted (empty) it will use `/apis/extensions/ingresses`
* When a namespace is provided it will use `apis/extensions/namepsaces/{namespace}/ingresses`

I'm still unfamiliar with how go does unit-testing, so I haven't included tests. If anyone can give me a pointer on which of the `kube_test.go` functions is most suited to include this test I'll make sure to add some in another commit.