### PR TITLE
replace the usage of X-Forwarded-Port for HTTPS redirects in Kubernetes

### DIFF
--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -152,7 +152,6 @@ func (rt *redirectTest) testRedirectHTTP(expectedID, expectedBackend string) {
 		Header: http.Header{
 			"Host":              []string{rt.rule.Host},
 			"X-Forwarded-Proto": []string{"http"},
-			"X-Forwarded-Port":  []string{"80"},
 		},
 	}
 
@@ -166,7 +165,6 @@ func (rt *redirectTest) testRedirectNotFound(expectedID, expectedBackend string)
 		Header: http.Header{
 			"Host":              []string{"www.notexists.org"},
 			"X-Forwarded-Proto": []string{"http"},
-			"X-Forwarded-Port":  []string{"80"},
 		},
 	}
 
@@ -321,9 +319,9 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			-> "http://1.2.3.4:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*") &&
 			Host("^www[.]example[.]org$") &&
 			PathRegexp("^/foo") &&
+			PathRegexp(".*") &&
 			PathRegexp(".*")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
@@ -332,8 +330,8 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 			PathRegexp(".*") &&
+			PathRegexp(".*") &&
 			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*") &&
 			Host("^www[.]example[.]org$")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
@@ -429,8 +427,8 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 			Host("^api[.]example[.]org$") &&
 			PathRegexp("^/bar") &&
 			PathRegexp(".*") &&
-			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*")
+			PathRegexp(".*") &&
+			Header("X-Forwarded-Proto", "http")
 			-> "http://5.6.7.8:8181";
 		kube___catchall__api_example_org____:
 			Host("^api[.]example[.]org$")
@@ -438,13 +436,13 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 		kube___catchall__api_example_org_____disable_https_redirect:
 			Host("^api[.]example[.]org$") &&
 			PathRegexp(".*") &&
-			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*")
+			PathRegexp(".*") &&
+			Header("X-Forwarded-Proto", "http")
 			-> <shunt>;
 		kube__redirect:
 			PathRegexp(/.*/) &&
-			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", /.*/)
+			PathRegexp(/.*/) &&
+			Header("X-Forwarded-Proto", "http")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
 	`
@@ -523,9 +521,9 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			-> "http://1.2.3.4:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*") &&
 			Host("^www[.]example[.]org$") &&
 			PathRegexp("^/foo") &&
+			PathRegexp(".*") &&
 			PathRegexp(".*")
 			-> redirectTo(301, "https:")
 			-> <shunt>;
@@ -534,8 +532,8 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 			PathRegexp(".*") &&
+			PathRegexp(".*") &&
 			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*") &&
 			Host("^www[.]example[.]org$")
 			-> redirectTo(301, "https:")
 			-> <shunt>;
@@ -548,8 +546,8 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			-> <shunt>;
 		kube__redirect:
 			PathRegexp(/.*/) &&
-			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", /.*/)
+			PathRegexp(/.*/) &&
+			Header("X-Forwarded-Proto", "http")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
 	`
@@ -628,9 +626,9 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			-> "http://1.2.3.4:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*") &&
 			Host("^www[.]example[.]org$") &&
 			PathRegexp("^/foo") &&
+			PathRegexp(".*") &&
 			PathRegexp(".*")
 			-> redirectTo(301, "https:")
 			-> <shunt>;
@@ -639,8 +637,8 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 			PathRegexp(".*") &&
+			PathRegexp(".*") &&
 			Header("X-Forwarded-Proto", "http") &&
-			HeaderRegexp("X-Forwarded-Port", ".*") &&
 			Host("^www[.]example[.]org$")
 			-> redirectTo(301, "https:")
 			-> <shunt>;

--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -321,16 +321,22 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$") &&
 			PathRegexp("^/foo") &&
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*")
+
 			-> redirectTo(308, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
 			Host("^www[.]example[.]org$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*") &&
+
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$")
 			-> redirectTo(308, "https:")
@@ -426,8 +432,11 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 		kube_namespace1__ingress2__api_example_org___bar__service2_disable_https_redirect:
 			Host("^api[.]example[.]org$") &&
 			PathRegexp("^/bar") &&
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*") &&
+
 			Header("X-Forwarded-Proto", "http")
 			-> "http://5.6.7.8:8181";
 		kube___catchall__api_example_org____:
@@ -435,13 +444,19 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 			-> <shunt>;
 		kube___catchall__api_example_org_____disable_https_redirect:
 			Host("^api[.]example[.]org$") &&
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*") &&
+
 			Header("X-Forwarded-Proto", "http")
 			-> <shunt>;
 		kube__redirect:
+
+			// increase priority of the redirect routes.
 			PathRegexp(/.*/) &&
 			PathRegexp(/.*/) &&
+
 			Header("X-Forwarded-Proto", "http")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
@@ -523,16 +538,22 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$") &&
 			PathRegexp("^/foo") &&
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*")
+
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
 			Host("^www[.]example[.]org$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*") &&
+
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$")
 			-> redirectTo(301, "https:")
@@ -545,8 +566,11 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			Host("^api[.]example[.]org$")
 			-> <shunt>;
 		kube__redirect:
+
+			// increase priority of the redirect routes.
 			PathRegexp(/.*/) &&
 			PathRegexp(/.*/) &&
+
 			Header("X-Forwarded-Proto", "http")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
@@ -628,16 +652,22 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$") &&
 			PathRegexp("^/foo") &&
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*")
+
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
 			Host("^www[.]example[.]org$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
+
+			// increase priority of the redirect routes.
 			PathRegexp(".*") &&
 			PathRegexp(".*") &&
+
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$")
 			-> redirectTo(301, "https:")

--- a/dataclients/kubernetes/redirect.go
+++ b/dataclients/kubernetes/redirect.go
@@ -81,16 +81,19 @@ func routeIDForRedirectRoute(baseID string, enable bool) string {
 }
 
 func initRedirectRoute(r *eskip.Route, code int) {
-	// the duplicate any-path (.*) is set to make sure that
-	// the redirect route has a higher priority during matching than
-	// the normal routes that may have max 2 predicates: path regexp
-	// and host.
-
 	if r.Headers == nil {
 		r.Headers = make(map[string]string)
 	}
 	r.Headers["X-Forwarded-Proto"] = "http"
 
+	// the below duplicate any-path (.*) is set to make sure that
+	// the redirect route has a higher priority during matching than
+	// the normal routes that may have max 2 predicates: path regexp
+	// and host.
+	//
+	// A better solution might be to implement a Weight() predicate
+	// and apply it here.
+	//
 	r.PathRegexps = append(r.PathRegexps, ".*")
 	r.PathRegexps = append(r.PathRegexps, ".*")
 
@@ -104,16 +107,19 @@ func initRedirectRoute(r *eskip.Route, code int) {
 }
 
 func initDisableRedirectRoute(r *eskip.Route) {
-	// the duplicate any-path (.*) is set to make sure that
-	// the redirect route has a higher priority during matching than
-	// the normal routes that may have max 2 predicates: path regexp
-	// and host.
-
 	if r.Headers == nil {
 		r.Headers = make(map[string]string)
 	}
 	r.Headers["X-Forwarded-Proto"] = "http"
 
+	// the below duplicate any-path (.*) is set to make sure that
+	// the redirect route has a higher priority during matching than
+	// the normal routes that may have max 2 predicates: path regexp
+	// and host.
+	//
+	// A better solution might be to implement a Weight() predicate
+	// and apply it here.
+	//
 	r.PathRegexps = append(r.PathRegexps, ".*")
 	r.PathRegexps = append(r.PathRegexps, ".*")
 }

--- a/dataclients/kubernetes/redirect.go
+++ b/dataclients/kubernetes/redirect.go
@@ -81,7 +81,7 @@ func routeIDForRedirectRoute(baseID string, enable bool) string {
 }
 
 func initRedirectRoute(r *eskip.Route, code int) {
-	// the forwarded port and any-path (.*) is set to make sure that
+	// the duplicate any-path (.*) is set to make sure that
 	// the redirect route has a higher priority during matching than
 	// the normal routes that may have max 2 predicates: path regexp
 	// and host.
@@ -91,14 +91,7 @@ func initRedirectRoute(r *eskip.Route, code int) {
 	}
 	r.Headers["X-Forwarded-Proto"] = "http"
 
-	if r.HeaderRegexps == nil {
-		r.HeaderRegexps = make(map[string][]string)
-	}
-	r.HeaderRegexps["X-Forwarded-Port"] = append(
-		r.HeaderRegexps["X-Forwarded-Port"],
-		".*",
-	)
-
+	r.PathRegexps = append(r.PathRegexps, ".*")
 	r.PathRegexps = append(r.PathRegexps, ".*")
 
 	r.Filters = append(r.Filters, &eskip.Filter{
@@ -111,7 +104,7 @@ func initRedirectRoute(r *eskip.Route, code int) {
 }
 
 func initDisableRedirectRoute(r *eskip.Route) {
-	// the forwarded port and any-path (.*) is set to make sure that
+	// the duplicate any-path (.*) is set to make sure that
 	// the redirect route has a higher priority during matching than
 	// the normal routes that may have max 2 predicates: path regexp
 	// and host.
@@ -121,14 +114,7 @@ func initDisableRedirectRoute(r *eskip.Route) {
 	}
 	r.Headers["X-Forwarded-Proto"] = "http"
 
-	if r.HeaderRegexps == nil {
-		r.HeaderRegexps = make(map[string][]string)
-	}
-	r.HeaderRegexps["X-Forwarded-Port"] = append(
-		r.HeaderRegexps["X-Forwarded-Port"],
-		".*",
-	)
-
+	r.PathRegexps = append(r.PathRegexps, ".*")
 	r.PathRegexps = append(r.PathRegexps, ".*")
 }
 


### PR DESCRIPTION
this header is used for prioritization. Since there is no guarantee that this header is always present, replacing it with an additional, always matching path regexp predicate.

Closes: #838 