### PR TITLE
Added opentracing spans to calls to tokeninfo and tokenintrospection endpoints

### DIFF
--- a/filters/auth/authclient.go
+++ b/filters/auth/authclient.go
@@ -17,7 +17,7 @@ import (
 const (
 	webhookSpanName        = "webhook"
 	tokenInfoSpanName      = "tokeninfo"
-	tokenIntrospectionSpan = "tokenIntrospection"
+	tokenIntrospectionSpan = "tokenintrospection"
 )
 
 type authClient struct {

--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -240,7 +240,7 @@ func (f *tokeninfoFilter) Request(ctx filters.FilterContext) {
 			return
 		}
 
-		authMap, err = f.authClient.getTokeninfo(token)
+		authMap, err = f.authClient.getTokeninfo(token, ctx)
 		if err != nil {
 			reason := authServiceAccess
 			if err == errInvalidToken {

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -141,7 +141,7 @@ func getOpenIDConfig(issuerURL string) (*openIDConfig, error) {
 	}
 
 	var cfg openIDConfig
-	err = jsonGet(u, "", &cfg, http.DefaultClient)
+	err = jsonGet(u, "", &cfg, http.DefaultClient, nil, nil, "")
 	return &cfg, err
 }
 

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -293,7 +293,7 @@ func (f *tokenintrospectFilter) Request(ctx filters.FilterContext) {
 			return
 		}
 
-		info, err = f.authClient.getTokenintrospect(token)
+		info, err = f.authClient.getTokenintrospect(token, ctx)
 		if err != nil {
 			reason := authServiceAccess
 			if err == errInvalidToken {


### PR DESCRIPTION
Using features implemented in PR #890 added opentracing into calls to the tokeninfo and tokenintrospection backends.

Signed-off-by: Arjun Naik <arjun.rn@gmail.com>