### PR TITLE
Reduce delay to when throttle type is bandwidth

### DIFF
--- a/cmd/skipper/breakerflags.go
+++ b/cmd/skipper/breakerflags.go
@@ -27,6 +27,10 @@ type breakerFlags []circuit.BreakerSettings
 var errInvalidBreakerConfig = errors.New("invalid breaker config")
 
 func (b *breakerFlags) String() string {
+	if b == nil {
+		return ""
+	}
+
 	s := make([]string, len(*b))
 	for i, bi := range *b {
 		s[i] = bi.String()

--- a/cmd/skipper/pluginflags.go
+++ b/cmd/skipper/pluginflags.go
@@ -21,6 +21,10 @@ func newPluginFlag() *pluginFlag {
 }
 
 func (f pluginFlag) String() string {
+	if f.listFlag == nil {
+		return ""
+	}
+
 	return f.listFlag.String()
 }
 

--- a/cmd/skipper/ratelimiterflags.go
+++ b/cmd/skipper/ratelimiterflags.go
@@ -23,6 +23,10 @@ type ratelimitFlags []ratelimit.Settings
 var errInvalidRatelimitConfig = errors.New("invalid ratelimit config")
 
 func (r *ratelimitFlags) String() string {
+	if r == nil {
+		return ""
+	}
+
 	s := make([]string, len(*r))
 	for i, ri := range *r {
 		s[i] = ri.String()


### PR DESCRIPTION
Found this when run `ineffassign` linter
```filters/diag/diag.go:324:6: ineffectual assignment to `delay` (ineffassign)
                                        delay -= time.Since(start)```