### PR TITLE
typo in godoc

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -72,7 +72,7 @@ const (
 	// response.
 	Debug
 
-	// HopeHeadersRemoval indicates whether the Hop Headers should be removed
+	// HopHeadersRemoval indicates whether the Hop Headers should be removed
 	// in compliance with RFC 2616
 	HopHeadersRemoval
 )


### PR DESCRIPTION
this fix will render godoc correctly and remove the golint warning