### PR TITLE
fix preserveHost filter documentation

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -120,13 +120,17 @@ Notes:
 ## stripQuery
 ## preserveHost
 
-Sets the incoming `Host: ` header also on the outgoing backend connection
+Sets the incoming `Host: ` header on the outgoing backend connection.
 
-Parameters: none
+It can be used to override the `proxyPreserveHost` behavior for individual routes.
+
+Parameters: "true" or "false"
+* "true" - use the Host header from the incoming request
+* "false" - use the host from the backend address
 
 Example:
 ```
-route1: * -> preserveHost() -> "http://backend.example.org";
+route1: * -> preserveHost("true") -> "http://backend.example.org";
 ```
 
 ## status


### PR DESCRIPTION
also added a note about overriding the `proxyPreserveHost` behavior