### PR TITLE
fix source from last predicate

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -50,16 +50,14 @@ func RemoteHost(r *http.Request) net.IP {
 //
 //     X-Forwarded-For: ip-address-1, ip-address-2, client-ip-address
 func RemoteHostFromLast(r *http.Request) net.IP {
-	a := r.Header["X-Forwarded-For"]
-	if a == nil {
-		return parse(r.RemoteAddr)
+	ffs := r.Header.Get("X-Forwarded-For")
+	ffa := strings.Split(ffs, ",")
+	ff := ffa[len(ffa)-1]
+	if ff != "" {
+		if ip := parse(strings.TrimSpace(ff)); ip != nil {
+			return ip
+		}
 	}
-	l := len(a) - 1
-	if l < 0 {
-		l = 0
-	}
-	if ffh := parse(a[l]); ffh != nil {
-		return ffh
-	}
+
 	return parse(r.RemoteAddr)
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -4,36 +4,38 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
-var netTests = []struct {
-	input  string
-	want   net.IP
-	fwdHdr string
-}{
-	{"127.0.0.1", net.IPv4(127, 0, 0, 1), ""},
-	{"1.2.3.4", net.IPv4(1, 2, 3, 4), ""},
-	{"100.200.300.400", nil, ""},
-	{"127.0.0.1:8080", net.IPv4(127, 0, 0, 1), ""},
-	{"127.0.0.1", net.IPv4(172, 16, 0, 1), "172.16.0.1"},
-	{"127.0.0.1", net.IPv4(127, 0, 0, 1), "invalid header"},
-	{"127.0.0.1", net.IPv4(172, 16, 0, 1), "172.16.0.1, 1.2.3.4, 8.7.6.5"}, // X-Forwarded-For with proxies in it
-	{"2001:4860:0:2001::68", net.ParseIP("2001:4860:0:2001::68"), ""},
-	{"127.0.0.1", net.ParseIP("2001:4860:0:2001::68"), "2001:4860:0:2001::68"},
-}
-
 func TestRemoteHost(t *testing.T) {
-	for _, test := range netTests {
-		r := &http.Request{RemoteAddr: test.input, Header: make(http.Header)}
-		if test.fwdHdr != "" {
-			r.Header.Set("x-forwarded-for", test.fwdHdr)
-		}
-		got := RemoteHost(r)
+	for _, tt := range []struct {
+		name   string
+		input  string
+		want   net.IP
+		fwdHdr string
+	}{
+		{"no header1", "127.0.0.1", net.IPv4(127, 0, 0, 1), ""},
+		{"no header2", "1.2.3.4", net.IPv4(1, 2, 3, 4), ""},
+		{"no header3", "100.200.300.400", nil, ""},
+		{"no header4", "127.0.0.1:8080", net.IPv4(127, 0, 0, 1), ""},
+		{"single header1", "127.0.0.1", net.IPv4(172, 16, 0, 1), "172.16.0.1"},
+		{"invalid header", "127.0.0.1", net.IPv4(127, 0, 0, 1), "invalid header"},
+		{"multiple header1", "127.0.0.1", net.IPv4(172, 16, 0, 1), "172.16.0.1, 1.2.3.4, 8.7.6.5"}, // X-Forwarded-For with proxies in it
+		{"no header5", "2001:4860:0:2001::68", net.ParseIP("2001:4860:0:2001::68"), ""},
+		{"single header2", "127.0.0.1", net.ParseIP("2001:4860:0:2001::68"), "2001:4860:0:2001::68"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{RemoteAddr: tt.input, Header: make(http.Header)}
+			if tt.fwdHdr != "" {
+				r.Header.Set("x-forwarded-for", tt.fwdHdr)
+			}
+			got := RemoteHost(r)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("Unexpected IP address '%v'. Wanted '%v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Unexpected IP address '%v'. Wanted '%v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -46,31 +48,32 @@ func BenchmarkRemoteHost(b *testing.B) {
 }
 
 func TestRemoteHostFromLast(t *testing.T) {
-	var localNetTests = []struct {
+	for _, tt := range []struct {
+		name   string
 		input  string
 		want   net.IP
 		fwdHdr []string
 	}{
-		{"127.0.0.1", net.IPv4(127, 0, 0, 1), []string{}},
-		{"1.2.3.4", net.IPv4(1, 2, 3, 4), []string{}},
-		{"100.200.300.400", nil, []string{}},
-		{"127.0.0.1:8080", net.IPv4(127, 0, 0, 1), []string{}},
-		{"127.0.0.1", net.IPv4(172, 16, 0, 1), []string{"172.16.0.1"}},
-		{"127.0.0.1", net.IPv4(127, 0, 0, 1), []string{"invalid header"}},
-		{"127.0.0.1", net.IPv4(8, 7, 6, 5), []string{"172.16.0.1", "1.2.3.4", "8.7.6.5"}},
-		{"127.0.0.1", net.IPv4(8, 7, 6, 5), []string{"1.2.3.4", "8.7.6.5"}},
-		{"127.0.0.1", net.IPv4(8, 7, 6, 5), []string{"8.7.6.5"}},
-	}
-	for _, test := range localNetTests {
-		r := &http.Request{RemoteAddr: test.input, Header: make(http.Header)}
-		for _, s := range test.fwdHdr {
-			r.Header.Add("x-forwarded-for", s)
-		}
-		got := RemoteHostFromLast(r)
+		{"no header", "127.0.0.1", net.IPv4(127, 0, 0, 1), []string{}},
+		{"no header2", "1.2.3.4", net.IPv4(1, 2, 3, 4), []string{}},
+		{"no header3", "100.200.300.400", nil, []string{}},
+		{"no header4", "127.0.0.1:8080", net.IPv4(127, 0, 0, 1), []string{}},
+		{"single header", "127.0.0.1", net.IPv4(172, 16, 0, 1), []string{"172.16.0.1"}},
+		{"invalid  header", "127.0.0.1", net.IPv4(127, 0, 0, 1), []string{"invalid header"}},
+		{"multiple entries", "127.0.0.1", net.IPv4(8, 7, 6, 5), []string{"172.16.0.1", "1.2.3.4", "8.7.6.5"}},
+		{"2 entries", "127.0.0.1", net.IPv4(8, 7, 6, 5), []string{"1.2.3.4", "8.7.6.5"}},
+		{"single header2", "127.0.0.1", net.IPv4(8, 7, 6, 5), []string{"8.7.6.5"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{RemoteAddr: tt.input, Header: make(http.Header)}
+			s := strings.Join(tt.fwdHdr, ", ")
+			r.Header.Set("x-forwarded-for", s)
+			got := RemoteHostFromLast(r)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("Unexpected IP address '%v'. Wanted '%v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Unexpected IP address '%v'. Wanted '%v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/predicates/source/source_test.go
+++ b/predicates/source/source_test.go
@@ -47,14 +47,16 @@ func TestCreate(t *testing.T) {
 		[]interface{}{"C0:FF::EE/32"},
 		false,
 	}} {
-		_, err := (&spec{}).Create(ti.args)
-		if err == nil && ti.err || err != nil && !ti.err {
-			t.Error(ti.msg, "failure case", err, ti.err)
-		}
-		_, err = (&spec{fromLast: true}).Create(ti.args)
-		if err == nil && ti.err || err != nil && !ti.err {
-			t.Error(ti.msg, "failure case", err, ti.err)
-		}
+		t.Run(ti.msg, func(t *testing.T) {
+			_, err := (&spec{}).Create(ti.args)
+			if err == nil && ti.err || err != nil && !ti.err {
+				t.Error(ti.msg, "failure case", err, ti.err)
+			}
+			_, err = (&spec{fromLast: true}).Create(ti.args)
+			if err == nil && ti.err || err != nil && !ti.err {
+				t.Error(ti.msg, "failure case", err, ti.err)
+			}
+		})
 	}
 }
 
@@ -102,7 +104,7 @@ func TestMatching(t *testing.T) {
 	}, {
 		"should use first X-Forwarded-For host (source instead of proxies) for matching",
 		[]interface{}{"8.8.8.8"},
-		&http.Request{RemoteAddr: "127.0.0.1", Header: http.Header{"X-Forwarded-For": []string{"8.8.8.8", "7.7.7.7", "6.6.6.6"}}},
+		&http.Request{RemoteAddr: "127.0.0.1", Header: http.Header{"X-Forwarded-For": []string{"8.8.8.8, 7.7.7.7, 6.6.6.6"}}},
 		true,
 	}, {
 		"should work for IPv6",
@@ -120,15 +122,17 @@ func TestMatching(t *testing.T) {
 		&http.Request{RemoteAddr: "C0:FF::EC"},
 		false,
 	}} {
-		pred, err := (&spec{}).Create(ti.args)
-		if err != nil {
-			t.Error("failed to create predicate", err)
-		} else {
-			matches := pred.Match(ti.req)
-			if matches != ti.matches {
-				t.Error(ti.msg, "failed to match as expected")
+		t.Run(ti.msg, func(t *testing.T) {
+			pred, err := (&spec{}).Create(ti.args)
+			if err != nil {
+				t.Error("failed to create predicate", err)
+			} else {
+				matches := pred.Match(ti.req)
+				if matches != ti.matches {
+					t.Error(ti.msg, "failed to match as expected")
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -176,7 +180,7 @@ func TestMatchingFromLast(t *testing.T) {
 	}, {
 		"should use first X-Forwarded-For host (source instead of proxies) for matching",
 		[]interface{}{"6.6.6.6"},
-		&http.Request{RemoteAddr: "127.0.0.1", Header: http.Header{"X-Forwarded-For": []string{"8.8.8.8", "7.7.7.7", "6.6.6.6"}}},
+		&http.Request{RemoteAddr: "127.0.0.1", Header: http.Header{"X-Forwarded-For": []string{"8.8.8.8, 7.7.7.7, 6.6.6.6"}}},
 		true,
 	}, {
 		"should work for IPv6",
@@ -194,14 +198,16 @@ func TestMatchingFromLast(t *testing.T) {
 		&http.Request{RemoteAddr: "C0:FF::EC"},
 		false,
 	}} {
-		pred, err := (&spec{fromLast: true}).Create(ti.args)
-		if err != nil {
-			t.Error("failed to create predicate", err)
-		} else {
-			matches := pred.Match(ti.req)
-			if matches != ti.matches {
-				t.Error(ti.msg, "failed to match from last as expected")
+		t.Run(ti.msg, func(t *testing.T) {
+			pred, err := (&spec{fromLast: true}).Create(ti.args)
+			if err != nil {
+				t.Error("failed to create predicate", err)
+			} else {
+				matches := pred.Match(ti.req)
+				if matches != ti.matches {
+					t.Error(ti.msg, "failed to match from last as expected")
+				}
 			}
-		}
+		})
 	}
 }


### PR DESCRIPTION
fix source from last predicate was based on wrong assumptions, we do not get parsed headers into string slice, but a plain string, so use Header.Get and work on the string ourselves

reported by a user

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>