### PR TITLE
implment a simple webhook

### DIFF
--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -36,6 +36,7 @@ const (
 	invalidScope       rejectReason = "invalid-scope"
 	invalidClaim       rejectReason = "invalid-claim"
 	invalidFilter      rejectReason = "invalid-filter"
+	invalidAccess      rejectReason = "invalid-access"
 )
 
 const (

--- a/filters/auth/authclient.go
+++ b/filters/auth/authclient.go
@@ -47,6 +47,10 @@ func (ac *authClient) getTokeninfo(token string) (map[string]interface{}, error)
 	return a, err
 }
 
+func (ac *authClient) getWebhook(r http.Request) (int, error) {
+	return doClonedGet(ac.url, ac.client, r)
+}
+
 func createHTTPClient(timeout time.Duration, quit chan struct{}) (*http.Client, error) {
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
@@ -113,4 +117,23 @@ func jsonPost(u *url.URL, auth string, doc *tokenIntrospectionInfo, client *http
 		return err
 	}
 	return json.Unmarshal(buf, &doc)
+}
+
+// doClonedGet requests url with the same headers and query as the
+// incoming request and returns with http statusCode and error.
+func doClonedGet(u *url.URL, client *http.Client, incoming *http.Request) (int, error) {
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return -1, err
+	}
+
+	copyHeader(req.Header, incoming.Header)
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		return -1, err
+	}
+	defer rsp.Body.Close()
+
+	return rsp.StatusCode, nil
 }

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/zalando/skipper/filters"
+)
+
+const WebhookName = "webhook"
+
+type (
+	webhookSpec   struct{}
+	webhookFilter struct {
+		authClient *authClient
+	}
+)
+
+// NewWebhook creates a new auth filter specification
+// to validate authorization for requests.
+func NewWebhook() filters.Spec {
+	return &webhookSpec{}
+}
+
+func (s *webhookSpec) Name() string {
+	return WebhookName
+}
+
+// CreateFilter creates an auth filter. The first argument is an URL
+// string.
+//
+//     s.CreateFilter("https://my-auth-service.example.org/auth")
+//
+func (s *webhookSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if l := len(args); l == 0 || l > 2 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	s, ok := args[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	ac, err := newAuthClient(s)
+	if err != nil {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	return &webhookFilter{
+		authClient: ac,
+	}
+}
+
+func copyHeader(to, from http.Header) {
+	for k, v := range from {
+		to[http.CanonicalHeaderKey(k)] = v
+	}
+}
+
+func (f *webhookFilter) Request(ctx filters.FilterContext) {
+	statusCode, err := f.ac.getWebhook(ctx.Request())
+	if err != nil {
+		unauthorized(ctx, WebhookName, authServiceAccess, f.authClient.url.Hostname())
+	}
+	if statusCode >= 400 {
+		unauthorized(ctx, WebhookName, invalidAccess, f.authClient.url.Hostname())
+	}
+	authorized(ctx, WebhookName)
+}
+
+func (f *webhookFilter) Response(filters.FilterContext) {}

--- a/filters/auth/webhook_test.go
+++ b/filters/auth/webhook_test.go
@@ -1,0 +1,1 @@
+package auth

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -93,6 +93,7 @@ func MakeRegistry() filters.Registry {
 		tee.NewTeeDeprecated(),
 		tee.NewTeeNoFollow(),
 		auth.NewBasicAuth(),
+		auth.NewWebhook(),
 		cookie.NewRequestCookie(),
 		cookie.NewResponseCookie(),
 		cookie.NewJSCookie(),


### PR DESCRIPTION
This implemetns a simple webhook filter, that clones all headers from the original request and send it to the webhook, which returns with either >= 400 status code or error to be unauthorized otherwise authorized.
 
missing:

- [ ] docs
- [ ] tests