### PR TITLE
Clearer JSON Serialization

### DIFF
--- a/filters/apiusagemonitoring/filter_endpointmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_endpointmetrics_test.go
@@ -393,5 +393,7 @@ func Test_Filter_String(t *testing.T) {
 	f := filter.(*apiUsageMonitoringFilter)
 	s1 := fmt.Sprintf("%s", f)
 	s2 := fmt.Sprintf("%s", *f)
-	assert.Equal(t, s1, s2)
+	expected := `apiusagemonitoring.apiUsageMonitoringFilter {"Spec":{},"Paths":[{"ApplicationId":"my_app","ApiId":"my_api","PathTemplate":"foo/orders/:order-id/order-items/:order-item-id","Matcher":"^\\/*foo\\/orders\\/.+\\/order-items\\/.+\\/*$","ClientTracking":null,"CommonPrefix":"my_app.my_api.","ClientPrefix":"my_app.my_api.*.*."},{"ApplicationId":"my_app","ApiId":"my_api","PathTemplate":"foo/orders/:order-id","Matcher":"^\\/*foo\\/orders\\/.+\\/*$","ClientTracking":null,"CommonPrefix":"my_app.my_api.","ClientPrefix":"my_app.my_api.*.*."},{"ApplicationId":"my_app","ApiId":"my_api","PathTemplate":"foo/orders","Matcher":"^\\/*foo\\/orders\\/*$","ClientTracking":null,"CommonPrefix":"my_app.my_api.","ClientPrefix":"my_app.my_api.*.*."},{"ApplicationId":"my_app","ApiId":"my_api","PathTemplate":"foo/customers/:customer-id","Matcher":"^\\/*foo\\/customers\\/.+\\/*$","ClientTracking":null,"CommonPrefix":"my_app.my_api.","ClientPrefix":"my_app.my_api.*.*."},{"ApplicationId":"my_app","ApiId":"my_api","PathTemplate":"foo/customers","Matcher":"^\\/*foo\\/customers\\/*$","ClientTracking":null,"CommonPrefix":"my_app.my_api.","ClientPrefix":"my_app.my_api.*.*."}]}`
+	assert.Equal(t, expected, s1)
+	assert.Equal(t, expected, s2)
 }

--- a/filters/apiusagemonitoring/pathinfo.go
+++ b/filters/apiusagemonitoring/pathinfo.go
@@ -6,13 +6,22 @@ import (
 	"regexp"
 )
 
+type Regex struct{ *regexp.Regexp }
+
+func (r *Regex) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(r.String())
+}
+
 // pathInfo contains the tracking information for a specific path.
 // The exported members are marshaled as JSON.
 type pathInfo struct {
 	ApplicationId  string
 	ApiId          string
 	PathTemplate   string
-	Matcher        *regexp.Regexp
+	Matcher        *Regex
 	ClientTracking *clientTrackingInfo
 	CommonPrefix   string
 	ClientPrefix   string
@@ -36,23 +45,6 @@ func newPathInfo(applicationId, apiId, pathTemplate string, clientTracking *clie
 		CommonPrefix:            commonPrefix,
 		ClientPrefix:            commonPrefix + "*.*.",
 	}
-}
-
-// MarshalJSON transforms a pathInfo into a JSON representation.
-// It is necessary (vs the reflection based marshalling) in order
-// to marshall the RegExp matcher as a string.
-func (p *pathInfo) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		ApplicationId string
-		ApiId         string
-		PathTemplate  string
-		Matcher       string
-	}{
-		ApplicationId: p.ApplicationId,
-		ApiId:         p.ApiId,
-		PathTemplate:  p.PathTemplate,
-		Matcher:       p.Matcher.String(),
-	})
 }
 
 // pathInfoByRegExRev allows sort.Sort to reorder a slice of `pathInfo` in

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -204,7 +204,7 @@ func (s *apiUsageMonitoringSpec) buildPathInfoListFromConfiguration(apis []*apiC
 					apiIndex, templateIndex, regExStr, info.PathTemplate, err)
 				continue
 			}
-			info.Matcher = regEx
+			info.Matcher = &Regex{regEx}
 
 			// Add valid entry to the results
 			paths = append(paths, info)


### PR DESCRIPTION
Interested in knowing here what you prefer in terms of customised JSON serialization.

Before: implementing `json.Marshaller` on the complete `pathInfo` struct, using a temporary anonymous struct to bypass only the `Matcher`, serialising the regular expression's string instead of the `regexp.Regexp` struct itself.

After: using a type definition `Regex` based on `regexp.Regexp` and implementing the `json.Marshaller` interface just for itself, marshalling its string. Using that type definition inside of `pathInfo`.