### PR TITLE
preserve only the span not the entire context of the incoming request

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -384,7 +384,10 @@ func mapRequest(r *http.Request, rt *routing.Route, host string, removeHopHeader
 		rr.Header.Add("Authorization", fmt.Sprintf("Basic %s", upBase64))
 	}
 
-	rr = rr.WithContext(r.Context())
+	ctxspan := ot.SpanFromContext(r.Context())
+	if ctxspan != nil {
+		rr = rr.WithContext(ot.ContextWithSpan(rr.Context(), ctxspan))
+	}
 
 	return rr, nil
 }


### PR DESCRIPTION
instead of preserving the context.Context of the incoming request to the outgoing request, preserve only the opentracing span. `skptesting/benchmark-proxy.sh` showed that this eliminates the 'context cancelled' errors.

- [x] preserve only the span between the incoming and outgoing request instead of the entire context.Context object
- [ ] prove with a unit test that this is the cause of the the 'context cancelled' errors