### PR TITLE
Differentiate authentication and authorization issues in response codes

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -416,7 +416,11 @@ this filter.
 
 The filter accepts variable number of string arguments, which are used to
 validate the incoming token from the `Authorization: Bearer <token>`
-header. If any of the configured scopes from the filter is found
+header. There are two rejection scenarios for this filter. If the token
+is not successfully validated by the oauth server, then a 401 Unauthorised
+response will be returned. However, if the token is successfully validated 
+but the required scope match isn't satisfied, then a 403 Forbidden response
+will be returned. If any of the configured scopes from the filter is found
 inside the tokeninfo result for the incoming token, it will allow the
 request to pass.
 
@@ -433,7 +437,11 @@ this filter.
 
 The filter accepts variable number of string arguments, which are used to
 validate the incoming token from the `Authorization: Bearer <token>`
-header. If all of the configured scopes from the filter are found
+header. There are two rejection scenarios for this filter. If the token
+is not successfully validated by the oauth server, then a 401 Unauthorised
+response will be returned. However, if the token is successfully validated 
+but the required scope match isn't satisfied, then a 403 Forbidden response
+will be returned. If all of the configured scopes from the filter are found
 inside the tokeninfo result for the incoming token, it will allow the
 request to pass.
 
@@ -450,9 +458,14 @@ this filter.
 
 The filter accepts an even number of variable arguments of type
 string, which are used to validate the incoming token from the
-`Authorization: Bearer <token>` header. If any of the configured key
-value pairs from the filter is found inside the tokeninfo result for
-the incoming token, it will allow the request to pass.
+`Authorization: Bearer <token>` header. There are two rejection scenarios 
+for this filter. If the token is not successfully validated by the oauth 
+server, then a 401 Unauthorised response will be returned. However, 
+if the token is successfully validated but the required scope match 
+isn't satisfied, then a 403 Forbidden response will be returned.
+If any of the configured key value pairs from the filter is found 
+inside the tokeninfo result for the incoming token, it will allow 
+the request to pass.
 
 Examples:
 
@@ -467,9 +480,14 @@ this filter.
 
 The filter accepts an even number of variable arguments of type
 string, which are used to validate the incoming token from the
-`Authorization: Bearer <token>` header. If all of the configured key
-value pairs from the filter are found inside the tokeninfo result for
-the incoming token, it will allow the request to pass.
+`Authorization: Bearer <token>` header. There are two rejection 
+scenarios for this filter. If the token is not successfully validated 
+by the oauth server, then a 401 Unauthorised response will be 
+returned. However, if the token is successfully validated but 
+the required scope match isn't satisfied, then a 403 Forbidden response 
+will be returned. If all of the configured key value pairs from 
+the filter are found inside the tokeninfo result for the incoming 
+token, it will allow the request to pass.
 
 Examples:
 

--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -91,6 +91,17 @@ func unauthorized(ctx filters.FilterContext, uname string, reason rejectReason, 
 	ctx.Serve(rsp)
 }
 
+func forbidden(ctx filters.FilterContext, uname string, reason rejectReason) {
+	log.Debugf("Forbidden: uname: %s, reason: %s", uname, reason)
+	ctx.StateBag()[logfilter.AuthUserKey] = uname
+	ctx.StateBag()[logfilter.AuthRejectReasonKey] = string(reason)
+	rsp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     make(map[string][]string),
+	}
+	ctx.Serve(rsp)
+}
+
 func authorized(ctx filters.FilterContext, uname string) {
 	ctx.StateBag()[logfilter.AuthUserKey] = uname
 }

--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -269,7 +269,7 @@ func (f *tokeninfoFilter) Request(ctx filters.FilterContext) {
 	}
 
 	if !allowed {
-		unauthorized(ctx, uid, invalidScope, f.authClient.url.Hostname())
+		forbidden(ctx, uid, invalidScope)
 		return
 	}
 	authorized(ctx, uid)

--- a/filters/auth/tokeninfo_test.go
+++ b/filters/auth/tokeninfo_test.go
@@ -32,9 +32,10 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		msg:         "invalid token",
 		authType:    OAuthTokeninfoAnyScopeName,
 		authBaseURL: testAuthPath,
+		args:        []interface{}{"not-matching-scope"},
 		hasAuth:     true,
 		auth:        "invalid-token",
-		expected:    http.StatusNotFound,
+		expected:    http.StatusUnauthorized,
 	}, {
 		msg:         "invalid scope",
 		authType:    OAuthTokeninfoAnyScopeName,
@@ -42,7 +43,7 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		args:        []interface{}{"not-matching-scope"},
 		hasAuth:     true,
 		auth:        testToken,
-		expected:    http.StatusUnauthorized,
+		expected:    http.StatusForbidden,
 	}, {
 		msg:         "oauthTokeninfoAnyScope: valid token, one valid scope",
 		authType:    OAuthTokeninfoAnyScopeName,
@@ -74,7 +75,7 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		args:        []interface{}{testScope, "other-scope"},
 		hasAuth:     true,
 		auth:        testToken,
-		expected:    http.StatusUnauthorized,
+		expected:    http.StatusForbidden,
 	}, {
 		msg:         "anyKV(): invalid key",
 		authType:    OAuthTokeninfoAnyKVName,
@@ -82,7 +83,7 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		args:        []interface{}{"not-matching-scope"},
 		hasAuth:     true,
 		auth:        testToken,
-		expected:    http.StatusNotFound,
+		expected:    http.StatusOK,
 	}, {
 		msg:         "anyKV(): valid token, one valid key, wrong value",
 		authType:    OAuthTokeninfoAnyKVName,
@@ -90,7 +91,7 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		args:        []interface{}{testKey, "other-value"},
 		hasAuth:     true,
 		auth:        testToken,
-		expected:    http.StatusUnauthorized,
+		expected:    http.StatusForbidden,
 	}, {
 		msg:         "anyKV(): valid token, one valid key value pair",
 		authType:    OAuthTokeninfoAnyKVName,
@@ -130,7 +131,7 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		args:        []interface{}{testKey, "other-value"},
 		hasAuth:     true,
 		auth:        testToken,
-		expected:    http.StatusUnauthorized,
+		expected:    http.StatusForbidden,
 	}, {
 		msg:         "allKV(): valid token, one valid key value pair",
 		authType:    OAuthTokeninfoAllKVName,
@@ -162,7 +163,7 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		args:        []interface{}{testKey, testValue, "wrongKey", "wrongValue"},
 		hasAuth:     true,
 		auth:        testToken,
-		expected:    http.StatusUnauthorized,
+		expected:    http.StatusForbidden,
 	}, {
 		msg:         "allKV(): valid token, one valid kv, multiple key value pairs2",
 		authType:    OAuthTokeninfoAllKVName,
@@ -170,7 +171,7 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 		args:        []interface{}{"wrongKey", "wrongValue", testKey, testValue},
 		hasAuth:     true,
 		auth:        testToken,
-		expected:    http.StatusUnauthorized,
+		expected:    http.StatusForbidden,
 	}} {
 		t.Run(ti.msg, func(t *testing.T) {
 			backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {}))


### PR DESCRIPTION
This addresses https://github.com/zalando/skipper/issues/1035

If the OAuthTokeninfo* family of filters reject a request
due to invalid scopes, then we will return a 403 response
code instead of the 401 response code to indicate that the
token was successfully authenticated but access to the resource
was rejected due to missing scopes in the token.