### PR TITLE
fix dropRequestHeaders in kubernetes should be applied before user filters

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -841,7 +841,7 @@ func applyAnnotationPredicates(m PathMode, r *eskip.Route, annotation string) er
 // because Ingress status field is v1.LoadBalancerIngress that only
 // supports IP and Hostname as string.
 func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
-	// TODO: apply the laod balancing by using the loadbalancer.BalanceRoute() function
+	// TODO: apply the load balancing by using the loadbalancer.BalanceRoute() function
 
 	routes := make([]*eskip.Route, 0, len(items))
 	hostRoutes := make(map[string][]*eskip.Route)
@@ -985,13 +985,13 @@ func (c *Client) ingressToRoutes(items []*ingressItem) ([]*eskip.Route, error) {
 							}
 						}
 
+						// only apply filters to member routes
 						if !isLBDecisionRoute && annotationFilter != "" {
 							annotationFilters, err := eskip.ParseFilters(annotationFilter)
 							if err != nil {
 								logger.Errorf("Can not parse annotation filters: %v", err)
 							} else {
-								sav := r.Filters[:]
-								r.Filters = append(annotationFilters, sav...)
+								r.Filters = append(r.Filters, annotationFilters...)
 							}
 						}
 

--- a/dataclients/kubernetes/lbannotationfilters_test.go
+++ b/dataclients/kubernetes/lbannotationfilters_test.go
@@ -94,8 +94,8 @@ func TestAnnotationFiltersInLBRoutes(t *testing.T) {
 		  Host(/^test[.]example[.]org$/)
 		  && PathRegexp(/^\/test1/)
 		  && LBMember("kube_namespace1__ingress1__test_example_org___test1__service1", 0)
-		  -> setPath("/foo")
 		  -> dropRequestHeader("X-Load-Balancer-Member")
+		  -> setPath("/foo")
 		  -> "http://42.0.1.0:8080";
 
 		// path rule, target 2:
@@ -103,8 +103,8 @@ func TestAnnotationFiltersInLBRoutes(t *testing.T) {
 		  Host(/^test[.]example[.]org$/)
 		  && PathRegexp(/^\/test1/)
 		  && LBMember("kube_namespace1__ingress1__test_example_org___test1__service1", 1)
-		  -> setPath("/foo")
 		  -> dropRequestHeader("X-Load-Balancer-Member")
+		  -> setPath("/foo")
 		  -> "http://42.1.0.1:8080";
 
 		// path rule group:


### PR DESCRIPTION
fix #808 and add dropRequestHeaders filter before the filters from the annotations applied by users

Signed-off-by: Sandor Szuecs <sandor.szuecs@zalando.de>