### PR TITLE
Drop `skipper.route` tag to reduce the size of the messages shipped

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -802,7 +802,6 @@ func (p *Proxy) makeBackendRequest(ctx *context) (*http.Response, *proxyError) {
 	ctx.proxySpan = tracing.CreateSpan(spanName, req.Context(), p.openTracer)
 	ext.SpanKindRPCClient.Set(ctx.proxySpan)
 	ctx.proxySpan.SetTag("skipper.route_id", ctx.route.Id)
-	ctx.proxySpan.SetTag("skipper.route", ctx.route.String())
 	u := cloneURL(req.URL)
 	u.RawQuery = ""
 	p.setCommonSpanInfo(u, req, ctx.proxySpan)


### PR DESCRIPTION
Currently, skipper creates spans that serializes to ~2.5 KB of payload in protobuf format based on my experiments. The main contributors to this are `skipper.route` tag, logs for marking filter start & done events, and the response stream events.

We can reduce the size by dropping these attributes however we may lose debugging abilities. To get around this, I propose we add feature flags under `OpenTracingParams` that would be passed to `Proxy`. In this way, we can enable logging these attributes when it is needed and keep it turned off by
default.

For now, we can drop `skipper.route` tag to reduce the size of the messages shipped for OpenTracing client.

In the future, we can have feature toggles to have the logs & additional tags enabled/disabled when necessary.

Relates to #1065 

Signed-off-by: Serbay Arslanhan <serbay.arslanhan@zalando.de>