### PR TITLE
Update readme with mac-specific info on tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,8 @@ Build and test all packages:
     make install
     make shortcheck
 
+> On Mac the tests may fail because of low max open file limit. Please make sure you have correct limits setup by following [these instructions](https://gist.github.com/tombigel/d503800a282fcadbee14b537735d202c).
+
 ##### Working from IntelliJ / GoLand
 
 To run or debug skipper from _IntelliJ IDEA_ or _GoLand_, you need to create this configuration:


### PR DESCRIPTION
On a fresh Mac computer `make short check` fails with max open files error. Adding a note to have a smoother experience for new collaborators.