### PR TITLE
skptesting fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _test_plugins/*.so
 _test_plugins_fail/*.so
 opentracingplugin/build
 build/
+skptesting/lorem.html

--- a/skptesting/benchmark-proxy.sh
+++ b/skptesting/benchmark-proxy.sh
@@ -7,6 +7,8 @@ fi
 
 source $GOPATH/src/github.com/zalando/skipper/skptesting/benchmark.inc
 
+check_deps
+
 trap cleanup-exit SIGINT
 
 log [generating content]

--- a/skptesting/benchmark.inc
+++ b/skptesting/benchmark.inc
@@ -12,7 +12,7 @@ if [ -z "$wd" ]; then wd=3; fi
 
 cwd=$GOPATH/src/github.com/zalando/skipper/skptesting
 cd $cwd
-go install github.com/zalando/skipper/...
+GO111MODULE=on go install github.com/zalando/skipper/...
 if [ $? -ne 0 ]; then exit -1; fi
 
 loremHead='<!doctype html>
@@ -96,4 +96,13 @@ bench() {
 
 log() {
 	echo $@ >&2
+}
+
+check_deps() {
+  which wrk &>/dev/null
+  if [ $? -eq 1 ]
+  then
+    echo "ERR: dependency 'wrk' https://github.com/wg/wrk not found in \$PATH"
+    exit 2
+  fi
 }


### PR DESCRIPTION
- check dependencies and add error message to point to a dependency if not satisfied
- use GO111MODULE=on to build skipper in skptesting