### PR TITLE
Create noop filter in case of invalid monitoring filter config

### DIFF
--- a/filters/apiusagemonitoring/noop.go
+++ b/filters/apiusagemonitoring/noop.go
@@ -16,5 +16,5 @@ func (s *noopSpec) CreateFilter(config []interface{}) (filters.Filter, error) {
 
 type noopFilter struct{}
 
-func (*noopFilter) Request(filters.FilterContext)  {}
-func (*noopFilter) Response(filters.FilterContext) {}
+func (noopFilter) Request(filters.FilterContext)  {}
+func (noopFilter) Response(filters.FilterContext) {}

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -2,7 +2,6 @@ package apiusagemonitoring
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/filters"
 	"regexp"
@@ -115,7 +114,8 @@ func (s *apiUsageMonitoringSpec) CreateFilter(args []interface{}) (filter filter
 	paths := s.buildPathInfoListFromConfiguration(apis)
 
 	if len(paths) == 0 {
-		return nil, fmt.Errorf("no valid configurations")
+		log.Error("no valid configurations, creating noop api usage monitoring filter")
+		return noopFilter{}, nil
 	}
 
 	filter = &apiUsageMonitoringFilter{

--- a/filters/apiusagemonitoring/spec_test.go
+++ b/filters/apiusagemonitoring/spec_test.go
@@ -88,74 +88,68 @@ func Test_FeatureNotEnabled_TypeNameAndCreatedFilterAreRight(t *testing.T) {
 	assert.Equal(t, filter, &noopFilter{})
 }
 
-func Test_CreateFilter_NoParam_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_NoParam_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{})
+	filter, err := spec.CreateFilter([]interface{}{})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
-func Test_CreateFilter_EmptyString_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_EmptyString_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{""})
+	filter, err := spec.CreateFilter([]interface{}{""})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
-func Test_CreateFilter_NotAString_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_NotAString_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{1234})
+	filter, err := spec.CreateFilter([]interface{}{1234})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
-func Test_CreateFilter_NotJson_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_NotJson_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{"I am not JSON"})
+	filter, err := spec.CreateFilter([]interface{}{"I am not JSON"})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
-func Test_CreateFilter_EmptyJson_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_EmptyJson_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{"{}"})
+	filter, err := spec.CreateFilter([]interface{}{"{}"})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
-func Test_CreateFilter_NoPathTemplate_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_NoPathTemplate_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{`{
+	filter, err := spec.CreateFilter([]interface{}{`{
 		"application_id": "app",
 		"api_id": "api",
 		"path_templates": []
 	}`})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
-func Test_CreateFilter_EmptyPathTemplate_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_EmptyPathTemplate_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{`{
+	filter, err := spec.CreateFilter([]interface{}{`{
 		"application_id": "my_app",
 		"api_id": "my_api",
 		"path_templates": [
@@ -163,16 +157,15 @@ func Test_CreateFilter_EmptyPathTemplate_ShouldReturnError(t *testing.T) {
 		]
 	}`})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
-func Test_CreateFilter_TypoInPropertyNames_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_TypoInPropertyNames_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
 	// path_template has no `s` and should cause a JSON decoding error.
-	_, err := spec.CreateFilter([]interface{}{`{
+	filter, err := spec.CreateFilter([]interface{}{`{
 		"application_id": "my_app",
 		"api_id": "my_api",
 		"path_template": [
@@ -180,9 +173,8 @@ func Test_CreateFilter_TypoInPropertyNames_ShouldReturnError(t *testing.T) {
 		]
 	}`})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
 func Test_CreateFilter_NonParsableParametersShouldBeLoggedAndIgnored(t *testing.T) {
@@ -265,36 +257,33 @@ func Test_CreateFilter_FullConfigSingleApi(t *testing.T) {
 	})
 }
 
-func Test_CreateFilter_NoApplicationId_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_NoApplicationId_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{`{
+	filter, err := spec.CreateFilter([]interface{}{`{
 		"api_id": "api",
 		"path_templates": [
 			"foo/orders"
 		]
 	}`})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 
 }
 
-func Test_CreateFilter_NoApiId_ShouldReturnError(t *testing.T) {
+func Test_CreateFilter_NoApiId_ShouldReturnNoopFilter(t *testing.T) {
 	spec := NewApiUsageMonitoring(true, "", "", "")
 
-	_, err := spec.CreateFilter([]interface{}{`{
+	filter, err := spec.CreateFilter([]interface{}{`{
 		"application_id": "api",
 		"path_templates": [
 			"foo/orders"
 		]
 	}`})
 
-	assert.NotNil(t, err)
-	assert.Error(t, err)
-	assert.Regexp(t, `.*no valid configurations.*`, err.Error())
-
+	assert.Nil(t, err)
+	assert.Equal(t, noopFilter{}, filter)
 }
 
 func Test_CreateFilter_FullConfigMultipleApis(t *testing.T) {


### PR DESCRIPTION
We don't want Skipper route creation to fail if a monitoring filter is provided with an invalid configuration. Let's make it less strict for now and return a `noop` filter if some information is missing.

Related to #949