### PR TITLE
Log access filter

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -121,6 +121,7 @@ const (
 	applicationLogLevelUsage        = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
 	applicationLogPrefixUsage       = "prefix for each log entry"
 	accessLogUsage                  = "output file for the access log, When not set, /dev/stderr is used"
+	accessLogFilterUsage            = "when this flag is set, access log are filtered by status code only"
 	accessLogDisabledUsage          = "when this flag is set, no access log is printed"
 	accessLogJSONEnabledUsage       = "when this flag is set, log in JSON format is used"
 	accessLogStripQueryUsage        = "when this flag is set, the access log strips the query strings from the access log"
@@ -269,6 +270,7 @@ var (
 	applicationLogLevel       string
 	applicationLogPrefix      string
 	accessLog                 string
+	accessLogFilter           string
 	accessLogDisabled         bool
 	accessLogJSONEnabled      bool
 	accessLogStripQuery       bool
@@ -418,6 +420,7 @@ func init() {
 	flag.StringVar(&applicationLogLevel, "application-log-level", defaultApplicationLogLevel, applicationLogLevelUsage)
 	flag.StringVar(&applicationLogPrefix, "application-log-prefix", defaultApplicationLogPrefix, applicationLogPrefixUsage)
 	flag.StringVar(&accessLog, "access-log", "", accessLogUsage)
+	flag.StringVar(&accessLogFilter, "access-log-filter", "", accessLogFilterUsage)
 	flag.BoolVar(&accessLogDisabled, "access-log-disabled", false, accessLogDisabledUsage)
 	flag.BoolVar(&accessLogJSONEnabled, "access-log-json-enabled", false, accessLogJSONEnabledUsage)
 	flag.BoolVar(&accessLogStripQuery, "access-log-strip-query", false, accessLogStripQueryUsage)
@@ -641,6 +644,7 @@ func main() {
 		ApplicationLogOutput:                applicationLog,
 		ApplicationLogPrefix:                applicationLogPrefix,
 		AccessLogOutput:                     accessLog,
+		AccessLogFilter:                     accessLogFilter,
 		AccessLogDisabled:                   accessLogDisabled,
 		AccessLogJSONEnabled:                accessLogJSONEnabled,
 		AccessLogStripQuery:                 accessLogStripQuery,

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -164,7 +164,7 @@ func newTestProxyWithParams(doc string, params Params) (*testProxy, error) {
 }
 
 func newTestProxy(doc string, flags Flags, pr ...PriorityRoute) (*testProxy, error) {
-	return newTestProxyWithFiltersAndParams(nil, doc, Params{Flags: flags, PriorityRoutes: pr})
+	return newTestProxyWithFiltersAndParams(nil, doc, Params{Flags: flags, PriorityRoutes: pr, AccessLogFilter: al.AccessLogFilter{Enable: true, Prefixes: nil}})
 }
 
 func (tp *testProxy) close() {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/zalando/skipper/filters"
+	al "github.com/zalando/skipper/filters/accesslog"
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/loadbalancer"
 	"github.com/zalando/skipper/logging"
@@ -1532,7 +1533,7 @@ func TestDisableAccessLog(t *testing.T) {
 	doc := fmt.Sprintf(`hello: Path("/hello") -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
 
 	tp, err := newTestProxyWithParams(doc, Params{
-		AccessLogDisabled: true,
+		AccessLogFilter: al.AccessLogFilter{Enable: true, Prefixes: nil},
 	})
 	if err != nil {
 		t.Error(err)
@@ -1597,7 +1598,7 @@ func TestDisableAccessLogWithFilter(t *testing.T) {
 			doc := fmt.Sprintf(`hello: Path("/hello") -> %s -> status(%d) -> inlineContent("%s") -> <shunt>`, ti.filter, ti.responseCode, response)
 
 			tp, err := newTestProxyWithParams(doc, Params{
-				AccessLogDisabled: false,
+				AccessLogFilter: al.AccessLogFilter{Enable: false, Prefixes: nil},
 			})
 			if err != nil {
 				t.Error(err)
@@ -1664,7 +1665,7 @@ func TestEnableAccessLogWithFilter(t *testing.T) {
 			doc := fmt.Sprintf(`hello: Path("/hello") -> %s -> status(%d) -> inlineContent("%s") -> <shunt>`, ti.filter, ti.responseCode, response)
 
 			tp, err := newTestProxyWithParams(doc, Params{
-				AccessLogDisabled: true,
+				AccessLogFilter: al.AccessLogFilter{Enable: true, Prefixes: nil},
 			})
 			if err != nil {
 				t.Error(err)
@@ -1787,7 +1788,7 @@ func benchmarkAccessLog(b *testing.B, filter string, responseCode int) {
 	doc := fmt.Sprintf(`hello: Path("/hello") %s -> status(%d) -> inlineContent("%s") -> <shunt>`, accessLogFilter, responseCode, response)
 
 	tp, err := newTestProxyWithParams(doc, Params{
-		AccessLogDisabled: false,
+		AccessLogFilter: al.AccessLogFilter{Enable: false, Prefixes: nil},
 	})
 	if err != nil {
 		b.Error(err)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1533,7 +1533,7 @@ func TestDisableAccessLog(t *testing.T) {
 	doc := fmt.Sprintf(`hello: Path("/hello") -> status(%d) -> inlineContent("%s") -> <shunt>`, http.StatusTeapot, response)
 
 	tp, err := newTestProxyWithParams(doc, Params{
-		AccessLogFilter: al.AccessLogFilter{Enable: true, Prefixes: nil},
+		AccessLogFilter: al.AccessLogFilter{Enable: false, Prefixes: nil},
 	})
 	if err != nil {
 		t.Error(err)
@@ -1598,7 +1598,7 @@ func TestDisableAccessLogWithFilter(t *testing.T) {
 			doc := fmt.Sprintf(`hello: Path("/hello") -> %s -> status(%d) -> inlineContent("%s") -> <shunt>`, ti.filter, ti.responseCode, response)
 
 			tp, err := newTestProxyWithParams(doc, Params{
-				AccessLogFilter: al.AccessLogFilter{Enable: false, Prefixes: nil},
+				AccessLogFilter: al.AccessLogFilter{Enable: true, Prefixes: nil},
 			})
 			if err != nil {
 				t.Error(err)
@@ -1665,7 +1665,7 @@ func TestEnableAccessLogWithFilter(t *testing.T) {
 			doc := fmt.Sprintf(`hello: Path("/hello") -> %s -> status(%d) -> inlineContent("%s") -> <shunt>`, ti.filter, ti.responseCode, response)
 
 			tp, err := newTestProxyWithParams(doc, Params{
-				AccessLogFilter: al.AccessLogFilter{Enable: true, Prefixes: nil},
+				AccessLogFilter: al.AccessLogFilter{Enable: false, Prefixes: nil},
 			})
 			if err != nil {
 				t.Error(err)
@@ -1788,7 +1788,7 @@ func benchmarkAccessLog(b *testing.B, filter string, responseCode int) {
 	doc := fmt.Sprintf(`hello: Path("/hello") %s -> status(%d) -> inlineContent("%s") -> <shunt>`, accessLogFilter, responseCode, response)
 
 	tp, err := newTestProxyWithParams(doc, Params{
-		AccessLogFilter: al.AccessLogFilter{Enable: false, Prefixes: nil},
+		AccessLogFilter: al.AccessLogFilter{Enable: true, Prefixes: nil},
 	})
 	if err != nil {
 		b.Error(err)


### PR DESCRIPTION
This PR allows to set an log access filter global.
By passing the flag --access-log-filter it is possible to log by HTTP status codes.

Example: --access-log-filter=2,301