### PR TITLE
Support loadbalancing routes for HTTP Upgrade handling.

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -724,15 +724,7 @@ func (p *Proxy) sendError(c *context, id string, code int) {
 }
 
 func (p *Proxy) makeUpgradeRequest(ctx *context, route *routing.Route, req *http.Request) error {
-	// have to parse url again, because path is not copied by mapRequest
-	backendURL, err := url.Parse(route.Backend)
-	if err != nil {
-		p.log.Errorf("can not parse backend %s, caused by: %s", route.Backend, err)
-		return &proxyError{
-			err:  err,
-			code: http.StatusBadGateway,
-		}
-	}
+	backendURL := req.URL
 
 	reverseProxy := httputil.NewSingleHostReverseProxy(backendURL)
 	reverseProxy.FlushInterval = p.flushInterval

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -723,7 +723,7 @@ func (p *Proxy) sendError(c *context, id string, code int) {
 	)
 }
 
-func (p *Proxy) makeUpgradeRequest(ctx *context, route *routing.Route, req *http.Request) error {
+func (p *Proxy) makeUpgradeRequest(ctx *context, req *http.Request) error {
 	backendURL := req.URL
 
 	reverseProxy := httputil.NewSingleHostReverseProxy(backendURL)
@@ -751,7 +751,7 @@ func (p *Proxy) makeBackendRequest(ctx *context) (*http.Response, *proxyError) {
 	}
 
 	if p.experimentalUpgrade && isUpgradeRequest(req) {
-		if err = p.makeUpgradeRequest(ctx, ctx.route, req); err != nil {
+		if err = p.makeUpgradeRequest(ctx, req); err != nil {
 			return nil, &proxyError{err: err}
 		}
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -739,6 +739,8 @@ func TestProcessesRequestWithHTTPUpgradeWithLoadBalancing(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent) // bad header on purpose for the test
 	}))
+	defer backend.Close()
+
 	u, _ := url.ParseRequestURI("wss://www.example.org/ws")
 	r := &http.Request{
 		URL:    u,

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -735,6 +735,32 @@ func TestProcessesRequestWithShuntBackend(t *testing.T) {
 	}
 }
 
+func TestProcessesRequestWithHTTPUpgradeWithLoadBalancing(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent) // bad header on purpose for the test
+	}))
+	u, _ := url.ParseRequestURI("wss://www.example.org/ws")
+	r := &http.Request{
+		URL:    u,
+		Method: "GET",
+		Header: http.Header{"Connection": []string{"Upgrade"}, "Upgrade": []string{"websocket"}}}
+	w := httptest.NewRecorder()
+
+	doc := fmt.Sprintf(`hello: Path("/ws") -> <roundRobin, "%s">;`, backend.URL)
+	tp, err := newTestProxyWithParams(doc, Params{ExperimentalUpgrade: true})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	defer tp.close()
+
+	tp.proxy.ServeHTTP(w, r)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("wrong response code %d", w.Code)
+	}
+}
+
 func TestProcessesRequestWithPriorityRoute(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Test-Header", "test-value")


### PR DESCRIPTION
Fixes #982.

The url in the request has the selected host for any type of routes.
I am not sure if any more changes are needed but with a local websocket server, this fix was enough.

This area of the code is not tested at all and this PR does not try to improve upon the situation. The added test just cover the bug that is fixing.