### PR TITLE
Stop being graceful on SIGINT

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -722,7 +722,7 @@ func listenAndServe(proxy http.Handler, o *Options) error {
 	idleConnsCH := make(chan struct{})
 	go func() {
 		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT)
+		signal.Notify(sigs, syscall.SIGTERM)
 
 		<-sigs
 


### PR DESCRIPTION
Stop being graceful on SIGINT, which is used locally and not by any autmation, which use SIGTERM instead

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>