### PR TITLE
add missing available in http.Transport timeouts

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -51,14 +51,16 @@ const (
 	defaultApplicationLogLevel  = "INFO"
 
 	// connections, timeouts:
-	defaultReadTimeoutServer          = 5 * time.Minute
-	defaultReadHeaderTimeoutServer    = 60 * time.Second
-	defaultWriteTimeoutServer         = 60 * time.Second
-	defaultIdleTimeoutServer          = 60 * time.Second
-	defaultTimeoutBackend             = 60 * time.Second
-	defaultKeepaliveBackend           = 30 * time.Second
-	defaultTLSHandshakeTimeoutBackend = 60 * time.Second
-	defaultMaxIdleConnsBackend        = 0
+	defaultReadTimeoutServer            = 5 * time.Minute
+	defaultReadHeaderTimeoutServer      = 60 * time.Second
+	defaultWriteTimeoutServer           = 60 * time.Second
+	defaultIdleTimeoutServer            = 60 * time.Second
+	defaultTimeoutBackend               = 60 * time.Second
+	defaultKeepaliveBackend             = 30 * time.Second
+	defaultTLSHandshakeTimeoutBackend   = 60 * time.Second
+	defaultResponseHeaderTimeoutBackend = 60 * time.Second
+	defaultExpectContinueTimeoutBackend = 30 * time.Second
+	defaultMaxIdleConnsBackend          = 0
 
 	// Auth:
 	defaultOAuthTokeninfoTimeout          = 2 * time.Second
@@ -161,22 +163,24 @@ const (
 	apiUsageMonitoringDefaultClientTrackingPatternUsage = "regular expression to default to when API usage monitoring filter configuration does not provide `client_tracking_pattern`"
 
 	// connections, timeouts:
-	idleConnsPerHostUsage           = "maximum idle connections per backend host"
-	closeIdleConnsPeriodUsage       = "period of closing all idle connections in seconds or as a duration string. Not closing when less than 0"
-	backendFlushIntervalUsage       = "flush interval for upgraded proxy connections"
-	experimentalUpgradeUsage        = "enable experimental feature to handle upgrade protocol requests"
-	experimentalUpgradeAuditUsage   = "enable audit logging of the request line and the messages during the experimental web socket upgrades"
-	readTimeoutServerUsage          = "set ReadTimeout for http server connections"
-	readHeaderTimeoutServerUsage    = "set ReadHeaderTimeout for http server connections"
-	writeTimeoutServerUsage         = "set WriteTimeout for http server connections"
-	idleTimeoutServerUsage          = "set IdleTimeout for http server connections"
-	maxHeaderBytesUsage             = "set MaxHeaderBytes for http server connections"
-	enableConnMetricsServerUsage    = "enables connection metrics for http server connections"
-	timeoutBackendUsage             = "sets the TCP client connection timeout for backend connections"
-	keepaliveBackendUsage           = "sets the keepalive for backend connections"
-	enableDualstackBackendUsage     = "enables DualStack for backend connections"
-	tlsHandshakeTimeoutBackendUsage = "sets the TLS handshake timeout for backend connections"
-	maxIdleConnsBackendUsage        = "sets the maximum idle connections for all backend connections"
+	idleConnsPerHostUsage             = "maximum idle connections per backend host"
+	closeIdleConnsPeriodUsage         = "period of closing all idle connections in seconds or as a duration string. Not closing when less than 0"
+	backendFlushIntervalUsage         = "flush interval for upgraded proxy connections"
+	experimentalUpgradeUsage          = "enable experimental feature to handle upgrade protocol requests"
+	experimentalUpgradeAuditUsage     = "enable audit logging of the request line and the messages during the experimental web socket upgrades"
+	readTimeoutServerUsage            = "set ReadTimeout for http server connections"
+	readHeaderTimeoutServerUsage      = "set ReadHeaderTimeout for http server connections"
+	writeTimeoutServerUsage           = "set WriteTimeout for http server connections"
+	idleTimeoutServerUsage            = "set IdleTimeout for http server connections"
+	maxHeaderBytesUsage               = "set MaxHeaderBytes for http server connections"
+	enableConnMetricsServerUsage      = "enables connection metrics for http server connections"
+	timeoutBackendUsage               = "sets the TCP client connection timeout for backend connections"
+	keepaliveBackendUsage             = "sets the keepalive for backend connections"
+	enableDualstackBackendUsage       = "enables DualStack for backend connections"
+	tlsHandshakeTimeoutBackendUsage   = "sets the TLS handshake timeout for backend connections"
+	responseHeaderTimeoutBackendUsage = "sets the HTTP response header timeout for backend connections"
+	expectContinueTimeoutBackendUsage = "sets the HTTP expect continue timeout for backend connections"
+	maxIdleConnsBackendUsage          = "sets the maximum idle connections for all backend connections"
 
 	// swarm:
 	enableSwarmUsage                       = "enable swarm communication between nodes in a skipper fleet"
@@ -291,22 +295,24 @@ var (
 	apiUsageMonitoringDefaultClientTrackingPattern string
 
 	// connections, timeouts:
-	idleConnsPerHost           int
-	closeIdleConnsPeriod       string
-	backendFlushInterval       time.Duration
-	experimentalUpgrade        bool
-	experimentalUpgradeAudit   bool
-	readTimeoutServer          time.Duration
-	readHeaderTimeoutServer    time.Duration
-	writeTimeoutServer         time.Duration
-	idleTimeoutServer          time.Duration
-	maxHeaderBytes             int
-	enableConnMetricsServer    bool
-	timeoutBackend             time.Duration
-	keepaliveBackend           time.Duration
-	enableDualstackBackend     bool
-	tlsHandshakeTimeoutBackend time.Duration
-	maxIdleConnsBackend        int
+	idleConnsPerHost             int
+	closeIdleConnsPeriod         string
+	backendFlushInterval         time.Duration
+	experimentalUpgrade          bool
+	experimentalUpgradeAudit     bool
+	readTimeoutServer            time.Duration
+	readHeaderTimeoutServer      time.Duration
+	writeTimeoutServer           time.Duration
+	idleTimeoutServer            time.Duration
+	maxHeaderBytes               int
+	enableConnMetricsServer      bool
+	timeoutBackend               time.Duration
+	keepaliveBackend             time.Duration
+	enableDualstackBackend       bool
+	tlsHandshakeTimeoutBackend   time.Duration
+	responseHeaderTimeoutBackend time.Duration
+	expectContinueTimeoutBackend time.Duration
+	maxIdleConnsBackend          int
 
 	// swarm:
 	enableSwarm                       bool
@@ -434,6 +440,8 @@ func init() {
 	flag.DurationVar(&keepaliveBackend, "keepalive-backend", defaultKeepaliveBackend, keepaliveBackendUsage)
 	flag.BoolVar(&enableDualstackBackend, "enable-dualstack-backend", true, enableDualstackBackendUsage)
 	flag.DurationVar(&tlsHandshakeTimeoutBackend, "tls-timeout-backend", defaultTLSHandshakeTimeoutBackend, tlsHandshakeTimeoutBackendUsage)
+	flag.DurationVar(&responseHeaderTimeoutBackend, "response-header-timeout-backend", defaultResponseHeaderTimeoutBackend, responseHeaderTimeoutBackendUsage)
+	flag.DurationVar(&expectContinueTimeoutBackend, "expect-continue-timeout-backend", defaultExpectContinueTimeoutBackend, expectContinueTimeoutBackendUsage)
 	flag.IntVar(&maxIdleConnsBackend, "max-idle-connection-backend", defaultMaxIdleConnsBackend, maxIdleConnsBackendUsage)
 	flag.BoolVar(&enableSwarm, "enable-swarm", false, enableSwarmUsage)
 	flag.StringVar(&swarmKubernetesNamespace, "swarm-namespace", swarm.DefaultNamespace, swarmKubernetesNamespaceUsage)
@@ -621,22 +629,24 @@ func main() {
 		WebhookTimeout:                 webhookTimeout,
 
 		// connections, timeouts:
-		IdleConnectionsPerHost:     idleConnsPerHost,
-		CloseIdleConnsPeriod:       time.Duration(clsic) * time.Second,
-		BackendFlushInterval:       backendFlushInterval,
-		ExperimentalUpgrade:        experimentalUpgrade,
-		ExperimentalUpgradeAudit:   experimentalUpgradeAudit,
-		ReadTimeoutServer:          readTimeoutServer,
-		ReadHeaderTimeoutServer:    readHeaderTimeoutServer,
-		WriteTimeoutServer:         writeTimeoutServer,
-		IdleTimeoutServer:          idleTimeoutServer,
-		MaxHeaderBytes:             maxHeaderBytes,
-		EnableConnMetricsServer:    enableConnMetricsServer,
-		TimeoutBackend:             timeoutBackend,
-		KeepAliveBackend:           keepaliveBackend,
-		DualStackBackend:           enableDualstackBackend,
-		TLSHandshakeTimeoutBackend: tlsHandshakeTimeoutBackend,
-		MaxIdleConnsBackend:        maxIdleConnsBackend,
+		IdleConnectionsPerHost:       idleConnsPerHost,
+		CloseIdleConnsPeriod:         time.Duration(clsic) * time.Second,
+		BackendFlushInterval:         backendFlushInterval,
+		ExperimentalUpgrade:          experimentalUpgrade,
+		ExperimentalUpgradeAudit:     experimentalUpgradeAudit,
+		ReadTimeoutServer:            readTimeoutServer,
+		ReadHeaderTimeoutServer:      readHeaderTimeoutServer,
+		WriteTimeoutServer:           writeTimeoutServer,
+		IdleTimeoutServer:            idleTimeoutServer,
+		MaxHeaderBytes:               maxHeaderBytes,
+		EnableConnMetricsServer:      enableConnMetricsServer,
+		TimeoutBackend:               timeoutBackend,
+		KeepAliveBackend:             keepaliveBackend,
+		DualStackBackend:             enableDualstackBackend,
+		TLSHandshakeTimeoutBackend:   tlsHandshakeTimeoutBackend,
+		ResponseHeaderTimeoutBackend: responseHeaderTimeoutBackend,
+		ExpectContinueTimeoutBackend: expectContinueTimeoutBackend,
+		MaxIdleConnsBackend:          maxIdleConnsBackend,
 
 		// swarm:
 		EnableSwarm:                       enableSwarm,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -45,6 +45,13 @@ const (
 	// The default period at which the idle connections are forcibly
 	// closed.
 	DefaultCloseIdleConnsPeriod = 20 * time.Second
+
+	// DefaultResponseHeaderTimeout, the default response header timeout
+	DefaultResponseHeaderTimeout = 60 * time.Second
+
+	// DefaultExpectContinueTimeout, the default timeout to expect
+	// a response for a 100 Continue request
+	DefaultExpectContinueTimeout = 30 * time.Second
 )
 
 // Flags control the behavior of the proxy.
@@ -162,6 +169,15 @@ type Params struct {
 
 	// Timeout sets the TCP client connection timeout for proxy http connections to the backend
 	Timeout time.Duration
+
+	// ResponseHeaderTimeout sets the HTTP response timeout for
+	// proxy http connections to the backend.
+	ResponseHeaderTimeout time.Duration
+
+	// ExpectContinueTimeout sets the HTTP timeout to expect a
+	// response for status Code 100 for proxy http connections to
+	// the backend.
+	ExpectContinueTimeout time.Duration
 
 	// KeepAlive sets the TCP keepalive for proxy http connections to the backend
 	KeepAlive time.Duration
@@ -454,6 +470,14 @@ func WithParams(p Params) *Proxy {
 		p.CloseIdleConnsPeriod = DefaultCloseIdleConnsPeriod
 	}
 
+	if p.ResponseHeaderTimeout == 0 {
+		p.ResponseHeaderTimeout = DefaultResponseHeaderTimeout
+	}
+
+	if p.ExpectContinueTimeout == 0 {
+		p.ExpectContinueTimeout = DefaultExpectContinueTimeout
+	}
+
 	if p.OpenTracer == nil {
 		p.OpenTracer = &ot.NoopTracer{}
 	}
@@ -464,12 +488,12 @@ func WithParams(p Params) *Proxy {
 			KeepAlive: p.KeepAlive,
 			DualStack: p.DualStack,
 		}).DialContext,
-		TLSHandshakeTimeout: p.TLSHandshakeTimeout,
-		//ResponseHeaderTimeout: 60 * time.Second,
-		//ExpectContinueTimeout: 30 * time.Second,
-		MaxIdleConns:        p.MaxIdleConns,
-		MaxIdleConnsPerHost: p.IdleConnectionsPerHost,
-		IdleConnTimeout:     p.CloseIdleConnsPeriod,
+		TLSHandshakeTimeout:   p.TLSHandshakeTimeout,
+		ResponseHeaderTimeout: p.ResponseHeaderTimeout,
+		ExpectContinueTimeout: p.ExpectContinueTimeout,
+		MaxIdleConns:          p.MaxIdleConns,
+		MaxIdleConnsPerHost:   p.IdleConnectionsPerHost,
+		IdleConnTimeout:       p.CloseIdleConnsPeriod,
 	}
 
 	quit := make(chan struct{})

--- a/skipper.go
+++ b/skipper.go
@@ -197,6 +197,15 @@ type Options struct {
 	// proxy http connections to the backend.
 	TimeoutBackend time.Duration
 
+	// ResponseHeaderTimeout sets the HTTP response timeout for
+	// proxy http connections to the backend.
+	ResponseHeaderTimeoutBackend time.Duration
+
+	// ExpectContinueTimeoutBackend sets the HTTP timeout to expect a
+	// response for status Code 100 for proxy http connections to
+	// the backend.
+	ExpectContinueTimeoutBackend time.Duration
+
 	// KeepAliveBackend sets the TCP keepalive for proxy http
 	// connections to the backend.
 	KeepAliveBackend time.Duration
@@ -792,6 +801,8 @@ func Run(o Options) error {
 		DefaultHTTPStatus:        o.DefaultHTTPStatus,
 		LoadBalancer:             lbInstance,
 		Timeout:                  o.TimeoutBackend,
+		ResponseHeaderTimeout:    o.ResponseHeaderTimeoutBackend,
+		ExpectContinueTimeout:    o.ExpectContinueTimeoutBackend,
 		KeepAlive:                o.KeepAliveBackend,
 		DualStack:                o.DualStackBackend,
 		TLSHandshakeTimeout:      o.TLSHandshakeTimeoutBackend,


### PR DESCRIPTION
add configurable timeouts for missing available in http.Transport timeouts for backend calls

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>