### PR TITLE
Add roundtrip start/end span logs

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -851,7 +851,9 @@ func (p *Proxy) makeBackendRequest(ctx *context) (*http.Response, *proxyError) {
 	req = req.WithContext(ot.ContextWithSpan(req.Context(), ctx.proxySpan))
 
 	p.metrics.IncCounter("outgoing." + req.Proto)
+	ctx.proxySpan.LogKV("http_roundtrip", StartEvent)
 	response, err := p.roundTripper.RoundTrip(req)
+	ctx.proxySpan.LogKV("http_roundtrip", EndEvent)
 	if err != nil {
 		p.tracing.setTag(ctx.proxySpan, ErrorTag, true)
 		ctx.proxySpan.LogKV(


### PR DESCRIPTION
This adds span logs for when roundtrip to backend is started and ended. This should enable us to better understand when a backend was called and how long it took to get the response.

Without this log we only see `dial_context` logs in some cases where a new connection has to be established but often we don't see it when a connection is re-used meaning we only see the `stream_Headers` logs when we start to stream the response from the backend back to the client calling skipper.

Example of how this looks:

![image](https://user-images.githubusercontent.com/128566/59838841-f4c8a380-934f-11e9-8d85-bc822fa23d1e.png)

Here the backend has a latency of `50ms`