### PR TITLE
Build lightstep image based on alpine

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -26,13 +26,8 @@ pipeline:
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
         RELEASE_VERSION="$(git describe --tags --always --dirty)"
         LIGHTSTEP_IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper-lightstep:${RELEASE_VERSION}"
-        IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper:${RELEASE_VERSION}"
       else
         LIGHTSTEP_IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper-lightstep-test:${CDP_BUILD_VERSION}"
-        IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper-test:${CDP_BUILD_VERSION}"
       fi
-      export CGO_ENABLED=1
-      export IMAGE
       export LIGHTSTEP_IMAGE
-      make deps
       cd packaging && make docker-lightstep-build docker-lightstep-push

--- a/packaging/Dockerfile.alpine
+++ b/packaging/Dockerfile.alpine
@@ -1,0 +1,9 @@
+FROM golang:alpine
+
+ENV CGO_ENABLED 1
+ENV GOOS linux
+ENV GOARCH amd64
+
+# add build deps
+RUN apk add -U git build-base && \
+    go get github.com/Masterminds/glide

--- a/packaging/Dockerfile.lightstep
+++ b/packaging/Dockerfile.lightstep
@@ -1,7 +1,11 @@
-FROM registry.opensource.zalan.do/stups/ubuntu:latest
+FROM registry.opensource.zalan.do/stups/alpine:latest
 MAINTAINER Skipper Maintainers <team-pathfinder@zalando.de>
+RUN apk --no-cache add ca-certificates && update-ca-certificates
+RUN mkdir -p /usr/bin
 ADD skipper eskip /usr/bin/
-EXPOSE 9090 9911
 RUN mkdir -p /plugins
 ADD build/tracing_lightstep.so /plugins/
+
+EXPOSE 9090 9911
+
 ENTRYPOINT ["/usr/bin/skipper", "-plugindir", "/plugins"]

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,18 +1,20 @@
 .PHONY: docker-push
 
-VERSION         ?= $(shell git rev-parse HEAD)
-REGISTRY        ?= registry-write.opensource.zalan.do/pathfinder
-IMAGE           ?= $(REGISTRY)/skipper:$(VERSION)
-LIGHTSTEP_IMAGE ?= $(REGISTRY)/skipper-lightstep:$(VERSION)
-CGO_ENABLED     ?= 0
+VERSION            ?= $(shell git rev-parse HEAD)
+REGISTRY           ?= registry-write.opensource.zalan.do/pathfinder
+IMAGE              ?= $(REGISTRY)/skipper:$(VERSION)
+LIGHTSTEP_IMAGE    ?= $(REGISTRY)/skipper-lightstep:$(VERSION)
+ALPINE_BUILD_IMAGE ?= $(REGISTRY)/skipper-alpine-build:latest
+PACKAGE            ?= github.com/zalando/skipper
+CGO_ENABLED        ?= 0
 
 default: docker-build
 
 skipper:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build github.com/zalando/skipper/cmd/skipper
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build $(PACKAGE)/cmd/skipper
 
 eskip:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build github.com/zalando/skipper/cmd/eskip
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build $(PACKAGE)/cmd/eskip
 
 clean:
 	rm -rf skipper eskip build/
@@ -31,7 +33,20 @@ plugins:
 		GOOS=linux GOARCH=amd64 CGO_ENABLED=1 make ;\
 		cp build/*.so $$CUR/build/
 
-docker-lightstep-build: skipper eskip plugins
+alpine.build: docker-alpine-build
+	docker run --rm -v $(shell pwd)/..:/go/src/$(PACKAGE) \
+		-w /go/src/$(PACKAGE)/packaging $(ALPINE_BUILD_IMAGE) \
+		make skipper eskip
+
+alpine.plugins: docker-alpine-build
+	docker run --rm -v $(shell pwd)/..:/go/src/$(PACKAGE) \
+		-w /go/src/$(PACKAGE)/packaging $(ALPINE_BUILD_IMAGE) \
+		make plugins
+
+docker-alpine-build:
+	docker build --rm -t $(ALPINE_BUILD_IMAGE) -f Dockerfile.alpine .
+
+docker-lightstep-build: alpine.build alpine.plugins
 	docker build -t $(LIGHTSTEP_IMAGE) -f Dockerfile.lightstep .
 
 docker-lightstep-push:


### PR DESCRIPTION
Build lightstep image based on alpine. This is done to reduce the image size. It's a reduction from `179MB` -> `45.6MB` compared to the ubuntu based image.

```
REPOSITORY                                                           TAG                                        IMAGE ID            CREATED             SIZE
registry.opensource.zalan.do/pathfinder/skipper-lightstep-test       pr-762-9                                   de824efae48c        4 minutes ago       45.6MB
registry.opensource.zalan.do/pathfinder/skipper-lightstep            v0.10.68                                   61a3b1c0a562        24 hours ago        179MB
```

It's implemented by adding new make targets `alpine.build` and `alpine.plugins` that builds skipper and plugins in a `golang:alpine` based image such that both skipper and the tracing plugin is linked against `musl` instead of `libc`.

Ref: https://github.com/zalando/skipper/pull/761