### PR TITLE
recognize api monitoring tag

### DIFF
--- a/filters/apiusagemonitoring/filter_clientmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_clientmetrics_test.go
@@ -44,7 +44,7 @@ func Test_Filter_ClientMetrics_ClientTrackingPatternDoesNotCompile(t *testing.T)
 		realmsTrackingPattern:        "service",
 		clientTrackingPattern:        s("(["),
 		header:                       headerUsersJoe,
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
 		expectedClientMetricPrefix:   "", // expecting no metrics
 	})
 }
@@ -57,8 +57,8 @@ func Test_Filter_ClientMetrics_NoMatchingPath_RealmIsKnown(t *testing.T) {
 		realmsTrackingPattern:        "services",
 		header:                       headerUsersJoe,
 		url:                          "https://www.example.com/non/configured/path/template",
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{unknown}.GET.{no-match}.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{unknown}.*.*.users.{all}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.*.*.users.{all}.",
 	})
 }
 
@@ -69,8 +69,8 @@ func Test_Filter_ClientMetrics_NoMatchingPath_RealmIsUnknown(t *testing.T) {
 		clientTrackingPattern:        s(".*"),
 		header:                       headerUsersJoe,
 		url:                          "https://www.example.com/non/configured/path/template",
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{unknown}.GET.{no-match}.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{unknown}.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.*.*.{unknown}.{unknown}.",
 	})
 }
 
@@ -80,8 +80,8 @@ func Test_Filter_ClientMetrics_MatchAll(t *testing.T) {
 		clientKeyName:                "client",
 		clientTrackingPattern:        s(".*"),
 		header:                       headerUsersJoe,
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.users.joe.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.users.joe.",
 		realmsTrackingPattern:        "users",
 	})
 }
@@ -99,8 +99,8 @@ func Test_Filter_ClientMetrics_MatchOneOfClientKeyName(t *testing.T) {
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.services.payments.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.services.payments.",
 		realmsTrackingPattern:        "services",
 	})
 }
@@ -120,8 +120,8 @@ func Test_Filter_ClientMetrics_MatchOneOfClientKeyName_UseFirstMatching(t *testi
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.services.but_I_should_come_first.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.services.but_I_should_come_first.",
 	})
 }
 
@@ -132,8 +132,8 @@ func Test_Filter_ClientMetrics_Realm1User1(t *testing.T) {
 		realmsTrackingPattern:        "users",
 		clientTrackingPattern:        clientTrackingPatternJustSomeUsers,
 		header:                       headerUsersJoe,
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.users.joe.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.users.joe.",
 	})
 }
 
@@ -151,8 +151,8 @@ func Test_Filter_ClientMetrics_Realm1User0(t *testing.T) {
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.users.{no-match}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.users.{no-match}.",
 	})
 }
 
@@ -170,8 +170,8 @@ func Test_Filter_ClientMetrics_Realm0User1(t *testing.T) {
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.nobodies.{all}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.nobodies.{all}.",
 	})
 }
 
@@ -189,8 +189,8 @@ func Test_Filter_ClientMetrics_Realm0User0(t *testing.T) {
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.nobodies.{all}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.nobodies.{all}.",
 	})
 }
 
@@ -208,8 +208,8 @@ func Test_Filter_ClientMetrics_AuthDoesNotHaveBearerPrefix(t *testing.T) {
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.{unknown}.{unknown}.",
 	})
 }
 
@@ -221,8 +221,8 @@ func Test_Filter_ClientMetrics_NoAuthHeader(t *testing.T) {
 		header:                http.Header{
 			/* no Authorization header */
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.{unknown}.{unknown}.",
 	})
 }
 
@@ -236,8 +236,8 @@ func Test_Filter_ClientMetrics_JWTIsNot3DotSeparatedString(t *testing.T) {
 				"Bearer " + "foo",
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.{unknown}.{unknown}.",
 	})
 }
 
@@ -251,8 +251,8 @@ func Test_Filter_ClientMetrics_JWTIsNotBase64Encoded(t *testing.T) {
 				"Bearer " + "there&is.no&way.this&is&base64",
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.{unknown}.{unknown}.",
 	})
 }
 
@@ -267,8 +267,8 @@ func Test_Filter_ClientMetrics_JWTBodyIsNoJSON(t *testing.T) {
 				"Bearer " + "header." + body + ".signature",
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.{unknown}.{unknown}.",
 	})
 }
 
@@ -285,8 +285,8 @@ func Test_Filter_ClientMetrics_JWTBodyHasNoRealm(t *testing.T) {
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.{unknown}.{unknown}.",
 	})
 }
 
@@ -304,8 +304,8 @@ func Test_Filter_ClientMetrics_JWTBodyHasNoClient_ShouldTrackRealm(t *testing.T)
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.users.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.users.{unknown}.",
 	})
 }
 
@@ -315,7 +315,7 @@ func Test_Filter_ClientMetrics_NoFlagRealmKeyName(t *testing.T) {
 		clientKeyName:                "client",
 		clientTrackingPattern:        clientTrackingPatternJustSomeUsers,
 		header:                       headerUsersJoe,
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
 		expectedClientMetricPrefix:   "", // expecting no metrics
 	})
 }
@@ -326,7 +326,7 @@ func Test_Filter_ClientMetrics_NoFlagClientKeyName(t *testing.T) {
 		clientKeyName:                "", // no client ID key name CLI flag
 		clientTrackingPattern:        clientTrackingPatternJustSomeUsers,
 		header:                       headerUsersJoe,
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
 		expectedClientMetricPrefix:   "", // expecting no metrics
 	})
 }
@@ -345,8 +345,8 @@ func Test_Filter_ClientMetrics_DefaultClientTrackingPattern_NoClientTrackingPatt
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.users.{all}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.users.{all}.",
 	})
 }
 
@@ -364,8 +364,8 @@ func Test_Filter_ClientMetrics_DefaultClientTrackingPattern_NoClientTrackingPatt
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_api.*.*.services.my_app.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.my_tag.my_api.*.*.services.my_app.",
 	})
 }
 
@@ -383,14 +383,14 @@ func Test_Filter_ClientMetrics_EmptyClientTrackingPatternInRouteFilterJSON(t *te
 				}),
 			},
 		},
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_api.GET.foo/orders.*.*.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET.foo/orders.*.*.",
 		expectedClientMetricPrefix:   "",
 	})
 }
 
 // may produce false-negatives
 func Test_Filter_ClientMetricsCache_ConcurrentAccess(t *testing.T) {
-	pathInfo := newPathInfo("application_id", "api_id", "orders", "orders",
+	pathInfo := newPathInfo("application_id", "tag", "api_id", "orders", "orders",
 		&clientTrackingInfo{RealmsTrackingMatcher: regexp.MustCompile("services"), ClientTrackingMatcher: regexp.MustCompile(`.*`)})
 
 	concurrencyLevel := 500

--- a/filters/apiusagemonitoring/filter_endpointmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_endpointmetrics_test.go
@@ -21,7 +21,7 @@ func Test_Filter_NoPathTemplate(t *testing.T) {
 		"https://www.example.org/a/b/c",
 		299,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.{unknown}.GET.{no-match}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*."
 			// no path matching: tracked as unknown
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
@@ -46,7 +46,7 @@ func Test_Filter_PathTemplateNoVariablePart(t *testing.T) {
 		"https://www.example.org/foo/orders",
 		400,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -70,7 +70,7 @@ func Test_Filter_PathTemplateWithVariablePart(t *testing.T) {
 		"https://www.example.org/foo/orders/1234",
 		204,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/{order-id}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders/{order-id}.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -94,11 +94,11 @@ func Test_Filter_PathTemplateWithMultipleVariablePart(t *testing.T) {
 		"https://www.example.org/foo/orders/1234/order-items/123",
 		301,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/{order-id}/order-items/{order-item-id}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders/{order-id}/order-items/{order-item-id}.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.NotContains(
 					t, counters,
-					"apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/{order-id}.http_count",
+					"apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders/{order-id}.http_count",
 					"Matched `foo/orders/{order-id}` instead of `foo/orders/{order-id}`/order-items/{order-item-id}")
 
 				assert.Equal(t,
@@ -123,7 +123,7 @@ func Test_Filter_PathTemplateFromSecondConfiguredApi(t *testing.T) {
 		"https://www.example.org/foo/customers/loremipsum",
 		502,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/customers/{customer-id}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/customers/{customer-id}.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -147,7 +147,7 @@ func Test_Filter_StatusCodes1xxAreMonitored(t *testing.T) {
 		"https://www.example.org/foo/orders",
 		100,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -171,7 +171,7 @@ func Test_Filter_StatusCodeOver599IsMonitored(t *testing.T) {
 		"https://www.example.org/foo/orders",
 		600,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -195,7 +195,7 @@ func Test_Filter_StatusCodeUnder100IsMonitoredWithoutHttpStatusCount(t *testing.
 		"https://www.example.org/foo/orders",
 		99,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -219,7 +219,7 @@ func Test_Filter_NonConfiguredPathTrackedUnderNoMatch(t *testing.T) {
 		"https://www.example.org/lapin/malin",
 		200,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.{unknown}.GET.{no-match}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -261,7 +261,7 @@ func Test_Filter_AllHttpMethodsAreSupported(t *testing.T) {
 				200,
 				func(pass int, m *metricstest.MockMetrics) {
 					pre := fmt.Sprintf(
-						"apiUsageMonitoring.custom.my_app.{unknown}.%s.{no-match}.*.*.",
+						"apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.%s.{no-match}.*.*.",
 						testCase.expectedMethodInMetric)
 					m.WithCounters(func(counters map[string]int64) {
 						assert.Equal(t,
@@ -288,7 +288,7 @@ func Test_Filter_PathTemplateMatchesInternalSlashes(t *testing.T) {
 		"https://www.example.org/foo/orders/1/2/3/order-items/123",
 		204,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.my_api.POST.foo/orders/{order-id}/order-items/{order-item-id}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.POST.foo/orders/{order-id}/order-items/{order-item-id}.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -308,6 +308,7 @@ func Test_Filter_PathTemplateMatchesInternalSlashesTooFollowingVarPart(t *testin
 	filterCreate := func() (filters.Filter, error) {
 		args := []interface{}{`{
 				"application_id": "my_app",
+                "tag": "my_tag",
 				"api_id": "my_api",
 				"path_templates": [
 					"foo/:a",
@@ -337,7 +338,7 @@ func Test_Filter_PathTemplateMatchesInternalSlashesTooFollowingVarPart(t *testin
 				fmt.Sprintf("https://www.example.org/%s", c.requestPath),
 				204,
 				func(pass int, m *metricstest.MockMetrics) {
-					pre := "apiUsageMonitoring.custom.my_app.my_api.GET." + c.expectedMatchedPathLabel + ".*.*."
+					pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET." + c.expectedMatchedPathLabel + ".*.*."
 					m.WithCounters(func(counters map[string]int64) {
 						assert.Equal(t,
 							map[string]int64{
@@ -359,6 +360,7 @@ func Test_Filter_PathTemplateMatchesPathFromRequestChain(t *testing.T) {
 	filterCreate := func() (filters.Filter, error) {
 		args := []interface{}{`{
 				"application_id": "my_app",
+                "tag": "my_tag",
 				"api_id": "my_api",
 				"path_templates": [
 					"foo/:a",
@@ -387,7 +389,7 @@ func Test_Filter_PathTemplateMatchesPathFromRequestChain(t *testing.T) {
 					ctx.FRequest.URL.Path = c.modifiedPath
 				},
 				func(pass int, m *metricstest.MockMetrics) {
-					pre := "apiUsageMonitoring.custom.my_app.my_api.GET." + c.expectedMatchedPathLabel + ".*.*."
+					pre := "apiUsageMonitoring.custom.my_app.my_tag.my_api.GET." + c.expectedMatchedPathLabel + ".*.*."
 					m.WithCounters(func(counters map[string]int64) {
 						assert.Equal(t,
 							map[string]int64{

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -2,11 +2,13 @@ package apiusagemonitoring
 
 import (
 	"encoding/json"
-	"github.com/sirupsen/logrus"
-	"github.com/zalando/skipper/filters"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/zalando/skipper/filters"
 )
 
 const (
@@ -14,6 +16,7 @@ const (
 
 	unknownPlaceholder = "{unknown}"
 	noMatchPlaceholder = "{no-match}"
+	noTagPlaceholder   = "{no-tag}"
 
 	regexUrlPathPart     = `.+`
 	regexOptionalSlashes = `\/*`
@@ -75,6 +78,7 @@ func NewApiUsageMonitoring(
 	unknownPath := newPathInfo(
 		unknownPlaceholder,
 		unknownPlaceholder,
+		unknownPlaceholder,
 		noMatchPlaceholder,
 		noMatchPlaceholder,
 		unknownPathClientTracking,
@@ -93,6 +97,7 @@ func NewApiUsageMonitoring(
 // apiConfig is the structure used to parse the parameters of the filter.
 type apiConfig struct {
 	ApplicationId         string   `json:"application_id"`
+	Tag                   string   `json:"tag"`
 	ApiId                 string   `json:"api_id"`
 	PathTemplates         []string `json:"path_templates"`
 	ClientTrackingPattern string   `json:"client_tracking_pattern"`
@@ -161,6 +166,7 @@ func (s *apiUsageMonitoringSpec) buildUnknownPathInfo(paths []*pathInfo) *pathIn
 	if applicationId != nil && *applicationId != "" {
 		return newPathInfo(
 			*applicationId,
+			s.unknownPath.Tag,
 			s.unknownPath.ApiId,
 			s.unknownPath.PathLabel,
 			s.unknownPath.PathTemplate,
@@ -209,7 +215,7 @@ func (s *apiUsageMonitoringSpec) buildPathInfoListFromConfiguration(apis []*apiC
 			normalisedPathTemplate, regExStr, pathLabel := generateRegExpStringForPathTemplate(template)
 
 			// Create new `pathInfo` with normalized PathTemplate
-			info := newPathInfo(applicationId, apiId, normalisedPathTemplate, pathLabel, clientTrackingInfo)
+			info := newPathInfo(applicationId, api.Tag, apiId, normalisedPathTemplate, pathLabel, clientTrackingInfo)
 
 			// Detect path template duplicates
 			if _, ok := existingPathTemplates[info.PathTemplate]; ok {

--- a/filters/apiusagemonitoring/testutils_test.go
+++ b/filters/apiusagemonitoring/testutils_test.go
@@ -4,18 +4,21 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/zalando/skipper/filters"
-	"github.com/zalando/skipper/filters/filtertest"
-	"github.com/zalando/skipper/metrics/metricstest"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/metrics/metricstest"
 )
 
 var defaultArgs = []interface{}{`{
 		"application_id": "my_app",
+		"tag": "my_tag",
 		"api_id": "my_api",
 	  	"path_templates": [
 			"foo/orders",
@@ -183,6 +186,7 @@ func testClientMetrics(t *testing.T, testCase clientMetricsTest) {
 			filterConf := map[string]interface{}{
 				"application_id": "my_app",
 				"api_id":         "my_api",
+				"tag":            "my_tag",
 				"path_templates": []string{
 					"foo/orders",
 				},


### PR DESCRIPTION
the API monitoring tag supports multiple instances of an application (such as staging and prod) in the same k8s cluster.