### PR TITLE
Warning against multiple Ingresses

### DIFF
--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -76,9 +76,52 @@ Cloud migration.
               serviceName: app-svc
               servicePort: 80
 
-!!! Warning
+### Multiple Ingresses defining the same route
 
-    If multiple backends define the same `Host` header, traffic routing will become non-deterministic
+    !!! Warning
+    
+    If multiple backends define the same `Host` header, traffic routing may become 
+    non-deterministic. 
+    
+Consider the following two ingresses which have the same hostname and therefore
+overlap. In skipper the routing of this is currently undefined as skipper
+doesn't pick one over the other, but just creates routes (possible overlapping)
+for each of the ingresses.
+
+In this example (taken from the issues we saw in production clusters) one
+ingress points to a service with no endpoints and the other to a service with
+endpoints. (Most likely service-x was renamed to service-x-live and the old
+ingress was forgot).
+
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+    name: service-x
+    spec:
+    rules:
+    - host: service-x.playground.zalan.do
+        http:
+        paths:
+        - backend:
+            serviceName: service-x # this service has 0 endpoints
+            servicePort: 80
+            apiVersion: extensions/v1beta1
+
+&#x200B;
+
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+    name: service-x-live
+    spec:
+    rules:
+    - host: service-x.playground.zalan.do
+        http:
+        paths:
+        - backend:
+            serviceName: service-x-live
+            servicePort: 80
+                
 ## Ingress path handling
 
 Ingress paths can be interpreted in four different modes:

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -80,8 +80,8 @@ Cloud migration.
 
 !!! Warning
     
-  If multiple backends define the same `Host` header, traffic routing may become 
-  non-deterministic. 
+    If multiple backends define the same `Host` header, traffic routing may become 
+    non-deterministic. 
     
 Consider the following two ingresses which have the same hostname and therefore
 overlap. In skipper the routing of this is currently undefined as skipper

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -76,6 +76,9 @@ Cloud migration.
               serviceName: app-svc
               servicePort: 80
 
+!!! Warning
+
+    If multiple backends define the same `Host` header, traffic routing will become non-deterministic
 ## Ingress path handling
 
 Ingress paths can be interpreted in four different modes:

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -80,8 +80,7 @@ Cloud migration.
 
 !!! Warning
     
-    If multiple backends define the same `Host` header, traffic routing may become 
-    non-deterministic. 
+    If multiple ingresses define the same host and the same predicates, traffic routing may become non-deterministic. 
     
 Consider the following two ingresses which have the same hostname and therefore
 overlap. In skipper the routing of this is currently undefined as skipper
@@ -99,13 +98,12 @@ ingress was forgot).
     name: service-x
     spec:
     rules:
-    - host: service-x.playground.zalan.do
+    - host: service-x.example.org
         http:
         paths:
         - backend:
             serviceName: service-x # this service has 0 endpoints
             servicePort: 80
-            apiVersion: extensions/v1beta1
 
 &#x200B;
 
@@ -115,7 +113,7 @@ ingress was forgot).
     name: service-x-live
     spec:
     rules:
-    - host: service-x.playground.zalan.do
+    - host: service-x.example.org
         http:
         paths:
         - backend:

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -80,8 +80,8 @@ Cloud migration.
 
     !!! Warning
     
-    If multiple backends define the same `Host` header, traffic routing may become 
-    non-deterministic. 
+        If multiple backends define the same `Host` header, traffic routing may become 
+        non-deterministic. 
     
 Consider the following two ingresses which have the same hostname and therefore
 overlap. In skipper the routing of this is currently undefined as skipper

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -78,10 +78,10 @@ Cloud migration.
 
 ### Multiple Ingresses defining the same route
 
-    !!! Warning
+!!! Warning
     
-        If multiple backends define the same `Host` header, traffic routing may become 
-        non-deterministic. 
+  If multiple backends define the same `Host` header, traffic routing may become 
+  non-deterministic. 
     
 Consider the following two ingresses which have the same hostname and therefore
 overlap. In skipper the routing of this is currently undefined as skipper


### PR DESCRIPTION
Warning against multiple ingresses defining the same Host header
 because that causes routing to become non-deterministic