### PR TITLE
Simplify CDP build with golang overlay

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,43 +1,18 @@
-build_steps:
-    - desc: 'Install required build software'
-      cmd: |
-        apt-get update
-        apt-get install -y make git apt-transport-https ca-certificates curl
-    - desc: 'Install go'
-      cmd: |
-        add-apt-repository -y ppa:longsleep/golang-backports
-        apt-get update
-        apt-get install -y golang-go
-    - desc: 'Install Docker'
-      cmd: |
-        # enable experimental features (--squash)
-        mkdir -p /etc/systemd/system/docker.service.d
-        cat << EOF > /etc/systemd/system/docker.service.d/docker.conf
-        [Service]
-        ExecStart=
-        ExecStart=/usr/bin/dockerd -H fd:// --experimental=true
-        EOF
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-        apt-key fingerprint 0EBFCD88
-        add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-        apt-get update
-        apt-get install -y docker-ce
-    - desc: 'Build & push docker image'
-      cmd: |
-        export GOPATH=$HOME/go
-        export PATH=$PATH:$HOME/go/bin
-        export TOP_DIR=$GOPATH/src/github.com/zalando
-        mkdir -p $TOP_DIR
-        cp -va $(pwd) $TOP_DIR/skipper
-        cd $TOP_DIR/skipper
-        IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
-        if [[ ${CDP_TARGET_BRANCH} == "master" && ${IS_PR_BUILD} != "true" ]]
-        then
-          RELEASE_VERSION=$(git describe --tags --always --dirty)
-          IMAGE=registry-write.opensource.zalan.do/pathfinder/skipper:${RELEASE_VERSION}
-        else
-          IMAGE=registry-write.opensource.zalan.do/pathfinder/skipper-test:${CDP_BUILD_VERSION}
-        fi
-        export IMAGE
-        make deps shortcheck
-        cd packaging && make docker-build docker-push
+version: "2017-09-20"
+pipeline:
+- id: build
+  overlay: ci/golang
+  type: script
+  working_dir: /go/src/github.com/zalando/skipper
+  commands:
+  - desc: build-push
+    cmd: |
+      if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
+        RELEASE_VERSION="$(git describe --tags --always --dirty)"
+        IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper:${RELEASE_VERSION}"
+      else
+        IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper-test:${CDP_BUILD_VERSION}"
+      fi
+      export IMAGE
+      make deps shortcheck
+      cd packaging && make docker-build docker-push


### PR DESCRIPTION
CDP now has an 'official' Golang overlay which simplifies the build a lot. Use that instead of installing Go manually.