### PR TITLE
limit number of inflight requests per route

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	golang.org/x/crypto v0.0.0-20170912191825-faadfbdc0353
 	golang.org/x/net v0.0.0-20181213202711-891ebc4b82d6
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/sys v0.0.0-20180831094639-fa5fdf94c789 // indirect
 	google.golang.org/appengine v1.2.0 // indirect
 	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b // indirect

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/logging"
 	"github.com/zalando/skipper/predicates"
+	"golang.org/x/sync/semaphore"
 )
 
 type incomingType uint
@@ -440,7 +441,7 @@ func processRouteDef(cpm map[string]PredicateSpec, fr filters.Registry, def *esk
 		return nil, err
 	}
 
-	r := &Route{Route: *def, Scheme: scheme, Host: host, Predicates: cps, Filters: fs}
+	r := &Route{Route: *def, Scheme: scheme, Host: host, Predicates: cps, Filters: fs, InflightRequests: semaphore.NewWeighted(1000)}
 	if err := processTreePredicates(r, def.Predicates); err != nil {
 		return nil, err
 	}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/logging"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -192,6 +193,8 @@ type Route struct {
 	// LBAlgorithm is the selected load balancing algorithm
 	// of a load balanced route.
 	LBAlgorithm LBAlgorithm
+
+	InflightRequests *semaphore.Weighted
 }
 
 // PostProcessor is an interface for custom post-processors applying changes


### PR DESCRIPTION
limit request per route, such that we do not get overrun by one slow backend

tested with 500Mi memory and 500m cpu, backend latency 5s, 25s and 50s, 500req/s to the mentioned backend
memory usage ~350Mi
The problem we saw with pprof is in the stdlib bufio.NewReaderSize and bufio.NewWriteterSize are spiking in memory usage

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>