### PR TITLE
Add command line flags for all etcd options

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -36,6 +36,7 @@ const (
 	// generic:
 	defaultAddress                         = ":9090"
 	defaultEtcdPrefix                      = "/skipper"
+	defaultEtcdTimeout                     = time.Second
 	defaultSourcePollTimeout               = int64(3000)
 	defaultSupportListener                 = ":9911"
 	defaultBackendFlushInterval            = 20 * time.Millisecond
@@ -125,6 +126,11 @@ const (
 	// route sources:
 	etcdUrlsUsage                  = "urls of nodes in an etcd cluster, storing route definitions"
 	etcdPrefixUsage                = "path prefix for skipper related data in etcd"
+	etcdTimeoutUsage               = "http client timeout duration for etcd"
+	etcdInsecureUsage              = "ignore the verification of TLS certificates for etcd"
+	etcdOAuthTokenUsage            = "optional token for OAuth authentication with etcd"
+	etcdUsernameUsage              = "optional username for basic authentication with etcd"
+	etcdPasswordUsage              = "optional password for basic authentication with etcd"
 	innkeeperURLUsage              = "API endpoint of the Innkeeper service, storing route definitions"
 	innkeeperAuthTokenUsage        = "fixed token for innkeeper authentication"
 	innkeeperPreRouteFiltersUsage  = "filters to be prepended to each route loaded from Innkeeper"
@@ -261,6 +267,11 @@ var (
 	// route sources:
 	etcdUrls                  string
 	etcdPrefix                string
+	etcdTimeout               time.Duration
+	etcdInsecure              bool
+	etcdOAuthToken            string
+	etcdUsername              string
+	etcdPassword              string
 	innkeeperURL              string
 	innkeeperAuthToken        string
 	innkeeperPreRouteFilters  string
@@ -395,6 +406,11 @@ func init() {
 	// route sources:
 	flag.StringVar(&etcdUrls, "etcd-urls", "", etcdUrlsUsage)
 	flag.StringVar(&etcdPrefix, "etcd-prefix", defaultEtcdPrefix, etcdPrefixUsage)
+	flag.DurationVar(&etcdTimeout, "etcd-timeout", defaultEtcdTimeout, etcdTimeoutUsage)
+	flag.BoolVar(&etcdInsecure, "etcd-insecure", false, etcdInsecureUsage)
+	flag.StringVar(&etcdOAuthToken, "etcd-oauth-token", "", etcdOAuthTokenUsage)
+	flag.StringVar(&etcdUsername, "etcd-username", "", etcdUsernameUsage)
+	flag.StringVar(&etcdPassword, "etcd-password", "", etcdPasswordUsage)
 	flag.StringVar(&innkeeperURL, "innkeeper-url", "", innkeeperURLUsage)
 	flag.StringVar(&innkeeperAuthToken, "innkeeper-auth-token", "", innkeeperAuthTokenUsage)
 	flag.StringVar(&innkeeperPreRouteFilters, "innkeeper-pre-route-filters", "", innkeeperPreRouteFiltersUsage)
@@ -604,6 +620,11 @@ func main() {
 		// route sources:
 		EtcdUrls:                  eus,
 		EtcdPrefix:                etcdPrefix,
+		EtcdWaitTimeout:           etcdTimeout,
+		EtcdInsecure:              etcdInsecure,
+		EtcdOAuthToken:            etcdOAuthToken,
+		EtcdUsername:              etcdUsername,
+		EtcdPassword:              etcdPassword,
 		InnkeeperUrl:              innkeeperURL,
 		InnkeeperAuthToken:        innkeeperAuthToken,
 		InnkeeperPreRouteFilters:  innkeeperPreRouteFilters,

--- a/skipper.go
+++ b/skipper.go
@@ -72,6 +72,15 @@ type Options struct {
 	// Skip TLS certificate check for etcd connections.
 	EtcdInsecure bool
 
+	// If set this value is used as Bearer token for etcd OAuth authorization.
+	EtcdOAuthToken string
+
+	// If set this value is used as username for etcd basic authorization.
+	EtcdUsername string
+
+	// If set this value is used as password for etcd basic authorization.
+	EtcdPassword string
+
 	// If set enables skipper to generate based on ingress resources in kubernetes cluster
 	Kubernetes bool
 
@@ -554,10 +563,13 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 
 	if len(o.EtcdUrls) > 0 {
 		etcdClient, err := etcd.New(etcd.Options{
-			Endpoints: o.EtcdUrls,
-			Prefix:    o.EtcdPrefix,
-			Timeout:   o.EtcdWaitTimeout,
-			Insecure:  o.EtcdInsecure,
+			Endpoints:  o.EtcdUrls,
+			Prefix:     o.EtcdPrefix,
+			Timeout:    o.EtcdWaitTimeout,
+			Insecure:   o.EtcdInsecure,
+			OAuthToken: o.EtcdOAuthToken,
+			Username:   o.EtcdUsername,
+			Password:   o.EtcdPassword,
 		})
 
 		if err != nil {


### PR DESCRIPTION
This commit adds command line flags for the following etcd options:
- Timeout
- Insecure
- OAuthToken
- Username
- Password

## Example usage
```bash
skipper -etcd-urls="https://etcd.example.org" -etcd-timeout=2s -etcd-insecure \
    -etcd-oauth-token="deadbeef" -etcd-username="user" -etcd-password="pass"
```

## Help output
```bash
  ...
  -etcd-insecure
    	ignore the verification of TLS certificates for etcd
  -etcd-oauth-token string
    	optional token for OAuth authentication with etcd
  -etcd-password string
    	optional password for basic authentication with etcd
  -etcd-prefix string
    	path prefix for skipper related data in etcd (default "/skipper")
  -etcd-timeout duration
    	http client timeout duration for etcd (default 1s)
  -etcd-urls string
    	urls of nodes in an etcd cluster, storing route definitions
  -etcd-username string
    	optional username for basic authentication with etcd
  ...
```
Closes #933 