### PR TITLE
Make proxy client TLS work with skipper.Options

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -843,6 +843,7 @@ func Run(o Options) error {
 		TLSHandshakeTimeout:      o.TLSHandshakeTimeoutBackend,
 		MaxIdleConns:             o.MaxIdleConnsBackend,
 		AccessLogDisabled:        o.AccessLogDisabled,
+		ClientTLS:                o.ClientTLS,
 	}
 
 	var theSwarm *swarm.Swarm


### PR DESCRIPTION
PR #928 introduced the possibility to add TLS client config to the proxy.
It was also added to the main skipper.Options, but not passed on. This commit fixes this.

Signed-off-by: Martin Bertschler <mbertschler@gmail.com>