### PR TITLE
differentiate error from backend and error during roundtrip

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -897,6 +897,7 @@ func (p *Proxy) makeBackendRequest(ctx *context) (*http.Response, *proxyError) {
 			return nil, &proxyError{err: cerr, code: 499}
 		}
 
+		p.log.Errorf("Unexpected error from Go stdlib net/http package during roundtrip: %v", err)
 		return nil, &proxyError{err: err}
 	}
 	p.tracing.setTag(ctx.proxySpan, HTTPStatusCodeTag, uint16(response.StatusCode))


### PR DESCRIPTION
log error from stdlib that we do not handle good enough and we want to differentiate error from backend and error during roundtrip

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>