### PR TITLE
Add "Cron" pred. that supports cron-like expressions to match routes

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -246,6 +246,28 @@ Between("2016-01-01T12:00:00+02:00", "2016-02-01T12:00:00+02:00")
 Between(1451642400, 1454320800)
 ```
 
+## Cron
+
+Matches routes when the given cron-like expression matches the system time.
+
+Parameters:
+* [Cron](https://en.wikipedia.org/wiki/Cron#CRON_expression)\-like expression. See [the package documentation](https://godoc.org/github.com/sarslanhan/cronmask#New) for supported & unsupported features.
+
+Examples:
+
+```
+// match everything
+Cron("* * * * *")
+// match only when the hour is between 5-7 (inclusive)
+Cron("* 5-7, * * *")
+// match only when the hour is between 5-7, equal to 8, or betweeen 12-15
+Cron("* 5-7,8,12-15 * * *")
+// match only when it is weekdays
+Cron("* * * * 1-5")
+// match only when it is weekdays & working hours
+Cron("* 7-18 * * 1-5")
+```
+
 ## QueryParam
 
 Match request based on the Query Params in URL

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -251,7 +251,8 @@ Between(1451642400, 1454320800)
 Matches routes when the given cron-like expression matches the system time.
 
 Parameters:
-* [Cron](https://en.wikipedia.org/wiki/Cron#CRON_expression)\-like expression. See [the package documentation](https://godoc.org/github.com/sarslanhan/cronmask#New) for supported & unsupported features.
+* [Cron](https://en.wikipedia.org/wiki/Cron#CRON_expression)\-like expression. See [the package documentation](https://godoc.org/github.com/sarslanhan/cronmask#New) for supported & unsupported features. Expressions are expected to be in the same time zone as the system that generates the `time.Time` instances.
+
 
 Examples:
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/sanity-io/litter v1.1.0
+	github.com/sarslanhan/cronmask v0.0.0-20190707115317-f0d333580bc8
 	github.com/sirupsen/logrus v1.4.2
 	github.com/sony/gobreaker v0.4.1
 	github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/sanity-io/litter v1.1.0
-	github.com/sarslanhan/cronmask v0.0.0-20190707140726-b3a65e58d3a3
+	github.com/sarslanhan/cronmask v0.0.0-20190709075623-766eca24d011
 	github.com/sirupsen/logrus v1.4.2
 	github.com/sony/gobreaker v0.4.1
 	github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/sanity-io/litter v1.1.0
-	github.com/sarslanhan/cronmask v0.0.0-20190707115317-f0d333580bc8
+	github.com/sarslanhan/cronmask v0.0.0-20190707140726-b3a65e58d3a3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/sony/gobreaker v0.4.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhD
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sanity-io/litter v1.1.0 h1:BllcKWa3VbZmOZbDCoszYLk7zCsKHz5Beossi8SUcTc=
 github.com/sanity-io/litter v1.1.0/go.mod h1:CJ0VCw2q4qKU7LaQr3n7UOSHzgEMgcGco7N/SkZQPjw=
-github.com/sarslanhan/cronmask v0.0.0-20190707140726-b3a65e58d3a3 h1:gmnjYYpsR8S7jmTyMiXiwJOFsmxfJZkESkfhhtDHm4I=
-github.com/sarslanhan/cronmask v0.0.0-20190707140726-b3a65e58d3a3/go.mod h1:NmI1tg7wwsf1hF6G5EtyGCrtNKsH2RIdYYoJa7GsnP8=
+github.com/sarslanhan/cronmask v0.0.0-20190709075623-766eca24d011 h1:S5j3KTsiGwmQSEJJBp0iIG87CDBCGCwbYLmVv8L/nuE=
+github.com/sarslanhan/cronmask v0.0.0-20190709075623-766eca24d011/go.mod h1:NmI1tg7wwsf1hF6G5EtyGCrtNKsH2RIdYYoJa7GsnP8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhD
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sanity-io/litter v1.1.0 h1:BllcKWa3VbZmOZbDCoszYLk7zCsKHz5Beossi8SUcTc=
 github.com/sanity-io/litter v1.1.0/go.mod h1:CJ0VCw2q4qKU7LaQr3n7UOSHzgEMgcGco7N/SkZQPjw=
-github.com/sarslanhan/cronmask v0.0.0-20190707115317-f0d333580bc8 h1:oQY9Bu4dqvfbmnRjbFt0BQvns0W1Wf7erBGprjvOLGM=
-github.com/sarslanhan/cronmask v0.0.0-20190707115317-f0d333580bc8/go.mod h1:NmI1tg7wwsf1hF6G5EtyGCrtNKsH2RIdYYoJa7GsnP8=
+github.com/sarslanhan/cronmask v0.0.0-20190707140726-b3a65e58d3a3 h1:gmnjYYpsR8S7jmTyMiXiwJOFsmxfJZkESkfhhtDHm4I=
+github.com/sarslanhan/cronmask v0.0.0-20190707140726-b3a65e58d3a3/go.mod h1:NmI1tg7wwsf1hF6G5EtyGCrtNKsH2RIdYYoJa7GsnP8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAmPf4YLrFg6oQUotqHQeUNWwkvo7jZp1GLU=
@@ -130,6 +132,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhD
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sanity-io/litter v1.1.0 h1:BllcKWa3VbZmOZbDCoszYLk7zCsKHz5Beossi8SUcTc=
 github.com/sanity-io/litter v1.1.0/go.mod h1:CJ0VCw2q4qKU7LaQr3n7UOSHzgEMgcGco7N/SkZQPjw=
+github.com/sarslanhan/cronmask v0.0.0-20190707115317-f0d333580bc8 h1:oQY9Bu4dqvfbmnRjbFt0BQvns0W1Wf7erBGprjvOLGM=
+github.com/sarslanhan/cronmask v0.0.0-20190707115317-f0d333580bc8/go.mod h1:NmI1tg7wwsf1hF6G5EtyGCrtNKsH2RIdYYoJa7GsnP8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/predicates/cron/cron.go
+++ b/predicates/cron/cron.go
@@ -49,14 +49,14 @@ func (*spec) Create(args []interface{}) (routing.Predicate, error) {
 }
 
 type predicate struct {
-	mask    cronmask.CronMask
+	mask    *cronmask.CronMask
 	getTime clock
 }
 
 func (p *predicate) Match(r *http.Request) bool {
 	now := p.getTime()
 
-	return p.mask.Matches(now)
+	return p.mask.Match(now)
 }
 
 func New() routing.PredicateSpec {

--- a/predicates/cron/cron.go
+++ b/predicates/cron/cron.go
@@ -44,7 +44,7 @@ func (*spec) Create(args []interface{}) (routing.Predicate, error) {
 
 	return &predicate{
 		mask:    mask,
-		getTime: getSystemTime,
+		getTime: time.Now,
 	}, nil
 }
 
@@ -57,10 +57,6 @@ func (p *predicate) Match(r *http.Request) bool {
 	now := p.getTime()
 
 	return p.mask.Matches(now)
-}
-
-func getSystemTime() time.Time {
-	return time.Now()
 }
 
 func New() routing.PredicateSpec {

--- a/predicates/cron/cron.go
+++ b/predicates/cron/cron.go
@@ -7,7 +7,7 @@ Package includes a single predicate: Cron.
 
 For supported & unsupported features refer to the "cronmask" package
 documentation (https://github.com/sarslanhan/cronmask).
- */
+*/
 package cron
 
 import (

--- a/predicates/cron/cron.go
+++ b/predicates/cron/cron.go
@@ -1,0 +1,68 @@
+/*
+Package cron implements custom predicates to match routes
+only when they also match the system time matches the given
+cron-like expressions.
+
+Package includes a single predicate: Cron.
+
+For supported & unsupported features refer to the "cronmask" package
+documentation (https://github.com/sarslanhan/cronmask).
+ */
+package cron
+
+import (
+	"github.com/sarslanhan/cronmask"
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/routing"
+	"net/http"
+	"time"
+)
+
+type clock func() time.Time
+
+type spec struct {
+}
+
+func (*spec) Name() string {
+	return "Cron"
+}
+
+func (*spec) Create(args []interface{}) (routing.Predicate, error) {
+	if len(args) != 1 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	expr, ok := args[0].(string)
+	if !ok {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	mask, err := cronmask.New(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &predicate{
+		mask:    mask,
+		getTime: getSystemTime,
+	}, nil
+}
+
+type predicate struct {
+	mask    cronmask.CronMask
+	getTime clock
+}
+
+func (p *predicate) Match(r *http.Request) bool {
+	now := p.getTime()
+
+	return p.mask.Matches(now)
+}
+
+func getSystemTime() time.Time {
+	return time.Now()
+}
+
+func New() routing.PredicateSpec {
+	return &spec{}
+}

--- a/predicates/cron/cron_test.go
+++ b/predicates/cron/cron_test.go
@@ -5,9 +5,9 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	testCases := []struct{
-		msg string
-		args []interface{}
+	testCases := []struct {
+		msg     string
+		args    []interface{}
 		isError bool
 	}{
 		{
@@ -55,11 +55,11 @@ func TestPredicateName(t *testing.T) {
 }
 
 func TestPredicateMatch(t *testing.T) {
-	testCases := []struct{
-		msg string
-		args []interface{}
+	testCases := []struct {
+		msg     string
+		args    []interface{}
 		matches bool
-		clock clock
+		clock   clock
 	}{
 		{
 			"match everything",

--- a/predicates/cron/cron_test.go
+++ b/predicates/cron/cron_test.go
@@ -1,0 +1,83 @@
+package cron
+
+import (
+	"testing"
+)
+
+func TestCreate(t *testing.T) {
+	testCases := []struct{
+		msg string
+		args []interface{}
+		isError bool
+	}{
+		{
+			"wrong number of arguments",
+			nil,
+			true,
+		},
+		{
+			"wrong number of arguments",
+			[]interface{}{"* * * * *", "unexpected argument"},
+			true,
+		},
+		{
+			"argument with mismatched type",
+			[]interface{}{1},
+			true,
+		},
+		{
+			"invalid cron-like expression",
+			[]interface{}{"a * * * *"},
+			true,
+		},
+		{
+			"valid arguments",
+			[]interface{}{"* * * * *"},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := New().Create(tc.args)
+
+		if err == nil && tc.isError {
+			t.Errorf("expected an error and got none for test case [%s]", tc.msg)
+		} else if err != nil && !tc.isError {
+			t.Errorf("expected no error and got %v for test case [%s]", err, tc.msg)
+		}
+	}
+}
+
+func TestPredicateName(t *testing.T) {
+	if name := New().Name(); name != "Cron" {
+		t.Errorf("predicate name does not match expecetation: %s", name)
+	}
+}
+
+func TestPredicateMatch(t *testing.T) {
+	testCases := []struct{
+		msg string
+		args []interface{}
+		matches bool
+		clock clock
+	}{
+		{
+			"match everything",
+			[]interface{}{"* * * * *"},
+			true,
+			getSystemTime,
+		},
+	}
+
+	for _, tc := range testCases {
+		p, err := New().Create(tc.args)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		if got := p.Match(nil); got != tc.matches {
+			t.Errorf("expected %t and got %t for the predicate on test case: %s", tc.matches, got, tc.msg)
+		}
+	}
+}

--- a/predicates/cron/cron_test.go
+++ b/predicates/cron/cron_test.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"testing"
+	"time"
 )
 
 func TestCreate(t *testing.T) {
@@ -65,7 +66,7 @@ func TestPredicateMatch(t *testing.T) {
 			"match everything",
 			[]interface{}{"* * * * *"},
 			true,
-			getSystemTime,
+			time.Now,
 		},
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/zalando/skipper/predicates/cron"
 	"io"
 	"net"
 	"net/http"
@@ -932,6 +933,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		interval.NewBetween(),
 		interval.NewBefore(),
 		interval.NewAfter(),
+		cron.New(),
 		cookie.New(),
 		query.New(),
 		traffic.New(),


### PR DESCRIPTION
Link to the small library that I created for this: https://github.com/sarslanhan/cronmask

Summary of the features removed because they don't match the use case:
- [Non-standard characters](https://en.wikipedia.org/wiki/Cron#Non-standard_characters)
- Year field - We could probably add this as well if you see the need.
- Command section
- Text representation of the fields "month" and "day of week"

Relates to https://github.com/zalando/skipper/issues/1082