### PR TITLE
fix doc pipeline and add east-west to TOC

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -31,8 +31,6 @@ pipeline:
       if [ "$CDP_PULL_REQUEST_NUMBER" ]; then
         mkdir -p site/pr/#{CDP_PULL_REQUEST_NUMBER}
         mv site/!(pr) site/pr/#{CDP_PULL_REQUEST_NUMBER}
-      else
-        mkdocs gh-deploy
       fi
   artifacts:
   - type: docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
         - Ingress Controller Deployment: kubernetes/ingress-controller.md
         - Ingress Usage: kubernetes/ingress-usage.md
         - Ingress Backends: kubernetes/ingress-backends.md
+        - East-West aka svc-to-svc: kubernetes/east-west-usage.md
     - Tutorials:
         - Basics: tutorials/basics.md
         - Common Use Cases: tutorials/common-use-cases.md


### PR DESCRIPTION
fix pipeline to not error caused by docs can not be pushed because of permissions

add east-west to kubernetes TOC

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>