### PR TITLE
add init flags to pass certificates files to connect with backend

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -173,8 +173,8 @@ const (
 	oidcSecretsFileUsage                 = "file storing the encryption key of the OID Connect token"
 
 	// TLS client certs
-	clientKeyFileUsage  = "TSL Key file for backend connections, multiple keys may be given comma separated - the order must match the certs"
-	clientCertFileUsage = "TSL certificate files for backend connections, multiple keys may be given comma separated - the order must match the keys"
+	clientKeyFileUsage  = "TLS Key file for backend connections, multiple keys may be given comma separated - the order must match the certs"
+	clientCertFileUsage = "TLS certificate files for backend connections, multiple keys may be given comma separated - the order must match the keys"
 
 	// API Monitoring:
 	apiUsageMonitoringEnableUsage                       = "enables the apiUsageMonitoring filter"
@@ -494,8 +494,8 @@ func init() {
 	flag.StringVar(&oidcSecretsFile, "oidc-secrets-file", "", oidcSecretsFileUsage)
 
 	// TLS client certs
-	flag.StringVar(&clientKeyFile, "client-tsl-key", "", clientKeyFileUsage)
-	flag.StringVar(&clientCertFile, "client-tsl-cert", "", clientCertFileUsage)
+	flag.StringVar(&clientKeyFile, "client-tls-key", "", clientKeyFileUsage)
+	flag.StringVar(&clientCertFile, "client-tls-cert", "", clientCertFileUsage)
 
 	// API Monitoring:
 	flag.BoolVar(&apiUsageMonitoringEnable, "enable-api-usage-monitoring", defaultApiUsageMonitoringEnable, apiUsageMonitoringEnableUsage)

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -15,6 +15,7 @@ package documentation.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -23,7 +24,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"crypto/tls"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -173,8 +173,8 @@ const (
 	oidcSecretsFileUsage                 = "file storing the encryption key of the OID Connect token"
 
 	// TLS client certs
-	clientKeyFileUsage  = "TLS Key file for backend connections, multiple keys may be given comma separated - the order must match the certs"
-	clientCertFileUsage  = "TLS certificate files for backend connections, multiple keys may be given comma separated - the order must match the keys"
+	clientKeyFileUsage  = "TSL Key file for backend connections, multiple keys may be given comma separated - the order must match the certs"
+	clientCertFileUsage = "TSL certificate files for backend connections, multiple keys may be given comma separated - the order must match the keys"
 
 	// API Monitoring:
 	apiUsageMonitoringEnableUsage                       = "enables the apiUsageMonitoring filter"
@@ -337,7 +337,7 @@ var (
 
 	// TLS client certs
 	clientKeyFile  string
-	clientCertFile  string
+	clientCertFile string
 
 	// API Monitoring
 	apiUsageMonitoringEnable                       bool
@@ -494,9 +494,8 @@ func init() {
 	flag.StringVar(&oidcSecretsFile, "oidc-secrets-file", "", oidcSecretsFileUsage)
 
 	// TLS client certs
-	flag.StringVar(&clientKeyFile, "client-tls-key", "", clientKeyFileUsage)
-	flag.StringVar(&clientCertFile, "client-tls-cert", "", clientCertFileUsage)
-
+	flag.StringVar(&clientKeyFile, "client-tsl-key", "", clientKeyFileUsage)
+	flag.StringVar(&clientCertFile, "client-tsl-cert", "", clientCertFileUsage)
 
 	// API Monitoring:
 	flag.BoolVar(&apiUsageMonitoringEnable, "enable-api-usage-monitoring", defaultApiUsageMonitoringEnable, apiUsageMonitoringEnableUsage)
@@ -786,23 +785,23 @@ func main() {
 		options.ProxyFlags |= proxy.HopHeadersRemoval
 	}
 
-	if clientKeyFile != "" && clientCertFile != ""{
+	if clientKeyFile != "" && clientCertFile != "" {
 		certsFiles := strings.Split(clientCertFile, ",")
 		keyFiles := strings.Split(clientKeyFile, ",")
 
 		var certificates []tls.Certificate
 
 		for i := range keyFiles {
-        	certificate, err := tls.LoadX509KeyPair(certsFiles[i],keyFiles[i])
-			if(err != nil){
-				log.Fatal("invalid key/cert pair",err)
+			certificate, err := tls.LoadX509KeyPair(certsFiles[i], keyFiles[i])
+			if err != nil {
+				log.Fatal("invalid key/cert pair", err)
 				return
 			}
-			certificates = append(certificates,certificate)
+			certificates = append(certificates, certificate)
 
-   	 }
-		options.ClientTLS =  &tls.Config{
-			Certificates : certificates,
+		}
+		options.ClientTLS = &tls.Config{
+			Certificates: certificates,
 		}
 	}
 

--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -173,8 +173,8 @@ const (
 	oidcSecretsFileUsage                 = "file storing the encryption key of the OID Connect token"
 
 	// TLS client certs
-	clientKeyFileUsage  = "TSL Key file for backend connections, multiple keys may be given comma separated - the order must match the certs"
-	clientCertFileUsage  = "TSL certificate files for backend connections, multiple keys may be given comma separated - the order must match the keys"
+	clientKeyFileUsage  = "TLS Key file for backend connections, multiple keys may be given comma separated - the order must match the certs"
+	clientCertFileUsage  = "TLS certificate files for backend connections, multiple keys may be given comma separated - the order must match the keys"
 
 	// API Monitoring:
 	apiUsageMonitoringEnableUsage                       = "enables the apiUsageMonitoring filter"
@@ -494,8 +494,8 @@ func init() {
 	flag.StringVar(&oidcSecretsFile, "oidc-secrets-file", "", oidcSecretsFileUsage)
 
 	// TLS client certs
-	flag.StringVar(&clientKeyFile, "client-tsl-key", "", clientKeyFileUsage)
-	flag.StringVar(&clientCertFile, "client-tsl-cert", "", clientCertFileUsage)
+	flag.StringVar(&clientKeyFile, "client-tls-key", "", clientKeyFileUsage)
+	flag.StringVar(&clientCertFile, "client-tls-cert", "", clientCertFileUsage)
 
 
 	// API Monitoring:

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,11 +1,11 @@
 .PHONY: docker-push
 
 VERSION            ?= $(shell git rev-parse HEAD)
-REGISTRY           ?= registry-write.opensource.zalan.do/pathfinder
-IMAGE              ?= $(REGISTRY)/skipper:$(VERSION)
-LIGHTSTEP_IMAGE    ?= $(REGISTRY)/skipper-lightstep:$(VERSION)
-OPENTRACING_IMAGE    ?= $(REGISTRY)/skipper-opentracing:$(VERSION)
-ALPINE_BUILD_IMAGE ?= $(REGISTRY)/skipper-alpine-build:latest
+REGISTRY           ?= dist.spotahome.net:5000/spotahome
+IMAGE              ?= $(REGISTRY)/skipper-custom:$(VERSION)
+LIGHTSTEP_IMAGE    ?= $(REGISTRY)/skipper-custom-lightstep:$(VERSION)
+OPENTRACING_IMAGE    ?= $(REGISTRY)/skipper-custom-opentracing:$(VERSION)
+ALPINE_BUILD_IMAGE ?= $(REGISTRY)/skipper-custom-alpine-build:latest
 PACKAGE            ?= github.com/zalando/skipper
 CGO_ENABLED        ?= 0
 GO111              ?= on

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,11 +1,11 @@
 .PHONY: docker-push
 
 VERSION            ?= $(shell git rev-parse HEAD)
-REGISTRY           ?= dist.spotahome.net:5000/spotahome
-IMAGE              ?= $(REGISTRY)/skipper-custom:$(VERSION)
-LIGHTSTEP_IMAGE    ?= $(REGISTRY)/skipper-custom-lightstep:$(VERSION)
-OPENTRACING_IMAGE    ?= $(REGISTRY)/skipper-custom-opentracing:$(VERSION)
-ALPINE_BUILD_IMAGE ?= $(REGISTRY)/skipper-custom-alpine-build:latest
+REGISTRY           ?= registry-write.opensource.zalan.do/pathfinder
+IMAGE              ?= $(REGISTRY)/skipper:$(VERSION)
+LIGHTSTEP_IMAGE    ?= $(REGISTRY)/skipper-lightstep:$(VERSION)
+OPENTRACING_IMAGE    ?= $(REGISTRY)/skipper-opentracing:$(VERSION)
+ALPINE_BUILD_IMAGE ?= $(REGISTRY)/skipper-alpine-build:latest
 PACKAGE            ?= github.com/zalando/skipper
 CGO_ENABLED        ?= 0
 GO111              ?= on


### PR DESCRIPTION
When working as a proxy, is usually need to pass to backend server certification data.

Currently skipper libs are prepared to fill this data, but there is not main flags to provide this info when using the main branch or the generated images.

This PR add two flags to provide these:

```
  -client-tsl-cert string
    	TSL certificate files for backend connections, multiple keys may be given comma separated - the order must match the keys
  -client-tsl-key string
    	TSL Key file for backend connections, multiple keys may be given comma separated - the order must match the certs
```