### PR TITLE
Add options to reduce the payload shipped per request

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -98,34 +98,36 @@ const (
 	maxAuditBodyUsage                    = "sets the max body to read to log in the audit log body"
 
 	// logging, metrics, tracing:
-	enablePrometheusMetricsUsage    = "switch to Prometheus metrics format to expose metrics. *Deprecated*: use metrics-flavour"
-	opentracingUsage                = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
-	opentracingIngressSpanNameUsage = "set the name of the initial, pre-routing, tracing span"
-	metricsListenerUsage            = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
-	metricsPrefixUsage              = "allows setting a custom path prefix for metrics export"
-	enableProfileUsage              = "enable profile information on the metrics endpoint with path /pprof"
-	debugGcMetricsUsage             = "enables reporting of the Go garbage collector statistics exported in debug.GCStats"
-	runtimeMetricsUsage             = "enables reporting of the Go runtime statistics exported in runtime and specifically runtime.MemStats"
-	serveRouteMetricsUsage          = "enables reporting total serve time metrics for each route"
-	serveHostMetricsUsage           = "enables reporting total serve time metrics for each host"
-	backendHostMetricsUsage         = "enables reporting total serve time metrics for each backend"
-	allFiltersMetricsUsage          = "enables reporting combined filter metrics for each route"
-	combinedResponseMetricsUsage    = "enables reporting combined response time metrics"
-	routeResponseMetricsUsage       = "enables reporting response time metrics for each route"
-	routeBackendErrorCountersUsage  = "enables counting backend errors for each route"
-	routeStreamErrorCountersUsage   = "enables counting streaming errors for each route"
-	routeBackendMetricsUsage        = "enables reporting backend response time metrics for each route"
-	metricsUseExpDecaySampleUsage   = "use exponentially decaying sample in metrics"
-	histogramMetricBucketsUsage     = "use custom buckets for prometheus histograms, must be a comma-separated list of numbers"
-	disableMetricsCompatsUsage      = "disables the default true value for all-filters-metrics, route-response-metrics, route-backend-errorCounters and route-stream-error-counters"
-	applicationLogUsage             = "output file for the application log. When not set, /dev/stderr is used"
-	applicationLogLevelUsage        = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
-	applicationLogPrefixUsage       = "prefix for each log entry"
-	accessLogUsage                  = "output file for the access log, When not set, /dev/stderr is used"
-	accessLogDisabledUsage          = "when this flag is set, no access log is printed"
-	accessLogJSONEnabledUsage       = "when this flag is set, log in JSON format is used"
-	accessLogStripQueryUsage        = "when this flag is set, the access log strips the query strings from the access log"
-	suppressRouteUpdateLogsUsage    = "print only summaries on route updates/deletes"
+	enablePrometheusMetricsUsage             = "switch to Prometheus metrics format to expose metrics. *Deprecated*: use metrics-flavour"
+	opentracingUsage                         = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
+	opentracingIngressSpanNameUsage          = "set the name of the initial, pre-routing, tracing span"
+	openTracingExcludedProxyTagsUsage        = "set tags that should be excluded from spans created for proxy operation. must be a comma-separated list of strings."
+	opentracingLogFilterLifecycleEventsUsage = "enables the logs for request & response filters' lifecycle events that are marking start & end times."
+	metricsListenerUsage                     = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
+	metricsPrefixUsage                       = "allows setting a custom path prefix for metrics export"
+	enableProfileUsage                       = "enable profile information on the metrics endpoint with path /pprof"
+	debugGcMetricsUsage                      = "enables reporting of the Go garbage collector statistics exported in debug.GCStats"
+	runtimeMetricsUsage                      = "enables reporting of the Go runtime statistics exported in runtime and specifically runtime.MemStats"
+	serveRouteMetricsUsage                   = "enables reporting total serve time metrics for each route"
+	serveHostMetricsUsage                    = "enables reporting total serve time metrics for each host"
+	backendHostMetricsUsage                  = "enables reporting total serve time metrics for each backend"
+	allFiltersMetricsUsage                   = "enables reporting combined filter metrics for each route"
+	combinedResponseMetricsUsage             = "enables reporting combined response time metrics"
+	routeResponseMetricsUsage                = "enables reporting response time metrics for each route"
+	routeBackendErrorCountersUsage           = "enables counting backend errors for each route"
+	routeStreamErrorCountersUsage            = "enables counting streaming errors for each route"
+	routeBackendMetricsUsage                 = "enables reporting backend response time metrics for each route"
+	metricsUseExpDecaySampleUsage            = "use exponentially decaying sample in metrics"
+	histogramMetricBucketsUsage              = "use custom buckets for prometheus histograms, must be a comma-separated list of numbers"
+	disableMetricsCompatsUsage               = "disables the default true value for all-filters-metrics, route-response-metrics, route-backend-errorCounters and route-stream-error-counters"
+	applicationLogUsage                      = "output file for the application log. When not set, /dev/stderr is used"
+	applicationLogLevelUsage                 = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
+	applicationLogPrefixUsage                = "prefix for each log entry"
+	accessLogUsage                           = "output file for the access log, When not set, /dev/stderr is used"
+	accessLogDisabledUsage                   = "when this flag is set, no access log is printed"
+	accessLogJSONEnabledUsage                = "when this flag is set, log in JSON format is used"
+	accessLogStripQueryUsage                 = "when this flag is set, the access log strips the query strings from the access log"
+	suppressRouteUpdateLogsUsage             = "print only summaries on route updates/deletes"
 
 	// route sources:
 	etcdUrlsUsage                  = "urls of nodes in an etcd cluster, storing route definitions"
@@ -249,34 +251,36 @@ var (
 	multiPlugins                    pluginFlags
 
 	// logging, metrics, tracing:
-	enablePrometheusMetrics   bool
-	openTracing               string
-	openTracingInitialSpan    string
-	metricsListener           string
-	metricsPrefix             string
-	enableProfile             bool
-	debugGcMetrics            bool
-	runtimeMetrics            bool
-	serveRouteMetrics         bool
-	serveHostMetrics          bool
-	backendHostMetrics        bool
-	allFiltersMetrics         bool
-	combinedResponseMetrics   bool
-	routeResponseMetrics      bool
-	routeBackendErrorCounters bool
-	routeStreamErrorCounters  bool
-	routeBackendMetrics       bool
-	metricsUseExpDecaySample  bool
-	histogramMetricBuckets    string
-	disableMetricsCompat      bool
-	applicationLog            string
-	applicationLogLevel       string
-	applicationLogPrefix      string
-	accessLog                 string
-	accessLogDisabled         bool
-	accessLogJSONEnabled      bool
-	accessLogStripQuery       bool
-	suppressRouteUpdateLogs   bool
+	enablePrometheusMetrics             bool
+	openTracing                         string
+	openTracingInitialSpan              string
+	openTracingExcludedProxyTags        string
+	opentracingLogFilterLifecycleEvents bool
+	metricsListener                     string
+	metricsPrefix                       string
+	enableProfile                       bool
+	debugGcMetrics                      bool
+	runtimeMetrics                      bool
+	serveRouteMetrics                   bool
+	serveHostMetrics                    bool
+	backendHostMetrics                  bool
+	allFiltersMetrics                   bool
+	combinedResponseMetrics             bool
+	routeResponseMetrics                bool
+	routeBackendErrorCounters           bool
+	routeStreamErrorCounters            bool
+	routeBackendMetrics                 bool
+	metricsUseExpDecaySample            bool
+	histogramMetricBuckets              string
+	disableMetricsCompat                bool
+	applicationLog                      string
+	applicationLogLevel                 string
+	applicationLogPrefix                string
+	accessLog                           string
+	accessLogDisabled                   bool
+	accessLogJSONEnabled                bool
+	accessLogStripQuery                 bool
+	suppressRouteUpdateLogs             bool
 
 	// route sources:
 	etcdUrls                  string
@@ -406,6 +410,8 @@ func init() {
 	flag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", false, enablePrometheusMetricsUsage)
 	flag.StringVar(&openTracing, "opentracing", "noop", opentracingUsage)
 	flag.StringVar(&openTracingInitialSpan, "opentracing-initial-span", "ingress", opentracingIngressSpanNameUsage)
+	flag.StringVar(&openTracingExcludedProxyTags, "opentracing-excluded-proxy-tags", "", openTracingExcludedProxyTagsUsage)
+	flag.BoolVar(&opentracingLogFilterLifecycleEvents, "opentracing-log-filter-lifecycle-events", true, opentracingLogFilterLifecycleEventsUsage)
 	flag.StringVar(&metricsListener, "metrics-listener", defaultMetricsListener, metricsListenerUsage)
 	flag.StringVar(&metricsPrefix, "metrics-prefix", defaultMetricsPrefix, metricsPrefixUsage)
 	flag.BoolVar(&enableProfile, "enable-profile", false, enableProfileUsage)

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -103,6 +103,7 @@ const (
 	opentracingIngressSpanNameUsage          = "set the name of the initial, pre-routing, tracing span"
 	openTracingExcludedProxyTagsUsage        = "set tags that should be excluded from spans created for proxy operation. must be a comma-separated list of strings."
 	opentracingLogFilterLifecycleEventsUsage = "enables the logs for request & response filters' lifecycle events that are marking start & end times."
+	opentracingLogStreamEventsUsage          = "enables the logs for events marking the times response headers & payload are streamed to the client"
 	metricsListenerUsage                     = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
 	metricsPrefixUsage                       = "allows setting a custom path prefix for metrics export"
 	enableProfileUsage                       = "enable profile information on the metrics endpoint with path /pprof"
@@ -256,6 +257,7 @@ var (
 	openTracingInitialSpan              string
 	openTracingExcludedProxyTags        string
 	opentracingLogFilterLifecycleEvents bool
+	opentracingLogStreamEvents          bool
 	metricsListener                     string
 	metricsPrefix                       string
 	enableProfile                       bool
@@ -412,6 +414,7 @@ func init() {
 	flag.StringVar(&openTracingInitialSpan, "opentracing-initial-span", "ingress", opentracingIngressSpanNameUsage)
 	flag.StringVar(&openTracingExcludedProxyTags, "opentracing-excluded-proxy-tags", "", openTracingExcludedProxyTagsUsage)
 	flag.BoolVar(&opentracingLogFilterLifecycleEvents, "opentracing-log-filter-lifecycle-events", true, opentracingLogFilterLifecycleEventsUsage)
+	flag.BoolVar(&opentracingLogStreamEvents, "opentracing-log-stream-events", true, opentracingLogStreamEventsUsage)
 	flag.StringVar(&metricsListener, "metrics-listener", defaultMetricsListener, metricsListenerUsage)
 	flag.StringVar(&metricsPrefix, "metrics-prefix", defaultMetricsPrefix, metricsPrefixUsage)
 	flag.BoolVar(&enableProfile, "enable-profile", false, enableProfileUsage)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -115,9 +115,8 @@ type OpenTracingParams struct {
 	// Default: false
 	LogFilterEvents bool
 
-	// IncludeTags controls what tags are enabled. Any tag that is not listed here will be ignored.
-	// Default: DefaultIncludedTags
-	IncludeTags []string
+	// ExcludeTags controls what tags are disabled. Any tag that is listed here will be ignored.
+	ExcludeTags []string
 }
 
 // Proxy initialization options.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -207,6 +207,8 @@ type Params struct {
 	// Client TLS to connect to Backends
 	ClientTLS *tls.Config
 
+	// OpenTracing contains parameters related to OpenTracing instrumentation. For default values
+	// check OpenTracingParams
 	OpenTracing *OpenTracingParams
 }
 

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -42,11 +42,8 @@ func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyPara
 	routingOptions.PostProcessors = []routing.PostProcessor{loadbalancer.NewAlgorithmProvider()}
 
 	rt := routing.New(routingOptions)
-
 	proxyParams.Routing = rt
-	//if proxyParams.OpenTracing == nil {
-	//	proxyParams.OpenTracing = &proxy.OpenTracingParams{ Tracer: &opentracing.NoopTracer{} }
-	//}
+
 	pr := proxy.WithParams(proxyParams)
 	tsp := httptest.NewServer(pr)
 

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -4,7 +4,6 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/loadbalancer"
@@ -45,9 +44,9 @@ func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyPara
 	rt := routing.New(routingOptions)
 
 	proxyParams.Routing = rt
-	if proxyParams.OpenTracer == nil {
-		proxyParams.OpenTracer = &opentracing.NoopTracer{}
-	}
+	//if proxyParams.OpenTracing == nil {
+	//	proxyParams.OpenTracing = &proxy.OpenTracingParams{ Tracer: &opentracing.NoopTracer{} }
+	//}
 	pr := proxy.WithParams(proxyParams)
 	tsp := httptest.NewServer(pr)
 

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -78,8 +78,7 @@ func (t *proxyTracing) setTag(span ot.Span, key string, value interface{}) *prox
 		return t
 	}
 
-	_, excluded := t.excludeTags[key]
-	if !excluded {
+	if !t.excludeTags[key] {
 		span.SetTag(key, value)
 	}
 

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -4,10 +4,27 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 )
 
-var (
+const (
+	ComponentTag      = "component"
+	ErrorTag          = "error"
+	FlowIDTag         = "component"
+	HostnameTag       = "hostname"
+	HTTPHostTag       = "http.host"
+	HTTPMethodTag     = "http.method"
+	HTTPRemoteAddrTag = "http.remote_addr"
+	HTTPPathTag       = "http.path"
+	HTTPUrlTag        = "http.url"
+	HTTPStatusCodeTag = "http.status_code"
 	SkipperRouteTag   = "skipper.route"
 	SkipperRouteIDTag = "skipper.route_id"
+	SpanKindTag       = "span.kind"
+	SpanKindClient    = "client"
+	SpanKindServer    = "server"
 )
+
+var DefaultIncludedTags []string = []string{
+
+}
 
 type proxyTracing struct {
 	tracer                   ot.Tracer
@@ -58,10 +75,10 @@ func (t *proxyTracing) logFilterEnd(span ot.Span, filterName string) {
 	t.logFilterLifecycleEvent(span, filterName, "done")
 }
 
-func (t *proxyTracing) setTag(span ot.Span, key string, value interface{}) ot.Span {
+func (t *proxyTracing) setTag(span ot.Span, key string, value interface{}) *proxyTracing {
 	if included, ok := t.includeTags[key]; included && ok {
 		span.SetTag(key, value)
 	}
 
-	return span
+	return t
 }

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -1,0 +1,67 @@
+package proxy
+
+import (
+	ot "github.com/opentracing/opentracing-go"
+)
+
+var (
+	SkipperRouteTag   = "skipper.route"
+	SkipperRouteIDTag = "skipper.route_id"
+)
+
+type proxyTracing struct {
+	tracer                   ot.Tracer
+	initialOperationName     string
+	logFilterLifecycleEvents bool
+	includeTags              map[string]bool
+}
+
+func newProxyTracing(p *OpenTracingParams) *proxyTracing {
+	if p == nil {
+		p = &OpenTracingParams{}
+	}
+
+	if p.InitialSpan == "" {
+		p.InitialSpan = "ingress"
+	}
+
+	if p.Tracer == nil {
+		p.Tracer = &ot.NoopTracer{}
+	}
+
+	includedTags := map[string]bool{}
+
+	for _, t := range p.IncludeTags {
+		includedTags[t] = true
+	}
+
+	return &proxyTracing{
+		tracer:                   p.Tracer,
+		initialOperationName:     p.InitialSpan,
+		logFilterLifecycleEvents: p.LogFilterEvents,
+	}
+}
+
+func (t *proxyTracing) logFilterLifecycleEvent(span ot.Span, filterName, event string) {
+	if !t.logFilterLifecycleEvents {
+		return
+	}
+
+	span.LogKV(filterName, event)
+}
+
+func (t *proxyTracing) logFilterStart(span ot.Span, filterName string) {
+	t.logFilterLifecycleEvent(span, filterName, "start")
+}
+
+func (t *proxyTracing) logFilterEnd(span ot.Span, filterName string) {
+	t.logFilterLifecycleEvent(span, filterName, "done")
+}
+
+func (t *proxyTracing) setTag(span ot.Span, key string, value interface{}) ot.Span {
+	if included, ok := t.includeTags[key]; included && ok {
+		span.SetTag(key, value)
+	}
+
+	return span
+}

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -43,8 +43,10 @@ func TestTracingFromWire(t *testing.T) {
 	doc := fmt.Sprintf(`hello: Path("/hello") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{}
 	params := Params{
-		OpenTracer: tracer,
-		Flags:      FlagsNone,
+		OpenTracing: &OpenTracingParams{
+			Tracer: tracer,
+		},
+		Flags: FlagsNone,
 	}
 
 	tp, err := newTestProxyWithParams(doc, params)
@@ -92,8 +94,10 @@ func TestTracingRoot(t *testing.T) {
 	doc := fmt.Sprintf(`hello: Path("/hello") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{TraceContent: traceContent}
 	params := Params{
-		OpenTracer: tracer,
-		Flags:      FlagsNone,
+		OpenTracing: &OpenTracingParams{
+			Tracer: tracer,
+		},
+		Flags: FlagsNone,
 	}
 
 	tp, err := newTestProxyWithParams(doc, params)
@@ -147,8 +151,10 @@ func TestTracingSpanName(t *testing.T) {
 	doc := fmt.Sprintf(`hello: Path("/hello") -> tracingSpanName("test-span") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{TraceContent: traceContent}
 	params := Params{
-		OpenTracer: tracer,
-		Flags:      FlagsNone,
+		OpenTracing: &OpenTracingParams{
+			Tracer: tracer,
+		},
+		Flags: FlagsNone,
 	}
 
 	tp, err := newTestProxyWithParams(doc, params)
@@ -190,9 +196,11 @@ func TestTracingInitialSpanName(t *testing.T) {
 	doc := fmt.Sprintf(`hello: Path("/hello") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{TraceContent: traceContent}
 	params := Params{
-		OpenTracer:             tracer,
-		OpenTracingInitialSpan: "test-initial-span",
-		Flags:                  FlagsNone,
+		OpenTracing: &OpenTracingParams{
+			Tracer:      tracer,
+			InitialSpan: "test-initial-span",
+		},
+		Flags: FlagsNone,
 	}
 
 	tp, err := newTestProxyWithParams(doc, params)
@@ -236,7 +244,7 @@ func TestTracingProxySpan(t *testing.T) {
 
 	doc := fmt.Sprintf(`* -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{}
-	tp, err := newTestProxyWithParams(doc, Params{OpenTracer: tracer})
+	tp, err := newTestProxyWithParams(doc, Params{OpenTracing: &OpenTracingParams{Tracer: tracer}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +296,7 @@ func TestTracingProxySpanWithRetry(t *testing.T) {
 	const docFmt = `r: * -> <roundRobin, "%s", "%s">;`
 	doc := fmt.Sprintf(docFmt, s0.URL, s1.URL)
 	tracer := &tracingtest.Tracer{}
-	tp, err := newTestProxyWithParams(doc, Params{OpenTracer: tracer})
+	tp, err := newTestProxyWithParams(doc, Params{OpenTracing: &OpenTracingParams{Tracer: tracer}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -448,6 +448,10 @@ type Options struct {
 	// response filters' start & end times.
 	OpenTracingLogFilterLifecycleEvents bool
 
+	// OpenTracingLogStreamEvents flag is used to enable/disable the logs that marks the
+	// times when response headers & payload are streamed to the client
+	OpenTracingLogStreamEvents bool
+
 	// PluginDir defines the directory to load plugins from, DEPRECATED, use PluginDirs
 	PluginDir string
 	// PluginDirs defines the directories to load plugins from
@@ -1083,6 +1087,7 @@ func Run(o Options) error {
 		InitialSpan:     o.OpenTracingInitialSpan,
 		ExcludeTags:     o.OpenTracingExcludedProxyTags,
 		LogFilterEvents: o.OpenTracingLogFilterLifecycleEvents,
+		LogStreamEvents: o.OpenTracingLogStreamEvents,
 	}
 
 	// create the proxy

--- a/skipper.go
+++ b/skipper.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	ot "github.com/opentracing/opentracing-go"
+	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/circuit"
 	"github.com/zalando/skipper/dataclients/kubernetes"
 	"github.com/zalando/skipper/dataclients/routestring"

--- a/skipper.go
+++ b/skipper.go
@@ -1063,16 +1063,18 @@ func Run(o Options) error {
 		if err != nil {
 			return err
 		}
-		proxyParams.OpenTracer = tracer
-		proxyParams.OpenTracingInitialSpan = o.OpenTracingInitialSpan
+		proxyParams.OpenTracing = &proxy.OpenTracingParams{
+			Tracer:      tracer,
+			InitialSpan: o.OpenTracingInitialSpan,
+		}
 	} else {
 		// always have a tracer available, so filter authors can rely on the
 		// existence of a tracer
-		proxyParams.OpenTracer, _ = tracing.LoadTracingPlugin(o.PluginDirs, []string{"noop"})
-	}
-
-	if proxyParams.OpenTracingInitialSpan != "" {
-		proxyParams.OpenTracingInitialSpan = o.OpenTracingInitialSpan
+		tracer, _ := tracing.LoadTracingPlugin(o.PluginDirs, []string{"noop"})
+		proxyParams.OpenTracing = &proxy.OpenTracingParams{
+			Tracer:      tracer,
+			InitialSpan: o.OpenTracingInitialSpan,
+		}
 	}
 
 	// create the proxy


### PR DESCRIPTION
Overall the PR adds 2 CLI options that are used in `Proxy`: `opentracing-excluded-proxy-tags` & `opentracing-log-filter-lifecycle-events`.

Some notes on additional changes:
- As a part of the PR I also attempted to unify how we set tags on `Proxy` level. 
- We could also extend functionality offered by `proxyTracing` by moving `tracing.CreateSpan` there as well as it is not used anywhere outside of `Proxy`.

Relates to #1065 
