### PR TITLE
A / B test example

### DIFF
--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -842,7 +842,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    zalando.org/skipper-predicate: Traffic(.1)
+    zalando.org/skipper-predicate: Traffic(.1, "flavor, "A")
     zalando.org/skipper-filter: responseCookie("flavor, "A", 31536000)
   name: app
 spec:


### PR DESCRIPTION
Added stickyness to Traffic on the cookie, without it we noticed an unstable behaviour (traffic routed partially to A and B)
Suggested in https://github.com/zalando/skipper/blob/master/docs/reference/predicates.md