### PR TITLE
Build the lightstep image with ubuntu base image.

### DIFF
--- a/packaging/Dockerfile.lightstep
+++ b/packaging/Dockerfile.lightstep
@@ -1,5 +1,7 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
+FROM registry.opensource.zalan.do/stups/ubuntu:latest
+MAINTAINER Skipper Maintainers <team-pathfinder@zalando.de>
+ADD skipper eskip /usr/bin/
+EXPOSE 9090 9911
 RUN mkdir -p /plugins
 ADD build/tracing_lightstep.so /plugins/
 ENTRYPOINT ["/usr/bin/skipper", "-plugindir", "/plugins"]

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -15,7 +15,7 @@ eskip:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build github.com/zalando/skipper/cmd/eskip
 
 clean:
-	rm -rf skipper eskip build/ *.so
+	rm -rf skipper eskip build/
 
 docker-build: clean skipper eskip
 	docker build -t $(IMAGE) .
@@ -27,11 +27,12 @@ plugins:
 	CUR=$(shell pwd) ; GOPATH=$(shell pwd)/build ;\
 		go get -d github.com/skipper-plugins/opentracing ;\
 		cd build/src/github.com/skipper-plugins/opentracing ;\
+		glide install -v;\
 		GOOS=linux GOARCH=amd64 CGO_ENABLED=1 make ;\
 		cp build/*.so $$CUR/build/
 
-docker-lightstep-build: clean docker-build plugins
-	docker build -t $(LIGHTSTEP_IMAGE) --build-arg BASE_IMAGE=$(IMAGE) -f Dockerfile.lightstep .
+docker-lightstep-build: skipper eskip plugins
+	docker build -t $(LIGHTSTEP_IMAGE) -f Dockerfile.lightstep .
 
 docker-lightstep-push:
 	docker push $(LIGHTSTEP_IMAGE)


### PR DESCRIPTION
The lightstep image needs libc to load plugins which is missing from the standard skipper Docker image. This PR changes the dockerfile to use a ubuntu base image.