### PR TITLE
cache authclient per tokeninfoURL

### DIFF
--- a/filters/auth/tokeninfo_test.go
+++ b/filters/auth/tokeninfo_test.go
@@ -360,3 +360,23 @@ func TestOAuth2TokenTimeout(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkOAuthTokeninfoFilter(b *testing.B) {
+	allF := make([]*tokeninfoFilter, 0)
+	for i := 0; i < b.N; i++ {
+		var spec filters.Spec
+		args := []interface{}{"uid"}
+		spec = NewOAuthTokeninfoAnyScope("https://127.0.0.1:12345/token", 3*time.Second)
+		f, err := spec.CreateFilter(args)
+		if err != nil {
+			b.Logf("error in creating filter")
+			break
+		}
+		f2 := f.(*tokeninfoFilter)
+		allF = append(allF, f2)
+	}
+
+	for i := range allF {
+		allF[i].Close()
+	}
+}


### PR DESCRIPTION
#739 tokeninfo filter should cache authclient per tokeninfoURL and reuse it instead of creating one for each filter

Right now a hashmap for the cache is not really needed, but we can easily create filters, that can pass the target tokeninfoURL to be able to change this per route.

```
% go test -benchmem -bench=BenchmarkOAuthTokeninfoFilter -run='^$' ./filters/auth/ -v
goos: darwin
goarch: amd64
pkg: github.com/zalando/skipper/filters/auth
BenchmarkOAuthTokeninfoFilter-8           300000              4481 ns/op            1739 B/op         17 allocs/op
PASS
ok      github.com/zalando/skipper/filters/auth 1.499s
% go test -benchmem -bench=BenchmarkOAuthTokeninfoFilter -run='^$' ./filters/auth/ -v
goos: darwin
goarch: amd64
pkg: github.com/zalando/skipper/filters/auth
BenchmarkOAuthTokeninfoFilter-8          5000000               412 ns/op             219 B/op          5 allocs/op
PASS
ok      github.com/zalando/skipper/filters/auth 2.514s
```