### PR TITLE
Fix custom routes for multiple hosts

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -905,10 +905,11 @@ func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 			host := []string{"^" + strings.Replace(rule.Host, ".", "[.]", -1) + "$"}
 
 			// add extra routes from optional annotation
-			for idx, route := range extraRoutes {
+			for idx, r := range extraRoutes {
+				route := *r
 				route.HostRegexps = host
 				route.Id = routeIDForCustom(i.Metadata.Namespace, i.Metadata.Name, route.Id, rule.Host, idx)
-				hostRoutes[rule.Host] = append(hostRoutes[rule.Host], route)
+				hostRoutes[rule.Host] = append(hostRoutes[rule.Host], &route)
 			}
 
 			// update Traffic field for each backend

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -624,10 +624,20 @@ func TestIngressData(t *testing.T) {
 					backendPort{"baz"},
 				),
 			),
+			testRule(
+				"www2.example.org",
+				testPathRule(
+					"/",
+					"bar",
+					backendPort{"baz"},
+				),
+			),
 		)},
 		map[string]string{
-			"kube_foo__qux__www_example_org_____bar": "http://1.2.3.4:8181",
-			"kube_foo__qux__0__www_example_org____":  "",
+			"kube_foo__qux__www_example_org_____bar":  "http://1.2.3.4:8181",
+			"kube_foo__qux__www2_example_org_____bar": "http://1.2.3.4:8181",
+			"kube_foo__qux__0__www_example_org____":   "",
+			"kube_foo__qux__0__www2_example_org____":  "",
 		},
 	}} {
 		t.Run(ti.msg, func(t *testing.T) {


### PR DESCRIPTION
This fixes an issue, where given an ingress with the custom routes
annotation `zalando.org/skipper-routes` and multiple rules defined, the
route would only be created for the last rule.

I.e. the following ingress:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    zalando.org/skipper-routes: |
      Method("OPTIONS") -> status(200) -> <shunt>
  name: app
spec:
  rules:
  - host: app-default.example.org
    http:
      paths:
      - backend:
          serviceName: app-svc
          servicePort: 80
  - host: app-alt.example.org
    http:
      paths:
      - backend:
          serviceName: app-svc
          servicePort: 80
```

Would produce the custom route:

```
Host(/^app-alt[.]example[.]org$/) && Method("OPTIONS") ->
  status(200) -> <shunt>
```

When it should create routes for both host names:

```
1: Host(/^app-default[.]example[.]org$/) && Method("OPTIONS") ->
  status(200) -> <shunt>;
2: Host(/^app-alt[.]example[.]org$/) && Method("OPTIONS") ->
  status(200) -> <shunt>;
```

The fix is to copy the base route instead of overwriting the same route
pointer.