### PR TITLE
Fix/cluster ratelimits with central sharded redis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-redis/redis v6.15.1+incompatible
+	github.com/go-redis/redis_rate v6.5.0+incompatible
 	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/google/go-cmp v0.0.0-20170901214248-d5735f74713c
@@ -66,6 +68,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20180831094639-fa5fdf94c789 // indirect
+	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
 	google.golang.org/appengine v1.2.0 // indirect
 	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b // indirect
 	google.golang.org/grpc v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,10 @@ github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 h1:MGKhKyiYrvMDZs
 github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598/go.mod h1:0FpDmbrt36utu8jEmeU05dPC9AB5tsLYVVi+ZHfyuwI=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-redis/redis v6.15.1+incompatible h1:BZ9s4/vHrIqwOb0OPtTQ5uABxETJ3NRuUNoSUurnkew=
+github.com/go-redis/redis v6.15.1+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis_rate v6.5.0+incompatible h1:K/G+KaoJgO3kbkLLbfdg0kzJsHhhk0gVGTMgstKgbsM=
+github.com/go-redis/redis_rate v6.5.0+incompatible/go.mod h1:Jxe7BhQuVncH6fUQ2rwoAkc8SesjCGIWkm6fNRQo4Qg=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -139,6 +143,8 @@ golang.org/x/sys v0.0.0-20180831094639-fa5fdf94c789 h1:T8D7l6WB3tLu+VpKvw06ieD/O
 golang.org/x/sys v0.0.0-20180831094639-fa5fdf94c789/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
+golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 google.golang.org/appengine v1.2.0 h1:S0iUepdCWODXRvtE+gcRDd15L+k+k1AiHlMiMjefH24=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b h1:lohp5blsw53GBXtLyLNaTXPXS9pJ1tiTw61ZHUoE9Qw=

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -166,7 +166,7 @@ func (c *clusterLimit) AllowRing(s string) bool {
 	return count <= int64(c.maxHits)
 }
 
-func (c *clusterLimit) AllowPipelined(s string) bool {
+func (c *clusterLimit) AllowClientPipelined(s string) bool {
 	key := swarmPrefix + c.group + "." + s
 	now := time.Now()
 	nowNanos := now.UnixNano()

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -1,7 +1,7 @@
 package ratelimit
 
 import (
-	"math"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis"
@@ -9,29 +9,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Swarmer interface defines the requirement for a Swarm, for use as
-// an exchange method for cluster ratelimits:
-// ratelimit.ClusterServiceRatelimit and
-// ratelimit.ClusterClientRatelimit.
-type Swarmer interface {
-	// ShareValue is used to share the local information with its peers.
-	ShareValue(string, interface{}) error
-	// Values is used to get global information about current rates.
-	Values(string) map[string]interface{}
-}
-
 // clusterLimit stores all data required for the cluster ratelimit.
 type clusterLimit struct {
-	group   string
-	local   limiter
-	maxHits int
-	window  time.Duration
-	swarm   Swarmer
-	resize  chan resizeLimit
-	quit    chan struct{}
-	client  *redis.Client
-	ring    *redis.Ring
-	limiter *redis_rate.Limiter
+	mu         sync.Mutex
+	group      string
+	maxHits    int
+	window     time.Duration
+	ring       *redis.Ring
+	limiter    *redis_rate.Limiter
+	retryAfter int
 }
 
 type resizeLimit struct {
@@ -42,16 +28,12 @@ type resizeLimit struct {
 // newClusterRateLimiter creates a new clusterLimit for given Settings
 // and use the given Swarmer. Group is used in log messages to identify
 // the ratelimit instance and has to be the same in all skipper instances.
-func newClusterRateLimiter(s Settings, sw Swarmer, group string) *clusterLimit {
-	// redisclient := redis.NewClient(&redis.Options{
-	// 	Addr:     "localhost:6379",
-	// 	Password: "", // no password set
-	// 	DB:       0,  // use default DB
-	// })
-
+func newClusterRateLimiter(s Settings, group string) *clusterLimit {
+	log.Infof("creating clusterLimiter")
 	ring := redis.NewRing(&redis.RingOptions{
 		Addrs: map[string]string{
-			"server1": "10.3.99.100:6379",
+			"server1": "skipper-redis-0.skipper-redis.kube-system.svc.cluster.local.:6379",
+			"server2": "skipper-redis-1.skipper-redis.kube-system.svc.cluster.local.:6379",
 		},
 	})
 	limiter := redis_rate.NewLimiter(ring)
@@ -60,12 +42,8 @@ func newClusterRateLimiter(s Settings, sw Swarmer, group string) *clusterLimit {
 
 	rl := &clusterLimit{
 		group:   group,
-		swarm:   sw,
 		maxHits: s.MaxHits,
 		window:  s.TimeWindow,
-		resize:  make(chan resizeLimit),
-		quit:    make(chan struct{}),
-		//client:  redisclient,
 		ring:    ring,
 		limiter: limiter,
 	}
@@ -76,34 +54,6 @@ func newClusterRateLimiter(s Settings, sw Swarmer, group string) *clusterLimit {
 		return nil
 	}
 	log.Debugf("pong: %v", pong)
-
-	// switch s.Type {
-	// case ClusterServiceRatelimit:
-	// 	log.Infof("new backend clusterRateLimiter")
-	// 	rl.local = circularbuffer.NewRateLimiter(s.MaxHits, s.TimeWindow)
-	// case ClusterClientRatelimit:
-	// 	log.Infof("new client clusterRateLimiter")
-	// 	rl.local = circularbuffer.NewClientRateLimiter(s.MaxHits, s.TimeWindow, s.CleanInterval)
-	// default:
-	// 	log.Errorf("Unknown ratelimit type: %s", s.Type)
-	// 	return nil
-	// }
-
-	// // TODO(sszuecs): we might want to have one goroutine for all of these
-	// go func() {
-	// 	for {
-	// 		select {
-	// 		case size := <-rl.resize:
-	// 			log.Debugf("%s resize clusterRatelimit: %v", group, size)
-	// 			// TODO(sszuecs): call with "go" ?
-	// 			rl.Resize(size.s, rl.maxHits/size.n)
-	// 		case <-rl.quit:
-	// 			log.Debugf("%s: quit clusterRatelimit", group)
-	// 			close(rl.resize)
-	// 			return
-	// 		}
-	// 	}
-	// }()
 
 	return rl
 }
@@ -116,70 +66,25 @@ const swarmPrefix string = `ratelimit.`
 // to decide to allow or not.
 func (c *clusterLimit) Allow(s string) bool {
 	key := swarmPrefix + c.group + "." + s
-	// nanos := time.Now().UTC().UnixNano()
-	// c.client.Set(key, nanos)
 	rate, delay, allowed := c.limiter.AllowN(key, int64(c.maxHits), c.window, 1)
 	log.Infof("rate: %v, delay: %v, allow: %v", rate, delay, allowed)
-	if rate == 0 {
+	if rate == 0 { // if redis is not reachable allow
+		log.Infof("allow rate is 0")
 		return true
 	}
+	retr := (c.window - delay) / time.Second
+	c.mu.Lock()
+	c.retryAfter = int(retr)
+	c.mu.Unlock()
 	return allowed
 }
 
-func (c *clusterLimit) Allow2(s string) bool {
-	key := swarmPrefix + c.group + "." + s
-
-	// t0 is the oldest entry in the local circularbuffer
-	// [ t3, t4, t0, t1, t2]
-	//           ^- current pointer to oldest
-	// now - t0
-	t0 := c.Oldest(s).UTC().UnixNano()
-
-	_ = c.local.Allow(s) // update local rate limit
-
-	if err := c.swarm.ShareValue(key, t0); err != nil {
-		log.Errorf("%s clusterRatelimit failed to share value: %v", c.group, err)
-	}
-
-	swarmValues := c.swarm.Values(key)
-	log.Debugf("%s: clusterRatelimit swarmValues(%d) for '%s': %v", c.group, len(swarmValues), swarmPrefix+s, swarmValues)
-
-	c.resize <- resizeLimit{s: s, n: len(swarmValues)}
-
-	now := time.Now().UTC().UnixNano()
-	rate := c.calcTotalRequestRate(now, swarmValues)
-	result := rate < float64(c.maxHits)
-	log.Debugf("%s clusterRatelimit: Allow=%v, %v < %d", c.group, result, rate, c.maxHits)
-	return result
+func (c *clusterLimit) Close()                       {}
+func (c *clusterLimit) Delta(s string) time.Duration { return 10 * c.window }
+func (c *clusterLimit) Oldest(s string) time.Time    { return time.Now().Add(-10 * c.window) }
+func (c *clusterLimit) Resize(s string, n int)       {}
+func (c *clusterLimit) RetryAfter(s string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.retryAfter
 }
-
-func (c *clusterLimit) calcTotalRequestRate(now int64, swarmValues map[string]interface{}) float64 {
-	var requestRate float64
-	maxNodeHits := math.Max(1.0, float64(c.maxHits)/(float64(len(swarmValues))))
-
-	for _, v := range swarmValues {
-		t0, ok := v.(int64)
-		if !ok || t0 == 0 {
-			continue
-		}
-		delta := time.Duration(now - t0)
-		adjusted := float64(delta) / float64(c.window)
-		log.Debugf("%s: %0.2f += %0.2f / %0.2f", c.group, requestRate, maxNodeHits, adjusted)
-		requestRate += maxNodeHits / adjusted
-	}
-	log.Debugf("%s requestRate: %0.2f", c.group, requestRate)
-	return requestRate
-}
-
-// Close should be called to teardown the clusterLimit.
-func (c *clusterLimit) Close() {
-	close(c.quit)
-	c.local.Close()
-}
-
-func (c *clusterLimit) Delta(s string) time.Duration { return c.local.Delta(s) }
-func (c *clusterLimit) Oldest(s string) time.Time    { return c.local.Oldest(s) }
-func (c *clusterLimit) Resize(s string, n int)       { c.local.Resize(s, n) }
-
-//func (c *clusterLimit) RetryAfter(s string) int      { return c.local.RetryAfter(s) }
-func (c *clusterLimit) RetryAfter(s string) int { return 10 }

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -15,45 +16,60 @@ type clusterLimit struct {
 	group      string
 	maxHits    int
 	window     time.Duration
+	client     *redis.Client
 	ring       *redis.Ring
 	limiter    *redis_rate.Limiter
 	retryAfter int
 }
 
-type resizeLimit struct {
-	s string
-	n int
-}
-
-// newClusterRateLimiter creates a new clusterLimit for given Settings
-// and use the given Swarmer. Group is used in log messages to identify
-// the ratelimit instance and has to be the same in all skipper instances.
+// newClusterRateLimiter creates a new clusterLimit for given
+// Settings. Group is used to identify the ratelimit instance, is used
+// in log messages and has to be the same in all skipper instances.
 func newClusterRateLimiter(s Settings, group string) *clusterLimit {
 	log.Infof("creating clusterLimiter")
-	ring := redis.NewRing(&redis.RingOptions{
-		Addrs: map[string]string{
-			"server1": "skipper-redis-0.skipper-redis.kube-system.svc.cluster.local.:6379",
-			"server2": "skipper-redis-1.skipper-redis.kube-system.svc.cluster.local.:6379",
-		},
+
+	// ring := redis.NewRing(&redis.RingOptions{
+	// 	Addrs: map[string]string{
+	// 		"server1": "skipper-redis-0.skipper-redis.kube-system.svc.cluster.local.:6379",
+	// 		"server2": "skipper-redis-1.skipper-redis.kube-system.svc.cluster.local.:6379",
+	// 	},
+	// })
+	// limiter := redis_rate.NewLimiter(ring)
+	// // Optional.
+	// //limiter.Fallback = rate.NewLimiter(rate.Every(s.TimeWindow), s.MaxHits)
+
+	// TODO(sszuecs):
+	client := redis.NewClient(&redis.Options{
+		Addr: "skipper-redis-0.skipper-redis.kube-system.svc.cluster.local.:6379",
+		//Addr:     "127.0.0.1:6379",
+		Password: "",
+		DB:       0,
 	})
-	limiter := redis_rate.NewLimiter(ring)
-	// Optional.
-	//limiter.Fallback = rate.NewLimiter(rate.Every(s.TimeWindow), s.MaxHits)
+	// TODO(sszuecs): if this is good wrap with context and add deadline
+	//client = client.WithContext(context.Background())
 
 	rl := &clusterLimit{
 		group:   group,
 		maxHits: s.MaxHits,
 		window:  s.TimeWindow,
-		ring:    ring,
-		limiter: limiter,
+		client:  client,
+		// ring:    ring,
+		// limiter: limiter,
 	}
 
-	pong, err := rl.ring.Ping().Result()
+	pong, err := rl.client.Ping().Result()
 	if err != nil {
 		log.Errorf("Failed to ping redis: %v", err)
 		return nil
 	}
 	log.Debugf("pong: %v", pong)
+
+	// pong, err = rl.ring.Ping().Result()
+	// if err != nil {
+	// 	log.Errorf("Failed to ping redis: %v", err)
+	// 	return nil
+	// }
+	// log.Debugf("pong: %v", pong)
 
 	return rl
 }
@@ -65,6 +81,45 @@ const swarmPrefix string = `ratelimit.`
 // and use the current cluster information to calculate global rates
 // to decide to allow or not.
 func (c *clusterLimit) Allow(s string) bool {
+	key := swarmPrefix + c.group + "." + s
+	now := time.Now()
+	//clearBefore := now.Add(c.window)
+
+	// run MULTI exec
+	pipe := c.client.TxPipeline()
+	defer pipe.Close()
+
+	// drop all elements of the set which occurred before one interval ago.
+	pipe.ZRemRangeByScore(key, "0.0", fmt.Sprintf("%v", float64(now.Add(-c.window).UnixNano())))
+	//c.client.ZRemRangeByScore(key, "0.0", fmt.Sprintf("%v", float64(now.Add(-c.window).UnixNano())))
+
+	// fetch all elements of the set
+	//zrangeResult := pipe.ZRange(key, 0, -1)
+	//c.client.ZRange(key, 0, -1)
+
+	// add the current timestamp to the set
+	pipe.ZAdd(key, redis.Z{Member: now.UnixNano(), Score: float64(now.UnixNano())})
+	//c.client.ZAdd(key, redis.Z{Member: now.UnixNano(), Score: float64(now.UnixNano())})
+
+	zcardResult := pipe.ZCard(key)
+
+	pipe.Expire(key, c.window)
+	_, err := pipe.Exec()
+	if err != nil {
+		log.Errorf("Failed to exec pipeline: %v", err)
+		return true
+	}
+
+	log.Debugf("number of requests from %s: %v", key, zcardResult.Val())
+
+	// After all operations are completed, we count the number of fetched elements. If it exceeds the limit, we don’t allow the action.
+	//count := c.client.ZCard(key).Val()
+	count := zcardResult.Val()
+	return count < int64(c.maxHits)
+}
+
+// no TxPipeline possible with the library https://github.com/go-redis/redis/blob/master/ring.go#L640
+func (c *clusterLimit) Allow2(s string) bool {
 	key := swarmPrefix + c.group + "." + s
 	rate, delay, allowed := c.limiter.AllowN(key, int64(c.maxHits), c.window, 1)
 	log.Infof("rate: %v, delay: %v, allow: %v", rate, delay, allowed)
@@ -84,6 +139,9 @@ func (c *clusterLimit) Delta(s string) time.Duration { return 10 * c.window }
 func (c *clusterLimit) Oldest(s string) time.Time    { return time.Now().Add(-10 * c.window) }
 func (c *clusterLimit) Resize(s string, n int)       {}
 func (c *clusterLimit) RetryAfter(s string) int {
+	return 1
+}
+func (c *clusterLimit) RetryAfter2(s string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.retryAfter

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -38,7 +38,7 @@ func newClusterRateLimiter(s Settings, group string) *clusterLimit {
 	// // Optional.
 	// //limiter.Fallback = rate.NewLimiter(rate.Every(s.TimeWindow), s.MaxHits)
 
-	// TODO(sszuecs):
+	// test for pipeline operations
 	client := redis.NewClient(&redis.Options{
 		Addr: "skipper-redis-0.skipper-redis.kube-system.svc.cluster.local.:6379",
 		//Addr:     "127.0.0.1:6379",

--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -32,6 +32,7 @@ func newClusterRateLimiter(s Settings, group string) *clusterLimit {
 		Addrs: map[string]string{
 			"server1": "skipper-redis-0.skipper-redis.kube-system.svc.cluster.local.:6379",
 			"server2": "skipper-redis-1.skipper-redis.kube-system.svc.cluster.local.:6379",
+			//"local": "127.0.0.1:6379",
 		},
 	})
 	//limiter := redis_rate.NewLimiter(ring)
@@ -63,7 +64,7 @@ func newClusterRateLimiter(s Settings, group string) *clusterLimit {
 	}
 	log.Debugf("pong: %v", pong)
 
-	pong, err := rl.ring.Ping().Result()
+	pong, err = rl.ring.Ping().Result()
 	if err != nil {
 		log.Errorf("Failed to ping redis: %v", err)
 		return nil

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -3,7 +3,6 @@ package ratelimit
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	circularbuffer "github.com/szuecs/rate-limit-buffer"
@@ -292,7 +291,7 @@ func (voidRatelimit) RetryAfter(string) int      { return 0 }
 func (voidRatelimit) Delta(string) time.Duration { return -1 * time.Second }
 func (voidRatelimit) Resize(string, int)         {}
 
-func newRatelimit(s Settings, sw Swarmer) *Ratelimit {
+func newRatelimit(s Settings) *Ratelimit {
 	var impl limiter
 	switch s.Type {
 	case ServiceRatelimit:
@@ -302,15 +301,9 @@ func newRatelimit(s Settings, sw Swarmer) *Ratelimit {
 	case ClientRatelimit:
 		impl = circularbuffer.NewClientRateLimiter(s.MaxHits, s.TimeWindow, s.CleanInterval)
 	case ClusterServiceRatelimit:
-		s.CleanInterval = 0
 		fallthrough
 	case ClusterClientRatelimit:
-		if sw != nil {
-			impl = newClusterRateLimiter(s, sw, s.Group)
-		} else {
-			fmt.Fprintf(os.Stderr, "ERROR: no -enable-swarm, falling back to no ratelimit for %q\n", s)
-			impl = voidRatelimit{}
-		}
+		impl = newClusterRateLimiter(s, s.Group)
 	default:
 		impl = voidRatelimit{}
 	}

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -22,18 +22,10 @@ type Registry struct {
 	defaults Settings
 	global   Settings
 	lookup   map[Settings]*Ratelimit
-	swarm    Swarmer
 }
 
 // NewRegistry initializes a registry with the provided default settings.
 func NewRegistry(settings ...Settings) *Registry {
-	return NewSwarmRegistry(nil, settings...)
-}
-
-// NewSwarmRegistry initializes a registry with an optional swarm and
-// the provided default settings. If swarm is nil, clusterRatelimits
-// will be replaced by voidRatelimit, which is a noop limiter implementation.
-func NewSwarmRegistry(swarm Swarmer, settings ...Settings) *Registry {
 	defaults := Settings{
 		Type:          DisableRatelimit,
 		MaxHits:       DefaultMaxhits,
@@ -45,7 +37,6 @@ func NewSwarmRegistry(swarm Swarmer, settings ...Settings) *Registry {
 		defaults: defaults,
 		global:   defaults,
 		lookup:   make(map[Settings]*Ratelimit),
-		swarm:    swarm,
 	}
 
 	if len(settings) > 0 {
@@ -61,7 +52,7 @@ func (r *Registry) get(s Settings) *Ratelimit {
 
 	rl, ok := r.lookup[s]
 	if !ok {
-		rl = newRatelimit(s, r.swarm)
+		rl = newRatelimit(s)
 		r.lookup[s] = rl
 	}
 


### PR DESCRIPTION
We seem not being able to fix clusterRatelimits with memberlist (swim) based backend.
Swim protocol is quite complex to investigate.

This PR is an effort to build cluster ratelimit based on redis ring

## test

For all tests the infrastructure has
1 ALB with 3 instances across 3 AZs
6x skipper running as backend
3x skipper running as ingress controller 
Ingress with filter `clusterClientRatelimit("routeB", 400, "10s")`

### baseline without ratelimit filter

summary: `p50 <18ms`, general `p99 < 100ms` and `max(p99) < 700ms`

```
Latencies     [mean, 50, 95, 99, max]  18.592907ms, 17.98213ms, 19.723449ms, 25.603368ms, 101.196585ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  17.977632ms, 17.499432ms, 18.765358ms, 21.989344ms, 94.711622ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  18.170771ms, 17.575727ms, 19.109102ms, 29.657374ms, 100.241814ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  18.522566ms, 17.565354ms, 18.697368ms, 55.609204ms, 102.324494ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  18.041476ms, 17.471397ms, 18.371078ms, 36.449372ms, 99.609948ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  18.025476ms, 17.602807ms, 18.572986ms, 22.686506ms, 91.364244ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  18.185819ms, 17.649681ms, 18.635176ms, 22.757859ms, 97.01436ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  19.066789ms, 18.313107ms, 19.250972ms, 46.499092ms, 128.117157ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  18.994869ms, 18.4214ms, 19.865792ms, 35.122654ms, 100.309255ms
Status Codes  [code:count]             200:500
Thu Feb 28 14:33:00 CET 2019
# test 250 req/s Thu Feb 28 14:33:10 CET 2019
Latencies     [mean, 50, 95, 99, max]  18.889509ms, 17.893615ms, 19.138183ms, 60.338104ms, 132.175625ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  18.59473ms, 17.902587ms, 19.094765ms, 39.493208ms, 117.058924ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  18.83423ms, 17.96592ms, 20.130759ms, 56.089287ms, 134.356044ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  24.950629ms, 17.075025ms, 30.708446ms, 274.898711ms, 407.549007ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  17.79568ms, 17.044411ms, 18.914491ms, 46.53899ms, 103.465217ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  17.77581ms, 17.136357ms, 18.329769ms, 34.77378ms, 109.370827ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  18.027854ms, 17.155405ms, 18.979312ms, 56.414228ms, 125.164663ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  17.576052ms, 17.045453ms, 18.118997ms, 31.695957ms, 104.454659ms
Status Codes  [code:count]             200:2500
Latencies     [mean, 50, 95, 99, max]  18.331091ms, 17.112052ms, 22.63004ms, 43.686538ms, 99.024739ms
Status Codes  [code:count]             200:2500
Thu Feb 28 14:34:40 CET 2019
# test 500 req/s Thu Feb 28 14:34:50 CET 2019
Latencies     [mean, 50, 95, 99, max]  18.974092ms, 16.930952ms, 20.030562ms, 96.219001ms, 190.769181ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  18.176525ms, 16.962143ms, 18.841558ms, 70.388273ms, 152.7503ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  17.91515ms, 16.900235ms, 18.303044ms, 65.343003ms, 145.035432ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  17.421857ms, 16.904534ms, 17.93596ms, 30.242253ms, 97.672641ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  17.415096ms, 16.918457ms, 18.221344ms, 26.574166ms, 95.118195ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  17.455344ms, 16.924026ms, 18.232614ms, 25.779854ms, 101.121698ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  17.887874ms, 17.145253ms, 19.001141ms, 37.898787ms, 250.966588ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  19.199189ms, 17.126934ms, 20.560506ms, 90.307667ms, 161.65819ms
Status Codes  [code:count]             200:5000
Latencies     [mean, 50, 95, 99, max]  19.073598ms, 17.099161ms, 18.8606ms, 101.88737ms, 192.217938ms
Status Codes  [code:count]             200:5000
Thu Feb 28 14:36:21 CET 2019
# test 1000 req/s Thu Feb 28 14:36:31 CET 2019
Latencies     [mean, 50, 95, 99, max]  19.205084ms, 16.986682ms, 19.809418ms, 112.867953ms, 192.013572ms
Status Codes  [code:count]             200:10000
Latencies     [mean, 50, 95, 99, max]  19.182669ms, 17.019836ms, 21.726162ms, 100.145684ms, 172.425249ms
Status Codes  [code:count]             200:10000
Latencies     [mean, 50, 95, 99, max]  36.070221ms, 17.032644ms, 213.23968ms, 398.829442ms, 558.253118ms
Status Codes  [code:count]             200:10000
Latencies     [mean, 50, 95, 99, max]  18.726905ms, 17.085664ms, 19.978562ms, 95.390615ms, 174.730256ms
Status Codes  [code:count]             200:10000  
Latencies     [mean, 50, 95, 99, max]  46.801695ms, 17.083113ms, 294.652178ms, 608.120854ms, 804.324093ms
Status Codes  [code:count]             200:10000  
Latencies     [mean, 50, 95, 99, max]  19.050412ms, 16.978429ms, 20.71235ms, 102.049536ms, 183.814149ms
Status Codes  [code:count]             200:10000  
Latencies     [mean, 50, 95, 99, max]  20.378405ms, 17.030722ms, 23.232828ms, 145.977615ms, 243.446323ms
Status Codes  [code:count]             200:10000  
Latencies     [mean, 50, 95, 99, max]  19.845048ms, 16.976712ms, 20.176273ms, 137.89942ms, 238.065767ms
Status Codes  [code:count]             200:10000  
Latencies     [mean, 50, 95, 99, max]  19.073115ms, 16.993929ms, 20.73733ms, 99.165201ms, 171.743614ms
Status Codes  [code:count]             200:10000  
Thu Feb 28 14:38:01 CET 2019
```

### test based on current swim based implementation skipper fix/cluster-ratelimits-2ndtry

summary: quite good results for status +/-40 for high traffic and for normal traffic good results

Latencies:

- best p50 with `p50 < 17ms` and most are `p50 < 11ms`  on high traffic
- `max(p99) = 1.9s` which could be because of a backend restart
- general `p99 <150ms` 

Problem: With one Pod delete it could not recover to get again precise results with having on going traffic for at least 2 minutes with +/-80.

```
# test 50 req/s Thu Feb 28 17:00:41 CET 2019
Latencies     [mean, 50, 95, 99, max]  18.665796ms, 16.703595ms, 22.04724ms, 123.890945ms, 224.786194ms
Status Codes  [code:count]             200:410  429:90  
Latencies     [mean, 50, 95, 99, max]  16.052347ms, 16.516684ms, 17.613181ms, 21.039148ms, 83.410587ms
Status Codes  [code:count]             429:101  200:399  
Latencies     [mean, 50, 95, 99, max]  16.726419ms, 16.875226ms, 21.982099ms, 25.169759ms, 81.58935ms
Status Codes  [code:count]             429:100  200:400  
Latencies     [mean, 50, 95, 99, max]  15.900834ms, 16.585284ms, 17.536195ms, 19.977225ms, 75.736974ms
Status Codes  [code:count]             200:401  429:99  
Latencies     [mean, 50, 95, 99, max]  17.293659ms, 16.881253ms, 26.924742ms, 31.442031ms, 80.980268ms
Status Codes  [code:count]             429:98  200:402  
Latencies     [mean, 50, 95, 99, max]  17.109288ms, 16.772451ms, 24.996449ms, 27.782892ms, 77.588988ms
Status Codes  [code:count]             429:95  200:405  
Latencies     [mean, 50, 95, 99, max]  17.157215ms, 16.753253ms, 25.413772ms, 28.476658ms, 75.986685ms
Status Codes  [code:count]             429:93  200:407  
Latencies     [mean, 50, 95, 99, max]  17.556899ms, 16.92426ms, 20.826193ms, 24.563305ms, 99.261174ms
Status Codes  [code:count]             429:90  200:410  
Latencies     [mean, 50, 95, 99, max]  17.438162ms, 16.67477ms, 26.603879ms, 30.202822ms, 99.948682ms
Status Codes  [code:count]             429:89  200:411  
Thu Feb 28 17:02:11 CET 2019
# test 250 req/s Thu Feb 28 17:02:21 CET 2019
Latencies     [mean, 50, 95, 99, max]  12.598658ms, 10.755063ms, 17.347401ms, 22.736999ms, 90.961555ms
Status Codes  [code:count]             429:2101  200:399  
Latencies     [mean, 50, 95, 99, max]  13.196028ms, 10.748673ms, 22.872965ms, 27.620195ms, 96.006589ms
Status Codes  [code:count]             200:400  429:2100  
Latencies     [mean, 50, 95, 99, max]  13.053051ms, 10.730938ms, 19.113772ms, 27.670098ms, 97.550056ms
Status Codes  [code:count]             429:2102  200:398  
Latencies     [mean, 50, 95, 99, max]  12.811157ms, 11.322439ms, 17.325323ms, 23.538781ms, 96.536927ms
Status Codes  [code:count]             200:401  429:2099  
Latencies     [mean, 50, 95, 99, max]  13.151699ms, 11.437839ms, 17.57931ms, 24.817157ms, 102.049709ms
Status Codes  [code:count]             200:403  429:2097  
Latencies     [mean, 50, 95, 99, max]  12.79034ms, 11.366377ms, 17.532082ms, 25.682863ms, 96.685726ms
Status Codes  [code:count]             429:2097  200:403  
Latencies     [mean, 50, 95, 99, max]  12.686742ms, 11.357199ms, 17.522243ms, 20.445117ms, 90.936776ms
Status Codes  [code:count]             429:2098  200:402  
Latencies     [mean, 50, 95, 99, max]  12.841873ms, 11.346028ms, 17.431436ms, 40.59391ms, 96.940976ms
Status Codes  [code:count]             200:404  429:2096  
Latencies     [mean, 50, 95, 99, max]  12.643079ms, 11.325267ms, 17.322948ms, 20.528363ms, 92.394914ms
Status Codes  [code:count]             200:404  429:2096  
Thu Feb 28 17:03:51 CET 2019
# test 500 req/s Thu Feb 28 17:04:01 CET 2019
Latencies     [mean, 50, 95, 99, max]  12.26801ms, 11.189926ms, 16.950599ms, 35.573109ms, 223.699674ms
Status Codes  [code:count]             200:399  429:4601  
Latencies     [mean, 50, 95, 99, max]  12.197915ms, 11.229852ms, 16.913485ms, 25.510843ms, 98.890011ms
Status Codes  [code:count]             200:399  429:4601  
Latencies     [mean, 50, 95, 99, max]  12.214171ms, 11.256757ms, 16.979555ms, 24.615523ms, 94.341064ms
Status Codes  [code:count]             200:399  429:4601  
Latencies     [mean, 50, 95, 99, max]  14.126054ms, 11.3021ms, 17.038463ms, 114.083185ms, 211.471459ms
Status Codes  [code:count]             200:399  429:4601  
Latencies     [mean, 50, 95, 99, max]  13.443964ms, 11.242037ms, 17.326862ms, 89.894282ms, 170.247055ms
Status Codes  [code:count]             429:4591  200:409  
Latencies     [mean, 50, 95, 99, max]  14.676363ms, 11.235638ms, 17.4966ms, 135.301315ms, 234.529954ms
Status Codes  [code:count]             200:414  429:4586  
Latencies     [mean, 50, 95, 99, max]  93.888846ms, 11.224779ms, 17.27747ms, 244.330635ms, 30.00044619s
Status Codes  [code:count]             0:2  200:406  429:4586  502:6  
Latencies     [mean, 50, 95, 99, max]  57.154044ms, 11.238969ms, 16.951562ms, 121.487168ms, 22.586761506s
Status Codes  [code:count]             200:393  429:4602  502:5  
Latencies     [mean, 50, 95, 99, max]  12.862109ms, 11.278568ms, 17.1702ms, 65.281795ms, 150.85987ms
Status Codes  [code:count]             200:399  429:4601  
Thu Feb 28 17:06:04 CET 2019
# test 1000 req/s Thu Feb 28 17:06:14 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.921863ms, 11.126536ms, 12.40125ms, 126.203059ms, 215.369638ms
Status Codes  [code:count]             200:399  429:9601  
Latencies     [mean, 50, 95, 99, max]  14.024796ms, 11.320055ms, 16.573915ms, 120.26864ms, 193.485505ms
Status Codes  [code:count]             200:433  429:9567  
Latencies     [mean, 50, 95, 99, max]  248.353741ms, 11.31764ms, 1.531465367s, 1.937721306s, 2.723922211s
Status Codes  [code:count]             200:399  0:666  429:8935  
Latencies     [mean, 50, 95, 99, max]  17.932575ms, 11.154628ms, 18.219372ms, 225.972098ms, 368.009031ms
Status Codes  [code:count]             429:9552  200:448  
Latencies     [mean, 50, 95, 99, max]  15.18446ms, 11.137483ms, 16.927977ms, 161.356843ms, 287.385794ms
Status Codes  [code:count]             429:9558  200:442  
Latencies     [mean, 50, 95, 99, max]  13.653656ms, 11.185222ms, 16.992445ms, 101.816985ms, 203.26529ms
Status Codes  [code:count]             429:9558  200:442  
Latencies     [mean, 50, 95, 99, max]  12.471923ms, 11.147874ms, 16.732648ms, 56.604788ms, 124.671517ms
Status Codes  [code:count]             429:9528  200:472  
Latencies     [mean, 50, 95, 99, max]  13.923362ms, 11.173413ms, 17.009002ms, 125.770318ms, 216.492798ms
Status Codes  [code:count]             200:468  429:9532  
Latencies     [mean, 50, 95, 99, max]  21.220874ms, 11.088429ms, 103.60739ms, 217.228755ms, 544.819813ms
Status Codes  [code:count]             429:9518  200:482  
Thu Feb 28 17:07:45 CET 2019
```

### test based on current swim based implementation skipper fix/cluster-ratelimits

TODO

### test based on current swim based implementation skipper v0.10.177

summary: precision is not good enough 

`p50 <18ms`, general `p99 < 100ms` and `max(p99) < 3s`
The spikes in p99 could be, caused by a backend restart, which were not tracked.

```
# test 50 req/s Thu Feb 28 14:01:43 CET 2019
Latencies     [mean, 50, 95, 99, max]  14.356729ms, 12.351785ms, 18.551783ms, 73.522291ms, 173.522182ms
Status Codes  [code:count]             429:448  200:52
Latencies     [mean, 50, 95, 99, max]  18.764894ms, 18.154147ms, 18.841292ms, 38.205528ms, 98.655671ms
Status Codes  [code:count]             200:500
Latencies     [mean, 50, 95, 99, max]  18.428387ms, 18.14631ms, 19.028089ms, 37.666608ms, 99.931976ms
Status Codes  [code:count]             200:473  429:27
Latencies     [mean, 50, 95, 99, max]  18.447913ms, 18.166088ms, 18.850332ms, 36.757067ms, 99.483914ms
Status Codes  [code:count]             429:25  200:475
Latencies     [mean, 50, 95, 99, max]  18.479275ms, 18.097414ms, 18.907208ms, 39.997554ms, 101.920837ms
Status Codes  [code:count]             200:478  429:22
Latencies     [mean, 50, 95, 99, max]  18.29641ms, 18.092374ms, 19.06362ms, 22.317747ms, 92.432799ms
Status Codes  [code:count]             200:476  429:24
Latencies     [mean, 50, 95, 99, max]  18.408259ms, 18.100175ms, 19.057354ms, 35.551675ms, 95.260094ms
Status Codes  [code:count]             200:478  429:22
Latencies     [mean, 50, 95, 99, max]  18.176049ms, 17.89549ms, 18.861338ms, 21.565965ms, 93.263231ms
Status Codes  [code:count]             200:487  429:13
Latencies     [mean, 50, 95, 99, max]  18.239453ms, 17.881139ms, 18.815135ms, 24.258723ms, 100.148944ms
Status Codes  [code:count]             200:487  429:13
Thu Feb 28 14:03:13 CET 2019
# test 250 req/s Thu Feb 28 14:03:23 CET 2019
Latencies     [mean, 50, 95, 99, max]  14.398034ms, 11.829942ms, 18.063718ms, 47.394984ms, 108.402328ms
Status Codes  [code:count]             200:899  429:1601
Latencies     [mean, 50, 95, 99, max]  14.502002ms, 11.763126ms, 17.96289ms, 57.16927ms, 126.748333ms
Status Codes  [code:count]             200:894  429:1606
Latencies     [mean, 50, 95, 99, max]  14.268591ms, 11.856844ms, 18.029405ms, 27.934367ms, 98.876946ms
Status Codes  [code:count]             200:909  429:1591
Latencies     [mean, 50, 95, 99, max]  164.09398ms, 11.44016ms, 20.654348ms, 3.376502447s, 21.386618054s
Status Codes  [code:count]             429:1593  502:7  200:900
Latencies     [mean, 50, 95, 99, max]  13.987123ms, 11.400583ms, 17.569053ms, 42.843811ms, 123.077338ms
Status Codes  [code:count]             200:895  429:1605
Latencies     [mean, 50, 95, 99, max]  14.003082ms, 11.354663ms, 17.575242ms, 55.436353ms, 131.517844ms
Status Codes  [code:count]             200:893  429:1607
Latencies     [mean, 50, 95, 99, max]  13.788186ms, 11.372047ms, 17.545542ms, 32.33792ms, 110.270963ms
Status Codes  [code:count]             429:1603  200:897
Latencies     [mean, 50, 95, 99, max]  13.834173ms, 11.407552ms, 17.568209ms, 35.402306ms, 113.841127ms
Status Codes  [code:count]             200:898  429:1602
Latencies     [mean, 50, 95, 99, max]  14.051508ms, 11.448417ms, 18.121864ms, 39.222235ms, 110.419554ms
Status Codes  [code:count]             200:898  429:1602
Thu Feb 28 14:05:05 CET 2019
# test 500 req/s Thu Feb 28 14:05:15 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.744463ms, 11.105908ms, 17.600074ms, 63.79645ms, 159.747824ms
Status Codes  [code:count]             429:3604  200:1396
Latencies     [mean, 50, 95, 99, max]  13.415151ms, 11.141468ms, 17.291865ms, 42.268009ms, 122.763501ms
Status Codes  [code:count]             200:1499  429:3501
Latencies     [mean, 50, 95, 99, max]  13.508124ms, 11.106623ms, 17.307096ms, 60.344881ms, 126.955372ms
Status Codes  [code:count]             429:3504  200:1496
Latencies     [mean, 50, 95, 99, max]  13.519094ms, 11.130591ms, 17.355398ms, 51.128966ms, 129.010948ms
Status Codes  [code:count]             200:1492  429:3508
Latencies     [mean, 50, 95, 99, max]  14.44023ms, 11.694435ms, 18.231865ms, 66.83797ms, 166.910481ms
Status Codes  [code:count]             200:1494  429:3506
Latencies     [mean, 50, 95, 99, max]  13.745814ms, 11.237548ms, 17.640668ms, 52.135249ms, 132.318227ms
Status Codes  [code:count]             429:3509  200:1491
Latencies     [mean, 50, 95, 99, max]  13.695935ms, 11.203472ms, 17.485477ms, 51.911518ms, 133.935807ms
Status Codes  [code:count]             200:1487  429:3513
Latencies     [mean, 50, 95, 99, max]  13.882421ms, 11.181664ms, 17.251736ms, 76.212638ms, 156.743216ms
Status Codes  [code:count]             200:1487  429:3513
Latencies     [mean, 50, 95, 99, max]  13.441594ms, 11.113774ms, 17.251696ms, 41.118933ms, 122.52483ms
Status Codes  [code:count]             200:1512  429:3488
Thu Feb 28 14:06:45 CET 2019
# test 1000 req/s Thu Feb 28 14:06:55 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.700374ms, 10.949204ms, 17.717607ms, 69.037966ms, 136.755945ms
Status Codes  [code:count]             429:7425  200:2575
Latencies     [mean, 50, 95, 99, max]  17.459803ms, 10.915558ms, 17.736802ms, 209.905499ms, 325.280075ms
Status Codes  [code:count]             200:2610  429:7390
Latencies     [mean, 50, 95, 99, max]  16.970824ms, 11.022393ms, 20.883363ms, 190.268858ms, 274.592495ms
Status Codes  [code:count]             200:2618  429:7382
Latencies     [mean, 50, 95, 99, max]  15.749669ms, 10.976781ms, 19.790679ms, 146.925073ms, 241.428507ms
Status Codes  [code:count]             200:2621  429:7379
Latencies     [mean, 50, 95, 99, max]  17.876894ms, 10.967719ms, 23.12014ms, 202.764254ms, 309.510468ms
Status Codes  [code:count]             200:2525  429:7475
Latencies     [mean, 50, 95, 99, max]  119.277608ms, 12.435147ms, 891.616935ms, 1.320097035s, 1.60851214s
Status Codes  [code:count]             429:7799  0:54  200:2147
Latencies     [mean, 50, 95, 99, max]  14.483886ms, 11.37783ms, 18.376853ms, 71.163982ms, 237.313388ms
Status Codes  [code:count]             200:3152  429:6848
Latencies     [mean, 50, 95, 99, max]  16.511551ms, 10.975583ms, 24.272133ms, 161.048776ms, 256.139121ms
Status Codes  [code:count]             200:3153  429:6847
Latencies     [mean, 50, 95, 99, max]  333.004655ms, 10.989611ms, 21.517555ms, 30.000351202s, 30.003017615s
Status Codes  [code:count]             200:3049  429:6845  0:106
Thu Feb 28 14:08:55 CET 2019
```

### test based on ring shards and pipelined Z commands

summary: precision seems to be ok +/- 20 requests as configured and precise also with heavy load 

Latencies

- `p50 < 18ms`
- general up to 500 req/s `p99 < 100ms` and  `max(p99)=18.5s` already at 50req/s, which might be caused by a backend instance restart

```
# test 50 req/s Thu Feb 28 14:23:21 CET 2019
Latencies     [mean, 50, 95, 99, max]  19.059521ms, 18.216652ms, 20.367129ms, 75.662178ms, 169.25396ms
Status Codes  [code:count]             200:400  429:100
Latencies     [mean, 50, 95, 99, max]  442.96714ms, 18.377943ms, 20.758322ms, 18.530525078s, 30.000879739s
Status Codes  [code:count]             429:102  200:393  502:1  0:4
Latencies     [mean, 50, 95, 99, max]  17.621103ms, 18.263192ms, 19.28138ms, 24.435897ms, 88.976088ms
Status Codes  [code:count]             200:401  429:99
Latencies     [mean, 50, 95, 99, max]  16.600235ms, 17.939946ms, 19.400431ms, 48.305309ms, 92.688326ms
Status Codes  [code:count]             429:200  200:300
Latencies     [mean, 50, 95, 99, max]  18.48213ms, 18.830937ms, 19.910358ms, 37.974456ms, 117.278964ms
Status Codes  [code:count]             200:396  429:104
Latencies     [mean, 50, 95, 99, max]  18.327665ms, 18.805798ms, 19.860243ms, 47.607022ms, 125.622292ms
Status Codes  [code:count]             200:378  429:122
Latencies     [mean, 50, 95, 99, max]  18.311778ms, 18.906819ms, 20.062917ms, 27.868991ms, 96.311409ms
Status Codes  [code:count]             200:394  429:106
Latencies     [mean, 50, 95, 99, max]  18.035058ms, 18.84789ms, 20.129839ms, 25.155102ms, 95.597498ms
Status Codes  [code:count]             200:373  429:127
Latencies     [mean, 50, 95, 99, max]  18.112024ms, 18.795359ms, 20.180577ms, 24.674735ms, 95.196938ms
Status Codes  [code:count]             200:390  429:110
Thu Feb 28 14:25:14 CET 2019
# test 250 req/s Thu Feb 28 14:25:24 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.70859ms, 11.74495ms, 19.034873ms, 54.379835ms, 134.087508ms
Status Codes  [code:count]             200:404  429:2096
Latencies     [mean, 50, 95, 99, max]  14.166105ms, 12.379714ms, 18.959012ms, 56.370593ms, 128.983388ms
Status Codes  [code:count]             200:398  429:2102
Latencies     [mean, 50, 95, 99, max]  14.057344ms, 12.325079ms, 18.970783ms, 49.32461ms, 98.195284ms
Status Codes  [code:count]             200:405  429:2095
Latencies     [mean, 50, 95, 99, max]  14.054179ms, 12.447474ms, 18.827704ms, 39.60335ms, 114.455656ms
Status Codes  [code:count]             200:396  429:2104
Latencies     [mean, 50, 95, 99, max]  13.951989ms, 12.397796ms, 18.901446ms, 37.231312ms, 113.602258ms
Status Codes  [code:count]             429:2113  200:387
Latencies     [mean, 50, 95, 99, max]  13.907659ms, 12.466591ms, 18.778682ms, 31.056573ms, 105.721151ms
Status Codes  [code:count]             200:388  429:2112
Latencies     [mean, 50, 95, 99, max]  14.131348ms, 12.549207ms, 18.967197ms, 32.373756ms, 110.306126ms
Status Codes  [code:count]             200:382  429:2118
Latencies     [mean, 50, 95, 99, max]  13.711995ms, 12.358502ms, 18.89508ms, 47.51694ms, 126.446533ms
Status Codes  [code:count]             200:380  429:2120
Latencies     [mean, 50, 95, 99, max]  13.987187ms, 12.425882ms, 18.897023ms, 35.111518ms, 217.912543ms
Status Codes  [code:count]             200:372  429:2128
Thu Feb 28 14:26:54 CET 2019
# test 500 req/s Thu Feb 28 14:27:04 CET 2019
Latencies     [mean, 50, 95, 99, max]  15.574231ms, 12.274216ms, 18.897765ms, 130.211949ms, 223.193791ms
Status Codes  [code:count]             200:400  429:4600
Latencies     [mean, 50, 95, 99, max]  16.89698ms, 12.257406ms, 19.056206ms, 183.055781ms, 292.532909ms
Status Codes  [code:count]             200:400  429:4600
Latencies     [mean, 50, 95, 99, max]  14.127633ms, 12.316369ms, 18.590501ms, 60.31734ms, 139.158363ms
Status Codes  [code:count]             429:4589  200:411
Latencies     [mean, 50, 95, 99, max]  20.588864ms, 12.523527ms, 41.647835ms, 243.642297ms, 330.740451ms
Status Codes  [code:count]             429:4613  200:387
Latencies     [mean, 50, 95, 99, max]  24.041402ms, 11.63355ms, 90.270297ms, 338.682042ms, 651.360013ms
Status Codes  [code:count]             200:389  429:4611
Latencies     [mean, 50, 95, 99, max]  13.854429ms, 11.436913ms, 17.859796ms, 100.711547ms, 191.676699ms
Status Codes  [code:count]             429:4626  200:374
Latencies     [mean, 50, 95, 99, max]  12.488565ms, 11.366661ms, 17.418607ms, 33.754619ms, 117.587288ms
Status Codes  [code:count]             429:4630  200:370
Latencies     [mean, 50, 95, 99, max]  13.02346ms, 11.495478ms, 17.766048ms, 55.108912ms, 229.576111ms
Status Codes  [code:count]             200:371  429:4629
Latencies     [mean, 50, 95, 99, max]  20.558677ms, 11.549882ms, 30.258353ms, 299.579554ms, 391.992407ms
Status Codes  [code:count]             429:4644  200:356
Thu Feb 28 14:28:35 CET 2019
# test 1000 req/s Thu Feb 28 14:28:45 CET 2019
Latencies     [mean, 50, 95, 99, max]  14.392793ms, 11.392163ms, 14.986282ms, 134.803711ms, 247.258496ms
Status Codes  [code:count]             429:9595  200:401  502:4
Latencies     [mean, 50, 95, 99, max]  16.173888ms, 11.326091ms, 15.654005ms, 189.635478ms, 299.489964ms
Status Codes  [code:count]             200:401  429:9599
Latencies     [mean, 50, 95, 99, max]  21.442863ms, 11.458362ms, 87.881713ms, 244.874975ms, 404.453352ms
Status Codes  [code:count]             429:9598  200:402
Latencies     [mean, 50, 95, 99, max]  14.386338ms, 11.284006ms, 14.976164ms, 122.177889ms, 216.953285ms
Status Codes  [code:count]             200:395  429:9605
Latencies     [mean, 50, 95, 99, max]  13.232854ms, 11.27251ms, 14.758744ms, 76.120718ms, 153.814542ms
Status Codes  [code:count]             429:9594  200:406  
Latencies     [mean, 50, 95, 99, max]  13.556457ms, 11.330263ms, 15.286986ms, 94.921738ms, 178.150969ms
Status Codes  [code:count]             200:395  429:9605  
Latencies     [mean, 50, 95, 99, max]  19.925346ms, 11.380555ms, 48.347641ms, 250.400117ms, 422.480229ms
Status Codes  [code:count]             200:394  429:9606  
Latencies     [mean, 50, 95, 99, max]  51.874422ms, 11.480821ms, 401.368411ms, 544.009141ms, 734.412492ms
Status Codes  [code:count]             429:9602  200:398  
Latencies     [mean, 50, 95, 99, max]  15.517233ms, 11.382016ms, 21.430396ms, 146.900308ms, 260.05071ms
Status Codes  [code:count]             429:9610  200:390  
Thu Feb 28 14:30:15 CET 2019
```

### test based on redis client and 2x pipelined Z commands

summary: precision problems with low traffic `151` instead of `400` allowed in one of the 50 req/s tests and +/-40 for all at 1000 req/s

Latencies

- `p50 < 18ms`
- general  `p99 < 500ms` and  `max(p99)=680ms`

```
# test 50 req/s Thu Feb 28 14:46:30 CET 2019
Latencies     [mean, 50, 95, 99, max]  17.994797ms, 18.275152ms, 20.645531ms, 27.596735ms, 107.748389ms
Status Codes  [code:count]             200:400  429:100  
Latencies     [mean, 50, 95, 99, max]  18.813792ms, 18.142001ms, 19.890846ms, 92.077842ms, 192.637366ms
Status Codes  [code:count]             200:400  429:100  
Latencies     [mean, 50, 95, 99, max]  17.808965ms, 18.241169ms, 20.188786ms, 31.629332ms, 99.918946ms
Status Codes  [code:count]             429:100  200:400  
Latencies     [mean, 50, 95, 99, max]  16.003903ms, 17.247189ms, 19.262617ms, 21.138364ms, 90.184671ms
Status Codes  [code:count]             200:265  429:235  
Latencies     [mean, 50, 95, 99, max]  16.082792ms, 18.089157ms, 20.141714ms, 25.881242ms, 92.1652ms
Status Codes  [code:count]             429:234  200:266  
Latencies     [mean, 50, 95, 99, max]  15.894566ms, 17.61561ms, 19.515143ms, 21.658534ms, 81.177594ms
Status Codes  [code:count]             429:234  200:266  
Latencies     [mean, 50, 95, 99, max]  15.067351ms, 13.029304ms, 19.978056ms, 22.94775ms, 91.176717ms
Status Codes  [code:count]             429:349  200:151  
Latencies     [mean, 50, 95, 99, max]  16.263298ms, 17.781937ms, 20.031074ms, 51.228263ms, 119.379125ms
Status Codes  [code:count]             429:257  200:243  
Latencies     [mean, 50, 95, 99, max]  16.912347ms, 17.911252ms, 19.289697ms, 57.487682ms, 100.838969ms
Status Codes  [code:count]             429:185  200:315  
Thu Feb 28 14:48:00 CET 2019
# test 250 req/s Thu Feb 28 14:48:10 CET 2019
Latencies     [mean, 50, 95, 99, max]  14.181225ms, 11.588929ms, 19.12782ms, 82.537589ms, 175.939928ms
Status Codes  [code:count]             200:400  429:2100  
Latencies     [mean, 50, 95, 99, max]  15.261694ms, 11.690138ms, 19.53341ms, 120.437004ms, 215.24003ms
Status Codes  [code:count]             200:400  429:2100  
Latencies     [mean, 50, 95, 99, max]  13.54965ms, 12.165813ms, 19.128402ms, 24.846388ms, 107.815519ms
Status Codes  [code:count]             200:398  429:2102  
Latencies     [mean, 50, 95, 99, max]  13.956621ms, 12.446398ms, 19.141729ms, 29.489397ms, 98.69131ms
Status Codes  [code:count]             200:384  429:2116  
Latencies     [mean, 50, 95, 99, max]  19.995645ms, 12.543132ms, 21.009376ms, 265.190659ms, 365.893428ms
Status Codes  [code:count]             200:374  429:2126  
Latencies     [mean, 50, 95, 99, max]  14.435014ms, 12.38962ms, 19.239155ms, 66.793642ms, 139.875812ms
Status Codes  [code:count]             429:2101  200:399  
Latencies     [mean, 50, 95, 99, max]  15.618777ms, 12.414111ms, 19.756878ms, 113.240418ms, 221.515967ms
Status Codes  [code:count]             429:2108  200:392  
Latencies     [mean, 50, 95, 99, max]  13.908426ms, 12.46694ms, 19.075046ms, 23.236521ms, 97.85808ms
Status Codes  [code:count]             429:2106  200:394  
Latencies     [mean, 50, 95, 99, max]  14.035953ms, 12.511701ms, 19.146508ms, 32.148576ms, 97.090823ms
Status Codes  [code:count]             429:2128  200:372  
Thu Feb 28 14:49:41 CET 2019
# test 500 req/s Thu Feb 28 14:49:51 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.389404ms, 11.332385ms, 17.844361ms, 84.980297ms, 171.177801ms
Status Codes  [code:count]             200:400  429:4600  
Latencies     [mean, 50, 95, 99, max]  13.743022ms, 11.895003ms, 18.926871ms, 62.040789ms, 121.637622ms
Status Codes  [code:count]             429:4600  200:400  
Latencies     [mean, 50, 95, 99, max]  61.123774ms, 11.528366ms, 422.916294ms, 661.945717ms, 912.939384ms
Status Codes  [code:count]             200:401  429:4599  
Latencies     [mean, 50, 95, 99, max]  12.901347ms, 11.382385ms, 17.789204ms, 54.967458ms, 148.417923ms
Status Codes  [code:count]             429:4620  200:380  
Latencies     [mean, 50, 95, 99, max]  12.508503ms, 11.333938ms, 17.79463ms, 40.138849ms, 224.069857ms
Status Codes  [code:count]             429:4656  200:344  
Latencies     [mean, 50, 95, 99, max]  12.453615ms, 11.394832ms, 17.861688ms, 26.247142ms, 102.845553ms
Status Codes  [code:count]             429:4646  200:354  
Latencies     [mean, 50, 95, 99, max]  12.750554ms, 11.529231ms, 17.804956ms, 34.13443ms, 103.81675ms
Status Codes  [code:count]             429:4648  200:352  
Latencies     [mean, 50, 95, 99, max]  12.703263ms, 11.379156ms, 17.803314ms, 45.52721ms, 138.789225ms
Status Codes  [code:count]             429:4655  200:345  
Latencies     [mean, 50, 95, 99, max]  12.402795ms, 11.319635ms, 17.770514ms, 34.432228ms, 104.987809ms
Status Codes  [code:count]             429:4673  200:327  
Thu Feb 28 14:51:21 CET 2019
# test 1000 req/s Thu Feb 28 14:51:31 CET 2019
Latencies     [mean, 50, 95, 99, max]  20.028281ms, 11.29326ms, 28.166582ms, 282.419263ms, 396.885402ms
Status Codes  [code:count]             200:402  429:9598  
Latencies     [mean, 50, 95, 99, max]  13.817916ms, 11.303934ms, 17.89109ms, 100.660964ms, 190.083372ms
Status Codes  [code:count]             429:9602  200:398  
Latencies     [mean, 50, 95, 99, max]  12.79482ms, 11.283494ms, 17.760966ms, 55.263906ms, 121.442862ms
Status Codes  [code:count]             429:9615  200:385  
Latencies     [mean, 50, 95, 99, max]  13.913912ms, 11.446868ms, 17.823186ms, 106.339333ms, 186.275395ms
Status Codes  [code:count]             429:9640  200:360  
Latencies     [mean, 50, 95, 99, max]  18.031244ms, 11.247551ms, 23.223666ms, 259.175748ms, 356.075178ms
Status Codes  [code:count]             200:370  429:9630  
Latencies     [mean, 50, 95, 99, max]  13.382245ms, 11.248359ms, 17.621791ms, 93.519834ms, 167.297961ms
Status Codes  [code:count]             429:9615  200:385  
Latencies     [mean, 50, 95, 99, max]  14.371505ms, 11.282696ms, 18.92146ms, 119.997225ms, 214.048824ms
Status Codes  [code:count]             200:371  429:9629  
Latencies     [mean, 50, 95, 99, max]  14.734347ms, 11.280707ms, 18.136987ms, 132.553323ms, 253.208949ms
Status Codes  [code:count]             200:364  429:9636  
Latencies     [mean, 50, 95, 99, max]  13.462396ms, 11.326571ms, 17.931591ms, 79.662549ms, 215.312406ms
Status Codes  [code:count]             429:9637  200:363  
Thu Feb 28 14:53:01 CET 2019
```

### test based on github.com/go-redis/redis_rate

summary: As you can see the precision `Status Codes` of the first requests are always quite bad, because of the general problem of token bucket algorithm, see also [blog1](https://www.figma.com/blog/an-alternative-approach-to-rate-limiting/) and [blog2](https://engineering.classdojo.com/blog/2015/02/06/rolling-rate-limiter/).

p99 up to >3s, which might be caused by backend restarts

```
# test 50 req/s Thu Feb 28 15:12:29 CET 2019
Latencies     [mean, 50, 95, 99, max]  16.860328ms, 17.282586ms, 18.659043ms, 24.454275ms, 102.880315ms
Status Codes  [code:count]             200:403  429:97  
Latencies     [mean, 50, 95, 99, max]  16.810519ms, 16.990255ms, 17.652087ms, 50.384862ms, 133.75074ms
Status Codes  [code:count]             200:400  429:100  
Latencies     [mean, 50, 95, 99, max]  16.43972ms, 16.95929ms, 17.712783ms, 23.817347ms, 99.721949ms
Status Codes  [code:count]             200:400  429:100  
Latencies     [mean, 50, 95, 99, max]  373.992516ms, 17.500738ms, 50.116593ms, 12.905982553s, 16.903109294s
Status Codes  [code:count]             429:100  200:398  502:2  
Latencies     [mean, 50, 95, 99, max]  71.450464ms, 17.246135ms, 20.799365ms, 2.375960599s, 5.781727307s
Status Codes  [code:count]             200:463  429:36  502:1  
Latencies     [mean, 50, 95, 99, max]  176.311318ms, 17.387979ms, 87.640999ms, 3.833020432s, 10.442610825s
Status Codes  [code:count]             200:397  502:3  429:100  
Latencies     [mean, 50, 95, 99, max]  18.078178ms, 17.256648ms, 18.726391ms, 51.576483ms, 115.3126ms
Status Codes  [code:count]             200:500  
Latencies     [mean, 50, 95, 99, max]  16.94428ms, 17.314842ms, 18.1127ms, 41.571231ms, 107.156527ms
Status Codes  [code:count]             200:401  429:99  
Latencies     [mean, 50, 95, 99, max]  17.708665ms, 17.881558ms, 19.846517ms, 49.086758ms, 112.007516ms
Status Codes  [code:count]             200:401  429:99  
Thu Feb 28 15:14:14 CET 2019
# test 250 req/s Thu Feb 28 15:14:24 CET 2019
Latencies     [mean, 50, 95, 99, max]  15.271303ms, 12.192791ms, 18.791936ms, 79.492041ms, 149.628123ms
Status Codes  [code:count]             200:800  429:1700  
Latencies     [mean, 50, 95, 99, max]  13.432481ms, 12.028864ms, 17.784706ms, 23.488923ms, 102.433694ms
Status Codes  [code:count]             429:2100  200:400  
Latencies     [mean, 50, 95, 99, max]  13.390198ms, 11.941265ms, 18.066653ms, 23.862178ms, 103.683921ms
Status Codes  [code:count]             429:2100  200:400  
Latencies     [mean, 50, 95, 99, max]  13.595745ms, 12.122424ms, 18.172398ms, 23.424561ms, 105.899202ms
Status Codes  [code:count]             429:2100  200:400  
Latencies     [mean, 50, 95, 99, max]  12.773293ms, 11.265908ms, 17.019747ms, 33.130143ms, 106.867722ms
Status Codes  [code:count]             429:2100  200:400  
Latencies     [mean, 50, 95, 99, max]  12.75405ms, 11.152552ms, 17.287189ms, 45.050553ms, 105.720929ms
Status Codes  [code:count]             429:2100  200:400  
Latencies     [mean, 50, 95, 99, max]  12.725482ms, 11.280383ms, 17.466216ms, 21.711541ms, 107.151367ms
Status Codes  [code:count]             429:2100  200:400  
Latencies     [mean, 50, 95, 99, max]  12.601545ms, 11.207705ms, 17.294126ms, 21.609902ms, 100.309968ms
Status Codes  [code:count]             429:2100  200:400  
Latencies     [mean, 50, 95, 99, max]  12.764951ms, 11.363328ms, 17.299268ms, 20.791964ms, 102.919727ms
Status Codes  [code:count]             200:400  429:2100  
Thu Feb 28 15:15:55 CET 2019
# test 500 req/s Thu Feb 28 15:16:05 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.144735ms, 11.731654ms, 17.792334ms, 24.534934ms, 104.012268ms
Status Codes  [code:count]             200:800  429:4200  
Latencies     [mean, 50, 95, 99, max]  13.046155ms, 11.78133ms, 17.689263ms, 51.66999ms, 139.056023ms
Status Codes  [code:count]             429:4600  200:400  
Latencies     [mean, 50, 95, 99, max]  12.797792ms, 11.799442ms, 17.409043ms, 25.549983ms, 107.262276ms
Status Codes  [code:count]             429:4600  200:400  
Latencies     [mean, 50, 95, 99, max]  12.698557ms, 11.642482ms, 17.39211ms, 27.641798ms, 218.329675ms
Status Codes  [code:count]             200:400  429:4600  
Latencies     [mean, 50, 95, 99, max]  13.044884ms, 11.664598ms, 17.458067ms, 45.843947ms, 120.861616ms
Status Codes  [code:count]             200:400  429:4600  
Latencies     [mean, 50, 95, 99, max]  13.201892ms, 11.665844ms, 17.496069ms, 64.046506ms, 153.477131ms
Status Codes  [code:count]             429:4600  200:400  
Latencies     [mean, 50, 95, 99, max]  12.939821ms, 11.643828ms, 17.512781ms, 46.607813ms, 109.245749ms
Status Codes  [code:count]             429:4600  200:400  
Latencies     [mean, 50, 95, 99, max]  12.445918ms, 11.389902ms, 17.097661ms, 26.698772ms, 116.840907ms
Status Codes  [code:count]             429:4600  200:400  
Latencies     [mean, 50, 95, 99, max]  13.172472ms, 11.029634ms, 17.02719ms, 82.965142ms, 229.411405ms
Status Codes  [code:count]             429:4600  200:400  
Thu Feb 28 15:17:35 CET 2019
# test 1000 req/s Thu Feb 28 15:17:45 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.079881ms, 11.032952ms, 16.840787ms, 77.562606ms, 172.073419ms
Status Codes  [code:count]             200:800  429:9200  
Latencies     [mean, 50, 95, 99, max]  13.54822ms, 11.033186ms, 16.785118ms, 117.560329ms, 207.103822ms
Status Codes  [code:count]             429:9600  200:400  
Latencies     [mean, 50, 95, 99, max]  13.317805ms, 11.015766ms, 16.662842ms, 104.945919ms, 195.927365ms
Status Codes  [code:count]             429:9600  200:400  
Latencies     [mean, 50, 95, 99, max]  18.211693ms, 10.861229ms, 45.999995ms, 217.224351ms, 357.029687ms
Status Codes  [code:count]             429:9600  200:400  
Latencies     [mean, 50, 95, 99, max]  13.827148ms, 11.552064ms, 17.078605ms, 110.433646ms, 202.851448ms
Status Codes  [code:count]             429:9600  200:400  
Latencies     [mean, 50, 95, 99, max]  13.136735ms, 11.679519ms, 17.339857ms, 72.348214ms, 222.921017ms
Status Codes  [code:count]             429:9600  200:400  
Latencies     [mean, 50, 95, 99, max]  13.33097ms, 11.66909ms, 17.105515ms, 78.74846ms, 238.246301ms
Status Codes  [code:count]             429:9600  200:400  
Latencies     [mean, 50, 95, 99, max]  14.3097ms, 11.729872ms, 17.636834ms, 114.792431ms, 191.051362ms
Status Codes  [code:count]             429:9600  200:400  
Latencies     [mean, 50, 95, 99, max]  14.406166ms, 11.785217ms, 17.522569ms, 112.999077ms, 192.010204ms
Status Codes  [code:count]             429:9600  200:400  
Thu Feb 28 15:19:15 CET 2019
```

## old
### test based on ring shards and pipelined Z commands

#### precision

test on localhost with redis ring of size 1 on localhost
```
% date; for i in {1..9}; do echo "GET http://127.0.0.1:9090/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status'; sleep 1; done; date
Wed Feb 27 23:19:40 CET 2019
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             429:4600  200:400  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             429:4600  200:400  
Status Codes  [code:count]             429:4600  200:400  
Status Codes  [code:count]             200:400  429:4600  
Wed Feb 27 23:21:19 CET 2019
```

#### pseudo benchmark overhead 

localhost benahcmark
```
% date; for i in {1..9}; do echo "GET http://127.0.0.1:9090/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Latencies'; sleep 1; done; date
Wed Feb 27 23:21:32 CET 2019
Latencies     [mean, 50, 95, 99, max]  838.315µs, 793.974µs, 1.246452ms, 2.070899ms, 13.850628ms
Latencies     [mean, 50, 95, 99, max]  824.999µs, 774.189µs, 1.248807ms, 2.226457ms, 9.933209ms
Latencies     [mean, 50, 95, 99, max]  863.425µs, 792.776µs, 1.199693ms, 2.745246ms, 15.744532ms
Latencies     [mean, 50, 95, 99, max]  852.732µs, 808.507µs, 1.256429ms, 2.046581ms, 18.362584ms
Latencies     [mean, 50, 95, 99, max]  835.288µs, 804.38µs, 1.211785ms, 1.84232ms, 7.357213ms
Latencies     [mean, 50, 95, 99, max]  843.275µs, 795.017µs, 1.236114ms, 1.948408ms, 13.062458ms
Latencies     [mean, 50, 95, 99, max]  911.839µs, 810.554µs, 1.241935ms, 3.648777ms, 24.72226ms
Latencies     [mean, 50, 95, 99, max]  853.867µs, 801.183µs, 1.242979ms, 2.052703ms, 11.16957ms
Latencies     [mean, 50, 95, 99, max]  860.433µs, 799.076µs, 1.22314ms, 2.221698ms, 19.212818ms
Wed Feb 27 23:23:11 CET 2019
```

### test based on ring shards and Z commands

The test was run in Kubernetes with skipper-ingress as deployment with a cpu+memory based hpa (it did not scale up or down in all cases) and backends skipper with an inline route having a `latency(5)` filter and return a string in both targets.  
Loadtest was run from a client outside Kubernetes from the internet.

#### precision

Precise results for 50 req/s and also for 250 req/s.
A little non precise results with overrate for 500 req/s, but I would say acceptable (`397-409`)

```
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=50 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; sleep 1; done; date
Wed Feb 27 22:21:17 CET 2019
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             429:100  200:400
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             429:100  200:400
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Wed Feb 27 22:22:56 CET 2019
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=250 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; sleep 1; done; date
Wed Feb 27 22:23:05 CET 2019
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Wed Feb 27 22:24:45 CET 2019
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; sleep 1; done; date
Wed Feb 27 22:24:51 CET 2019
Status Codes  [code:count]             200:403  0:954  429:3643
Status Codes  [code:count]             200:398  0:891  429:3711  
Status Codes  [code:count]             200:397  0:888  429:3715  
Status Codes  [code:count]             200:397  0:866  429:3737  
Status Codes  [code:count]             200:398  0:955  429:3647  
Status Codes  [code:count]             429:3821  200:400  0:779  
Status Codes  [code:count]             200:399  0:873  429:3728  
Status Codes  [code:count]             429:3747  200:397  0:856  
Status Codes  [code:count]             429:3694  200:409  0:897  
Wed Feb 27 22:26:36 CET 2019
```

localhost precision

```
% date; for i in {1..9}; do echo "GET http://127.0.0.1:9090/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status'; sleep 1; done; date   
Wed Feb 27 23:30:46 CET 2019
Status Codes  [code:count]             429:4600  200:400  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             429:4600  200:400  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Status Codes  [code:count]             200:400  429:4600  
Wed Feb 27 23:32:26 CET 2019
```

#### pseudo benchmark overhead 

localhost benchmarks

```
% date; for i in {1..9}; do echo "GET http://127.0.0.1:9090/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Latencies'; sleep 1; done; date
Wed Feb 27 23:32:38 CET 2019
Latencies     [mean, 50, 95, 99, max]  905.912µs, 873.521µs, 1.284488ms, 1.885031ms, 10.29924ms
Latencies     [mean, 50, 95, 99, max]  920.416µs, 872.851µs, 1.292756ms, 2.168676ms, 11.017666ms
Latencies     [mean, 50, 95, 99, max]  916.085µs, 875.175µs, 1.29204ms, 1.878276ms, 11.295457ms
Latencies     [mean, 50, 95, 99, max]  906.095µs, 872.222µs, 1.279157ms, 1.775708ms, 13.684616ms
Latencies     [mean, 50, 95, 99, max]  890.456µs, 859.362µs, 1.284134ms, 1.745892ms, 10.832522ms
Latencies     [mean, 50, 95, 99, max]  906.446µs, 868.125µs, 1.289145ms, 1.732453ms, 8.86953ms
Latencies     [mean, 50, 95, 99, max]  900.166µs, 867.487µs, 1.284759ms, 1.803102ms, 9.522586ms
Latencies     [mean, 50, 95, 99, max]  896.705µs, 863.846µs, 1.292905ms, 1.915895ms, 8.275398ms
Latencies     [mean, 50, 95, 99, max]  899.607µs, 866.735µs, 1.288691ms, 1.904481ms, 5.646216ms
Wed Feb 27 23:34:17 CET 2019
```

### test based on redis client and 2x pipelined Z commands

The test was run in Kubernetes with skipper-ingress as deployment with a cpu+memory based hpa (it did not scale up or down in all cases) and backends skipper with an inline route having a `latency(5)` filter and return a string in both targets.  
Loadtest was run from a client outside Kubernetes from the internet.

#### precision

Precise results for 50 req/s and also for 250 req/s.
A little non precise results with overrate for 500 req/s, but I would say acceptable (`391-405`)

```
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=50 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; sleep 1; done; date
Wed Feb 27 21:28:43 CET 2019
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             429:100  200:400
Wed Feb 27 21:30:23 CET 2019
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=250 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; sleep 1; done; date
Wed Feb 27 21:30:55 CET 2019
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2079  0:21
Status Codes  [code:count]             200:400  429:2100
Status Codes  [code:count]             200:400  429:2100
Wed Feb 27 21:32:35 CET 2019
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; sleep 1; done; date
Wed Feb 27 21:33:32 CET 2019
Status Codes  [code:count]             200:400  0:1285  429:3315
Status Codes  [code:count]             0:902  429:3693  200:405
Status Codes  [code:count]             200:395  0:809  429:3796
Status Codes  [code:count]             429:3599  200:403  0:998
Status Codes  [code:count]             200:391  0:782  429:3827
Status Codes  [code:count]             200:391  0:1030  429:3579
Status Codes  [code:count]             200:391  0:897  429:3712
Status Codes  [code:count]             200:400  0:1037  429:3563
Status Codes  [code:count]             200:396  0:789  429:3815
Wed Feb 27 21:35:22 CET 2019
```

#### pseudo benchmark overhead 

TODO

### test based on github.com/go-redis/redis_rate

The test was run in Kubernetes with skipper-ingress as deployment with a cpu+memory based hpa (it did not scale up or down in all cases) and backends skipper with an inline route having a `latency(5)` filter and return a string in both targets.  
Loadtest was run from a client outside Kubernetes from the internet.

#### precision

In general: First round seems not to be precise, sometimes double amount is allowed.

```
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=50 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; done; date; sleep 30
Wed Feb 27 14:10:19 CET 2019
Status Codes  [code:count]             200:427  429:73
Status Codes  [code:count]             429:100  200:400
Status Codes  [code:count]             429:100  200:400
Status Codes  [code:count]             429:100  200:400
Status Codes  [code:count]             429:100  200:400
Status Codes  [code:count]             502:12  429:100  200:388
Status Codes  [code:count]             200:500
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:401  429:99
Wed Feb 27 14:12:04 CET 2019
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=50 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; done; date; sleep 30
Wed Feb 27 14:15:01 CET 2019
Status Codes  [code:count]             200:489  429:11
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             200:401  429:99
Status Codes  [code:count]             200:401  429:99
Status Codes  [code:count]             200:400  429:100
Status Codes  [code:count]             429:100  200:400
Status Codes  [code:count]             200:401  429:99
Wed Feb 27 14:16:31 CET 2019
```

Rate 500/s for 10s in each round with cluster ratelimit of 400/10s allowed.
Test shows we allow ~500 req/10s not 400:
```
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep 'Status Codes'; done; date; sleep 30
Wed Feb 27 14:16:58 CET 2019
Status Codes  [code:count]             429:4099  200:901
Status Codes  [code:count]             429:4499  200:501
Status Codes  [code:count]             429:4501  200:499
Status Codes  [code:count]             429:4500  200:500
Status Codes  [code:count]             429:4502  200:498
Status Codes  [code:count]             429:4499  200:501
Status Codes  [code:count]             200:500  429:4500
Status Codes  [code:count]             429:4500  200:500
Status Codes  [code:count]             429:4501  200:499
Wed Feb 27 14:18:28 CET 2019
```

#### pseudo benchmark overhead 
Test backends are running registry.opensource.zalan.do/pathfinder/skipper:v0.10.112 with default CPU/memory requests and limits and inline routes. In the ratelimited case `'* -> latency(5) -> inlineContent("<body style=''color: green; background-color:white;''><h1>Hello KIAC!</h1>") -> <shunt>'` and the not ratelimited case `'* -> latency(5) -> inlineContent("connect") -> <shunt>'`.


ratelimited test:
```
% date; for i in {1..9}; do echo "GET https://test1.example.org/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep Latencies;  done; date; sleep 30
Wed Feb 27 14:29:36 CET 2019
Latencies     [mean, 50, 95, 99, max]  15.697839ms, 12.445717ms, 18.829629ms, 125.794203ms, 200.902177ms
Latencies     [mean, 50, 95, 99, max]  14.357372ms, 12.409305ms, 18.533861ms, 69.100371ms, 238.844262ms
Latencies     [mean, 50, 95, 99, max]  15.005368ms, 12.512913ms, 20.617909ms, 78.69912ms, 150.635746ms
Latencies     [mean, 50, 95, 99, max]  15.215283ms, 12.458676ms, 18.838121ms, 119.251743ms, 225.732629ms
Latencies     [mean, 50, 95, 99, max]  14.175592ms, 12.398268ms, 18.442086ms, 63.70969ms, 222.439909ms
Latencies     [mean, 50, 95, 99, max]  14.278065ms, 12.403431ms, 18.455477ms, 74.859188ms, 146.95435ms
Latencies     [mean, 50, 95, 99, max]  13.311083ms, 11.565244ms, 17.638515ms, 66.425587ms, 139.698508ms
Latencies     [mean, 50, 95, 99, max]  17.037202ms, 11.56974ms, 17.747863ms, 218.993782ms, 311.37559ms
Latencies     [mean, 50, 95, 99, max]  13.124845ms, 11.617684ms, 17.796039ms, 51.503579ms, 118.300862ms
Wed Feb 27 14:31:06 CET 2019
```

test without ratelimit
```
% date; for i in {1..9}; do echo "GET https://c1.kiac-test.teapot.zalan.do/" | vegeta attack -rate=500 -duration=10s -http2=false | tee results.bin | vegeta report | grep Latencies; done; date; sleep 30
Wed Feb 27 14:52:31 CET 2019
Latencies     [mean, 50, 95, 99, max]  13.753222ms, 11.460581ms, 12.758488ms, 126.089707ms, 213.064594ms
Latencies     [mean, 50, 95, 99, max]  14.954102ms, 11.445548ms, 13.775738ms, 160.551015ms, 251.242087ms
Latencies     [mean, 50, 95, 99, max]  13.758443ms, 11.465367ms, 13.183915ms, 111.731867ms, 198.561196ms
Latencies     [mean, 50, 95, 99, max]  12.429947ms, 11.502661ms, 13.414156ms, 49.04997ms, 114.374389ms
Latencies     [mean, 50, 95, 99, max]  13.161417ms, 11.411348ms, 12.504579ms, 97.741411ms, 192.544586ms
Latencies     [mean, 50, 95, 99, max]  12.502194ms, 11.528071ms, 13.998378ms, 48.307657ms, 112.707037ms
Latencies     [mean, 50, 95, 99, max]  21.660995ms, 11.590774ms, 25.508941ms, 334.65832ms, 444.161564ms
Latencies     [mean, 50, 95, 99, max]  13.934447ms, 10.848228ms, 12.127747ms, 160.962769ms, 242.475441ms
Latencies     [mean, 50, 95, 99, max]  20.252804ms, 10.892414ms, 22.359943ms, 302.473775ms, 466.976726ms
Wed Feb 27 14:54:01 CET 2019
```