### PR TITLE
Added parent span to context so that it can be used in filters

### DIFF
--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -301,6 +301,36 @@ zalando.org/skipper-routes: |
 Make sure the `;` semicolon is used to terminate the routes, if you
 use multiple routes definitions.
 
+**Disclaimer**: This feature works only with having different `Path*`
+predicates in ingress, if there are no paths rules defined. For
+example this will **not** work:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: skipper-ingress
+  annotations:
+    kubernetes.io/ingress.class: skipper
+    zalando.org/skipper-routes: |
+       redirect1: Path("/foo/") -> redirectTo(308, "/bar/") -> <shunt>;
+  spec:
+    rules:
+      - host: foo.bar
+        http:
+          paths:
+            - path: /something/
+              backend:
+                serviceName: something
+                servicePort: 80
+            - path: /else/
+              backend:
+                serviceName: else
+                servicePort: 80
+```
+
+A possible solution will be a skipper route CRD: https://github.com/zalando/skipper/issues/660
+
 ## Filters - Basic HTTP manipulations
 
 HTTP manipulations are done by using skipper filters. Changes can be

--- a/filters/auth/authclient.go
+++ b/filters/auth/authclient.go
@@ -4,12 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/opentracing/opentracing-go"
+	"github.com/zalando/skipper/filters"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+)
+
+const (
+	webhookSpanName = "webhook"
 )
 
 type authClient struct {
@@ -48,10 +53,33 @@ func (ac *authClient) getTokeninfo(token string) (map[string]interface{}, error)
 	return a, err
 }
 
-const webhookSpanName = "webhook"
+func (ac *authClient) getWebhook(ctx filters.FilterContext) (int, error) {
+	return ac.doClonedGet(ctx)
+}
 
-func (ac *authClient) getWebhook(r *http.Request, tracer opentracing.Tracer, parentSpan opentracing.Span) (int, error) {
-	return doClonedGet(ac.url, ac.client, r, tracer, parentSpan, webhookSpanName)
+// doClonedGet requests url with the same headers and query as the
+// incoming request and returns with http statusCode and error.
+func (ac *authClient) doClonedGet(ctx filters.FilterContext) (int, error) {
+	tracer := ctx.Tracer()
+	parentSpan := ctx.ParentSpan()
+	request := ctx.Request()
+	span := tracer.StartSpan(webhookSpanName, opentracing.ChildOf(parentSpan.Context()))
+	defer span.Finish()
+	req, err := http.NewRequest("GET", ac.url.String(), nil)
+	if err != nil {
+		return -1, err
+	}
+
+	tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
+	copyHeader(req.Header, request.Header)
+
+	rsp, err := ac.client.Do(req)
+	if err != nil {
+		return -1, err
+	}
+	defer rsp.Body.Close()
+
+	return rsp.StatusCode, nil
 }
 
 func createHTTPClient(timeout time.Duration, quit chan struct{}) (*http.Client, error) {
@@ -121,27 +149,4 @@ func jsonPost(u *url.URL, auth string, doc *tokenIntrospectionInfo, client *http
 		return err
 	}
 	return json.Unmarshal(buf, &doc)
-}
-
-// doClonedGet requests url with the same headers and query as the
-// incoming request and returns with http statusCode and error.
-func doClonedGet(u *url.URL, client *http.Client, incoming *http.Request, tracer opentracing.Tracer,
-	parentSpan opentracing.Span, childSpanName string) (int, error) {
-	span := tracer.StartSpan(childSpanName, opentracing.ChildOf(parentSpan.Context()))
-	defer span.Finish()
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return -1, err
-	}
-
-	tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
-	copyHeader(req.Header, incoming.Header)
-
-	rsp, err := client.Do(req)
-	if err != nil {
-		return -1, err
-	}
-	defer rsp.Body.Close()
-
-	return rsp.StatusCode, nil
 }

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -60,9 +60,7 @@ func copyHeader(to, from http.Header) {
 }
 
 func (f *webhookFilter) Request(ctx filters.FilterContext) {
-	tracer := ctx.Tracer()
-	parentSpan := ctx.ParentSpan()
-	statusCode, err := f.authClient.getWebhook(ctx.Request(), tracer, parentSpan)
+	statusCode, err := f.authClient.getWebhook(ctx)
 	if err != nil {
 		unauthorized(ctx, WebhookName, authServiceAccess, f.authClient.url.Hostname())
 	}

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -60,7 +60,9 @@ func copyHeader(to, from http.Header) {
 }
 
 func (f *webhookFilter) Request(ctx filters.FilterContext) {
-	statusCode, err := f.authClient.getWebhook(ctx.Request())
+	tracer := ctx.Tracer()
+	parentSpan := ctx.ParentSpan()
+	statusCode, err := f.authClient.getWebhook(ctx.Request(), tracer, parentSpan)
 	if err != nil {
 		unauthorized(ctx, WebhookName, authServiceAccess, f.authClient.url.Hostname())
 	}

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -79,6 +79,9 @@ type FilterContext interface {
 
 	// Allow filters to add Tags, Baggage to the trace or set the ComponentName.
 	Tracer() opentracing.Tracer
+
+	// Allow filters to create their own spans
+	ParentSpan() opentracing.Span
 }
 
 // Metrics provides possibility to use custom metrics from filter implementations. The custom metrics will

--- a/filters/filtertest/filtertest.go
+++ b/filters/filtertest/filtertest.go
@@ -21,7 +21,7 @@ package filtertest
 import (
 	"net/http"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/filters"
 )
 
@@ -70,6 +70,10 @@ func (fc *Context) Tracer() opentracing.Tracer {
 	}
 	return &opentracing.NoopTracer{}
 }
+func (fc *Context) ParentSpan() opentracing.Span {
+	return opentracing.StartSpan("test_span")
+}
+
 func (fc *Context) Serve(resp *http.Response) {
 	fc.FServedWithResponse = true
 	fc.FResponse = resp

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -36,6 +36,7 @@ type context struct {
 	metrics               *filterMetrics
 	tracer                opentracing.Tracer
 	proxySpan             opentracing.Span
+	parentSpan            opentracing.Span
 
 	routeLookup *routing.RouteLookup
 }
@@ -194,7 +195,7 @@ func (c *context) OutgoingHost() string                { return c.outgoingHost }
 func (c *context) SetOutgoingHost(h string)            { c.outgoingHost = h }
 func (c *context) Metrics() filters.Metrics            { return c.metrics }
 func (c *context) Tracer() opentracing.Tracer          { return c.tracer }
-
+func (c *context) ParentSpan() opentracing.Span        { return c.parentSpan }
 func (c *context) Serve(r *http.Response) {
 	r.Request = c.Request()
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -584,9 +584,9 @@ func (p *Proxy) applyFiltersToRequest(f []*routing.RouteFilter, ctx *context) []
 	}
 
 	filtersStart := time.Now()
-
 	filtersSpan := tracing.CreateSpan("request_filters", ctx.request.Context(), p.openTracer)
 	defer filtersSpan.Finish()
+	ctx.parentSpan = filtersSpan
 
 	var filters = make([]*routing.RouteFilter, 0, len(f))
 	for _, fi := range f {

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/filters"
 )
 
@@ -87,6 +87,8 @@ func (l *luaContext) SetOutgoingHost(_ string) {}
 func (l *luaContext) Metrics() filters.Metrics { return nil }
 
 func (l *luaContext) Tracer() opentracing.Tracer { return nil }
+
+func (l *luaContext) ParentSpan() opentracing.Span { return nil }
 
 func TestStateBag(t *testing.T) {
 	code := `function request(ctx, params); ctx.state_bag["foo"] = "bar"; end`


### PR DESCRIPTION
Added the filter span to filter context so that it can used in the filters. Also implemented opentracing for webhook authentication so that a span is created and propagated forward to the downstream.

The result trace looks like as show below:

![filter-span](https://user-images.githubusercontent.com/626536/50387174-6fdd3400-06f6-11e9-9f4b-95821a88c33b.png)
