### PR TITLE
fix close-idle-conns-period flag

### DIFF
--- a/cmd/skipper/breakerflags.go
+++ b/cmd/skipper/breakerflags.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/zalando/skipper/circuit"
 )
 
-const breakerUsage = `set global or host specific circuit breakers, e.g. -breaker type=rate,host=www.example.org,window=300,failures=30
+const breakerUsage = `set global or host specific circuit breakers, e.g. -breaker type=rate,host=www.example.org,window=300s,failures=30
 	possible breaker properties:
 	type: consecutive/rate/disabled (defaults to consecutive)
 	host: a host name that overrides the global for a host
@@ -73,7 +74,7 @@ func (b *breakerFlags) Set(value string) error {
 
 			s.Failures = i
 		case "timeout":
-			d, err := parseDurationFlag(kv[1])
+			d, err := time.ParseDuration(kv[1])
 			if err != nil {
 				return err
 			}
@@ -87,7 +88,7 @@ func (b *breakerFlags) Set(value string) error {
 
 			s.HalfOpenRequests = i
 		case "idle-ttl":
-			d, err := parseDurationFlag(kv[1])
+			d, err := time.ParseDuration(kv[1])
 			if err != nil {
 				return err
 			}

--- a/cmd/skipper/ratelimiterflags.go
+++ b/cmd/skipper/ratelimiterflags.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/zalando/skipper/ratelimit"
 )
 
-const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=local,max-hits=20,time-window=60
+const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=local,max-hits=20,time-window=60s
 	possible ratelimit properties:
 	type: local/service/disabled (defaults to disabled)
 	max-hits: the number of hits a ratelimiter can get
@@ -59,7 +60,7 @@ func (r *ratelimitFlags) Set(value string) error {
 			}
 			s.MaxHits = i
 		case "time-window":
-			d, err := parseDurationFlag(kv[1])
+			d, err := time.ParseDuration(kv[1])
 			if err != nil {
 				return err
 			}

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -80,7 +80,7 @@ Cloud migration.
 
 !!! Warning
 
-    If multiple ingresses define the same host and the same predicates, traffic routing may become non-deterministic. 
+    If multiple ingresses define the same host and the same predicates, traffic routing may become non-deterministic.
 
 Consider the following two ingresses which have the same hostname and therefore
 overlap. In skipper the routing of this is currently undefined as skipper
@@ -682,7 +682,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    zalando.org/skipper-filter: clusterRatelimit(50, "1m")
+    zalando.org/skipper-filter: clusterRatelimit("groupSvcApp", 50, "1m")
   name: app
 spec:
   rules:
@@ -704,7 +704,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    zalando.org/skipper-filter: clusterRatelimit(10, "1h", "xfwd")
+    zalando.org/skipper-filter: clusterClientRatelimit("groupSvcApp", 10, "1h")
   name: app
 spec:
   rules:

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -717,7 +717,7 @@ See also the [circuit breaker docs](https://godoc.org/github.com/zalando/skipper
 
 ## ~~localRatelimit~~
 
-**DEPRECATED** use [clientRatelimit](#clientRatelimit) with the same
+**DEPRECATED** use [clientRatelimit](#clientratelimit) with the same
   settings instead.
 
 ## clientRatelimit
@@ -726,7 +726,7 @@ Per skipper instance calculated ratelimit, that allows number of
 requests by client. The definition of the same client is based on data
 of the http header and can be changed with an optional third
 parameter. If the third parameter is set skipper will use the
-Authorization header to put the request in the same client bucket,
+defined HTTP header to put the request in the same client bucket,
 else the X-Forwarded-For Header will be used. You need to run skipper
 with command line flag `-enable-ratelimits`. Skipper will consume
 roughly 15 MB per filter for 100.000 clients.
@@ -735,11 +735,11 @@ Parameters:
 
 * number of allowed requests per time period (int)
 * time period for requests being counted (time.Duration)
-* optional parameter can be set to: "auth" (string)
+* optional parameter to set the same client by header (string)
 
 ```
 clientRatelimit(3, "1m")
-clientRatelimit(3, "1m", "auth")
+clientRatelimit(3, "1m", "Authorization")
 ```
 
 See also the [ratelimit docs](https://godoc.org/github.com/zalando/skipper/ratelimit).
@@ -770,22 +770,21 @@ ratelimit group across one or more routes.  The rate limit group
 allows the given number of requests by client. The definition of the
 same client is based on data of the http header and can be changed
 with an optional fourth parameter. If the fourth parameter is set
-skipper will use the Authorization header to put the request in the
-same client bucket, else the X-Forwarded-For Header will be used.  You
-need to run skipper with command line flags `-enable-swarm` and
-`-enable-ratelimits`. Skipper will consume roughly 15 MB per filter
-for 100.000 clients and 1000 skipper peers.
+skipper will use the HTTP header defined by this to put the request in
+the same client bucket, else the X-Forwarded-For Header will be used.
+You need to run skipper with command line flags `-enable-swarm` and
+`-enable-ratelimits`. See also our [cluster ratelimit tutorial](../../tutorials/ratelimit/#cluster-ratelimit)
 
 Parameters:
 
 * rate limit group (string)
 * number of allowed requests per time period (int)
 * time period for requests being counted (time.Duration)
-* optional parameter can be set to: "auth" (string)
+* optional parameter to set the same client by header (string)
 
 ```
 clusterClientRatelimit("groupA", 10, "1h")
-clusterClientRatelimit("groupA", 10, "1h", "auth")
+clusterClientRatelimit("groupA", 10, "1h", "Authorization")
 ```
 
 See also the [ratelimit docs](https://godoc.org/github.com/zalando/skipper/ratelimit).
@@ -797,7 +796,8 @@ rate limit group. The first parameter is a string to select the same
 ratelimit group across one or more routes.  The rate limit group
 allows the given number of requests to a backend. You need to have run
 skipper with command line flags `-enable-swarm` and
-`-enable-ratelimits`.
+`-enable-ratelimits`. See also our [cluster ratelimit tutorial](../../tutorials/ratelimit/#cluster-ratelimit)
+
 
 Parameters:
 
@@ -949,7 +949,7 @@ auditLog()
 
 Filter sets the backend host for a route, value is taken from the provided header.
 Can be used only with `<dynamic>` backend. Meant to be used together with [setDynamicBackendSchemeFromHeader](#setdynamicbackendschemefromheader)
-or [setDynamicBackendScheme](#setdynamicbackendscheme). If this filter chained together with [setDynamicBackendUrlFromHeader](#setdynamicbackendurlfromheader) 
+or [setDynamicBackendScheme](#setdynamicbackendscheme). If this filter chained together with [setDynamicBackendUrlFromHeader](#setdynamicbackendurlfromheader)
 or [setDynamicBackendUrl](#setdynamicbackendurl) filters, the latter ones would have priority.
 
 Parameters:
@@ -966,7 +966,7 @@ foo: * -> setDynamicBackendHostFromHeader("X-Forwarded-Host") -> <dynamic>;
 
 Filter sets the backend scheme for a route, value is taken from the provided header.
 Can be used only with `<dynamic>` backend. Meant to be used together with [setDynamicBackendHostFromHeader](#setdynamicbackendhostfromheader)
-or [setDynamicBackendHost](#setdynamicbackendhost). If this filter chained together with 
+or [setDynamicBackendHost](#setdynamicbackendhost). If this filter chained together with
 [setDynamicBackendUrlFromHeader](#setdynamicbackendurlfromheader) or [setDynamicBackendUrl](#setdynamicbackendurl), the latter ones would have priority.
 
 Parameters:
@@ -982,7 +982,7 @@ foo: * -> setDynamicBackendSchemeFromHeader("X-Forwarded-Proto") -> <dynamic>;
 ## setDynamicBackendUrlFromHeader
 
 Filter sets the backend url for a route, value is taken from the provided header.
-Can be used only with `<dynamic>` backend. 
+Can be used only with `<dynamic>` backend.
 
 Parameters:
 
@@ -998,7 +998,7 @@ foo: * -> setDynamicBackendUrlFromHeader("X-Custom-Url") -> <dynamic>;
 
 Filter sets the backend host for a route. Can be used only with `<dynamic>` backend.
 Meant to be used together with [setDynamicBackendSchemeFromHeader](#setdynamicbackendschemefromheader)
-or [setDynamicBackendScheme](#setdynamicbackendscheme). If this filter chained together with [setDynamicBackendUrlFromHeader](#setdynamicbackendurlfromheader) 
+or [setDynamicBackendScheme](#setdynamicbackendscheme). If this filter chained together with [setDynamicBackendUrlFromHeader](#setdynamicbackendurlfromheader)
 or [setDynamicBackendUrl](#setdynamicbackendurl), the latter ones would have priority.
 
 Parameters:
@@ -1015,7 +1015,7 @@ foo: * -> setDynamicBackendHost("example.com") -> <dynamic>;
 
 Filter sets the backend scheme for a route. Can be used only with `<dynamic>` backend.
 Meant to be used together with [setDynamicBackendHostFromHeader](#setdynamicbackendhostfromheader)
-or [setDynamicBackendHost](#setdynamicbackendhost). If this filter chained together with 
+or [setDynamicBackendHost](#setdynamicbackendhost). If this filter chained together with
 [setDynamicBackendUrlFromHeader](#setdynamicbackendurlfromheader) or [setDynamicBackendUrl](#setdynamicbackendurl), the latter ones would have priority.
 
 Parameters:
@@ -1030,7 +1030,7 @@ foo: * -> setDynamicBackendScheme("https") -> <dynamic>;
 
 ## setDynamicBackendUrl
 
-Filter sets the backend url for a route. Can be used only with `<dynamic>` backend. 
+Filter sets the backend url for a route. Can be used only with `<dynamic>` backend.
 
 Parameters:
 

--- a/ratelimit/doc.go
+++ b/ratelimit/doc.go
@@ -3,15 +3,19 @@ Package ratelimit implements rate limiting functionality for the proxy.
 
 It provides per process rate limiting. It can be
 configured globally, or based on routes. Rate limiting can be lookuped
-based on HTTP headers like X-Forwarded-For or Authorization.
+based on HTTP headers for example X-Forwarded-For or Authorization.
 
-Lookuper Type - Authorization Header
+Lookuper Type - SameBucketLookuper
 
-This lookuper will use the content of the Authorization header to
-calculate rate limiting. This will work for Bearer tokens or Basic
-Auth without change of the rate limiter configuration.
+This lookuper will use a static string to point always to the same
+bucket. This means all requests are counted the same.
 
-Lookuper Type - X-Forwarded-For Header
+Lookuper Type - HeaderLookuper
+
+This lookuper will use the content of the the specified header to
+calculate rate limiting.
+
+Lookuper Type - XForwardedForLookuper
 
 This lookuper will use the remote IP of the origin request to
 calculate rate limiting. If there is no such header it will use the
@@ -44,7 +48,7 @@ The following configuration will rate limit requests after 100
 requests within 1 minute with the same Authorization Header
 
     % cat ratelimit-auth.eskip
-    all: * -> clientRatelimit(100,"1m","auth") -> "http://www.example.org/"
+    all: * -> clientRatelimit(100,"1m","Authorization") -> "http://www.example.org/"
     % skipper -enable-ratelimits -routes-file=ratelimit-auth.eskip
 
 The following configuration will rate limit requests to /login after 10 requests
@@ -91,8 +95,16 @@ representation of Go's time.Duration, e.g. 1m30s.
 Settings - Lookuper
 
 Defines an optional configuration to choose which Header should be
-used to group client requests. It accepts the default
-"x-forwarded-for" or "auth"
+used to group client requests. It accepts any header, for example
+"Authorization".
+
+Settings - Group
+
+Defines the ratelimit group, which can be the same for different
+routes, if you want to have one ratelimiter spanning more than one
+route. Make sure your settings are the same for the whole group. In
+case of different settings for the same group the behavior is
+undefined and could toggle between different configurations.
 
 HTTP Response
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -74,11 +74,13 @@ const (
 
 	// ClusterClientRatelimit is used to calculate a rate limit
 	// for a whole skipper fleet per user for a backend, needs
-	// swarm to be enabled with -enable-swarm.
-	// One filter consumes memory calculated
-	// by the following formular, where N is the number of
-	// individual clients put into the same bucket, M the maximum
-	// number of requests allowed, S the number of skipper peers:
+	// swarm to be enabled with -enable-swarm. In case of redis it
+	// will not consume more memory.
+	// In case of swim based cluster ratelimit, one filter
+	// consumes memory calculated by the following formular, where
+	// N is the number of individual clients put into the same
+	// bucket, M the maximum number of requests allowed, S the
+	// number of skipper peers:
 	//
 	//    memory = N * M * 15 + S * len(peername)
 	//


### PR DESCRIPTION
fix -close-idle-conns-period flag handling to use plain time.Duration parsing and not adjusted string handling which does not work

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>