### PR TITLE
add lb test proxy bench

### DIFF
--- a/skptesting/benchmark-proxy-lbroute.sh
+++ b/skptesting/benchmark-proxy-lbroute.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+if [ "$1" == -help ]; then
+	log $0 [duration] [connections] [warmup-duration]
+	exit 0
+fi
+
+source $GOPATH/src/github.com/zalando/skipper/skptesting/benchmark.inc
+
+check_deps
+
+trap cleanup-exit SIGINT
+
+log; log [starting servers]
+
+# 2 backends
+skipper -access-log-disabled -address ":9000" -inline-routes "r: * -> inlineContent(\"A\") -> status(200) -> <shunt>;" &
+pids="$pids $!"
+skipper -access-log-disabled -address ":9001" -inline-routes "r: * -> inlineContent(\"B\") -> status(200) -> <shunt>;" &
+pids="$pids $!"
+
+# lb
+skp :9090 lb.eskip
+log [servers started, wait 1 sec]
+sleep 1
+
+log; log [warmup]
+warmup :9090 "Host: test.example.org"
+log [warmup done]
+
+log; log [benchmarking skipper]
+bench :9090 "Host: test.example.org"
+log [benchmarking skipper done]
+
+cleanup
+log; log [all done]

--- a/skptesting/lb.eskip
+++ b/skptesting/lb.eskip
@@ -1,0 +1,11 @@
+r0: Host(/^test[.]example[.]org$/) && LBMember("x", 0)
+  -> dropRequestHeader("X-Load-Balancer-Member")
+  -> "http://127.0.0.1:9000";
+
+r_1: Host(/^test[.]example[.]org$/) && LBMember("x", 1)
+  -> dropRequestHeader("X-Load-Balancer-Member")
+  -> "http://127.0.0.1:9001";
+
+lb_group: Host(/^test[.]example[.]org$/) && LBGroup("x")
+  -> lbDecide("x", 2)
+  -> <loopback>;


### PR DESCRIPTION
```
[warmup]
Running 3s test @ http://127.0.0.1:9090/lorem.html
Requests/sec:   6472.76
Transfer/sec:    847.02KB
[warmup done]

[benchmarking skipper]
Running 12s test @ http://127.0.0.1:9090/lorem.html
  2 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    16.81ms    8.36ms  95.39ms   72.78%
    Req/Sec     3.88k   462.79     6.14k    75.00%
  92910 requests in 12.08s, 11.87MB read
Requests/sec:   7694.21
Transfer/sec:      0.98MB
[benchmarking skipper done]
```

```
[warmup]
Running 3s test @ http://127.0.0.1:9090/lorem.html
Requests/sec:   7359.63
Transfer/sec:      0.94MB
[warmup done]

[benchmarking skipper]
Running 12s test @ http://127.0.0.1:9090/lorem.html
  2 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    19.14ms   10.55ms 141.38ms   74.64%
    Req/Sec     3.45k   699.76     4.79k    64.58%
  82473 requests in 12.04s, 10.54MB read
Requests/sec:   6852.45
Transfer/sec:      0.88MB
[benchmarking skipper done]
```

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>