### PR TITLE
Access log disable filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -890,23 +890,33 @@ accessLogDisabled("false")
 ## disableAccessLog
 
 Filter overrides global Skipper `AccessLogDisabled` setting and allows to turn-off the access log for specific route
-while access log, in general, is enabled.
+while access log, in general, is enabled. It is also possible to disable access logs only for a subset of response codes 
+from backend by providing an optional list of response code prefixes.
+
+Parameters:
+* response code prefixes (variadic int) - optional
 
 Example:
 
 ```
 disableAccessLog()
+disableAccessLog(1, 301, 40)
 ```
 
 ## enableAccessLog
 
 Filter overrides global Skipper `AccessLogDisabled` setting and allows to turn-on the access log for specific route
-while access log, in general, is disabled.
+while access log, in general, is disabled. It is also possible to enable access logs only for a subset of response codes
+from backend by providing an optional list of response code prefixes.
+
+Parameters:
+* response code prefixes (variadic int) - optional
 
 Example:
 
 ```
 enableAccessLog()
+enableAccessLog(1, 301, 20)
 ```
 
 ## auditLog

--- a/filters/accesslog/control.go
+++ b/filters/accesslog/control.go
@@ -40,6 +40,8 @@ func extractFilterValues(args []interface{}, enable bool) (filters.Filter, error
 		}
 		if ok {
 			prefixes = append(prefixes, intPref)
+		} else {
+			return nil, filters.ErrInvalidFilterParameters
 		}
 	}
 	return &AccessLogFilter{Enable: enable, Prefixes: prefixes}, nil

--- a/filters/accesslog/control.go
+++ b/filters/accesslog/control.go
@@ -13,11 +13,46 @@ const (
 	AccessLogEnabledKey = "statebag:access_log:proxy:enabled"
 )
 
+// Common filter struct for holding access log state
+type AccessLogFilter struct {
+	Enable   bool
+	Prefixes []int
+}
+
+func (al *AccessLogFilter) Request(ctx filters.FilterContext) {
+	bag := ctx.StateBag()
+	bag[AccessLogEnabledKey] = al
+}
+
+func (*AccessLogFilter) Response(filters.FilterContext) {}
+
+func extractFilterValues(args []interface{}, enable bool) (filters.Filter, error) {
+	prefixes := make([]int, 0)
+	for _, prefix := range args {
+		intPref, ok := 0, false
+		switch prefix.(type) {
+		case float32:
+			intPref, ok = int(prefix.(float32)), true
+		case float64:
+			intPref, ok = int(prefix.(float64)), true
+		default:
+			intPref, ok = prefix.(int)
+		}
+		if ok {
+			prefixes = append(prefixes, intPref)
+		}
+	}
+	return &AccessLogFilter{Enable: enable, Prefixes: prefixes}, nil
+}
+
 type disableAccessLog struct{}
 
-// NewDisableAccessLog creates a filter spec to disable access log for specific route
+// NewDisableAccessLog creates a filter spec to disable access log for specific route.
+// Optionally takes in response code prefixes as arguments. When provided, access log is disabled
+// only if response code matches one of the arguments.
 //
-// 	disableAccessLog()
+//  	disableAccessLog() or
+//  	disableAccessLog(1, 20, 301)  to disable logs for 1xx, 20x and 301 codes
 func NewDisableAccessLog() filters.Spec {
 	return &disableAccessLog{}
 }
@@ -25,21 +60,17 @@ func NewDisableAccessLog() filters.Spec {
 func (*disableAccessLog) Name() string { return DisableAccessLogName }
 
 func (al *disableAccessLog) CreateFilter(args []interface{}) (filters.Filter, error) {
-	return al, nil
+	return extractFilterValues(args, false)
 }
-
-func (al *disableAccessLog) Request(ctx filters.FilterContext) {
-	bag := ctx.StateBag()
-	bag[AccessLogEnabledKey] = false
-}
-
-func (*disableAccessLog) Response(filters.FilterContext) {}
 
 type enableAccessLog struct{}
 
 // NewEnableAccessLog creates a filter spec to enable access log for specific route
+// Optionally takes in response code prefixes as arguments. When provided, access log is enabled
+// only if response code matches one of the arguments.
 //
 // 	enableAccessLog()
+// 	enableAccessLog(1, 20, 301)  to enable logs for 1xx, 20x and 301 codes
 func NewEnableAccessLog() filters.Spec {
 	return &enableAccessLog{}
 }
@@ -47,12 +78,5 @@ func NewEnableAccessLog() filters.Spec {
 func (*enableAccessLog) Name() string { return EnableAccessLogName }
 
 func (al *enableAccessLog) CreateFilter(args []interface{}) (filters.Filter, error) {
-	return al, nil
+	return extractFilterValues(args, true)
 }
-
-func (al *enableAccessLog) Request(ctx filters.FilterContext) {
-	bag := ctx.StateBag()
-	bag[AccessLogEnabledKey] = true
-}
-
-func (*enableAccessLog) Response(filters.FilterContext) {}

--- a/filters/accesslog/control_test.go
+++ b/filters/accesslog/control_test.go
@@ -10,47 +10,65 @@ import (
 
 func TestAccessLogControl(t *testing.T) {
 	for _, ti := range []struct {
-		msg    string
-		state  filters.Spec
-		args   []interface{}
-		result AccessLogFilter
+		msg     string
+		state   filters.Spec
+		args    []interface{}
+		result  AccessLogFilter
+		isError bool
 	}{
 		{
-			msg:    "enables-access-log",
-			state:  NewEnableAccessLog(),
-			args:   nil,
-			result: AccessLogFilter{true, make([]int, 0)},
+			msg:     "enables-access-log",
+			state:   NewEnableAccessLog(),
+			args:    nil,
+			result:  AccessLogFilter{true, make([]int, 0)},
+			isError: false,
 		},
 		{
-			msg:    "enable-access-log-selective",
-			state:  NewEnableAccessLog(),
-			args:   []interface{}{2, 4, 300},
-			result: AccessLogFilter{true, []int{2, 4, 300}},
+			msg:     "enable-access-log-selective",
+			state:   NewEnableAccessLog(),
+			args:    []interface{}{2, 4, 300},
+			result:  AccessLogFilter{true, []int{2, 4, 300}},
+			isError: false,
 		},
 		{
-			msg:    "disables-access-log",
-			state:  NewDisableAccessLog(),
-			args:   nil,
-			result: AccessLogFilter{false, make([]int, 0)},
+			msg:     "enable-access-log-error-string",
+			state:   NewEnableAccessLog(),
+			args:    []interface{}{1, "a"},
+			result:  AccessLogFilter{},
+			isError: true,
 		},
 		{
-			msg:    "disables-access-log-selective",
-			state:  NewDisableAccessLog(),
-			args:   []interface{}{1, 201, 30},
-			result: AccessLogFilter{false, []int{1, 201, 30}},
+			msg:     "disables-access-log",
+			state:   NewDisableAccessLog(),
+			args:    nil,
+			result:  AccessLogFilter{false, make([]int, 0)},
+			isError: false,
 		},
 		{
-			msg:    "disables-access-log-ignore-string-convert-float",
-			state:  NewDisableAccessLog(),
-			args:   []interface{}{1.0, 201, "a"},
-			result: AccessLogFilter{false, []int{1, 201}},
+			msg:     "disables-access-log-selective",
+			state:   NewDisableAccessLog(),
+			args:    []interface{}{1, 201, 30},
+			result:  AccessLogFilter{false, []int{1, 201, 30}},
+			isError: false,
+		},
+		{
+			msg:     "disables-access-log-convert-float",
+			state:   NewDisableAccessLog(),
+			args:    []interface{}{1.0, 201},
+			result:  AccessLogFilter{false, []int{1, 201}},
+			isError: false,
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
 			f, err := ti.state.CreateFilter(ti.args)
 
-			if err != nil {
-				return
+			if ti.isError {
+				if err == nil {
+					t.Errorf("Unexpected error creating filter %v", err)
+					return
+				} else {
+					return
+				}
 			}
 
 			var ctx filtertest.Context

--- a/filters/accesslog/disable.go
+++ b/filters/accesslog/disable.go
@@ -37,7 +37,7 @@ func (*accessLogDisabled) CreateFilter(args []interface{}) (filters.Filter, erro
 
 func (al *accessLogDisabled) Request(ctx filters.FilterContext) {
 	bag := ctx.StateBag()
-	bag[AccessLogEnabledKey] = !al.disabled
+	bag[AccessLogEnabledKey] = &AccessLogFilter{!al.disabled, nil}
 }
 
 func (*accessLogDisabled) Response(filters.FilterContext) {}

--- a/filters/accesslog/disable_test.go
+++ b/filters/accesslog/disable_test.go
@@ -1,6 +1,7 @@
 package accesslog
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"testing"
 
 	"github.com/zalando/skipper/filters"
@@ -11,37 +12,37 @@ func TestAccessLogDisabled(t *testing.T) {
 	for _, ti := range []struct {
 		msg    string
 		state  []interface{}
-		result bool
+		result AccessLogFilter
 		err    error
 	}{
 		{
 			msg:    "false-value-enables-access-log",
 			state:  []interface{}{"false"},
-			result: true,
+			result: AccessLogFilter{true, nil},
 			err:    nil,
 		},
 		{
 			msg:    "true-value-disables-access-log",
 			state:  []interface{}{"true"},
-			result: false,
+			result: AccessLogFilter{false, nil},
 			err:    nil,
 		},
 		{
 			msg:    "unknown-argument-leads-to-error",
 			state:  []interface{}{"unknownValue"},
-			result: false,
+			result: AccessLogFilter{true, nil},
 			err:    filters.ErrInvalidFilterParameters,
 		},
 		{
 			msg:    "no-arguments-lead-to-error",
 			state:  []interface{}{},
-			result: false,
+			result: AccessLogFilter{true, nil},
 			err:    filters.ErrInvalidFilterParameters,
 		},
 		{
 			msg:    "multiple-arguments-lead-to-error",
 			state:  []interface{}{"true", "second"},
-			result: false,
+			result: AccessLogFilter{true, nil},
 			err:    filters.ErrInvalidFilterParameters,
 		},
 	} {
@@ -62,7 +63,7 @@ func TestAccessLogDisabled(t *testing.T) {
 
 			f.Request(&ctx)
 			bag := ctx.StateBag()
-			if bag[AccessLogEnabledKey] != ti.result {
+			if diff := cmp.Diff(bag[AccessLogEnabledKey], &ti.result); diff != "" {
 				t.Errorf("access log state is not equal to expected '%v': %v", ti.result, bag[AccessLogEnabledKey])
 			}
 		})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -194,6 +194,8 @@ type Params struct {
 
 var (
 	hostname               = ""
+	disabledAccessLog      = al.AccessLogFilter{Enable: false, Prefixes: nil}
+	enabledAccessLog       = al.AccessLogFilter{Enable: true, Prefixes: nil}
 	errMaxLoopbacksReached = errors.New("max loopbacks reached")
 	errRouteLookupFailed   = &proxyError{err: errors.New("route lookup failed")}
 	errCircuitBreakerOpen  = &proxyError{
@@ -1114,7 +1116,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		accessLogEnabled, ok := ctx.stateBag[al.AccessLogEnabledKey].(*al.AccessLogFilter)
 
 		if !ok {
-			accessLogEnabled = &al.AccessLogFilter{Enable: !p.accessLogDisabled, Prefixes: nil}
+			if p.accessLogDisabled {
+				accessLogEnabled = &disabledAccessLog
+			} else {
+				accessLogEnabled = &enabledAccessLog
+			}
 		}
 		statusCode := lw.GetCode()
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1070,7 +1070,7 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 	p.sendError(ctx, id, code)
 }
 
-func shouldLog(statusCode int, filter al.AccessLogFilter) bool {
+func shouldLog(statusCode int, filter *al.AccessLogFilter) bool {
 	if len(filter.Prefixes) == 0 {
 		return filter.Enable
 	}
@@ -1118,7 +1118,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		statusCode := lw.GetCode()
 
-		if shouldLog(statusCode, *accessLogEnabled) {
+		if shouldLog(statusCode, accessLogEnabled) {
 			entry := &logging.AccessEntry{
 				Request:      r,
 				ResponseSize: lw.GetBytes(),

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1417,69 +1417,137 @@ func TestDisableAccessLog(t *testing.T) {
 }
 
 func TestDisableAccessLogWithFilter(t *testing.T) {
-	var buf bytes.Buffer
-	logging.Init(logging.Options{
-		AccessLogOutput: &buf})
+	for _, ti := range []struct {
+		msg          string
+		filter       string
+		responseCode int
+		disabled     bool
+	}{
+		{
+			msg:          "disable-log-for-all",
+			filter:       "disableAccessLog()",
+			responseCode: 201,
+			disabled:     true,
+		},
+		{
+			msg:          "disable-log-match-exact",
+			filter:       "disableAccessLog(200)",
+			responseCode: 200,
+			disabled:     true,
+		},
+		{
+			msg:          "disable-log-match-prefix",
+			filter:       "disableAccessLog(3)",
+			responseCode: 302,
+			disabled:     true,
+		},
+		{
+			msg:          "disable-log-no-match",
+			filter:       "disableAccessLog(1,20,300)",
+			responseCode: 500,
+			disabled:     false,
+		},
+	} {
+		t.Run(ti.msg, func(t *testing.T) {
+			var buf bytes.Buffer
+			logging.Init(logging.Options{
+				AccessLogOutput: &buf})
 
-	response := "7 bytes"
+			response := "7 bytes"
 
-	u, _ := url.ParseRequestURI("https://www.example.org/hello")
-	r := &http.Request{
-		URL:    u,
-		Method: "GET",
-		Header: http.Header{"Connection": []string{"token"}}}
-	w := httptest.NewRecorder()
+			u, _ := url.ParseRequestURI("https://www.example.org/hello")
+			r := &http.Request{
+				URL:    u,
+				Method: "GET",
+				Header: http.Header{"Connection": []string{"token"}}}
+			w := httptest.NewRecorder()
 
-	doc := fmt.Sprintf(`hello: Path("/hello") -> disableAccessLog() -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
+			doc := fmt.Sprintf(`hello: Path("/hello") -> %s -> status(%d) -> inlineContent("%s") -> <shunt>`, ti.filter, ti.responseCode, response)
 
-	tp, err := newTestProxyWithParams(doc, Params{
-		AccessLogDisabled: false,
-	})
-	if err != nil {
-		t.Error(err)
-		return
-	}
+			tp, err := newTestProxyWithParams(doc, Params{
+				AccessLogDisabled: false,
+			})
+			if err != nil {
+				t.Error(err)
+				return
+			}
 
-	defer tp.close()
+			defer tp.close()
 
-	tp.proxy.ServeHTTP(w, r)
+			tp.proxy.ServeHTTP(w, r)
 
-	if buf.Len() != 0 {
-		t.Error("failed to disable access log")
+			if ti.disabled != (buf.Len() == 0) {
+				t.Error("failed to disable access log")
+			}
+		})
 	}
 }
 
 func TestEnableAccessLogWithFilter(t *testing.T) {
-	var buf bytes.Buffer
-	logging.Init(logging.Options{
-		AccessLogOutput: &buf})
+	for _, ti := range []struct {
+		msg          string
+		filter       string
+		responseCode int
+		shouldLog    bool
+	}{
+		{
+			msg:          "enable-log-for-all",
+			filter:       "enableAccessLog()",
+			responseCode: 201,
+			shouldLog:    true,
+		},
+		{
+			msg:          "enable-log-match-exact",
+			filter:       "enableAccessLog(200)",
+			responseCode: 200,
+			shouldLog:    true,
+		},
+		{
+			msg:          "enable-log-match-prefix",
+			filter:       "enableAccessLog(3)",
+			responseCode: 302,
+			shouldLog:    true,
+		},
+		{
+			msg:          "enable-log-no-match",
+			filter:       "enableAccessLog(1,20,300)",
+			responseCode: 500,
+			shouldLog:    false,
+		},
+	} {
+		t.Run(ti.msg, func(t *testing.T) {
+			var buf bytes.Buffer
+			logging.Init(logging.Options{
+				AccessLogOutput: &buf})
 
-	response := "7 bytes"
+			response := "7 bytes"
 
-	u, _ := url.ParseRequestURI("https://www.example.org/hello")
-	r := &http.Request{
-		URL:    u,
-		Method: "GET",
-		Header: http.Header{"Connection": []string{"token"}}}
-	w := httptest.NewRecorder()
+			u, _ := url.ParseRequestURI("https://www.example.org/hello")
+			r := &http.Request{
+				URL:    u,
+				Method: "GET",
+				Header: http.Header{"Connection": []string{"token"}}}
+			w := httptest.NewRecorder()
 
-	doc := fmt.Sprintf(`hello: Path("/hello") -> enableAccessLog() -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
+			doc := fmt.Sprintf(`hello: Path("/hello") -> %s -> status(%d) -> inlineContent("%s") -> <shunt>`, ti.filter, ti.responseCode, response)
 
-	tp, err := newTestProxyWithParams(doc, Params{
-		AccessLogDisabled: true,
-	})
-	if err != nil {
-		t.Error(err)
-		return
-	}
+			tp, err := newTestProxyWithParams(doc, Params{
+				AccessLogDisabled: true,
+			})
+			if err != nil {
+				t.Error(err)
+				return
+			}
 
-	defer tp.close()
+			defer tp.close()
 
-	tp.proxy.ServeHTTP(w, r)
+			tp.proxy.ServeHTTP(w, r)
 
-	output := buf.String()
-	if !strings.Contains(output, fmt.Sprintf(`"%s - -" %d %d "-" "-" 0 - - -`, r.Method, http.StatusTeapot, len(response))) {
-		t.Error("failed to log access", output)
+			output := buf.String()
+			if ti.shouldLog != strings.Contains(output, fmt.Sprintf(`"%s - -" %d %d "-" "-" 0 - - -`, r.Method, ti.responseCode, len(response))) {
+				t.Error("failed to log access", output)
+			}
+		})
 	}
 }
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1636,14 +1636,14 @@ func TestHopHeaderRemovalDisabled(t *testing.T) {
 }
 
 func benchmarkAccessLog(b *testing.B, filter string, responseCode int) {
-	response 	 := "some bytes"
+	response := "some bytes"
 
 	u, _ := url.ParseRequestURI("https://www.example.org/hello")
 	r := &http.Request{
 		URL:    u,
 		Method: "GET",
 		Header: http.Header{"Connection": []string{"token"}}}
-	
+
 	accessLogFilter := filter
 	if filter == "" {
 		accessLogFilter = ""
@@ -1664,14 +1664,16 @@ func benchmarkAccessLog(b *testing.B, filter string, responseCode int) {
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
-		for(pb.Next()) {
+		for pb.Next() {
 			tp.proxy.ServeHTTP(httptest.NewRecorder(), r)
 		}
 	})
 }
 
-func BenchmarkAccessLogNoFilter(b *testing.B) {benchmarkAccessLog(b, "", 200)}
-func BenchmarkAccessLogDisablePrint(b *testing.B) {benchmarkAccessLog(b, "disableAccessLog(1,3)", 200)}
-func BenchmarkAccessLogDisable(b *testing.B) {benchmarkAccessLog(b, "disableAccessLog(1,3,200)", 200)}
-func BenchmarkAccessLogEnablePrint(b *testing.B) {benchmarkAccessLog(b, "enableAccessLog(1,200,3)", 200)}
-func BenchmarkAccessLogEnable(b *testing.B) {benchmarkAccessLog(b, "enableAccessLog(1,3)", 200)}
+func BenchmarkAccessLogNoFilter(b *testing.B)     { benchmarkAccessLog(b, "", 200) }
+func BenchmarkAccessLogDisablePrint(b *testing.B) { benchmarkAccessLog(b, "disableAccessLog(1,3)", 200) }
+func BenchmarkAccessLogDisable(b *testing.B)      { benchmarkAccessLog(b, "disableAccessLog(1,3,200)", 200) }
+func BenchmarkAccessLogEnablePrint(b *testing.B) {
+	benchmarkAccessLog(b, "enableAccessLog(1,200,3)", 200)
+}
+func BenchmarkAccessLogEnable(b *testing.B) { benchmarkAccessLog(b, "enableAccessLog(1,3)", 200) }


### PR DESCRIPTION
Adds ability to enable/disable logs based on response code returned by the backend. This would allow more fine grained control for high throughput systems which don't want to log 2xx responses (~99.99% of responses) but still would like to log errors.

Fixes #909 