### PR TITLE
Fix/graceful shutdown

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -52,6 +52,7 @@ const (
 	defaultApplicationLogLevel  = "INFO"
 
 	// connections, timeouts:
+	defaultWaitForHealthcheckInterval   = (10 + 5) * 3 * time.Second // kube-ingress-aws-controller default
 	defaultReadTimeoutServer            = 5 * time.Minute
 	defaultReadHeaderTimeoutServer      = 60 * time.Second
 	defaultWriteTimeoutServer           = 60 * time.Second
@@ -173,6 +174,7 @@ const (
 	apiUsageMonitoringRealmsTrackingPatternUsage        = "regular expression used for matching monitored realms (defaults is 'services')"
 
 	// connections, timeouts:
+	waitForHealthcheckIntervalUsage   = "period waiting to become unhealthy in the loadbalancer pool in front of this instance, before shutdown triggered by SIGINT or SIGTERM"
 	idleConnsPerHostUsage             = "maximum idle connections per backend host"
 	closeIdleConnsPeriodUsage         = "period of closing all idle connections in seconds or as a duration string. Not closing when less than 0"
 	backendFlushIntervalUsage         = "flush interval for upgraded proxy connections"
@@ -315,6 +317,7 @@ var (
 	apiUsageMonitoringRealmsTrackingPattern        string
 
 	// connections, timeouts:
+	waitForHealthcheckInterval   time.Duration
 	idleConnsPerHost             int
 	closeIdleConnsPeriod         string
 	backendFlushInterval         time.Duration
@@ -455,6 +458,8 @@ func init() {
 	flag.StringVar(&apiUsageMonitoringRealmsTrackingPattern, "api-usage-monitoring-realms-tracking-pattern", defaultApiUsageMonitoringRealmsTrackingPattern, apiUsageMonitoringRealmsTrackingPatternUsage)
 
 	// connections, timeouts:
+	flag.DurationVar(&waitForHealthcheckInterval, "wait-for-healthcheck-interval", defaultWaitForHealthcheckInterval, waitForHealthcheckIntervalUsage)
+
 	flag.IntVar(&idleConnsPerHost, "idle-conns-num", proxy.DefaultIdleConnsPerHost, idleConnsPerHostUsage)
 	flag.StringVar(&closeIdleConnsPeriod, "close-idle-conns-period", strconv.Itoa(int(proxy.DefaultCloseIdleConnsPeriod/time.Second)), closeIdleConnsPeriodUsage)
 	flag.DurationVar(&backendFlushInterval, "backend-flush-interval", defaultBackendFlushInterval, backendFlushIntervalUsage)
@@ -670,6 +675,7 @@ func main() {
 		OIDCSecretsFile:                oidcSecretsFile,
 
 		// connections, timeouts:
+		WaitForHealthcheckInterval:   waitForHealthcheckInterval,
 		IdleConnectionsPerHost:       idleConnsPerHost,
 		CloseIdleConnsPeriod:         time.Duration(clsic) * time.Second,
 		BackendFlushInterval:         backendFlushInterval,

--- a/skipper.go
+++ b/skipper.go
@@ -51,6 +51,11 @@ const DefaultPluginDir = "./plugins"
 
 // Options to start skipper.
 type Options struct {
+	// WaitForHealthcheckInterval sets the time that skipper waits
+	// for the loadbalancer in front to become unhealthy. Defaults
+	// to 0.
+	WaitForHealthcheckInterval time.Duration
+
 	// WhitelistedHealthcheckCIDR appends the whitelisted IP Range to the inernalIPS range for healthcheck purposes
 	WhitelistedHealthCheckCIDR []string
 
@@ -713,7 +718,10 @@ func listenAndServe(proxy http.Handler, o *Options) error {
 
 		<-sigs
 
-		log.Info("Got shutdown signal")
+		log.Infof("Got shutdown signal, wait %v for health check", o.WaitForHealthcheckInterval)
+		time.Sleep(o.WaitForHealthcheckInterval)
+
+		log.Info("Start shutdown")
 		if err := srv.Shutdown(context.Background()); err != nil {
 			log.Errorf("Failed to graceful shutdown: %v", err)
 		}

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -6,9 +6,13 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/zalando/skipper/dataclients/routestring"
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/proxy"
 	"github.com/zalando/skipper/routing"
@@ -207,4 +211,93 @@ func TestHTTPServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to stream response body: %v", err)
 	}
+}
+
+func TestHTTPServerShutdown(t *testing.T) {
+	d := 1 * time.Second
+
+	o := Options{
+		Address:                    ":19999",
+		WaitForHealthcheckInterval: d,
+	}
+
+	// simulate a backend that got a request and should be handled correctly
+	dc, err := routestring.New(`r0: * -> latency("3s") -> inlineContent("OK") -> status(200) -> <shunt>`)
+	if err != nil {
+		t.Errorf("Failed to create dataclient: %v", err)
+	}
+
+	rt := routing.New(routing.Options{
+		FilterRegistry: builtin.MakeRegistry(),
+		DataClients: []routing.DataClient{
+			dc,
+		},
+	})
+	defer rt.Close()
+
+	proxy := proxy.New(rt, proxy.OptionsNone)
+	defer proxy.Close()
+	go func() {
+		if errLas := listenAndServe(proxy, &o); errLas != nil {
+			t.Logf("Failed to liste and serve: %v", errLas)
+		}
+	}()
+
+	pid := syscall.Getpid()
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		t.Errorf("Failed to find current process: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	installSigHandler := make(chan struct{}, 1)
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGTERM)
+
+		installSigHandler <- struct{}{}
+
+		<-sigs
+
+		// ongoing requests passing in before shutdown
+		time.Sleep(d / 2)
+		r, err2 := waitConnGet("http://" + o.Address)
+		if r != nil {
+			defer r.Body.Close()
+		}
+		if err2 != nil {
+			t.Fatalf("Cannot connect to the local server for testing: %v ", err2)
+		}
+		if r.StatusCode != 200 {
+			t.Fatalf("Status code should be 200, instead got: %d\n", r.StatusCode)
+		}
+		body, err2 := ioutil.ReadAll(r.Body)
+		if err2 != nil {
+			t.Fatalf("Failed to stream response body: %v", err2)
+		}
+		if s := string(body); s != "OK" {
+			t.Errorf("Failed to get the right content: %s", s)
+		}
+
+		// requests on closed listener should fail
+		time.Sleep(d / 2)
+		r2, err2 := waitConnGet("http://" + o.Address)
+		if r2 != nil {
+			defer r2.Body.Close()
+		}
+		if err2 == nil {
+			t.Fatalf("Can connect to a closed server for testing")
+		}
+	}()
+
+	<-installSigHandler
+	time.Sleep(d / 2)
+
+	if err = p.Signal(syscall.SIGTERM); err != nil {
+		t.Errorf("Failed to signal process: %v", err)
+	}
+	wg.Wait()
+	time.Sleep(d)
 }

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -251,8 +251,8 @@ func TestHTTPServerShutdown(t *testing.T) {
 
 	var wg sync.WaitGroup
 	installSigHandler := make(chan struct{}, 1)
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGTERM)
@@ -268,14 +268,14 @@ func TestHTTPServerShutdown(t *testing.T) {
 			defer r.Body.Close()
 		}
 		if err2 != nil {
-			t.Fatalf("Cannot connect to the local server for testing: %v ", err2)
+			t.Errorf("Cannot connect to the local server for testing: %v ", err2)
 		}
 		if r.StatusCode != 200 {
-			t.Fatalf("Status code should be 200, instead got: %d\n", r.StatusCode)
+			t.Errorf("Status code should be 200, instead got: %d\n", r.StatusCode)
 		}
 		body, err2 := ioutil.ReadAll(r.Body)
 		if err2 != nil {
-			t.Fatalf("Failed to stream response body: %v", err2)
+			t.Errorf("Failed to stream response body: %v", err2)
 		}
 		if s := string(body); s != "OK" {
 			t.Errorf("Failed to get the right content: %s", s)
@@ -288,7 +288,7 @@ func TestHTTPServerShutdown(t *testing.T) {
 			defer r2.Body.Close()
 		}
 		if err2 == nil {
-			t.Fatalf("Can connect to a closed server for testing")
+			t.Error("Can connect to a closed server for testing")
 		}
 	}()
 


### PR DESCRIPTION
In combination with kube-ingress-aws-controller we seem to have again a problem on graceful shutdown with recent Kubernetes versions. I remember testing this before and it was reliably working, but somehow we introduced a bug on tear down, which this PR fixes. I added a test to test clean graceful shutdown with ongoing requests.

Probably fixes #964, too.

Manually tested in Kubernetes with vegeta and 50 req/s to a cluster with 3 skipper-ingress in a 3 AZ cluster with ALB infront created by kube-ingress-aws-controller.
Now even `kubectl -n kube-system delete pods -l application=skipper-ingress` is safe to run.

Manually tested on localhost

Backend 1m latency:
```
% ./bin/skipper -inline-routes '* -> latency("1m") -> inlineContent("Hello from 127.0.0.1:9090") -> <shunt>' -support-listener :9111
[APP]INFO[0000] Expose metrics in codahale format
[APP]INFO[0000] support listener on :9111
[APP]INFO[0000] proxy listener on :9090
[APP]INFO[0000] TLS settings not found, defaulting to HTTP
[APP]INFO[0000] route settings, reset, route: : * -> latency("1m") -> inlineContent("Hello from 127.0.0.1:9090") -> <shunt>
[APP]INFO[0000] route settings received
[APP]INFO[0000] route settings applied

127.0.0.1 - - [12/Mar/2019:09:51:35 +0100] "GET / HTTP/1.1" 200 25 "-" "curl/7.49.0" 60000 127.0.0.1:9090 - -
```

lb-skipper in front:
```
./bin/skipper -address=:9999 -serve-host-metrics -route-backend-metrics -experimental-upgrade -inline-routes='* -> <roundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9090">'
```

client started before SIGINT to lb-skipper:
```
curl -v http://127.0.0.1:9999/                                  suess-new
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 9999 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:9999
> User-Agent: curl/7.49.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Length: 25
< Content-Type: text/plain; charset=utf-8
< Date: Tue, 12 Mar 2019 08:59:53 GMT
< Server: Skipper
< Connection: close
<
* Closing connection 0
Hello from 127.0.0.1:9090
```

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>