### PR TITLE
kubernetes: fetch endpoints/services once

### DIFF
--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -32,9 +32,9 @@ func (s sortRoutes) Less(i, j int) bool { return s[i].Id < s[j].Id }
 func (s sortRoutes) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) {
-	s := services{
-		"namespace1": map[string]*service{
-			"service1": testService("1.2.3.4", map[string]int{"port1": 8080}),
+	s := &serviceList{
+		Items: []*service{
+			testService("namespace1", "service1", "1.2.3.4", map[string]int{"port1": 8080}),
 		},
 	}
 	i := &ingressList{Items: []*ingressItem{
@@ -93,8 +93,8 @@ func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) 
 
 	ingress := i.Items[0]
 	rule := ingress.Spec.Rules[0]
-	service := s[ingress.Metadata.Namespace][rule.Http.Paths[0].Backend.ServiceName].Spec
-	fallbackService := s[i.Items[0].Metadata.Namespace][i.Items[0].Spec.DefaultBackend.ServiceName].Spec
+	service := s.Items[0].Spec
+	fallbackService := s.Items[0].Spec
 	backend := fmt.Sprintf("http://%s:%d", service.ClusterIP, service.Ports[0].Port)
 	fallbackBackend := fmt.Sprintf("http://%s:%d", fallbackService.ClusterIP, fallbackService.Ports[0].Port)
 

--- a/dataclients/kubernetes/lbannotationfilters_test.go
+++ b/dataclients/kubernetes/lbannotationfilters_test.go
@@ -6,13 +6,14 @@ import (
 
 func TestAnnotationFiltersInLBRoutes(t *testing.T) {
 	svc := testServiceWithTargetPort(
+		"namespace1", "service1",
 		"1.2.3.4",
 		map[string]int{"port1": 8080},
 		map[int]*backendPort{8080: {8080}},
 	)
 
-	services := services{
-		"namespace1": map[string]*service{"service1": svc},
+	services := &serviceList{
+		Items: []*service{svc},
 	}
 
 	subsets := []*subset{{
@@ -33,9 +34,12 @@ func TestAnnotationFiltersInLBRoutes(t *testing.T) {
 		}},
 	}}
 
-	endpoints := endpoints{
-		"namespace1": map[string]endpoint{
-			"service1": {Subsets: subsets},
+	endpoints := &endpointList{
+		Items: []*endpoint{
+			{
+				Meta:    &metadata{Namespace: "namespace1", Name: "service1"},
+				Subsets: subsets,
+			},
 		},
 	}
 

--- a/dataclients/kubernetes/lbtarget_test.go
+++ b/dataclients/kubernetes/lbtarget_test.go
@@ -6,13 +6,14 @@ import (
 
 func testSingleIngressWithTargets(t *testing.T, targets []string, expectedRoutes string) {
 	svc := testServiceWithTargetPort(
+		"namespace1", "service1",
 		"1.2.3.4",
 		map[string]int{"port1": 8080},
 		map[int]*backendPort{8080: {8080}},
 	)
 
-	services := services{
-		"namespace1": map[string]*service{"service1": svc},
+	services := &serviceList{
+		Items: []*service{svc},
 	}
 
 	var subsets []*subset
@@ -28,9 +29,12 @@ func testSingleIngressWithTargets(t *testing.T, targets []string, expectedRoutes
 		})
 	}
 
-	endpoints := endpoints{
-		"namespace1": map[string]endpoint{
-			"service1": {Subsets: subsets},
+	endpoints := &endpointList{
+		Items: []*endpoint{
+			{
+				Meta:    &metadata{Namespace: "namespace1", Name: "service1"},
+				Subsets: subsets,
+			},
 		},
 	}
 

--- a/dataclients/kubernetes/lbtrafficswitch_test.go
+++ b/dataclients/kubernetes/lbtrafficswitch_test.go
@@ -26,14 +26,16 @@ func TestLBWithTrafficControl(t *testing.T) {
 		  -> <shunt>;
 	`
 
-	services := services{
-		"namespace1": map[string]*service{
-			"service1v1": testServiceWithTargetPort(
+	services := &serviceList{
+		Items: []*service{
+			testServiceWithTargetPort(
+				"namespace1", "service1v1",
 				"1.2.3.4",
 				map[string]int{"port1": 8080},
 				map[int]*backendPort{8080: {8080}},
 			),
-			"service1v2": testServiceWithTargetPort(
+			testServiceWithTargetPort(
+				"namespace1", "service1v2",
 				"1.2.3.5",
 				map[string]int{"port1": 8080},
 				map[int]*backendPort{8080: {8080}},
@@ -41,48 +43,54 @@ func TestLBWithTrafficControl(t *testing.T) {
 		},
 	}
 
-	endpoints := endpoints{
-		"namespace1": map[string]endpoint{
-			"service1v1": {Subsets: []*subset{
-				{
-					Addresses: []*address{{
-						IP: "42.0.1.2",
-					}},
-					Ports: []*port{{
-						Name: "port1",
-						Port: 8080,
-					}},
+	endpoints := &endpointList{
+		[]*endpoint{
+			{
+				Meta: &metadata{Namespace: "namespace1", Name: "service1v1"},
+				Subsets: []*subset{
+					{
+						Addresses: []*address{{
+							IP: "42.0.1.2",
+						}},
+						Ports: []*port{{
+							Name: "port1",
+							Port: 8080,
+						}},
+					},
+					{
+						Addresses: []*address{{
+							IP: "42.0.1.3",
+						}},
+						Ports: []*port{{
+							Name: "port1",
+							Port: 8080,
+						}},
+					},
 				},
-				{
-					Addresses: []*address{{
-						IP: "42.0.1.3",
-					}},
-					Ports: []*port{{
-						Name: "port1",
-						Port: 8080,
-					}},
+			},
+			{
+				Meta: &metadata{Namespace: "namespace1", Name: "service1v2"},
+				Subsets: []*subset{
+					{
+						Addresses: []*address{{
+							IP: "42.0.1.4",
+						}},
+						Ports: []*port{{
+							Name: "port1",
+							Port: 8080,
+						}},
+					},
+					{
+						Addresses: []*address{{
+							IP: "42.0.1.5",
+						}},
+						Ports: []*port{{
+							Name: "port1",
+							Port: 8080,
+						}},
+					},
 				},
-			}},
-			"service1v2": {Subsets: []*subset{
-				{
-					Addresses: []*address{{
-						IP: "42.0.1.4",
-					}},
-					Ports: []*port{{
-						Name: "port1",
-						Port: 8080,
-					}},
-				},
-				{
-					Addresses: []*address{{
-						IP: "42.0.1.5",
-					}},
-					Ports: []*port{{
-						Name: "port1",
-						Port: 8080,
-					}},
-				},
-			}},
+			},
 		},
 	}
 

--- a/dataclients/kubernetes/update_test.go
+++ b/dataclients/kubernetes/update_test.go
@@ -3,7 +3,7 @@ package kubernetes
 import "testing"
 
 func TestUpdateOnlyChangedRoutes(t *testing.T) {
-	api := newTestAPIWithEndpoints(t, make(services), &ingressList{}, make(endpoints))
+	api := newTestAPIWithEndpoints(t, &serviceList{}, &ingressList{}, &endpointList{})
 	defer api.Close()
 
 	k, err := New(Options{


### PR DESCRIPTION
Instead of fetching individual services/endpoints for every ingress, fetch them all at once when refreshing. In clusters with lots of ingresses and/or skippers this will bring down the apiserver RPS by Skipper from 1500+ to  15.