### PR TITLE
Fix Header and HeaderRegexp examples

### DIFF
--- a/docs/predicates.md
+++ b/docs/predicates.md
@@ -134,8 +134,8 @@ Parameters:
 Examples:
 
 ```
-HeaderRegexp("X-Forwarded-For", "/^192\.168\.0\.[0-2]?[0-9]?[0-9] /")
-HeaderRegexp("Server", "/skipper/")
+HeaderRegexp("X-Forwarded-For", "^192\.168\.0\.[0-2]?[0-9]?[0-9] ")
+HeaderRegexp("Server", "skipper")
 ```
 
 ## Cookie

--- a/docs/predicates.md
+++ b/docs/predicates.md
@@ -118,7 +118,7 @@ Examples:
 
 ```
 Header("X-Forwarded-For", "192.168.0.2")
-Header("Server", "skipper")
+Header("Accept", "application/json")
 ```
 
 ## HeaderRegexp
@@ -135,7 +135,7 @@ Examples:
 
 ```
 HeaderRegexp("X-Forwarded-For", "^192\.168\.0\.[0-2]?[0-9]?[0-9] ")
-HeaderRegexp("Server", "skipper")
+HeaderRegexp("Accept", "application/(json|xml)")
 ```
 
 ## Cookie


### PR DESCRIPTION
* The slashes for HeaderRegexp are misleading. Could be the initial example was using this format: `HeaderRegexp("Server", /skipper/)`.
* Use a request header for the examples.