### PR TITLE
add queryToHeader filter

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -709,3 +709,29 @@ headerToQuery("X-Foo-Header", "foo-query-param")
 
 The above filter will set `foo-query-param` query param respectively to the `X-Foo-Header` header
 and will override the value if the queryparam exists already
+
+## queryToHeader
+
+Filter which assigns the value of a given query param from the
+incoming Request to a given Header with optional format string value.
+
+Parameters:
+
+* The name of the query param key to pick from request
+* The name of the header to add to request
+* The format string used to create the header value, which gets the
+  value from the query value as before
+
+Examples:
+
+```
+queryToHeader("foo-query-param", "X-Foo-Header")
+queryToHeader("access_token", "Authorization", "Bearer %s")
+```
+
+The first filter will set `X-Foo-Header` header respectively to the `foo-query-param` query param
+and will not override the value if the header exists already.
+
+The second filter will set `Authorization` header to the
+`access_token` query param with a prefix value `Bearer ` and will
+not override the value if the header exists already.

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -50,6 +50,7 @@ const (
 	DropQueryName       = "dropQuery"
 	InlineContentName   = "inlineContent"
 	HeaderToQueryName   = "headerToQuery"
+	QueryToHeaderName   = "queryToHeader"
 )
 
 // Returns a Registry object initialized with the default set of filter
@@ -84,6 +85,7 @@ func MakeRegistry() filters.Registry {
 		NewCopyRequestHeader(),
 		NewCopyResponseHeader(),
 		NewHeaderToQuery(),
+		NewQueryToHeader(),
 		diag.NewRandom(),
 		diag.NewLatency(),
 		diag.NewBandwidth(),

--- a/filters/builtin/querytoheader.go
+++ b/filters/builtin/querytoheader.go
@@ -1,0 +1,86 @@
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/zalando/skipper/filters"
+)
+
+type (
+	queryToHeaderSpec struct {
+	}
+
+	queryToHeaderFilter struct {
+		headerName     string
+		queryParamName string
+		formatString   string
+	}
+)
+
+// NewQueryToHeader creates a filter which converts query params
+// from the incoming Request to headers
+//
+//     queryToHeader("foo-query-param", "X-Foo-Header")
+//
+// The above filter will set the value of "X-Foo-Header" header to the
+// value of "foo-query-param" query param , to the request and will
+// not override the value if the header exists already
+//
+// The header value can be created by a formatstring with an optional third parameter
+//
+//     queryToHeader("foo-query-param", "X-Foo-Header", "prefix %s postfix")
+//     queryToHeader("access_token", "Authorization", "Bearer %s")
+//
+func NewQueryToHeader() filters.Spec {
+	return &queryToHeaderSpec{}
+}
+
+func (*queryToHeaderSpec) Name() string {
+	return QueryToHeaderName
+}
+
+// CreateFilter creates a `queryToHeader` filter instance with below signature
+// s.CreateFilter("foo-query-param", "X-Foo-Header")
+func (*queryToHeaderSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if l := len(args); l < 2 || l > 3 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	q, ok := args[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	h, ok := args[1].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	formatString := "%s"
+	if len(args) == 3 {
+		formatString, ok = args[2].(string)
+		if !ok {
+			return nil, filters.ErrInvalidFilterParameters
+		}
+	}
+
+	return &queryToHeaderFilter{headerName: h, queryParamName: q, formatString: formatString}, nil
+}
+
+func (f *queryToHeaderFilter) Request(ctx filters.FilterContext) {
+	req := ctx.Request()
+
+	headerValue := req.Header.Get(f.headerName)
+	if headerValue != "" {
+		return
+	}
+
+	v := req.URL.Query().Get(f.queryParamName)
+	if v == "" {
+		return
+	}
+
+	req.Header.Set(f.headerName, fmt.Sprintf(f.formatString, v))
+}
+
+func (*queryToHeaderFilter) Response(ctx filters.FilterContext) {}

--- a/filters/builtin/querytoheader_test.go
+++ b/filters/builtin/querytoheader_test.go
@@ -1,0 +1,48 @@
+package builtin
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func TestQueryToHeaderFilter_Request(t *testing.T) {
+	for _, ti := range []struct {
+		msg      string
+		args     []interface{}
+		expected string
+	}{{
+		msg:      "2 valid args",
+		args:     []interface{}{"foo", "X-Foo-Header"},
+		expected: "bar",
+	}, {
+		msg:      "3 valid args",
+		args:     []interface{}{"foo", "X-Foo-Header", "MyPrefix %s"},
+		expected: "MyPrefix bar",
+	}} {
+		t.Run(ti.msg, func(t *testing.T) {
+
+			spec := NewQueryToHeader()
+			f, err := spec.CreateFilter(ti.args)
+			if err != nil {
+				t.Error(err)
+			}
+
+			u := fmt.Sprintf("https://example.org?%s=bar", ti.args[0])
+			req, err := http.NewRequest("Get", u, nil)
+			if err != nil {
+				t.Error(err)
+			}
+
+			ctx := &filtertest.Context{FRequest: req}
+			f.Request(ctx)
+			if headerKey, ok := ti.args[1].(string); !ok {
+				t.Errorf("failed to cast to string %v", ti.args[1])
+			} else if v := req.Header.Get(headerKey); v != ti.expected {
+				t.Errorf("failed to copy query to header, expected='%s', but got value='%s'", ti.expected, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
queryToHeader("q", "X-Q") will copy the value of q param to the value of X-Q header.

The optional 3rd argument can be used to prepend the value, for example to add "Bearer ".