### PR TITLE
Switch back to upstream of github.com/opentracing/opentracing-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/ginkgo v1.6.0 // indirect
 	github.com/onsi/gomega v1.4.1 // indirect
 	github.com/opentracing/basictracer-go v1.0.0
-	github.com/opentracing/opentracing-go v1.0.2
+	github.com/opentracing/opentracing-go v1.0.3-0.20180908211932-6aa6febac7b9
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.0-pre1.0.20180824101016-4eb539fa85a2
@@ -54,5 +54,3 @@ require (
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 	layeh.com/gopher-json v0.0.0-20180103211521-1aab82196e3b
 )
-
-replace github.com/opentracing/opentracing-go => github.com/szuecs/opentracing-go v1.0.3-0.20180907073729-e14b9d480998

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/opentracing/basictracer-go v1.0.0 h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7l
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.0.3-0.20180908211932-6aa6febac7b9 h1:dDQXWijI6UukC+e3mrPFS7fYIdKPZ0Zrt6uQgF6yBzE=
+github.com/opentracing/opentracing-go v1.0.3-0.20180908211932-6aa6febac7b9/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
https://github.com/opentracing/opentracing-go/pull/191 was merged, so we no longer need the fork introduced in https://github.com/zalando/skipper/pull/774