### PR TITLE
Improve the routing table information documentation

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -379,7 +379,7 @@ of the last route table update `X-Timestamp`, using a HEAD request:
     Date: Sun, 04 Feb 2018 20:54:31 GMT
 
 The number of routes given is limited (1024 routes by default).
-In order to control this limits, there are two filters: `limit` and
+In order to control this limits, there are two parameters: `limit` and
 `offset`. The `limit` defines the number of routes to get and
 `offset` where to start the list. Thanks to this, it's possible
 to get the results paginated or getting all of them at the same time.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -377,3 +377,11 @@ of the last route table update `X-Timestamp`, using a HEAD request:
     X-Count: 1
     X-Timestamp: 1517777628
     Date: Sun, 04 Feb 2018 20:54:31 GMT
+
+The number of routes given is limited (1024 routes by default).
+In order to control this limits, there are two filters: `limit` and
+`offset`. The `limit` defines the number of routes to get and
+`offset` where to start the list. Thanks to this, it's possible
+to get the results paginated or getting all of them at the same time.
+
+    % curl localhost:9911/routes?offset=200&limit=100


### PR DESCRIPTION
This PR adds information about getting the routes from Skipper. It explains the limit of routes given by default and how to configure it.

It fixes #713 