### PR TITLE
support ingress with service type ExternalName

### DIFF
--- a/dataclients/kubernetes/definitions.go
+++ b/dataclients/kubernetes/definitions.go
@@ -136,8 +136,10 @@ func (sp servicePort) String() string {
 }
 
 type serviceSpec struct {
-	ClusterIP string         `json:"clusterIP"`
-	Ports     []*servicePort `json:"ports"`
+	Type         string         `json:"type"`
+	ClusterIP    string         `json:"clusterIP"`
+	ExternalName string         `json:"externalName"`
+	Ports        []*servicePort `json:"ports"`
 }
 
 type service struct {

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -568,6 +568,53 @@ func TestIngressData(t *testing.T) {
 			"kube_foo__qux__www_example_org_____bar": "http://1.2.3.4:8181",
 		},
 	}, {
+		"ingress with service type ExternalName should proxy to externalName",
+		[]*service{
+			&service{
+				Meta: &metadata{
+					Namespace: "foo",
+					Name:      "extname",
+				},
+				Spec: &serviceSpec{
+					Type:         "ExternalName",
+					ExternalName: "www.zalando.de",
+					Ports: []*servicePort{
+						&servicePort{
+							Name: "ext",
+							Port: 443,
+							TargetPort: &backendPort{
+								value: 443,
+							},
+						},
+					},
+				},
+			},
+		},
+		[]*ingressItem{testIngress(
+			"foo",
+			"qux",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			backendPort{value: 443},
+			1.0,
+			testRule(
+				"www.zalando.de",
+				testPathRule(
+					"/",
+					"extname",
+					backendPort{value: 443},
+				),
+			),
+		)},
+		map[string]string{
+			"kube_foo__qux______www_zalando_de": "https://www.zalando.de:443",
+		},
+	}, {
 		"ignore ingress entries with missing metadata",
 		[]*service{
 			testService("foo", "bar", "1.2.3.4", map[string]int{"baz": 8181}),


### PR DESCRIPTION
feature: #549 ingress with backend svc type ExternalName to do a proxy call to the externalName defined in the target service

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>