### PR TITLE
fix: protect concurrent map access in apimonitoring (#968)

### DIFF
--- a/filters/apiusagemonitoring/filter_clientmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_clientmetrics_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/base64"
 	"net/http"
 	"testing"
+	"sync"
+	"regexp"
+	"strconv"
 )
 
 type clientMetricsTest struct {
@@ -383,4 +386,22 @@ func Test_Filter_ClientMetrics_EmptyClientTrackingPatternInRouteFilterJSON(t *te
 		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
 		expectedClientMetricPrefix:   "",
 	})
+}
+
+// may produce false-negatives
+func Test_Filter_ClientMetricsCache_ConcurrentAccess(t *testing.T) {
+	pathInfo := newPathInfo("application_id", "api_id", "orders", "orders",
+		&clientTrackingInfo{RealmsTrackingMatcher: regexp.MustCompile("services"), ClientTrackingMatcher: regexp.MustCompile(`.*`)})
+
+	concurrencyLevel := 500
+
+	var wg sync.WaitGroup
+	wg.Add(concurrencyLevel)
+	for i := 0; i < concurrencyLevel; i++ {
+		go func() {
+			getClientMetricsNames("services.service_id_"+strconv.Itoa(i), pathInfo)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }

--- a/filters/apiusagemonitoring/filter_clientmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_clientmetrics_test.go
@@ -3,10 +3,10 @@ package apiusagemonitoring
 import (
 	"encoding/base64"
 	"net/http"
-	"testing"
-	"sync"
 	"regexp"
 	"strconv"
+	"sync"
+	"testing"
 )
 
 type clientMetricsTest struct {

--- a/filters/apiusagemonitoring/filter_clientmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_clientmetrics_test.go
@@ -398,10 +398,10 @@ func Test_Filter_ClientMetricsCache_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(concurrencyLevel)
 	for i := 0; i < concurrencyLevel; i++ {
-		go func() {
+		go func(i int) {
 			getClientMetricsNames("services.service_id_"+strconv.Itoa(i), pathInfo)
 			wg.Done()
-		}()
+		}(i)
 	}
 	wg.Wait()
 }

--- a/filters/apiusagemonitoring/pathinfo.go
+++ b/filters/apiusagemonitoring/pathinfo.go
@@ -3,6 +3,7 @@ package apiusagemonitoring
 import (
 	"net/http"
 	"regexp"
+	"sync"
 )
 
 // pathInfo contains the tracking information for a specific path.
@@ -17,21 +18,17 @@ type pathInfo struct {
 	ClientPrefix   string
 
 	metricPrefixesPerMethod [methodIndexLength]*endpointMetricNames
-	metricPrefixedPerClient map[string]*clientMetricNames
+	metricPrefixedPerClient sync.Map
 }
 
 func newPathInfo(applicationId, apiId, pathTemplate string, pathLabel string, clientTracking *clientTrackingInfo) *pathInfo {
 	commonPrefix := applicationId + "." + apiId + "."
-	var metricPrefixedPerClient map[string]*clientMetricNames
-	if clientTracking != nil {
-		metricPrefixedPerClient = make(map[string]*clientMetricNames)
-	}
 	return &pathInfo{
 		ApplicationId:           applicationId,
 		ApiId:                   apiId,
 		PathTemplate:            pathTemplate,
 		PathLabel:               pathLabel,
-		metricPrefixedPerClient: metricPrefixedPerClient,
+		metricPrefixedPerClient: sync.Map{},
 		ClientTracking:          clientTracking,
 		CommonPrefix:            commonPrefix,
 		ClientPrefix:            commonPrefix + "*.*.",


### PR DESCRIPTION
fixes #968.

With respect to #972 I state, that I see absolutely no need to complicate maintenance with an own low level `sync.Map` implementation, that for real use cases has a performance difference of ±5%. This is a premature optimization.

By the way, @maxim-tschumak checked this in a small micro benchmark. For congestion patterns, the sync.Map even outperformed the manual implementation, but this seems not to be very realistic for our use case.