### PR TITLE
Deprecate accessLogDisabled in favor of disableAccessLog and enableAccessLog filters

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -754,7 +754,9 @@ The second filter will set `Authorization` header to the
 `access_token` query param with a prefix value `Bearer ` and will
 not override the value if the header exists already.
 
-## accessLogDisabled
+## ~~accessLogDisabled~~
+
+**Deprecated:** use [disableAccessLog](#disableaccesslog) or [enableAccessLog](#enableaccesslog)
 
 The `accessLogDisabled` filter overrides global Skipper `AccessLogDisabled` setting for a specific route, which allows to either turn-off
 the access log for specific route while access log, in general, is enabled or vice versa.
@@ -763,4 +765,26 @@ Example:
 
 ```
 accessLogDisabled("false")
+```
+
+## disableAccessLog
+
+Filter overrides global Skipper `AccessLogDisabled` setting and allows to turn-off the access log for specific route
+while access log, in general, is enabled.
+
+Example:
+
+```
+disableAccessLog()
+```
+
+## enableAccessLog
+
+Filter overrides global Skipper `AccessLogDisabled` setting and allows to turn-on the access log for specific route
+while access log, in general, is disabled.
+
+Example:
+
+```
+enableAccessLog()
 ```

--- a/filters/accesslog/control.go
+++ b/filters/accesslog/control.go
@@ -1,0 +1,58 @@
+package accesslog
+
+import "github.com/zalando/skipper/filters"
+
+const (
+	// DisableAccessLogName is the filter name seen by the user
+	DisableAccessLogName = "disableAccessLog"
+
+	// EnableAccessLogName is the filter name seen by the user
+	EnableAccessLogName = "enableAccessLog"
+
+	// AccessLogEnabledKey is the key used in the state bag to pass the access log state to the proxy.
+	AccessLogEnabledKey = "statebag:access_log:proxy:enabled"
+)
+
+type disableAccessLog struct{}
+
+// NewDisableAccessLog creates a filter spec to disable access log for specific route
+//
+// 	disableAccessLog()
+func NewDisableAccessLog() filters.Spec {
+	return &disableAccessLog{}
+}
+
+func (*disableAccessLog) Name() string { return DisableAccessLogName }
+
+func (al *disableAccessLog) CreateFilter(args []interface{}) (filters.Filter, error) {
+	return al, nil
+}
+
+func (al *disableAccessLog) Request(ctx filters.FilterContext) {
+	bag := ctx.StateBag()
+	bag[AccessLogEnabledKey] = false
+}
+
+func (*disableAccessLog) Response(filters.FilterContext) {}
+
+type enableAccessLog struct{}
+
+// NewEnableAccessLog creates a filter spec to enable access log for specific route
+//
+// 	enableAccessLog()
+func NewEnableAccessLog() filters.Spec {
+	return &enableAccessLog{}
+}
+
+func (*enableAccessLog) Name() string { return EnableAccessLogName }
+
+func (al *enableAccessLog) CreateFilter(args []interface{}) (filters.Filter, error) {
+	return al, nil
+}
+
+func (al *enableAccessLog) Request(ctx filters.FilterContext) {
+	bag := ctx.StateBag()
+	bag[AccessLogEnabledKey] = true
+}
+
+func (*enableAccessLog) Response(filters.FilterContext) {}

--- a/filters/accesslog/control_test.go
+++ b/filters/accesslog/control_test.go
@@ -1,0 +1,44 @@
+package accesslog
+
+import (
+	"testing"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func TestAccessLogControl(t *testing.T) {
+	for _, ti := range []struct {
+		msg    string
+		state  filters.Spec
+		result bool
+	}{
+		{
+			msg:    "false-value-enables-access-log",
+			state:  NewEnableAccessLog(),
+			result: true,
+		},
+		{
+			msg:    "true-value-disables-access-log",
+			state:  NewDisableAccessLog(),
+			result: false,
+		},
+	} {
+		t.Run(ti.msg, func(t *testing.T) {
+			f, err := ti.state.CreateFilter([]interface{}{})
+
+			if err != nil {
+				return
+			}
+
+			var ctx filtertest.Context
+			ctx.FStateBag = make(map[string]interface{})
+
+			f.Request(&ctx)
+			bag := ctx.StateBag()
+			if bag[AccessLogEnabledKey] != ti.result {
+				t.Errorf("access log state is not equal to expected '%v': %v", ti.result, bag[AccessLogEnabledKey])
+			}
+		})
+	}
+}

--- a/filters/accesslog/disable.go
+++ b/filters/accesslog/disable.go
@@ -7,9 +7,6 @@ import (
 const (
 	// AccessLogDisabledName is the filter name seen by the user
 	AccessLogDisabledName = "accessLogDisabled"
-
-	// AccessLogDisabledKey is the key used in the state bag to pass the access log state to the proxy.
-	AccessLogDisabledKey = "statebag:access_log:proxy:disabled"
 )
 
 type accessLogDisabled struct {
@@ -19,6 +16,7 @@ type accessLogDisabled struct {
 // NewAccessLogDisabled creates a filter spec for overriding the state of the AccessLogDisabled setting. (By default global setting is used.)
 //
 // 	accessLogDisabled("false")
+// Deprecated: use disableAccessLog or enableAccessLog
 func NewAccessLogDisabled() filters.Spec {
 	return &accessLogDisabled{}
 }
@@ -39,7 +37,7 @@ func (*accessLogDisabled) CreateFilter(args []interface{}) (filters.Filter, erro
 
 func (al *accessLogDisabled) Request(ctx filters.FilterContext) {
 	bag := ctx.StateBag()
-	bag[AccessLogDisabledKey] = al.disabled
+	bag[AccessLogEnabledKey] = !al.disabled
 }
 
 func (*accessLogDisabled) Response(filters.FilterContext) {}

--- a/filters/accesslog/disable_test.go
+++ b/filters/accesslog/disable_test.go
@@ -17,13 +17,13 @@ func TestAccessLogDisabled(t *testing.T) {
 		{
 			msg:    "false-value-enables-access-log",
 			state:  []interface{}{"false"},
-			result: false,
+			result: true,
 			err:    nil,
 		},
 		{
 			msg:    "true-value-disables-access-log",
 			state:  []interface{}{"true"},
-			result: true,
+			result: false,
 			err:    nil,
 		},
 		{
@@ -62,8 +62,8 @@ func TestAccessLogDisabled(t *testing.T) {
 
 			f.Request(&ctx)
 			bag := ctx.StateBag()
-			if bag[AccessLogDisabledKey] != ti.result {
-				t.Errorf("access log state is not equal to expected '%v': %v", ti.result, bag[AccessLogDisabledKey])
+			if bag[AccessLogEnabledKey] != ti.result {
+				t.Errorf("access log state is not equal to expected '%v': %v", ti.result, bag[AccessLogEnabledKey])
 			}
 		})
 	}

--- a/filters/accesslog/doc.go
+++ b/filters/accesslog/doc.go
@@ -1,15 +1,18 @@
 /*
-Package accesslog provides a request filter that gives ability to override AccessLogDisabled setting.
+Package accesslog provides request filters that give the ability to override AccessLogDisabled setting.
 
 How It Works
 
-The filter accepts one argument of "true" or "false" value. If the argument value is "true" access log entries for this
-route won't be produced even if global AccessLogDisabled is false. Otherwise, if argument value is "false" access log
-entries for this route will be produced even if global AccessLogDisabled is true.
+There are two filters that change the state of access log "disableAccessLog" and "enableAccessLog". If "disableAccessLog" is
+present access log entries for this route won't be produced even if global AccessLogDisabled is false. Otherwise, if
+"enableAccessLog" filter is present access log entries for this route will be produced even if global AccessLogDisabled
+is true.
 
 Usage
 
-	accessLogDisabled("true")
-	accessLogDisabled("false")
+    enableAccessLog()
+    disableAccessLog()
+
+Note: accessLogDisabled("true") filter is deprecated in favor of "disableAccessLog" and "enableAccessLog"
 */
 package accesslog

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -113,6 +113,8 @@ func MakeRegistry() filters.Registry {
 		logfilter.NewUnverifiedAuditLog(),
 		tracing.NewSpanName(),
 		accesslog.NewAccessLogDisabled(),
+		accesslog.NewDisableAccessLog(),
+		accesslog.NewEnableAccessLog(),
 	} {
 		r.Register(s)
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1073,13 +1073,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx.startServe,
 	)
 
-	accessLogDisabled, ok := ctx.stateBag[accesslog.AccessLogDisabledKey].(bool)
+	accessLogEnabled, ok := ctx.stateBag[accesslog.AccessLogEnabledKey].(bool)
 
 	if !ok {
-		accessLogDisabled = p.accessLogDisabled
+		accessLogEnabled = !p.accessLogDisabled
 	}
 
-	if !accessLogDisabled {
+	if accessLogEnabled {
 		entry := &logging.AccessEntry{
 			Request:      r,
 			ResponseSize: lw.GetBytes(),

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1369,7 +1369,7 @@ func TestDisableAccessLogWithFilter(t *testing.T) {
 		Header: http.Header{"Connection": []string{"token"}}}
 	w := httptest.NewRecorder()
 
-	doc := fmt.Sprintf(`hello: Path("/hello") -> accessLogDisabled("true") -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
+	doc := fmt.Sprintf(`hello: Path("/hello") -> disableAccessLog() -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
 
 	tp, err := newTestProxyWithParams(doc, Params{
 		AccessLogDisabled: false,
@@ -1402,7 +1402,7 @@ func TestEnableAccessLogWithFilter(t *testing.T) {
 		Header: http.Header{"Connection": []string{"token"}}}
 	w := httptest.NewRecorder()
 
-	doc := fmt.Sprintf(`hello: Path("/hello") -> accessLogDisabled("false") -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
+	doc := fmt.Sprintf(`hello: Path("/hello") -> enableAccessLog() -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
 
 	tp, err := newTestProxyWithParams(doc, Params{
 		AccessLogDisabled: true,


### PR DESCRIPTION
As was discussed in https://github.com/zalando/skipper/pull/752#issuecomment-421052414

* Creating `disableAccessLog` and `enableAccessLog` filters.
* Deprecating `accessLogDisabled`.