### PR TITLE
define key roles and cleanup maintainers file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -67,6 +67,24 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
+## Roles
+
+The following roles are defined in the project:
+
+* maintainer
+* contributor
+
+### Maintainer
+
+Maintainers are listed in
+[MAINTAINERS](https://github.com/zalando/skipper/blob/master/MAINTAINERS)
+and are responsible for the healthiness of the project as stated in
+the sections above.
+
+### Contributor
+
+Everyone who interacts with the project is a contributor.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,2 @@
 Arpad Ryszka <arpad.ryszka@zalando.de>
-Dan Persa <dan.persa@zalando.de>
-Kolja Wilcke <kolja.wilcke@zalando.de>
-Luis Mineiro <luis.mineiro@zalando.de>
-Moritz Grauel <moritz.grauel@zalando.de>
 Sandor Szuecs <sandor.szuecs@zalando.de>


### PR DESCRIPTION
we have to define key roles in the project to achieve silver in CII best practices https://bestpractices.coreinfrastructure.org/en/projects/2461

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>