### PR TITLE
Add cookieToHeader filter

### DIFF
--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -60,6 +60,7 @@ const (
 	InlineContentName   = "inlineContent"
 	HeaderToQueryName   = "headerToQuery"
 	QueryToHeaderName   = "queryToHeader"
+	CookieToHeaderName  = "cookieToHeader"
 )
 
 // Returns a Registry object initialized with the default set of filter
@@ -95,6 +96,7 @@ func MakeRegistry() filters.Registry {
 		NewCopyResponseHeader(),
 		NewHeaderToQuery(),
 		NewQueryToHeader(),
+		NewCookieToHeader(),
 		NewSetDynamicBackendHostFromHeader(),
 		NewSetDynamicBackendSchemeFromHeader(),
 		NewSetDynamicBackendUrlFromHeader(),

--- a/filters/builtin/cookie_to_header.go
+++ b/filters/builtin/cookie_to_header.go
@@ -1,0 +1,73 @@
+package builtin
+
+import (
+	"github.com/zalando/skipper/filters"
+)
+
+type (
+	cookieToHeaderSpec struct {
+	}
+
+	cookieToHeaderFilter struct {
+		cookieName string
+		headerName string
+		prefix     string
+	}
+)
+
+// NewCookieToHeader creates a filter which copies a cookie value
+// from the incoming Request to headers, with an optional prefix
+//
+// 		cookieToHeader("jwt", "Authorization", "Bearer ")
+//
+// The above filter will set the value of the Authorization header in the request to
+// 'Bearer <contents of the "jwt" cookie>'
+func NewCookieToHeader() filters.Spec {
+	return &cookieToHeaderSpec{}
+}
+
+func (spec *cookieToHeaderSpec) Name() string {
+	return CookieToHeaderName
+}
+
+func (spec *cookieToHeaderSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	switch len(args) {
+	case 2, 3:
+	default:
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	cookieName, ok := args[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	headerName, ok := args[1].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	prefix := ""
+	if len(args) >= 3 {
+		prefix, ok = args[2].(string)
+		if !ok {
+			return nil, filters.ErrInvalidFilterParameters
+		}
+	}
+
+	return &cookieToHeaderFilter{
+		cookieName: cookieName,
+		headerName: headerName,
+		prefix:     prefix,
+	}, nil
+}
+
+func (f *cookieToHeaderFilter) Request(ctx filters.FilterContext) {
+	req := ctx.Request()
+
+	if cookie, err := req.Cookie(f.cookieName); err == nil {
+		req.Header.Set(f.headerName, f.prefix+cookie.Value)
+	}
+}
+
+func (f *cookieToHeaderFilter) Response(ctx filters.FilterContext) {}

--- a/filters/builtin/cookie_to_header_test.go
+++ b/filters/builtin/cookie_to_header_test.go
@@ -1,0 +1,47 @@
+package builtin
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func TestCookieToHeader_Request(t *testing.T) {
+	for _, ti := range []struct {
+		name     string
+		params   []interface{}
+		expected string
+	}{
+		{
+			name:     "simple",
+			params:   []interface{}{"jwt", "Authorization"},
+			expected: "verysecure",
+		},
+		{
+			name:     "with prefix",
+			params:   []interface{}{"jwt", "Authorization", "Bearer "},
+			expected: "Bearer verysecure",
+		},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+			spec := NewCookieToHeader()
+			f, err := spec.CreateFilter(ti.params)
+			if err != nil {
+				t.Error(err)
+			}
+
+			req, err := http.NewRequest("Get", "https://example.org", nil)
+			if err != nil {
+				t.Error(err)
+			}
+			req.AddCookie(&http.Cookie{Name: "jwt", Value: "verysecure"})
+
+			ctx := &filtertest.Context{FRequest: req}
+			f.Request(ctx)
+			if req.Header.Get("Authorization") != ti.expected {
+				t.Error("failed to move authorization cookie to authorization header:", req.Header.Get("Authorization"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This should allow us to expose APIs that support bearer tokens (e.g. Kubernetes Dashboard) to web browsers without having to proxy every single request.