### PR TITLE
add create flag for log output files

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -659,7 +659,7 @@ func getLogOutput(name string) (io.Writer, error) {
 		return os.Stderr, nil
 	}
 
-	return os.OpenFile(name, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	return os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
 }
 
 func initLog(o Options) error {


### PR DESCRIPTION
when a file defined by the -access-log and -application-log flags doesn't exist, skipper currently cannot create it. This PR aims to fix it.