### PR TITLE
add tag= parameter for lightstep plugin

### DIFF
--- a/tracing/tracers/lightstep/lightstep.go
+++ b/tracing/tracers/lightstep/lightstep.go
@@ -36,9 +36,10 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 		case "tag":
 			if len(parts) > 1 {
 				tags := strings.SplitN(parts[1], "=", 2)
-				if len(tags) == 2 {
-					globalTags[tags[0]] = tags[1]
+				if len(tags) != 2 {
+					return nil, fmt.Errorf("missing value for tag %s", tags[0])
 				}
+				globalTags[tags[0]] = tags[1]
 			}
 		case "collector":
 			var err error


### PR DESCRIPTION
this can be used to set tags present on any span, example

```
./bin/skipper -opentracing="lightstep tag=cluster=localhost token=<myToken> tag=foo=bar"
```

will set the tags `foo=bar` and `cluster=localhost` on any span

Signed-off-by: Hanno Hecker <hanno@zalando.de>