### PR TITLE
Fix/cluster ratelimits 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/sirupsen/logrus v1.0.4
 	github.com/sony/gobreaker v0.0.0-20170530031423-e9556a45379e
 	github.com/stretchr/testify v1.2.2
-	github.com/szuecs/rate-limit-buffer v0.7.0
+	github.com/szuecs/rate-limit-buffer v0.7.1
 	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 // indirect
 	github.com/uber-go/atomic v1.3.2 // indirect
 	github.com/uber/jaeger-client-go v2.14.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/szuecs/rate-limit-buffer v0.7.0 h1:/CPaOt1oLElQFnOAOYXxrN/kDMyCSp6iKSna2sYZ6X0=
 github.com/szuecs/rate-limit-buffer v0.7.0/go.mod h1:BxqrsmnHsCnWcvbtdcaDLEBmjNEvRFU5LQ8edoZ9B0M=
+github.com/szuecs/rate-limit-buffer v0.7.1 h1:kpVLwDvpCTFQi8uhiXQrhAKWzNUaEKhArFdjb4GQ8F4=
+github.com/szuecs/rate-limit-buffer v0.7.1/go.mod h1:BxqrsmnHsCnWcvbtdcaDLEBmjNEvRFU5LQ8edoZ9B0M=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber-go/atomic v1.3.2 h1:Azu9lPBWRNKzYXSIwRfgRuDuS0YKsK4NFhiQv98gkxo=

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -854,6 +854,7 @@ func (p *Proxy) checkRatelimit(ctx *context) (ratelimit.Settings, int) {
 	if !ok || len(settings) < 1 {
 		return ratelimit.Settings{}, 0
 	}
+	p.log.Infof("checkRatelimit settings: %d", len(settings))
 
 	for _, setting := range settings {
 		rl := p.limiters.Get(setting)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -854,7 +854,7 @@ func (p *Proxy) checkRatelimit(ctx *context) (ratelimit.Settings, int) {
 	if !ok || len(settings) < 1 {
 		return ratelimit.Settings{}, 0
 	}
-	p.log.Infof("checkRatelimit settings: %d", len(settings))
+	p.log.Debugf("checkRatelimit settings: %d", len(settings))
 
 	for _, setting := range settings {
 		rl := p.limiters.Get(setting)
@@ -862,6 +862,7 @@ func (p *Proxy) checkRatelimit(ctx *context) (ratelimit.Settings, int) {
 			p.log.Errorf("RateLimiter is nil for setting: %s", setting)
 			continue
 		}
+		p.log.Debugf("rl settings: %s", rl)
 
 		if setting.Lookuper == nil {
 			p.log.Errorf("Lookuper is nil for setting: %s", setting)

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -113,12 +113,12 @@ func (c *clusterLimit) Allow(s string) bool {
 	now := time.Now().UTC().UnixNano()
 	rate := c.calcTotalRequestRate(now, swarmValues)
 	c.metrics.UpdateGauge("swarm."+key+".rate", rate)
-	result := rate < float64(c.maxHits)
-	return result
+	return rate < float64(c.maxHits)
 }
 
 func (c *clusterLimit) calcTotalRequestRate(now int64, swarmValues map[string]interface{}) float64 {
 	var requestRate float64
+	// len(swarmValues) will
 	maxNodeHits := math.Max(1.0, float64(c.maxHits)/(float64(len(swarmValues))))
 
 	for k, v := range swarmValues {

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -41,16 +41,12 @@ type resizeLimit struct {
 // and use the given Swarmer. Group is used in log messages to identify
 // the ratelimit instance and has to be the same in all skipper instances.
 func newClusterRateLimiter(s Settings, sw Swarmer, group string) *clusterLimit {
-	log.Infof("newClusterRateLimiter")
-	m := metrics.Default
-	m.UpdateGauge("mytest", float64(10))
-
 	rl := &clusterLimit{
 		group:   group,
 		swarm:   sw,
 		maxHits: s.MaxHits,
 		window:  s.TimeWindow,
-		metrics: m,
+		metrics: metrics.Default,
 		resize:  make(chan resizeLimit),
 		quit:    make(chan struct{}),
 	}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -254,6 +254,10 @@ type Ratelimit struct {
 	impl     limiter
 }
 
+func (l *Ratelimit) String() string {
+	return l.settings.String()
+}
+
 // Allow returns true if the s is not ratelimited, false if it is
 // ratelimited
 func (l *Ratelimit) Allow(s string) bool {

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	circularbuffer "github.com/szuecs/rate-limit-buffer"
 	"github.com/zalando/skipper/net"
 )
@@ -293,6 +294,7 @@ func (voidRatelimit) Delta(string) time.Duration { return -1 * time.Second }
 func (voidRatelimit) Resize(string, int)         {}
 
 func newRatelimit(s Settings, sw Swarmer) *Ratelimit {
+	log.Infof("newRatelimit: %s", s)
 	var impl limiter
 	switch s.Type {
 	case ServiceRatelimit:

--- a/skptesting/lb-with-ratelimit.eskip
+++ b/skptesting/lb-with-ratelimit.eskip
@@ -1,27 +1,7 @@
-r0: Host(/^test[.]example[.]org$/) && LBMember("x", 0)
-  -> dropRequestHeader("X-Load-Balancer-Member")
+r0: Host(/^www[.]example[.]org$/)
   -> clusterClientRatelimit("groupA", 1800, "1m")
-  -> "http://127.0.0.1:9000";
+  -> <roundRobin, "http://127.0.0.1:9991", "http://127.0.0.1:9992", "http://127.0.0.1:9993">;
 
-r1: Host(/^test[.]example[.]org$/) && LBMember("x", 1)
-  -> dropRequestHeader("X-Load-Balancer-Member")
-  -> clusterClientRatelimit("groupA", 1800, "1m")
-  -> "http://127.0.0.1:9001";
-
-lb_group: Host(/^test[.]example[.]org$/) && LBGroup("x")
-  -> lbDecide("x", 2)
-  -> <loopback>;
-
-r2: Host(/^foo[.]example[.]org$/) && LBMember("y", 0)
-  -> dropRequestHeader("X-Load-Balancer-Member")
+r2: Host(/^foo[.]example[.]org$/)
   -> clusterClientRatelimit("groupB", 450, "1m")
-  -> "http://127.0.0.1:9000";
-
-r3: Host(/^foo[.]example[.]org$/) && LBMember("y", 1)
-  -> dropRequestHeader("X-Load-Balancer-Member")
-  -> clusterClientRatelimit("groupB", 450, "1m")
-  -> "http://127.0.0.1:9001";
-
-lb_group2: Host(/^foo[.]example[.]org$/) && LBGroup("y")
-  -> lbDecide("y", 2)
-  -> <loopback>;
+  -> <roundRobin, "http://127.0.0.1:9991", "http://127.0.0.1:9992", "http://127.0.0.1:9993">;

--- a/swarm/message.go
+++ b/swarm/message.go
@@ -95,6 +95,10 @@ func (sv sharedValues) set(source, key string, value interface{}) {
 	sv[key][source] = value
 }
 
+func (sv sharedValues) delete(source string) {
+	delete(sv, source)
+}
+
 func encodeMessage(m *message) ([]byte, error) {
 	// we're not saving the encoder together with the connections, because
 	// even if the reflection info would be cached, it's very fragile and

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -275,9 +275,6 @@ func (s *Swarm) control() {
 		select {
 		case req := <-s.getOutgoing:
 			s.messages = takeMaxLatest(s.messages, req.overhead, req.limit)
-			if len(s.messages) <= 0 {
-				log.Debugf("SWARM: getOutgoing with %d messages, should not happen", len(s.messages))
-			}
 			req.ret <- s.messages
 		case m := <-s.outgoing:
 			s.messages = append(s.messages, m.encoded)

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -310,13 +310,11 @@ func (s *Swarm) control() {
 					}
 				}
 			} else {
-				log.Debugf("SWARM: got message: %#v", m)
+				log.Errorf("SWARM: got message with unknown type: %#v", m)
 			}
 		case req := <-s.getValues:
-			log.Debugf("SWARM: getValues for key: %s", req.key)
 			req.ret <- s.shared[req.key]
 		case <-s.leave:
-			log.Debugf("SWARM: %s got leave signal", s.Local())
 			if s.mlist == nil {
 				log.Warningf("SWARM: Leave called, but %s already seem to be left", s.Local())
 				return
@@ -385,7 +383,6 @@ func (s *Swarm) Values(key string) map[string]interface{} {
 	}
 	s.getValues <- req
 	d := <-req.ret
-	log.Debugf("SWARM: d: %#v", d)
 	return d
 }
 


### PR DESCRIPTION

cluster ratelimits aka cleanup data in swarm aka fix shutdown skipper procedure, which is ok for the general case but not for the cleanup swarm case.

needs 
- [ ] fix for unready skipper are counted in swarm already (increase skipper instances will increase divisor, which result in less traffic allowed)
- [ ] cleanup
- [ ] proper implementation
