### PR TITLE
fix chunked transfer-encoding

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -16,8 +16,13 @@ import (
 
 const unknownHost = "_unknownhost_"
 
+type flushedResponseWriter interface {
+	http.ResponseWriter
+	http.Flusher
+}
+
 type context struct {
-	responseWriter       http.ResponseWriter
+	responseWriter       flushedResponseWriter
 	request              *http.Request
 	response             *http.Response
 	route                *routing.Route
@@ -116,7 +121,7 @@ func appendParams(to, from map[string]string) map[string]string {
 }
 
 func newContext(
-	w http.ResponseWriter,
+	w flushedResponseWriter,
 	r *http.Request,
 	preserveOriginal bool,
 	m metrics.Metrics,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1117,7 +1117,9 @@ func (p *Proxy) serveResponse(ctx *context) {
 	}
 
 	ctx.responseWriter.WriteHeader(ctx.response.StatusCode)
-	err := copyStream(ctx.responseWriter.(flusherWriter), ctx.response.Body, p.tracing, ctx.proxySpan)
+	fw := ctx.responseWriter.(flusherWriter)
+	fw.Flush()
+	err := copyStream(fw, ctx.response.Body, p.tracing, ctx.proxySpan)
 	if err != nil {
 		p.metrics.IncErrorsStreaming(ctx.route.Id)
 		p.log.Error("error while copying the response stream", err)


### PR DESCRIPTION
fix #1103 http headers should be sent before the body
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>