### PR TITLE
use go1.10.x in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.x
+  - 1.10.x
 
 env:
   global:


### PR DESCRIPTION
preventing travis build with go1.11beta1 because it changes gofmt formatting