### PR TITLE
fix format check to be as strict as format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ fmt: $(SOURCES)
 	@gofmt -w -s $(SOURCES)
 
 check-fmt: $(SOURCES)
-	@if [ "$$(gofmt -d $(SOURCES))" != "" ]; then false; else true; fi
+	@if [ "$$(gofmt -s -d $(SOURCES))" != "" ]; then false; else true; fi
 
 precommit: fmt build vet staticcheck check-race shortcheck
 

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -570,7 +570,7 @@ func TestIngressData(t *testing.T) {
 	}, {
 		"ingress with service type ExternalName should proxy to externalName",
 		[]*service{
-			&service{
+			{
 				Meta: &metadata{
 					Namespace: "foo",
 					Name:      "extname",
@@ -579,7 +579,7 @@ func TestIngressData(t *testing.T) {
 					Type:         "ExternalName",
 					ExternalName: "www.zalando.de",
 					Ports: []*servicePort{
-						&servicePort{
+						{
 							Name: "ext",
 							Port: 443,
 							TargetPort: &backendPort{


### PR DESCRIPTION
- update the check-fmt Makefile task to match fmt
- fix formatting of code file that was formatted without the `-s` flag 

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>