### PR TITLE
add route id to filter context

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -71,6 +71,9 @@ type FilterContext interface {
 	// value in case it's a shunt, loopback. In case of dynamic backend is empty.
 	BackendUrl() string
 
+	// Gives filters access to the route id.
+	RouteId() string
+
 	// Returns the host that will be set for the outgoing proxy request as the
 	// 'Host' header.
 	OutgoingHost() string

--- a/filters/filtertest/filtertest.go
+++ b/filters/filtertest/filtertest.go
@@ -28,6 +28,7 @@ type Context struct {
 	FParams             map[string]string
 	FStateBag           map[string]interface{}
 	FBackendUrl         string
+	FRouteID            string
 	FOutgoingHost       string
 	FMetrics            filters.Metrics
 	FTracer             opentracing.Tracer
@@ -47,6 +48,7 @@ func (fc *Context) StateBag() map[string]interface{}    { return fc.FStateBag }
 func (fc *Context) OriginalRequest() *http.Request      { return nil }
 func (fc *Context) OriginalResponse() *http.Response    { return nil }
 func (fc *Context) BackendUrl() string                  { return fc.FBackendUrl }
+func (fc *Context) RouteId() string                     { return fc.FRouteID }
 func (fc *Context) OutgoingHost() string                { return fc.FOutgoingHost }
 func (fc *Context) SetOutgoingHost(h string)            { fc.FOutgoingHost = h }
 func (fc *Context) Metrics() filters.Metrics            { return fc.FMetrics }

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -193,6 +193,7 @@ func (c *context) Served() bool                        { return c.deprecatedServ
 func (c *context) PathParam(key string) string         { return c.pathParams[key] }
 func (c *context) StateBag() map[string]interface{}    { return c.stateBag }
 func (c *context) BackendUrl() string                  { return c.route.Backend }
+func (c *context) RouteId() string                     { return c.route.Id }
 func (c *context) OriginalRequest() *http.Request      { return c.originalRequest }
 func (c *context) OriginalResponse() *http.Response    { return c.originalResponse }
 func (c *context) OutgoingHost() string                { return c.outgoingHost }

--- a/script/script.go
+++ b/script/script.go
@@ -301,6 +301,8 @@ func getRequestValue(f filters.FilterContext) func(*lua.LState) int {
 			ret = lua.LString(f.OutgoingHost())
 		case "backend_url":
 			ret = lua.LString(f.BackendUrl())
+		case "route_id":
+			ret = lua.LString(f.RouteId())
 		case "remote_addr":
 			ret = lua.LString(f.Request().RemoteAddr)
 		case "content_length":

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -80,6 +80,8 @@ func (l *luaContext) StateBag() map[string]interface{} {
 
 func (l *luaContext) BackendUrl() string { return "" }
 
+func (l *luaContext) RouteId() string { return "" }
+
 func (l *luaContext) OutgoingHost() string { return "www.example.com" }
 
 func (l *luaContext) SetOutgoingHost(_ string) {}


### PR DESCRIPTION
i need a way inside plugin to understand to what route, request is related. In my situation i have plugin for route policy so i need a way to fetch specific rules from service to validate the request, so the easiest way i'm see here is get route id from filter context.

[feature request](https://github.com/zalando/skipper/issues/1128)