### PR TITLE
fix kube dataclient: custom-routes should set path according to ingress

### DIFF
--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -37,6 +37,7 @@ func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) 
 			"",
 			"",
 			"",
+			"",
 			backendPort{"port1"},
 			1.0,
 			testRule(

--- a/dataclients/kubernetes/lbannotationfilters_test.go
+++ b/dataclients/kubernetes/lbannotationfilters_test.go
@@ -45,6 +45,7 @@ func TestAnnotationFiltersInLBRoutes(t *testing.T) {
 		`setPath("/foo")`,
 		"",
 		"",
+		"",
 		backendPort{"port1"},
 		1.0,
 		testRule(

--- a/dataclients/kubernetes/lbtarget_test.go
+++ b/dataclients/kubernetes/lbtarget_test.go
@@ -40,6 +40,7 @@ func testSingleIngressWithTargets(t *testing.T, targets []string, expectedRoutes
 		"",
 		"",
 		"",
+		"",
 		backendPort{"port1"},
 		1.0,
 		testRule(

--- a/dataclients/kubernetes/lbtrafficswitch_test.go
+++ b/dataclients/kubernetes/lbtrafficswitch_test.go
@@ -8,31 +8,31 @@ func TestLBWithTrafficControl(t *testing.T) {
 		  LBMember("kube_namespace1__ingress1______", 0)
 		  -> dropRequestHeader("X-Load-Balancer-Member")
 		  -> "http://42.0.1.2:8080";
-		
+
 		kube_namespace1__ingress1______1:
 		  LBMember("kube_namespace1__ingress1______", 1)
 		  -> dropRequestHeader("X-Load-Balancer-Member")
 		  -> "http://42.0.1.3:8080";
-		
+
 		kube_namespace1__ingress1________lb_group:
 		  LBGroup("kube_namespace1__ingress1______")
 		  -> lbDecide("kube_namespace1__ingress1______", 2)
 		  -> <loopback>;
-		
+
 		kube_namespace1__ingress1__test_example_org___test1__service1v1_0:
 		  Host(/^test[.]example[.]org$/) &&
 		  PathRegexp(/^\/test1/) &&
 		  LBMember("kube_namespace1__ingress1__test_example_org___test1__service1v1", 0)
 		  -> dropRequestHeader("X-Load-Balancer-Member")
 		  -> "http://42.0.1.2:8080";
-		
+
 		kube_namespace1__ingress1__test_example_org___test1__service1v1_1:
 		  Host(/^test[.]example[.]org$/) &&
 		  PathRegexp(/^\/test1/) &&
 		  LBMember("kube_namespace1__ingress1__test_example_org___test1__service1v1", 1)
 		  -> dropRequestHeader("X-Load-Balancer-Member")
 		  -> "http://42.0.1.3:8080";
-		
+
 		// the traffic predicate should be on the decision route:
 		kube_namespace1__ingress1__test_example_org___test1__service1v1__lb_group:
 		  Host(/^test[.]example[.]org$/) &&
@@ -41,28 +41,28 @@ func TestLBWithTrafficControl(t *testing.T) {
 		  LBGroup("kube_namespace1__ingress1__test_example_org___test1__service1v1")
 		  -> lbDecide("kube_namespace1__ingress1__test_example_org___test1__service1v1", 2)
 		  -> <loopback>;
-		
+
 		kube_namespace1__ingress1__test_example_org___test1__service1v2_0:
 		  Host(/^test[.]example[.]org$/) &&
 		  PathRegexp(/^\/test1/) &&
 		  LBMember("kube_namespace1__ingress1__test_example_org___test1__service1v2", 0)
 		  -> dropRequestHeader("X-Load-Balancer-Member")
 		  -> "http://42.0.1.4:8080";
-		
+
 		kube_namespace1__ingress1__test_example_org___test1__service1v2_1:
 		  Host(/^test[.]example[.]org$/) &&
 		  PathRegexp(/^\/test1/) &&
 		  LBMember("kube_namespace1__ingress1__test_example_org___test1__service1v2", 1)
 		  -> dropRequestHeader("X-Load-Balancer-Member")
 		  -> "http://42.0.1.5:8080";
-		
+
 		kube_namespace1__ingress1__test_example_org___test1__service1v2__lb_group:
 		  Host(/^test[.]example[.]org$/) &&
 		  PathRegexp(/^\/test1/) &&
 		  LBGroup("kube_namespace1__ingress1__test_example_org___test1__service1v2")
 		  -> lbDecide("kube_namespace1__ingress1__test_example_org___test1__service1v2", 2)
 		  -> <loopback>;
-		
+
 		kube___catchall__test_example_org____:
 		  Host(/^test[.]example[.]org$/)
 		  -> <shunt>;
@@ -129,7 +129,7 @@ func TestLBWithTrafficControl(t *testing.T) {
 	}
 
 	ingress := testIngress("namespace1", "ingress1", "service1v1",
-		"", "", "", "",
+		"", "", "", "", "",
 		backendPort{"port1"},
 		1.0,
 		testRule(

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -79,7 +79,7 @@ func TestPathMatchingModes(t *testing.T) {
 
 	setIngressWithPath := func(p string, annotations ...string) {
 		i := testIngress(
-			"namespace1", "ingress1", "service1", "", "", "", "", backendPort{8080}, 1.0,
+			"namespace1", "ingress1", "service1", "", "", "", "", "", backendPort{8080}, 1.0,
 			testRule("www.example.org", testPathRule(p, "service1", backendPort{8080})),
 		)
 
@@ -337,12 +337,12 @@ func TestIngressSpecificMode(t *testing.T) {
 	defer api.Close()
 
 	ingressWithDefault := testIngress(
-		"namespace1", "ingress1", "service1", "", "", "", "", backendPort{8080}, 1.0,
+		"namespace1", "ingress1", "service1", "", "", "", "", "", backendPort{8080}, 1.0,
 		testRule("www.example.org", testPathRule("^/foo", "service1", backendPort{8080})),
 	)
 
 	ingressWithCustom := testIngress(
-		"namespace1", "ingress1", "service1", "", "", "", "", backendPort{8080}, 1.0,
+		"namespace1", "ingress1", "service1", "", "", "", "", "", backendPort{8080}, 1.0,
 		testRule("www.example.org", testPathRule("/bar", "service1", backendPort{8080})),
 	)
 	ingressWithCustom.Metadata.Annotations[pathModeAnnotationKey] = pathPrefixString


### PR DESCRIPTION
fix #718 kube dataclient: custom-routes annotation should specify the path with pathmode if set in the ingress spec