### PR TITLE
MID-855: Enrich forwardToken filter with masking abilities

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -98,34 +98,37 @@ const (
 	maxAuditBodyUsage                    = "sets the max body to read to log in the audit log body"
 
 	// logging, metrics, tracing:
-	enablePrometheusMetricsUsage    = "switch to Prometheus metrics format to expose metrics. *Deprecated*: use metrics-flavour"
-	opentracingUsage                = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
-	opentracingIngressSpanNameUsage = "set the name of the initial, pre-routing, tracing span"
-	metricsListenerUsage            = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
-	metricsPrefixUsage              = "allows setting a custom path prefix for metrics export"
-	enableProfileUsage              = "enable profile information on the metrics endpoint with path /pprof"
-	debugGcMetricsUsage             = "enables reporting of the Go garbage collector statistics exported in debug.GCStats"
-	runtimeMetricsUsage             = "enables reporting of the Go runtime statistics exported in runtime and specifically runtime.MemStats"
-	serveRouteMetricsUsage          = "enables reporting total serve time metrics for each route"
-	serveHostMetricsUsage           = "enables reporting total serve time metrics for each host"
-	backendHostMetricsUsage         = "enables reporting total serve time metrics for each backend"
-	allFiltersMetricsUsage          = "enables reporting combined filter metrics for each route"
-	combinedResponseMetricsUsage    = "enables reporting combined response time metrics"
-	routeResponseMetricsUsage       = "enables reporting response time metrics for each route"
-	routeBackendErrorCountersUsage  = "enables counting backend errors for each route"
-	routeStreamErrorCountersUsage   = "enables counting streaming errors for each route"
-	routeBackendMetricsUsage        = "enables reporting backend response time metrics for each route"
-	metricsUseExpDecaySampleUsage   = "use exponentially decaying sample in metrics"
-	histogramMetricBucketsUsage     = "use custom buckets for prometheus histograms, must be a comma-separated list of numbers"
-	disableMetricsCompatsUsage      = "disables the default true value for all-filters-metrics, route-response-metrics, route-backend-errorCounters and route-stream-error-counters"
-	applicationLogUsage             = "output file for the application log. When not set, /dev/stderr is used"
-	applicationLogLevelUsage        = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
-	applicationLogPrefixUsage       = "prefix for each log entry"
-	accessLogUsage                  = "output file for the access log, When not set, /dev/stderr is used"
-	accessLogDisabledUsage          = "when this flag is set, no access log is printed"
-	accessLogJSONEnabledUsage       = "when this flag is set, log in JSON format is used"
-	accessLogStripQueryUsage        = "when this flag is set, the access log strips the query strings from the access log"
-	suppressRouteUpdateLogsUsage    = "print only summaries on route updates/deletes"
+	enablePrometheusMetricsUsage             = "switch to Prometheus metrics format to expose metrics. *Deprecated*: use metrics-flavour"
+	opentracingUsage                         = "list of arguments for opentracing (space separated), first argument is the tracer implementation"
+	opentracingIngressSpanNameUsage          = "set the name of the initial, pre-routing, tracing span"
+	openTracingExcludedProxyTagsUsage        = "set tags that should be excluded from spans created for proxy operation. must be a comma-separated list of strings."
+	opentracingLogFilterLifecycleEventsUsage = "enables the logs for request & response filters' lifecycle events that are marking start & end times."
+	opentracingLogStreamEventsUsage          = "enables the logs for events marking the times response headers & payload are streamed to the client"
+	metricsListenerUsage                     = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
+	metricsPrefixUsage                       = "allows setting a custom path prefix for metrics export"
+	enableProfileUsage                       = "enable profile information on the metrics endpoint with path /pprof"
+	debugGcMetricsUsage                      = "enables reporting of the Go garbage collector statistics exported in debug.GCStats"
+	runtimeMetricsUsage                      = "enables reporting of the Go runtime statistics exported in runtime and specifically runtime.MemStats"
+	serveRouteMetricsUsage                   = "enables reporting total serve time metrics for each route"
+	serveHostMetricsUsage                    = "enables reporting total serve time metrics for each host"
+	backendHostMetricsUsage                  = "enables reporting total serve time metrics for each backend"
+	allFiltersMetricsUsage                   = "enables reporting combined filter metrics for each route"
+	combinedResponseMetricsUsage             = "enables reporting combined response time metrics"
+	routeResponseMetricsUsage                = "enables reporting response time metrics for each route"
+	routeBackendErrorCountersUsage           = "enables counting backend errors for each route"
+	routeStreamErrorCountersUsage            = "enables counting streaming errors for each route"
+	routeBackendMetricsUsage                 = "enables reporting backend response time metrics for each route"
+	metricsUseExpDecaySampleUsage            = "use exponentially decaying sample in metrics"
+	histogramMetricBucketsUsage              = "use custom buckets for prometheus histograms, must be a comma-separated list of numbers"
+	disableMetricsCompatsUsage               = "disables the default true value for all-filters-metrics, route-response-metrics, route-backend-errorCounters and route-stream-error-counters"
+	applicationLogUsage                      = "output file for the application log. When not set, /dev/stderr is used"
+	applicationLogLevelUsage                 = "log level for application logs, possible values: PANIC, FATAL, ERROR, WARN, INFO, DEBUG"
+	applicationLogPrefixUsage                = "prefix for each log entry"
+	accessLogUsage                           = "output file for the access log, When not set, /dev/stderr is used"
+	accessLogDisabledUsage                   = "when this flag is set, no access log is printed"
+	accessLogJSONEnabledUsage                = "when this flag is set, log in JSON format is used"
+	accessLogStripQueryUsage                 = "when this flag is set, the access log strips the query strings from the access log"
+	suppressRouteUpdateLogsUsage             = "print only summaries on route updates/deletes"
 
 	// route sources:
 	etcdUrlsUsage                  = "urls of nodes in an etcd cluster, storing route definitions"
@@ -249,34 +252,37 @@ var (
 	multiPlugins                    pluginFlags
 
 	// logging, metrics, tracing:
-	enablePrometheusMetrics   bool
-	openTracing               string
-	openTracingInitialSpan    string
-	metricsListener           string
-	metricsPrefix             string
-	enableProfile             bool
-	debugGcMetrics            bool
-	runtimeMetrics            bool
-	serveRouteMetrics         bool
-	serveHostMetrics          bool
-	backendHostMetrics        bool
-	allFiltersMetrics         bool
-	combinedResponseMetrics   bool
-	routeResponseMetrics      bool
-	routeBackendErrorCounters bool
-	routeStreamErrorCounters  bool
-	routeBackendMetrics       bool
-	metricsUseExpDecaySample  bool
-	histogramMetricBuckets    string
-	disableMetricsCompat      bool
-	applicationLog            string
-	applicationLogLevel       string
-	applicationLogPrefix      string
-	accessLog                 string
-	accessLogDisabled         bool
-	accessLogJSONEnabled      bool
-	accessLogStripQuery       bool
-	suppressRouteUpdateLogs   bool
+	enablePrometheusMetrics             bool
+	openTracing                         string
+	openTracingInitialSpan              string
+	openTracingExcludedProxyTags        string
+	opentracingLogFilterLifecycleEvents bool
+	opentracingLogStreamEvents          bool
+	metricsListener                     string
+	metricsPrefix                       string
+	enableProfile                       bool
+	debugGcMetrics                      bool
+	runtimeMetrics                      bool
+	serveRouteMetrics                   bool
+	serveHostMetrics                    bool
+	backendHostMetrics                  bool
+	allFiltersMetrics                   bool
+	combinedResponseMetrics             bool
+	routeResponseMetrics                bool
+	routeBackendErrorCounters           bool
+	routeStreamErrorCounters            bool
+	routeBackendMetrics                 bool
+	metricsUseExpDecaySample            bool
+	histogramMetricBuckets              string
+	disableMetricsCompat                bool
+	applicationLog                      string
+	applicationLogLevel                 string
+	applicationLogPrefix                string
+	accessLog                           string
+	accessLogDisabled                   bool
+	accessLogJSONEnabled                bool
+	accessLogStripQuery                 bool
+	suppressRouteUpdateLogs             bool
 
 	// route sources:
 	etcdUrls                  string
@@ -406,6 +412,9 @@ func init() {
 	flag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", false, enablePrometheusMetricsUsage)
 	flag.StringVar(&openTracing, "opentracing", "noop", opentracingUsage)
 	flag.StringVar(&openTracingInitialSpan, "opentracing-initial-span", "ingress", opentracingIngressSpanNameUsage)
+	flag.StringVar(&openTracingExcludedProxyTags, "opentracing-excluded-proxy-tags", "", openTracingExcludedProxyTagsUsage)
+	flag.BoolVar(&opentracingLogFilterLifecycleEvents, "opentracing-log-filter-lifecycle-events", true, opentracingLogFilterLifecycleEventsUsage)
+	flag.BoolVar(&opentracingLogStreamEvents, "opentracing-log-stream-events", true, opentracingLogStreamEventsUsage)
 	flag.StringVar(&metricsListener, "metrics-listener", defaultMetricsListener, metricsListenerUsage)
 	flag.StringVar(&metricsPrefix, "metrics-prefix", defaultMetricsPrefix, metricsPrefixUsage)
 	flag.BoolVar(&enableProfile, "enable-profile", false, enableProfileUsage)
@@ -595,6 +604,8 @@ func main() {
 		log.Warn(`"api-usage-monitoring-default-client-tracking-pattern" parameter is deprecated`)
 	}
 
+	excludedProxyTags := strings.Split(openTracingExcludedProxyTags, ",")
+
 	options := skipper.Options{
 		// generic:
 		Address:                         address,
@@ -624,6 +635,9 @@ func main() {
 		EnablePrometheusMetrics:             enablePrometheusMetrics,
 		OpenTracing:                         strings.Split(openTracing, " "),
 		OpenTracingInitialSpan:              openTracingInitialSpan,
+		OpenTracingExcludedProxyTags:        excludedProxyTags,
+		OpenTracingLogStreamEvents:          opentracingLogStreamEvents,
+		OpenTracingLogFilterLifecycleEvents: opentracingLogFilterLifecycleEvents,
 		MetricsListener:                     metricsListener,
 		MetricsPrefix:                       metricsPrefix,
 		EnableProfile:                       enableProfile,

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -687,9 +687,10 @@ secureOauthTokenintrospectionAllKV("issuerURL", "", "", "k1", "v1", "k2", "v2")
 
 ## forwardToken
 
-The filter accepts a single string as an argument. The argument is the header
-name where the result of token info or token introspection is added when the
-request is passed to the backend.
+The filter accepts a variable number of string arguments but there must be at least 1 input which represents the header
+name where the result of token info or token introspection is added when the request is passed to the backend. Input
+arguments after the first, are considered to be keys within the JSON that you want to be excluded from forwarding to
+the backend service.
 
 If this filter is used when there is no token introspection or token info data
 then it does not have any effect.
@@ -698,6 +699,7 @@ Examples:
 
 ```
 forwardToken("X-Tokeninfo-Forward")
+forwardToken("X-Tokeninfo-Forward", "access_token")
 ```
 
 ## oauthOIDCUserInfo

--- a/filters/auth/forwardtoken_test.go
+++ b/filters/auth/forwardtoken_test.go
@@ -42,20 +42,30 @@ func TestForwardTokenInfo(t *testing.T) {
 	for _, ti := range []struct {
 		msg                string
 		headerName         string
+		maskedJSONKeys     []interface{}
 		tokenInfo          testTokeninfo
 		oauthFilterPresent bool
 	}{
 		{
 			msg:                "Basic Test",
 			headerName:         "X-Skipper-Tokeninfo",
+			maskedJSONKeys:     []interface{}{},
 			tokenInfo:          testTokeninfo{Uid: "test", Scope: []string{"uid"}},
 			oauthFilterPresent: true,
 		},
 		{
 			msg:                "No OAuth Filter Test Test",
 			headerName:         "X-Skipper-Tokeninfo",
+			maskedJSONKeys:     []interface{}{},
 			tokenInfo:          testTokeninfo{Uid: "test", Scope: []string{"uid"}},
 			oauthFilterPresent: false,
+		},
+		{
+			msg:                "Test JSON Key Masking",
+			headerName:         "X-Skipper-Tokeninfo",
+			maskedJSONKeys:     []interface{}{"uid"},
+			tokenInfo:          testTokeninfo{Uid: "test", Scope: []string{"uid"}},
+			oauthFilterPresent: true,
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
@@ -68,8 +78,14 @@ func TestForwardTokenInfo(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Failed to unmarshall header value %s", tokenInfo)
 					}
-					if !reflect.DeepEqual(info, ti.tokenInfo) {
-						t.Fatalf("Did not receive token info in header %s", ti.headerName)
+					if len(ti.maskedJSONKeys) == 0 {
+						if !reflect.DeepEqual(info, ti.tokenInfo) {
+							t.Fatalf("Did not receive token info in header %s", ti.headerName)
+						}
+					} else {
+						if reflect.DeepEqual(info, ti.tokenInfo) {
+							t.Fatalf("Token Info header was not properly masked %s", ti.headerName)
+						}
 					}
 					t.Logf("tokeninfo present in header %s", ti.headerName)
 				} else {
@@ -108,12 +124,13 @@ func TestForwardTokenInfo(t *testing.T) {
 			}
 
 			ftSpec := NewForwardToken()
-			_, err := ftSpec.CreateFilter([]interface{}{ti.headerName})
+			filterArgs := append([]interface{}{ti.headerName}, ti.maskedJSONKeys...)
+			_, err := ftSpec.CreateFilter(filterArgs)
 			if err != nil {
-				t.Fatalf("error in creating filter")
+				t.Fatalf("error in creating filter: %v", err)
 			}
 			fr.Register(ftSpec)
-			routeFilters = append(routeFilters, &eskip.Filter{Name: ftSpec.Name(), Args: []interface{}{ti.headerName}})
+			routeFilters = append(routeFilters, &eskip.Filter{Name: ftSpec.Name(), Args: filterArgs})
 
 			r := &eskip.Route{Filters: routeFilters, Backend: clientServer.URL}
 

--- a/filters/auth/forwardtoken_test.go
+++ b/filters/auth/forwardtoken_test.go
@@ -45,6 +45,7 @@ func TestForwardTokenInfo(t *testing.T) {
 		maskedJSONKeys     []interface{}
 		tokenInfo          testTokeninfo
 		oauthFilterPresent bool
+		matchHeaderExactly bool
 	}{
 		{
 			msg:                "Basic Test",
@@ -52,6 +53,7 @@ func TestForwardTokenInfo(t *testing.T) {
 			maskedJSONKeys:     []interface{}{},
 			tokenInfo:          testTokeninfo{Uid: "test", Scope: []string{"uid"}},
 			oauthFilterPresent: true,
+			matchHeaderExactly: true,
 		},
 		{
 			msg:                "No OAuth Filter Test Test",
@@ -59,6 +61,7 @@ func TestForwardTokenInfo(t *testing.T) {
 			maskedJSONKeys:     []interface{}{},
 			tokenInfo:          testTokeninfo{Uid: "test", Scope: []string{"uid"}},
 			oauthFilterPresent: false,
+			matchHeaderExactly: true,
 		},
 		{
 			msg:                "Test JSON Key Masking",
@@ -66,6 +69,15 @@ func TestForwardTokenInfo(t *testing.T) {
 			maskedJSONKeys:     []interface{}{"uid"},
 			tokenInfo:          testTokeninfo{Uid: "test", Scope: []string{"uid"}},
 			oauthFilterPresent: true,
+			matchHeaderExactly: false,
+		},
+		{
+			msg:                "Test JSON Key Masking Non Existant Key",
+			headerName:         "X-Skipper-Tokeninfo",
+			maskedJSONKeys:     []interface{}{"blah_blah"},
+			tokenInfo:          testTokeninfo{Uid: "test", Scope: []string{"uid"}},
+			oauthFilterPresent: true,
+			matchHeaderExactly: true,
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
@@ -78,7 +90,7 @@ func TestForwardTokenInfo(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Failed to unmarshall header value %s", tokenInfo)
 					}
-					if len(ti.maskedJSONKeys) == 0 {
+					if ti.matchHeaderExactly {
 						if !reflect.DeepEqual(info, ti.tokenInfo) {
 							t.Fatalf("Did not receive token info in header %s", ti.headerName)
 						}

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -4,7 +4,6 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/loadbalancer"
@@ -43,11 +42,8 @@ func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyPara
 	routingOptions.PostProcessors = []routing.PostProcessor{loadbalancer.NewAlgorithmProvider()}
 
 	rt := routing.New(routingOptions)
-
 	proxyParams.Routing = rt
-	if proxyParams.OpenTracer == nil {
-		proxyParams.OpenTracer = &opentracing.NoopTracer{}
-	}
+
 	pr := proxy.WithParams(proxyParams)
 	tsp := httptest.NewServer(pr)
 

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	ot "github.com/opentracing/opentracing-go"
+)
+
+const (
+	ClientRequestStateTag = "client.request"
+	ComponentTag          = "component"
+	ErrorTag              = "error"
+	FlowIDTag             = "component"
+	HostnameTag           = "hostname"
+	HTTPHostTag           = "http.host"
+	HTTPMethodTag         = "http.method"
+	HTTPRemoteAddrTag     = "http.remote_addr"
+	HTTPPathTag           = "http.path"
+	HTTPUrlTag            = "http.url"
+	HTTPStatusCodeTag     = "http.status_code"
+	SkipperRouteTag       = "skipper.route"
+	SkipperRouteIDTag     = "skipper.route_id"
+	SpanKindTag           = "span.kind"
+
+	ClientRequestCanceled = "canceled"
+	SpanKindClient        = "client"
+	SpanKindServer        = "server"
+
+	EndEvent           = "start"
+	StartEvent         = "start"
+	StreamHeadersEvent = "stream_Headers"
+)
+
+type proxyTracing struct {
+	tracer                   ot.Tracer
+	initialOperationName     string
+	logFilterLifecycleEvents bool
+	logStreamEvents          bool
+	excludeTags              map[string]bool
+}
+
+func newProxyTracing(p *OpenTracingParams) *proxyTracing {
+	if p == nil {
+		p = &OpenTracingParams{}
+	}
+
+	if p.InitialSpan == "" {
+		p.InitialSpan = "ingress"
+	}
+
+	if p.Tracer == nil {
+		p.Tracer = &ot.NoopTracer{}
+	}
+
+	excludedTags := map[string]bool{}
+
+	for _, t := range p.ExcludeTags {
+		excludedTags[t] = true
+	}
+
+	return &proxyTracing{
+		tracer:                   p.Tracer,
+		initialOperationName:     p.InitialSpan,
+		logFilterLifecycleEvents: p.LogFilterEvents,
+		logStreamEvents:          p.LogStreamEvents,
+		excludeTags:              excludedTags,
+	}
+}
+
+func (t *proxyTracing) logEvent(span ot.Span, eventName, eventValue string) {
+	if span == nil {
+		return
+	}
+
+	span.LogKV(eventName, eventValue)
+}
+
+func (t *proxyTracing) setTag(span ot.Span, key string, value interface{}) *proxyTracing {
+	if span == nil {
+		return t
+	}
+
+	if !t.excludeTags[key] {
+		span.SetTag(key, value)
+	}
+
+	return t
+}
+
+func (t *proxyTracing) logFilterEvent(span ot.Span, filterName, event string) {
+	if !t.logFilterLifecycleEvents {
+		return
+	}
+
+	t.logEvent(span, filterName, event)
+}
+
+func (t *proxyTracing) logStreamEvent(span ot.Span, eventName, eventValue string) {
+	if !t.logStreamEvents {
+		return
+	}
+
+	t.logEvent(span, eventName, eventValue)
+}
+
+func (t *proxyTracing) logFilterStart(span ot.Span, filterName string) {
+	t.logFilterEvent(span, filterName, StartEvent)
+}
+
+func (t *proxyTracing) logFilterEnd(span ot.Span, filterName string) {
+	t.logFilterEvent(span, filterName, EndEvent)
+}


### PR DESCRIPTION
  * In order to avoid security concerns around token details being forwarded
in non standard headers, this masking ability will enable you to exlude some
keys from the token Info response from being forwarded.