### PR TITLE
Set URL from Host and TLS in dynamic backend

### DIFF
--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -238,6 +238,11 @@ $ curl -sv localhost:9090/ >/dev/null
 * Connection #0 to host localhost left intact
 ```
 
+When no filters modifying the target are set (e.g. `r0: * -> <dynamic>;`), the
+target host defaults to either the `Host` header or the host name given in the
+URL, and the target scheme defaults to either `https` when TLS is
+configured or `http` when TLS is not configured.
+
 ## Load Balancer backend
 
 The loadbalancer backend, `<$algorithm, "backend1", "backend2">`, will

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -379,6 +379,19 @@ func copyStream(to flusherWriter, from io.Reader, span ot.Span) error {
 	}
 }
 
+func setRequestURLFromRequest(u *url.URL, r *http.Request) {
+	if u.Host == "" {
+		u.Host = r.Host
+	}
+	if u.Scheme == "" {
+		if r.TLS != nil {
+			u.Scheme = "https"
+		} else {
+			u.Scheme = "http"
+		}
+	}
+}
+
 func setRequestURLForDynamicBackend(u *url.URL, stateBag map[string]interface{}) {
 	dbu, ok := stateBag[filters.DynamicBackendURLKey].(string)
 	if ok && dbu != "" {
@@ -412,6 +425,7 @@ func mapRequest(r *http.Request, rt *routing.Route, host string, removeHopHeader
 	u := r.URL
 	switch rt.BackendType {
 	case eskip.DynamicBackend:
+		setRequestURLFromRequest(u, r)
 		setRequestURLForDynamicBackend(u, stateBag)
 	case eskip.LBBackend:
 		setRequestURLForLoadBalancedBackend(u, rt, routing.NewLBContext(r, rt))


### PR DESCRIPTION
When using dynamic backend, it is expected to use one of the
`setDynamicBackend*` filters to fill the host and scheme for the request
URL. However, there are cases in which we don't want to set it explicitly,
for example:

    foo: * -> compress("text/html") -> <dynamic>

Now if I do something like:

    curl -x http://skipper:9090 http://httpbin.org/anything

it complains about URL scheme and host not being set.

In this commit, the host and scheme part are automatically set for the
request URL before they're set from the statebag. This still allows the
user to modify host and scheme using the `setDynamicBackend*` filters
but if let unset, it will fallback to some sane defaults.