### PR TITLE
Update travis config to use Go 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.11.x
+  - 1.12.x
 
 env:
   global:


### PR DESCRIPTION
Go 1.12 is the latest stable version of Go and also used in the CDP
build.