### PR TITLE
Activate compatibility defaults on Prometheus metrics

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -51,6 +51,8 @@ type Prometheus struct {
 
 // NewPrometheus returns a new Prometheus metric backend.
 func NewPrometheus(opts Options) *Prometheus {
+	opts = applyCompatibilityDefaults(opts)
+
 	namespace := promNamespace
 	if opts.Prefix != "" {
 		namespace = strings.TrimSuffix(opts.Prefix, ".")


### PR DESCRIPTION
I've found that the Prometheus metrics does not have the default compatibility options activated by default.

If you see the comment for `DisableCompatibilityDefaults`, you can see the following:
https://github.com/zalando/skipper/blob/7d1e7ba519fc513bae8a7ecb8a5faec398c24ef1/metrics/metrics.go#L141-L146

So, with this PR, the compatibility defaults are also applied on Prometheus metrics.