### PR TITLE
sync.Map to protect `metricPrefixedPerClient` against concurrent calls

### DIFF
--- a/filters/apiusagemonitoring/filter.go
+++ b/filters/apiusagemonitoring/filter.go
@@ -82,13 +82,13 @@ func (f *apiUsageMonitoringFilter) Response(c filters.FilterContext) {
 }
 
 func (f *apiUsageMonitoringFilter) getClientMetricsNames(realmClientKey string, path *pathInfo) *clientMetricNames {
-	prefixes, ok := path.metricPrefixedPerClient[realmClientKey]
+	pref, ok := path.metricPrefixedPerClient.Load(realmClientKey)
 	if ok {
-		return prefixes
+		return pref.(*clientMetricNames)
 	}
 
 	clientPrefixForThisClient := path.ClientPrefix + realmClientKey + "."
-	prefixes = &clientMetricNames{
+	prefixes := &clientMetricNames{
 		countAll: clientPrefixForThisClient + metricCountAll,
 		countPerStatusCodeRange: [6]string{
 			clientPrefixForThisClient + metricCountUnknownClass,
@@ -100,7 +100,7 @@ func (f *apiUsageMonitoringFilter) getClientMetricsNames(realmClientKey string, 
 		},
 		latencySum: clientPrefixForThisClient + metricLatencySum,
 	}
-	path.metricPrefixedPerClient[realmClientKey] = prefixes
+	path.metricPrefixedPerClient.Store(realmClientKey, prefixes)
 	return prefixes
 }
 

--- a/filters/apiusagemonitoring/pathinfo.go
+++ b/filters/apiusagemonitoring/pathinfo.go
@@ -3,6 +3,7 @@ package apiusagemonitoring
 import (
 	"net/http"
 	"regexp"
+	"sync"
 )
 
 // pathInfo contains the tracking information for a specific path.
@@ -17,21 +18,17 @@ type pathInfo struct {
 	ClientPrefix   string
 
 	metricPrefixesPerMethod [methodIndexLength]*endpointMetricNames
-	metricPrefixedPerClient map[string]*clientMetricNames
+	metricPrefixedPerClient *sync.Map
 }
 
 func newPathInfo(applicationId, apiId, pathTemplate string, pathLabel string, clientTracking *clientTrackingInfo) *pathInfo {
 	commonPrefix := applicationId + "." + apiId + "."
-	var metricPrefixedPerClient map[string]*clientMetricNames
-	if clientTracking != nil {
-		metricPrefixedPerClient = make(map[string]*clientMetricNames)
-	}
 	return &pathInfo{
 		ApplicationId:           applicationId,
 		ApiId:                   apiId,
 		PathTemplate:            pathTemplate,
 		PathLabel:               pathLabel,
-		metricPrefixedPerClient: metricPrefixedPerClient,
+		metricPrefixedPerClient: new(sync.Map),
 		ClientTracking:          clientTracking,
 		CommonPrefix:            commonPrefix,
 		ClientPrefix:            commonPrefix + "*.*.",


### PR DESCRIPTION
Fixes #968

I'm also happy to provide a fix based on lower-level locks. Depends on how fast we want to roll out the fix and your preferences.