### PR TITLE
Add missing opentracing related flags

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -604,6 +604,8 @@ func main() {
 		log.Warn(`"api-usage-monitoring-default-client-tracking-pattern" parameter is deprecated`)
 	}
 
+	excludedProxyTags := strings.Split(openTracingExcludedProxyTags, ",")
+
 	options := skipper.Options{
 		// generic:
 		Address:                         address,
@@ -633,6 +635,9 @@ func main() {
 		EnablePrometheusMetrics:             enablePrometheusMetrics,
 		OpenTracing:                         strings.Split(openTracing, " "),
 		OpenTracingInitialSpan:              openTracingInitialSpan,
+		OpenTracingExcludedProxyTags:        excludedProxyTags,
+		OpenTracingLogStreamEvents:          opentracingLogStreamEvents,
+		OpenTracingLogFilterLifecycleEvents: opentracingLogFilterLifecycleEvents,
 		MetricsListener:                     metricsListener,
 		MetricsPrefix:                       metricsPrefix,
 		EnableProfile:                       enableProfile,


### PR DESCRIPTION
I missed these on https://github.com/zalando/skipper/pull/1066. Otherwise those flags are parsed but not passed to skipper while creating an instance.

Relates to #1065 as well.

Signed-off-by: Serbay Arslanhan <serbay.arslanhan@zalando.de>