### PR TITLE
add RequestContext(ctx context.Context) to filtercontext

### DIFF
--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -228,7 +228,7 @@ func (f *tokeninfoFilter) validateAllKV(h map[string]interface{}) bool {
 func (f *tokeninfoFilter) Request(ctx filters.FilterContext) {
 	span, stdlibctx := opentracing.StartSpanFromContext(ctx.Request().Context(), "tokeninfo_filter", nil)
 	defer span.Finish()
-	ctx.RequestContext(stdlibctx)
+	ctx.SetRequestContext(stdlibctx)
 
 	r := ctx.Request()
 	var authMap map[string]interface{}

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -141,7 +141,7 @@ func getOpenIDConfig(issuerURL string) (*openIDConfig, error) {
 	}
 
 	var cfg openIDConfig
-	err = jsonGet(u, "", &cfg, http.DefaultClient)
+	err = jsonGet(nil, u, "", &cfg, http.DefaultClient)
 	return &cfg, err
 }
 

--- a/filters/builtin/copy_test.go
+++ b/filters/builtin/copy_test.go
@@ -181,7 +181,7 @@ func Test_copySpec_CreateFilter(t *testing.T) {
 	}
 }
 
-func buildfilterSetRequestContext() filters.FilterContext {
+func buildfilterRequestContext() filters.FilterContext {
 	r, _ := http.NewRequest("GET", "http://example.org/api/v3", nil)
 	r.Header.Add("X-Src", "header src content")
 	return &filtertest.Context{FRequest: r}
@@ -216,7 +216,7 @@ func Test_copyFilter_Request(t *testing.T) {
 				dst: "X-Dst",
 			},
 			args: args{
-				ctx: buildfilterSetRequestContext(),
+				ctx: buildfilterRequestContext(),
 			},
 			expect: "header src content",
 		},

--- a/filters/builtin/copy_test.go
+++ b/filters/builtin/copy_test.go
@@ -181,7 +181,7 @@ func Test_copySpec_CreateFilter(t *testing.T) {
 	}
 }
 
-func buildfilterRequestContext() filters.FilterContext {
+func buildfilterSetRequestContext() filters.FilterContext {
 	r, _ := http.NewRequest("GET", "http://example.org/api/v3", nil)
 	r.Header.Add("X-Src", "header src content")
 	return &filtertest.Context{FRequest: r}
@@ -216,7 +216,7 @@ func Test_copyFilter_Request(t *testing.T) {
 				dst: "X-Dst",
 			},
 			args: args{
-				ctx: buildfilterRequestContext(),
+				ctx: buildfilterSetRequestContext(),
 			},
 			expect: "header src content",
 		},

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -21,7 +21,7 @@ type FilterContext interface {
 	Request() *http.Request
 
 	// Updates the context in the Request
-	RequestContext(context.Context)
+	SetRequestContext(context.Context)
 
 	// The response object. It is returned to the client with its
 	// properties changed by the filters.

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -18,6 +19,9 @@ type FilterContext interface {
 	// The incoming request object. It is forwarded to the route endpoint
 	// with its properties changed by the filters.
 	Request() *http.Request
+
+	// Updates the context in the Request
+	RequestContext(context.Context)
 
 	// The response object. It is returned to the client with its
 	// properties changed by the filters.

--- a/filters/filtertest/context_test.go
+++ b/filters/filtertest/context_test.go
@@ -1,0 +1,29 @@
+package filtertest
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/filters"
+)
+
+func TestRequestContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "test", 1)
+	req, _ := http.NewRequest("GET", "http://localhost:9090", nil)
+	req = req.WithContext(ctx)
+	fc := filters.FilterContext(&Context{FRequest: req})
+
+	origVal := fc.Request().Context().Value("test").(int)
+
+	fc.RequestContext(context.WithValue(fc.Request().Context(), "test", 2))
+
+	newVal := fc.Request().Context().Value("test").(int)
+	if newVal == origVal {
+		t.Errorf("orig and new context value are the same...")
+	}
+	if newVal != 2 || origVal != 1 {
+		t.Errorf("invalid value fetched from context")
+	}
+}

--- a/filters/filtertest/context_test.go
+++ b/filters/filtertest/context_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/zalando/skipper/filters"
 )
 
-func TestRequestContext(t *testing.T) {
+func TestSetRequestContext(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "test", 1)
 	req, _ := http.NewRequest("GET", "http://localhost:9090", nil)
@@ -17,7 +17,7 @@ func TestRequestContext(t *testing.T) {
 
 	origVal := fc.Request().Context().Value("test").(int)
 
-	fc.RequestContext(context.WithValue(fc.Request().Context(), "test", 2))
+	fc.SetRequestContext(context.WithValue(fc.Request().Context(), "test", 2))
 
 	newVal := fc.Request().Context().Value("test").(int)
 	if newVal == origVal {

--- a/filters/filtertest/filtertest.go
+++ b/filters/filtertest/filtertest.go
@@ -54,7 +54,7 @@ func (f *Filter) Response(ctx filters.FilterContext) {}
 
 func (fc *Context) ResponseWriter() http.ResponseWriter { return fc.FResponseWriter }
 func (fc *Context) Request() *http.Request              { return fc.FRequest }
-func (fc *Context) RequestContext(ctx context.Context)  { fc.FRequest = fc.FRequest.WithContext(ctx) }
+func (fc *Context) SetRequestContext(ctx context.Context)  { fc.FRequest = fc.FRequest.WithContext(ctx) }
 func (fc *Context) Response() *http.Response            { return fc.FResponse }
 func (fc *Context) MarkServed()                         { fc.FServed = true }
 func (fc *Context) Served() bool                        { return fc.FServed }

--- a/filters/filtertest/filtertest.go
+++ b/filters/filtertest/filtertest.go
@@ -52,20 +52,20 @@ func (spec *Filter) Name() string                    { return spec.FilterName }
 func (f *Filter) Request(ctx filters.FilterContext)  {}
 func (f *Filter) Response(ctx filters.FilterContext) {}
 
-func (fc *Context) ResponseWriter() http.ResponseWriter { return fc.FResponseWriter }
-func (fc *Context) Request() *http.Request              { return fc.FRequest }
-func (fc *Context) SetRequestContext(ctx context.Context)  { fc.FRequest = fc.FRequest.WithContext(ctx) }
-func (fc *Context) Response() *http.Response            { return fc.FResponse }
-func (fc *Context) MarkServed()                         { fc.FServed = true }
-func (fc *Context) Served() bool                        { return fc.FServed }
-func (fc *Context) PathParam(key string) string         { return fc.FParams[key] }
-func (fc *Context) StateBag() map[string]interface{}    { return fc.FStateBag }
-func (fc *Context) OriginalRequest() *http.Request      { return nil }
-func (fc *Context) OriginalResponse() *http.Response    { return nil }
-func (fc *Context) BackendUrl() string                  { return fc.FBackendUrl }
-func (fc *Context) OutgoingHost() string                { return fc.FOutgoingHost }
-func (fc *Context) SetOutgoingHost(h string)            { fc.FOutgoingHost = h }
-func (fc *Context) Metrics() filters.Metrics            { return fc.FMetrics }
+func (fc *Context) ResponseWriter() http.ResponseWriter   { return fc.FResponseWriter }
+func (fc *Context) Request() *http.Request                { return fc.FRequest }
+func (fc *Context) SetRequestContext(ctx context.Context) { fc.FRequest = fc.FRequest.WithContext(ctx) }
+func (fc *Context) Response() *http.Response              { return fc.FResponse }
+func (fc *Context) MarkServed()                           { fc.FServed = true }
+func (fc *Context) Served() bool                          { return fc.FServed }
+func (fc *Context) PathParam(key string) string           { return fc.FParams[key] }
+func (fc *Context) StateBag() map[string]interface{}      { return fc.FStateBag }
+func (fc *Context) OriginalRequest() *http.Request        { return nil }
+func (fc *Context) OriginalResponse() *http.Response      { return nil }
+func (fc *Context) BackendUrl() string                    { return fc.FBackendUrl }
+func (fc *Context) OutgoingHost() string                  { return fc.FOutgoingHost }
+func (fc *Context) SetOutgoingHost(h string)              { fc.FOutgoingHost = h }
+func (fc *Context) Metrics() filters.Metrics              { return fc.FMetrics }
 func (fc *Context) Tracer() opentracing.Tracer {
 	if fc.FTracer != nil {
 		return fc.FTracer

--- a/filters/filtertest/filtertest.go
+++ b/filters/filtertest/filtertest.go
@@ -19,6 +19,7 @@ FilterContext interfaces used during tests.
 package filtertest
 
 import (
+	"context"
 	"net/http"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -53,6 +54,7 @@ func (f *Filter) Response(ctx filters.FilterContext) {}
 
 func (fc *Context) ResponseWriter() http.ResponseWriter { return fc.FResponseWriter }
 func (fc *Context) Request() *http.Request              { return fc.FRequest }
+func (fc *Context) RequestContext(ctx context.Context)  { fc.FRequest = fc.FRequest.WithContext(ctx) }
 func (fc *Context) Response() *http.Response            { return fc.FResponse }
 func (fc *Context) MarkServed()                         { fc.FServed = true }
 func (fc *Context) Served() bool                        { return fc.FServed }

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	corectx "context"
+	stdlibctx "context"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/filters"
@@ -182,21 +182,21 @@ func (c *context) setResponse(r *http.Response, preserveOriginal bool) {
 	}
 }
 
-func (c *context) ResponseWriter() http.ResponseWriter { return c.responseWriter }
-func (c *context) Request() *http.Request              { return c.request }
-func (c *context) RequestContext(ctx corectx.Context)  { c.request = c.request.WithContext(ctx) }
-func (c *context) Response() *http.Response            { return c.response }
-func (c *context) MarkServed()                         { c.deprecatedServed = true }
-func (c *context) Served() bool                        { return c.deprecatedServed || c.servedWithResponse }
-func (c *context) PathParam(key string) string         { return c.pathParams[key] }
-func (c *context) StateBag() map[string]interface{}    { return c.stateBag }
-func (c *context) BackendUrl() string                  { return c.route.Backend }
-func (c *context) OriginalRequest() *http.Request      { return c.originalRequest }
-func (c *context) OriginalResponse() *http.Response    { return c.originalResponse }
-func (c *context) OutgoingHost() string                { return c.outgoingHost }
-func (c *context) SetOutgoingHost(h string)            { c.outgoingHost = h }
-func (c *context) Metrics() filters.Metrics            { return c.metrics }
-func (c *context) Tracer() opentracing.Tracer          { return c.tracer }
+func (c *context) ResponseWriter() http.ResponseWriter  { return c.responseWriter }
+func (c *context) Request() *http.Request               { return c.request }
+func (c *context) RequestContext(ctx stdlibctx.Context) { c.request = c.request.WithContext(ctx) }
+func (c *context) Response() *http.Response             { return c.response }
+func (c *context) MarkServed()                          { c.deprecatedServed = true }
+func (c *context) Served() bool                         { return c.deprecatedServed || c.servedWithResponse }
+func (c *context) PathParam(key string) string          { return c.pathParams[key] }
+func (c *context) StateBag() map[string]interface{}     { return c.stateBag }
+func (c *context) BackendUrl() string                   { return c.route.Backend }
+func (c *context) OriginalRequest() *http.Request       { return c.originalRequest }
+func (c *context) OriginalResponse() *http.Response     { return c.originalResponse }
+func (c *context) OutgoingHost() string                 { return c.outgoingHost }
+func (c *context) SetOutgoingHost(h string)             { c.outgoingHost = h }
+func (c *context) Metrics() filters.Metrics             { return c.metrics }
+func (c *context) Tracer() opentracing.Tracer           { return c.tracer }
 
 func (c *context) Serve(r *http.Response) {
 	r.Request = c.Request()

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -182,21 +182,21 @@ func (c *context) setResponse(r *http.Response, preserveOriginal bool) {
 	}
 }
 
-func (c *context) ResponseWriter() http.ResponseWriter  { return c.responseWriter }
-func (c *context) Request() *http.Request               { return c.request }
+func (c *context) ResponseWriter() http.ResponseWriter     { return c.responseWriter }
+func (c *context) Request() *http.Request                  { return c.request }
 func (c *context) SetRequestContext(ctx stdlibctx.Context) { c.request = c.request.WithContext(ctx) }
-func (c *context) Response() *http.Response             { return c.response }
-func (c *context) MarkServed()                          { c.deprecatedServed = true }
-func (c *context) Served() bool                         { return c.deprecatedServed || c.servedWithResponse }
-func (c *context) PathParam(key string) string          { return c.pathParams[key] }
-func (c *context) StateBag() map[string]interface{}     { return c.stateBag }
-func (c *context) BackendUrl() string                   { return c.route.Backend }
-func (c *context) OriginalRequest() *http.Request       { return c.originalRequest }
-func (c *context) OriginalResponse() *http.Response     { return c.originalResponse }
-func (c *context) OutgoingHost() string                 { return c.outgoingHost }
-func (c *context) SetOutgoingHost(h string)             { c.outgoingHost = h }
-func (c *context) Metrics() filters.Metrics             { return c.metrics }
-func (c *context) Tracer() opentracing.Tracer           { return c.tracer }
+func (c *context) Response() *http.Response                { return c.response }
+func (c *context) MarkServed()                             { c.deprecatedServed = true }
+func (c *context) Served() bool                            { return c.deprecatedServed || c.servedWithResponse }
+func (c *context) PathParam(key string) string             { return c.pathParams[key] }
+func (c *context) StateBag() map[string]interface{}        { return c.stateBag }
+func (c *context) BackendUrl() string                      { return c.route.Backend }
+func (c *context) OriginalRequest() *http.Request          { return c.originalRequest }
+func (c *context) OriginalResponse() *http.Response        { return c.originalResponse }
+func (c *context) OutgoingHost() string                    { return c.outgoingHost }
+func (c *context) SetOutgoingHost(h string)                { c.outgoingHost = h }
+func (c *context) Metrics() filters.Metrics                { return c.metrics }
+func (c *context) Tracer() opentracing.Tracer              { return c.tracer }
 
 func (c *context) Serve(r *http.Response) {
 	r.Request = c.Request()

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"time"
 
+	corectx "context"
+
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/metrics"
@@ -182,6 +184,7 @@ func (c *context) setResponse(r *http.Response, preserveOriginal bool) {
 
 func (c *context) ResponseWriter() http.ResponseWriter { return c.responseWriter }
 func (c *context) Request() *http.Request              { return c.request }
+func (c *context) RequestContext(ctx corectx.Context)  { c.request = c.request.WithContext(ctx) }
 func (c *context) Response() *http.Response            { return c.response }
 func (c *context) MarkServed()                         { c.deprecatedServed = true }
 func (c *context) Served() bool                        { return c.deprecatedServed || c.servedWithResponse }

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -184,7 +184,7 @@ func (c *context) setResponse(r *http.Response, preserveOriginal bool) {
 
 func (c *context) ResponseWriter() http.ResponseWriter  { return c.responseWriter }
 func (c *context) Request() *http.Request               { return c.request }
-func (c *context) RequestContext(ctx stdlibctx.Context) { c.request = c.request.WithContext(ctx) }
+func (c *context) SetRequestContext(ctx stdlibctx.Context) { c.request = c.request.WithContext(ctx) }
 func (c *context) Response() *http.Response             { return c.response }
 func (c *context) MarkServed()                          { c.deprecatedServed = true }
 func (c *context) Served() bool                         { return c.deprecatedServed || c.servedWithResponse }

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -53,7 +53,7 @@ func (l *luaContext) Request() *http.Request {
 	return l.request
 }
 
-func (l *luaContext) RequestContext(ctx context.Context) {
+func (l *luaContext) SetRequestContext(ctx context.Context) {
 	l.request = l.request.WithContext(ctx)
 }
 

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -1,6 +1,7 @@
 package script
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -50,6 +51,10 @@ func (l *luaContext) ResponseWriter() http.ResponseWriter {
 
 func (l *luaContext) Request() *http.Request {
 	return l.request
+}
+
+func (l *luaContext) RequestContext(ctx context.Context) {
+	l.request = l.request.WithContext(ctx)
 }
 
 func (l *luaContext) Response() *http.Response {


### PR DESCRIPTION
this allows filters to set the context of the request. This is needed when e.g. an opentracing span
should be set as new current span and this span is then retrieved at a later point as parent span