### PR TITLE
Speedup CI buildtime

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -15,12 +15,8 @@ pipeline:
       export IMAGE
       make deps shortcheck
       cd packaging && make docker-build docker-push
-- id: build-lightstep
-  overlay: ci/golang
-  type: script
-  working_dir: /go/src/github.com/zalando/skipper
-  commands:
-  - desc: build-push
+
+  - desc: build-push-lightstep
     cmd: |
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
         RELEASE_VERSION="$(git describe --tags --always --dirty)"
@@ -30,12 +26,8 @@ pipeline:
       fi
       export LIGHTSTEP_IMAGE
       cd packaging && make docker-lightstep-build docker-lightstep-push
-- id: build-opentracing
-  overlay: ci/golang
-  type: script
-  working_dir: /go/src/github.com/zalando/skipper
-  commands:
-  - desc: build-push
+
+  - desc: build-push-opentracing
     cmd: |
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
         RELEASE_VERSION="$(git describe --tags --always --dirty)"

--- a/etcd/install.sh
+++ b/etcd/install.sh
@@ -1,21 +1,20 @@
 #! /bin/bash
-
-set -e 
+set -eo pipefail
 
 ETCD_VERSION=master
 if [  $# -gt 0 ]; then
     ETCD_VERSION="$1"
 fi
 
-mkdir -p $GOPATH/src/github.com/coreos
-cd $GOPATH/src/github.com/coreos
-git clone https://github.com/coreos/etcd.git || echo etcd repository exists
-cd etcd
-git checkout master
-git pull
-git checkout $ETCD_VERSION
-rm -rf gopath
-echo building etcd $ETCD_VERSION
-./build
-mkdir -p $GOPATH/bin
-mv bin/etcd $GOPATH/bin
+if [ -z "${GOBIN}" ]; then
+    LOCAL_GOBIN="$GOPATH/bin"
+else
+    LOCAL_GOBIN="$GOBIN"
+fi
+
+mkdir -p "$LOCAL_GOBIN"
+wget \
+    "https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" \
+    -O /tmp/etcd.tar.gz
+tar -xzf /tmp/etcd.tar.gz --strip-components=1 \
+    -C "$LOCAL_GOBIN" "etcd-${ETCD_VERSION}-linux-amd64/etcd"


### PR DESCRIPTION
Speed up CI build time in two ways.

1. Download etcd binary instead of pulling all sources and building from source.
2. Reduce `delivery.yaml` configuration to a single build step with multiple commands. Each build step is run on a separate VM so this reduces the build time a lot because we build all images on a single VM and avoid pulling the same dependencies three times on three different build VMs.