### PR TITLE
Fix docs about PathRegexp

### DIFF
--- a/docs/predicates.md
+++ b/docs/predicates.md
@@ -68,10 +68,10 @@ Parameters:
 Examples:
 
 ```
-PathRegexp("/^foo\/bar/")
-PathRegexp("/foo\/bar$/")
-PathRegexp("/foo\/bar/")
-PathRegexp("/^foo\/(bar|qux)/")
+PathRegexp("^/foo/bar")
+PathRegexp("/foo/bar$")
+PathRegexp("/foo/bar/")
+PathRegexp("^/foo/(bar|qux)")
 ```
 
 ## Host


### PR DESCRIPTION
Fix the examples for `PathRegexp` which were wrong.