### PR TITLE
Make unverifiedAuditLog configurable

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -951,6 +951,10 @@ be wrote to the log file. By default, the value of the audit header will be equa
 the Authorization token. This can be changed by providing a `string` input to the filter which matches another key from the
 token.
 
+*N.B.* It is important to note that, if the content of the `X-Unverified-Audit` header does not match the following regex, then
+a default value of `invalid-sub` will be populated in the header instead:
+    `^[a-zA-z0-9_/:?=&%@.#-]*$`    
+
 Examples:
 
 ```

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -947,7 +947,7 @@ auditLog()
 ## unverifiedAuditLog
 
 Filter `unverifiedAuditLog()` adds a Header, `X-Unverified-Audit`, to the request, the content of which, will also
-be wrote to the log file. By default, the value of the audit header will be equal to the value of the `sub` key, from
+be written to the log file. By default, the value of the audit header will be equal to the value of the `sub` key, from
 the Authorization token. This can be changed by providing a `string` input to the filter which matches another key from the
 token.
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -944,6 +944,22 @@ Example:
 auditLog()
 ```
 
+## unverifiedAuditLog
+
+Filter `unverifiedAuditLog()` adds a Header, `X-Unverified-Audit`, to the request, the content of which, will also
+be wrote to the log file. By default, the value of the audit header will be equal to the value of the `sub` key, from
+the Authorization token. This can be changed by providing a `string` input to the filter which matches another key from the
+token.
+
+Examples:
+
+```
+unverifiedAuditLog()
+```
+
+```
+unverifiedAuditLog("azp")
+```
 
 ## setDynamicBackendHostFromHeader
 

--- a/filters/log/log_test.go
+++ b/filters/log/log_test.go
@@ -12,37 +12,67 @@ func TestRequest(t *testing.T) {
 		msg      string
 		tok      string
 		expected string
+		input    string
 	}{
 		{
 			msg:      "request with token",
 			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJjNGRkZmU5ZC1hMGQzLTRhZmItYmYyNi0yNGI5NTg4NzMxYTAiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
 			expected: "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0",
+			input:    "",
 		},
 		{
 			msg:      "request with empty token",
 			tok:      "",
 			expected: "",
+			input:    "",
 		},
 		{
 			msg:      "request with wrong token",
 			tok:      "foo.bar.baz",
 			expected: "",
+			input:    "",
 		},
 		{
 			msg:      "request with prepared Sub in token, which does not contain valid data",
 			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIweK3e774iLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0K.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
 			expected: defaultSub,
+			input:    "",
 		},
 		{
 			msg:      "request with prepared Sub in token, which does contain valid URI data",
 			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJodHRwOi8vZm9vLm9yZy9wMT9hPWIjNSIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vcmVhbG0iOiJ1c2VycyIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vdG9rZW4iOiJCZWFyZXIiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL21hbmFnZWQtaWQiOiJzc3p1ZWNzIiwiYXpwIjoienRva2VuIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9icCI6IjgxMGQxZDAwLTQzMTItNDNlNS1iZDMxLWQ4MzczZmRkMjRjNyIsImF1dGhfdGltZSI6MTUyMzI1OTQ2OCwiaXNzIjoiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbSIsImV4cCI6MTUyNTAyNDI4NSwiaWF0IjoxNTI1MDIwNjc1fQo.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
 			expected: "http://foo.org/p1?a=b#5",
+			input:    "",
+		},
+		{
+			msg:      "request with sub passed as filter input",
+			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJjNGRkZmU5ZC1hMGQzLTRhZmItYmYyNi0yNGI5NTg4NzMxYTAiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
+			expected: "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0",
+			input:    "sub",
+		},
+		{
+			msg:      "request with non sub passed as filter input",
+			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJjNGRkZmU5ZC1hMGQzLTRhZmItYmYyNi0yNGI5NTg4NzMxYTAiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
+			expected: "ztoken",
+			input:    "azp",
+		},
+		{
+			msg:      "request with invalid key passed as filter input",
+			tok:      "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJjNGRkZmU5ZC1hMGQzLTRhZmItYmYyNi0yNGI5NTg4NzMxYTAiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA",
+			expected: "",
+			input:    "blahBlah",
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
-			spec := &unverifiedAuditLog{}
+			spec := &unverifiedAuditLogSpec{}
 
-			fltr, err := spec.CreateFilter([]interface{}{})
+			var filterInp []interface{}
+			if ti.input == "" {
+				filterInp = []interface{}{}
+			} else {
+				filterInp = []interface{}{ti.input}
+			}
+			fltr, err := spec.CreateFilter(filterInp)
 			if err != nil {
 				t.Errorf("Failed to create filter: %v", err)
 				return


### PR DESCRIPTION
Adds an optional single input value to the unverifiedAuditLog filter
which acts as a lookup key for the Auth token in case you need to
log something other than the sub. If no parameter is provided for
the unverifiedAuditLog filter then it will default to "sub"