### PR TITLE
docs: Fix the Host predicate regex example

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -13,7 +13,7 @@ Predicates can be chained using the double ampersand operator `&&`.
 Example route with a Host, Method and Path match predicates and a backend:
 
 ```
-all: Host("^my-host-header\.example\.org$") && Method("GET") && Path("/hello") -> "http://127.0.0.1:1234/";
+all: Host(/^my-host-header\.example\.org$/) && Method("GET") && Path("/hello") -> "http://127.0.0.1:1234/";
 ```
 
 ## Path
@@ -85,8 +85,8 @@ Parameters:
 Examples:
 
 ```
-Host("/^my-host-header\.example\.org$/")
-Host("/header\.example\.org$/")
+Host(/^my-host-header\.example\.org$/)
+Host(/header\.example\.org$/)
 ```
 
 ## Method


### PR DESCRIPTION
The docs state that regular expressions should be surrounded by slashes
(`/`), but just below, the `Host` example was surrounded by double
quotes.

In the `Host` paragraph, there were both slashes and quotes; the example
would fail. I have changed them to just slashes for consistency.