### PR TITLE
Correctly build skipper binary for lightstep image

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -29,7 +29,7 @@ pipeline:
         LIGHTSTEP_IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper-lightstep-test:${CDP_BUILD_VERSION}"
       fi
       export LIGHTSTEP_IMAGE
-      cd packaging && make docker-lightstep-build docker-lightstep-push
+      cd packaging && make clean && make docker-lightstep-build docker-lightstep-push
 
   - desc: build-push-opentracing
     cmd: |
@@ -42,4 +42,4 @@ pipeline:
         OPENTRACING_IMAGE="registry-write.opensource.zalan.do/pathfinder/skipper-opentracing-test:${CDP_BUILD_VERSION}"
       fi
       export OPENTRACING_IMAGE
-      cd packaging && make docker-opentracing-build docker-opentracing-push
+      cd packaging && make clean && make docker-opentracing-build docker-opentracing-push


### PR DESCRIPTION
#770 tried to speed up the CDP build but introduced a bug where it would build the lightstep image with the statically linked skipper binary from the previous build step.

The fix is to run `make clean` before building the lightstep image so we build a new `skipper` binary linked against musl similar to the plugin.


Works!

```
$ docker run registry.opensource.zalan.do/pathfinder/skipper-lightstep-test:pr-777-1 
Unable to find image 'registry.opensource.zalan.do/pathfinder/skipper-lightstep-test:pr-777-1' locally
pr-777-1: Pulling from pathfinder/skipper-lightstep-test
8e3ba11ec2a2: Already exists 
fed9443358de: Pull complete 
61cc3ffcb3b8: Pull complete 
c8dedfa011d4: Pull complete 
9457ac0abbeb: Pull complete 
ca1a567d4505: Pull complete 
Digest: sha256:5d82fdcec362f664f24a89c2d8a7378c9150d31de118a44eca8ba8362f562f10
Status: Downloaded newer image for registry.opensource.zalan.do/pathfinder/skipper-lightstep-test:pr-777-1
[APP]time="2018-09-07T11:13:53Z" level=info msg="found plugin tracing_lightstep at plugins/tracing_lightstep.so"
[APP]time="2018-09-07T11:13:53Z" level=info msg="found plugin tracing_lightstep at /plugins/tracing_lightstep.so"
[APP]time="2018-09-07T11:13:53Z" level=info msg="attempting to load plugin from /plugins/tracing_lightstep.so"
[APP]time="2018-09-07T11:13:53Z" level=warning msg="no route source specified"
[APP]time="2018-09-07T11:13:53Z" level=info msg="Expose metrics in codahale format"
[APP]time="2018-09-07T11:13:53Z" level=info msg="support listener on :9911"
[APP]time="2018-09-07T11:13:53Z" level=info msg="proxy listener on :9090"
[APP]time="2018-09-07T11:13:53Z" level=info msg="certPathTLS or keyPathTLS not found, defaulting to HTTP"
```