### PR TITLE
apiUsageMonitoring: Accept '/' in path pattern variable parts

### DIFF
--- a/filters/apiusagemonitoring/filter_test.go
+++ b/filters/apiusagemonitoring/filter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zalando/skipper/filters/filtertest"
 	"github.com/zalando/skipper/metrics/metricstest"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -84,15 +85,16 @@ func Test_Filter_NoPathTemplate(t *testing.T) {
 		"https://www.example.org/a/b/c",
 		299,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>."
 			// no path matching: tracked as unknown
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.http2xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http2xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -107,15 +109,16 @@ func Test_Filter_NoConfiguration(t *testing.T) {
 		"https://www.example.org/a/b/c",
 		200,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>."
 			// no path matching: tracked as unknown
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.http2xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http2xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -127,14 +130,15 @@ func Test_Filter_PathTemplateNoVariablePart(t *testing.T) {
 		"https://www.example.org/foo/orders",
 		400,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders."
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http4xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http4xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -146,14 +150,15 @@ func Test_Filter_PathTemplateWithVariablePart(t *testing.T) {
 		"https://www.example.org/foo/orders/1234",
 		204,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id."
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id.http2xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http2xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -165,14 +170,20 @@ func Test_Filter_PathTemplateWithMultipleVariablePart(t *testing.T) {
 		"https://www.example.org/foo/orders/1234/order-items/123",
 		301,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id/order-items/:order-item-id."
+			if !assert.NotContains(
+				t, m.Counters,
+				"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id.http_count",
+				"Matched `foo/orders/:order-id` instead of `foo/orders/:order-id`/order-items/:order-item-id") {
+			}
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id/order-items/:order-item-id.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id/order-items/:order-item-id.http3xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http3xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id/order-items/:order-item-id.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -184,14 +195,15 @@ func Test_Filter_PathTemplateFromSecondConfiguredApi(t *testing.T) {
 		"https://www.example.org/foo/customers/loremipsum",
 		502,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/customers/:customer-id."
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/customers/:customer-id.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/customers/:customer-id.http5xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http5xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.my_app.my_api.POST.foo/customers/:customer-id.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -203,14 +215,15 @@ func Test_Filter_StatusCodes1xxAreMonitored(t *testing.T) {
 		"https://www.example.org/foo/orders",
 		100,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders."
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http1xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http1xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -222,14 +235,15 @@ func Test_Filter_StatusCodeOver599IsMonitored(t *testing.T) {
 		"https://www.example.org/foo/orders",
 		600,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders."
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http_count": int64(pass),
-					//"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http*xx_count" <--- no code group tracked
+					pre + "http_count": int64(pass),
+					//pre + "http*xx_count" <--- no code group tracked
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -241,14 +255,15 @@ func Test_Filter_StatusCodeUnder100IsMonitoredWithoutHttpStatusCount(t *testing.
 		"https://www.example.org/foo/orders",
 		99,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders."
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http_count": int64(pass),
-					//"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.http*xx_count" <--- no code group tracked
+					pre + "http_count": int64(pass),
+					//pre + "http*xx_count" <--- no code group tracked
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -260,14 +275,15 @@ func Test_Filter_NonConfiguredPathTrackedUnderUnknown(t *testing.T) {
 		"https://www.example.org/lapin/malin",
 		200,
 		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>."
 			assert.Equal(t,
 				map[string]int64{
-					"apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.http_count":    int64(pass),
-					"apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.http2xx_count": int64(pass),
+					pre + "http_count":    int64(pass),
+					pre + "http2xx_count": int64(pass),
 				},
 				m.Counters,
 			)
-			assert.Contains(t, m.Measures, "apiUsageMonitoring.custom.<unknown>.<unknown>.GET.<unknown>.latency")
+			assert.Contains(t, m.Measures, pre+"latency")
 		})
 }
 
@@ -297,27 +313,84 @@ func Test_Filter_AllHttpMethodsAreSupported(t *testing.T) {
 				"https://www.example.org/lapin/malin",
 				200,
 				func(t *testing.T, pass int, m *metricstest.MockMetrics) {
-
-					httpCountMetricKey := fmt.Sprintf(
-						"apiUsageMonitoring.custom.<unknown>.<unknown>.%s.<unknown>.http_count",
+					pre := fmt.Sprintf(
+						"apiUsageMonitoring.custom.<unknown>.<unknown>.%s.<unknown>.",
 						testCase.expectedMethodInMetric)
-					httpStatusClassCountMetricKey := fmt.Sprintf(
-						"apiUsageMonitoring.custom.<unknown>.<unknown>.%s.<unknown>.http2xx_count",
-						testCase.expectedMethodInMetric)
-
 					assert.Equal(t,
 						map[string]int64{
-							httpCountMetricKey:            int64(pass),
-							httpStatusClassCountMetricKey: int64(pass),
+							pre + "http_count":    int64(pass),
+							pre + "http2xx_count": int64(pass),
 						},
 						m.Counters,
 					)
+					assert.Contains(t, m.Measures, pre+"latency")
+				})
+		})
+	}
+}
 
-					latencyMetricKey := fmt.Sprintf(
-						"apiUsageMonitoring.custom.<unknown>.<unknown>.%s.<unknown>.latency",
-						testCase.expectedMethodInMetric)
+func Test_Filter_PathTemplateMatchesInternalSlashes(t *testing.T) {
+	testWithFilter(
+		t,
+		createFilterForTest,
+		http.MethodPost,
+		"https://www.example.org/foo/orders/1/2/3/order-items/123",
+		204,
+		func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/:order-id/order-items/:order-item-id."
+			assert.Equal(t,
+				map[string]int64{
+					pre + "http_count":    int64(pass),
+					pre + "http2xx_count": int64(pass),
+				},
+				m.Counters,
+			)
+			assert.Contains(t, m.Measures, pre+"latency")
+		})
+}
 
-					assert.Contains(t, m.Measures, latencyMetricKey)
+func Test_Filter_PathTemplateMatchesInternalSlashesTooFollowingVarPart(t *testing.T) {
+	filterCreate := func() (filters.Filter, error) {
+		args = []interface{}{`{
+				"application_id": "my_app",
+				"api_id": "my_api",
+			  	"path_templates": [
+                  "foo/:a",
+                  "foo/:a/:b",
+                  "foo/:a/:b/:c"
+				]
+			}`}
+		spec := NewApiUsageMonitoring(true)
+		return spec.CreateFilter(args)
+	}
+	for _, c := range []struct {
+		requestPath                 string
+		expectedMatchedPathTemplate string
+	}{
+		{"foo/1", "foo/:a"},
+		{"foo/1/2", "foo/:a/:b"},
+		{"foo/1/2/3", "foo/:a/:b/:c"},
+		{"foo/1/2/3/4", "foo/:a/:b/:c"},
+		{"foo/1/2/3/4/5", "foo/:a/:b/:c"},
+	} {
+		subTestName := strings.Replace(c.requestPath, "/", "_", -1)
+		t.Run(subTestName, func(t *testing.T) {
+			testWithFilter(
+				t,
+				filterCreate,
+				http.MethodGet,
+				fmt.Sprintf("https://www.example.org/%s", c.requestPath),
+				204,
+				func(t *testing.T, pass int, m *metricstest.MockMetrics) {
+					pre := "apiUsageMonitoring.custom.my_app.my_api.GET." + c.expectedMatchedPathTemplate + "."
+					assert.Equal(t,
+						map[string]int64{
+							pre + "http_count":    int64(pass),
+							pre + "http2xx_count": int64(pass),
+						},
+						m.Counters,
+					)
+					assert.Contains(t, m.Measures, pre+"latency")
 				})
 		})
 	}

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/filters"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -13,8 +14,8 @@ const (
 
 	unknownElementPlaceholder = "<unknown>"
 
-	regexUrlPathPart     = `[^\/]+`
-	regexOptionalSlashes = `[\/]*`
+	regexUrlPathPart     = `.+`
+	regexOptionalSlashes = `\/*`
 )
 
 var (
@@ -154,8 +155,17 @@ func buildPathInfoListFromConfiguration(apis []*apiConfig) []*pathInfo {
 		}
 	}
 
+	// Sort the paths by their matcher's RegEx
+	sort.Sort(pathInfoByRegExRev(paths))
+
 	return paths
 }
+
+type pathInfoByRegExRev []*pathInfo
+
+func (s pathInfoByRegExRev) Len() int           { return len(s) }
+func (s pathInfoByRegExRev) Less(i, j int) bool { return s[i].Matcher.String() > s[j].Matcher.String() }
+func (s pathInfoByRegExRev) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // generateRegExpStringForPathTemplate normalizes the given path template and
 // creates a regular expression from it.


### PR DESCRIPTION
## New Feature

Accept '/' in path pattern variable parts

## Side Effects

* better reg ex generation
* match from more complex reg ex to simpler
* clearer testing