### PR TITLE
fix swarm/clusterClient reatlimit integration

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -654,8 +654,10 @@ func main() {
 
 		// swarm:
 		EnableSwarm:                       enableSwarm,
+		SwarmKubernetesNamespace:          swarmKubernetesNamespace,
 		SwarmKubernetesLabelSelectorKey:   swarmKubernetesLabelSelectorKey,
 		SwarmKubernetesLabelSelectorValue: swarmKubernetesLabelSelectorValue,
+		SwarmPort:                         swarmPort,
 		SwarmMaxMessageBuffer:             swarmMaxMessageBuffer,
 		SwarmLeaveTimeout:                 swarmLeaveTimeout,
 	}

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -107,6 +107,7 @@ func MakeRegistry() filters.Registry {
 		ratelimit.NewLocalRatelimit(),
 		ratelimit.NewRatelimit(),
 		ratelimit.NewClusterRateLimit(),
+		ratelimit.NewClusterClientRateLimit(),
 		ratelimit.NewDisableRatelimit(),
 		loadbalancer.NewDecide(),
 		script.NewLuaScript(),

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -281,7 +281,7 @@ func localRatelimitFilter(args []interface{}) (filters.Filter, error) {
 	}, nil
 }
 
-func disableFilter(args []interface{}) (filters.Filter, error) {
+func disableFilter([]interface{}) (filters.Filter, error) {
 	return &filter{
 		settings: ratelimit.Settings{
 			Type: ratelimit.DisableRatelimit,
@@ -298,7 +298,7 @@ func (s *spec) CreateFilter(args []interface{}) (filters.Filter, error) {
 	case ratelimit.ClusterServiceRatelimit:
 		return clusterRatelimitFilter(args)
 	case ratelimit.ClusterClientRatelimit:
-		return clusterRatelimitFilter(args)
+		return clusterClientRatelimitFilter(args)
 	default:
 		return disableFilter(args)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/abbot/go-http-auth v0.0.0-20150922224136-efc9484eee77
 	github.com/armon/go-metrics v0.0.0-20180713145231-3c58d8115a78 // indirect
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
+	github.com/cenkalti/backoff v2.1.0+incompatible
 	github.com/cjoudrey/gluahttp v0.0.0-20161028104506-b4bfe0c50fea
 	github.com/cjoudrey/gluaurl v0.0.0-20161028222611-31cbb9bef199
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/armon/go-metrics v0.0.0-20180713145231-3c58d8115a78 h1:mdRSArcFLfW0Vo
 github.com/armon/go-metrics v0.0.0-20180713145231-3c58d8115a78/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/cenkalti/backoff v2.1.0+incompatible h1:FIRvWBZrzS4YC7NT5cOuZjexzFvIr+Dbi6aD1cZaNBk=
+github.com/cenkalti/backoff v2.1.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cjoudrey/gluahttp v0.0.0-20161028104506-b4bfe0c50fea h1:iCaXYAUf9iatN39UadJvkjNdxIMEEauPWCkIRBkF+g8=
 github.com/cjoudrey/gluahttp v0.0.0-20161028104506-b4bfe0c50fea/go.mod h1:X97UjDTXp+7bayQSFZk2hPvCTmTZIicUjZQRtkwgAKY=
 github.com/cjoudrey/gluaurl v0.0.0-20161028222611-31cbb9bef199 h1:cJ1E8ZwZLfercTX3dywnCAQDilbbi+m2cw3+8tCFpRo=

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -47,12 +47,16 @@ func newClusterRateLimiter(s Settings, sw Swarmer, name string) *clusterLimit {
 		resize:  make(chan resizeLimit),
 		quit:    make(chan struct{}),
 	}
-	if s.CleanInterval == 0 {
+	switch s.Type {
+	case ClusterServiceRatelimit:
 		log.Infof("new backend clusterRateLimiter")
 		rl.local = circularbuffer.NewRateLimiter(s.MaxHits, s.TimeWindow)
-	} else {
+	case ClusterClientRatelimit:
 		log.Infof("new client clusterRateLimiter")
 		rl.local = circularbuffer.NewClientRateLimiter(s.MaxHits, s.TimeWindow, s.CleanInterval)
+	default:
+		log.Errorf("Unknown ratelimit type: %s", s.Type)
+		return nil
 	}
 
 	// TODO(sszuecs): we might want to have one goroutine for all of these

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -35,6 +35,9 @@ const (
 
 	// DisableRatelimitName is the name of the DisableRatelimit, which will be shown in log
 	DisableRatelimitName = "disableRatelimit"
+
+	// UknownRatelimitName is to print unknown ratelimit settings in error messages
+	UknownRatelimitName = "unknownRatelimit"
 )
 
 // RatelimitType defines the type of  the used ratelimit
@@ -88,6 +91,27 @@ const (
 	// DisableRatelimit is used to disable rate limit
 	DisableRatelimit
 )
+
+func (rt RatelimitType) String() string {
+	switch rt {
+	case DisableRatelimit:
+		return DisableRatelimitName
+	case ClientRatelimit:
+		return ClientRatelimitName
+	case ClusterClientRatelimit:
+		return ClusterClientRatelimitName
+	case ClusterServiceRatelimit:
+		return ClusterServiceRatelimitName
+	case LocalRatelimit:
+		return LocalRatelimitName
+	case ServiceRatelimit:
+		return ServiceRatelimitName
+	default:
+		return UknownRatelimitName
+
+	}
+
+}
 
 // Lookuper makes it possible to be more flexible for ratelimiting.
 type Lookuper interface {

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -258,7 +258,6 @@ type limiter interface {
 // implemetations and stores settings for the ratelimiter
 type Ratelimit struct {
 	settings Settings
-	ts       time.Time
 	impl     limiter
 }
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -153,18 +153,20 @@ func (XForwardedForLookuper) Lookup(req *http.Request) string {
 	return net.RemoteHost(req).String()
 }
 
-// AuthLookuper implements Lookuper interface and will select a bucket
+// HeaderLookuper implements Lookuper interface and will select a bucket
 // by Authorization header.
-type AuthLookuper struct{}
+type HeaderLookuper struct {
+	key string
+}
 
-// NewAuthLookuper returns an empty AuthLookuper
-func NewAuthLookuper() AuthLookuper {
-	return AuthLookuper{}
+// NewHeaderLookuper returns HeaderLookuper configured to lookup header named k
+func NewHeaderLookuper(k string) HeaderLookuper {
+	return HeaderLookuper{key: k}
 }
 
 // Lookup returns the content of the Authorization header.
-func (AuthLookuper) Lookup(req *http.Request) string {
-	return req.Header.Get("Authorization")
+func (h HeaderLookuper) Lookup(req *http.Request) string {
+	return req.Header.Get(h.key)
 }
 
 // Settings configures the chosen rate limiter

--- a/swarm/kubernetes.go
+++ b/swarm/kubernetes.go
@@ -33,6 +33,7 @@ const (
 	serviceAccountRootCAKey = "ca.crt"
 	serviceHostEnvVar       = "KUBERNETES_SERVICE_HOST"
 	servicePortEnvVar       = "KUBERNETES_SERVICE_PORT"
+	maxRetries              = 12
 )
 
 var (
@@ -57,7 +58,7 @@ type ClientKubernetes struct {
 	httpClient *http.Client
 	apiURL     string
 	token      string
-	retry      *backoff.ConstantBackOff
+	retry      backoff.BackOff
 	quit       chan struct{}
 }
 
@@ -118,7 +119,7 @@ func NewClientKubernetes(kubernetesInCluster bool, kubernetesURL string) (*Clien
 		httpClient: httpClient,
 		apiURL:     apiURL,
 		token:      token,
-		retry:      backoff.NewConstantBackOff(5 * time.Second),
+		retry:      backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), maxRetries),
 		quit:       quit,
 	}, nil
 }

--- a/swarm/nodeinfoclient.go
+++ b/swarm/nodeinfoclient.go
@@ -24,7 +24,8 @@ func NewNodeInfoClient(o Options) (nodeInfoClient, func()) {
 	log.Infof("swarm type: %s", o.swarm)
 	switch o.swarm {
 	case swarmKubernetes:
-		return NewNodeInfoClientKubernetes(o), func() {}
+		cli := NewNodeInfoClientKubernetes(o)
+		return cli, cli.client.Stop
 	case swarmFake:
 		return NewNodeInfoClientFake(o), func() {
 			// reset fakePeers to cleanup swarm nodes for tests
@@ -144,7 +145,7 @@ func (c *nodeInfoClientKubernetes) GetNodeInfo() ([]*NodeInfo, error) {
 	for _, i := range il.Items {
 		addr := net.ParseIP(i.Status.PodIP)
 		if addr == nil {
-			log.Warn(fmt.Sprintf("SWARM: failed to parse the ip %s", i.Status.PodIP))
+			log.Errorf("SWARM: failed to parse the ip %s", i.Status.PodIP)
 			continue
 		}
 		nodes = append(nodes, &NodeInfo{Name: i.Metadata.Name, Addr: addr, Port: c.port})

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -35,7 +35,7 @@ func getSwarmType(o Options) swarmType {
 	if o.FakeSwarm {
 		return swarmFake
 	}
-	if o.KubernetesOptions != nil && o.KubernetesOptions.KubernetesInCluster && o.KubernetesOptions.KubernetesAPIBaseURL != "" {
+	if o.KubernetesOptions != nil {
 		return swarmKubernetes
 	}
 	return swarmUnknown
@@ -262,7 +262,8 @@ func (s *Swarm) control() {
 		case req := <-s.getOutgoing:
 			s.messages = takeMaxLatest(s.messages, req.overhead, req.limit)
 			if len(s.messages) <= 0 {
-				log.Warning("SWARM: getOutgoing with 0 messages, should not happen")
+				time.Sleep(10 * time.Millisecond)
+				continue
 			}
 			req.ret <- s.messages
 		case m := <-s.outgoing:

--- a/swarm/utils.go
+++ b/swarm/utils.go
@@ -28,7 +28,6 @@ func getSelf(nodes []*NodeInfo) *NodeInfo {
 				log.Errorf("SWARM: could not parse cidr: %v", err)
 				continue
 			}
-			log.Infof("getSelf: ip: %v, ni: %s", ip, ni.Addr)
 			if ip.Equal(ni.Addr) {
 				return ni
 			}


### PR DESCRIPTION
fix: clusterClientRatelimit was no initialized correctly
fix: kubernetes-swarm retry connection to kube-apiserver
fix: kubernetes-swarm add connection timeouts to http client
fix: add missing configuration to intialize swarm
fix: kubernetes-swarm tear down handling stops goroutine
fix: clusterClientRatelimit filter parsing
log: reduce log volume caused by swarm

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>