### PR TITLE
monitor route creation time

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zalando/skipper"
 	"github.com/zalando/skipper/dataclients/kubernetes"
 	"github.com/zalando/skipper/eskip"
@@ -121,6 +122,7 @@ const (
 	routeBackendErrorCountersUsage           = "enables counting backend errors for each route"
 	routeStreamErrorCountersUsage            = "enables counting streaming errors for each route"
 	routeBackendMetricsUsage                 = "enables reporting backend response time metrics for each route"
+	routeCreationMetricsUsage                = "enables reporting for route creation times"
 	metricsFlavourUsage                      = "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale' and 'prometheus', you can select both of them"
 	metricsUseExpDecaySampleUsage            = "use exponentially decaying sample in metrics"
 	histogramMetricBucketsUsage              = "use custom buckets for prometheus histograms, must be a comma-separated list of numbers"
@@ -295,6 +297,7 @@ var (
 	accessLogJSONEnabled                bool
 	accessLogStripQuery                 bool
 	suppressRouteUpdateLogs             bool
+	routeCreationMetrics                bool
 
 	// route sources:
 	etcdUrls                  string
@@ -448,6 +451,7 @@ func init() {
 	flag.BoolVar(&routeBackendErrorCounters, "route-backend-error-counters", false, routeBackendErrorCountersUsage)
 	flag.BoolVar(&routeStreamErrorCounters, "route-stream-error-counters", false, routeStreamErrorCountersUsage)
 	flag.BoolVar(&routeBackendMetrics, "route-backend-metrics", false, routeBackendMetricsUsage)
+	flag.BoolVar(&routeCreationMetrics, "route-creation-metrics", false, routeCreationMetricsUsage)
 	flag.BoolVar(&metricsUseExpDecaySample, "metrics-exp-decay-sample", false, metricsUseExpDecaySampleUsage)
 	flag.StringVar(&histogramMetricBuckets, "histogram-metric-buckets", "", histogramMetricBucketsUsage)
 	flag.BoolVar(&disableMetricsCompat, "disable-metrics-compat", false, disableMetricsCompatsUsage)
@@ -677,6 +681,7 @@ func main() {
 		EnableRouteBackendErrorsCounters:    routeBackendErrorCounters,
 		EnableRouteStreamingErrorsCounters:  routeStreamErrorCounters,
 		EnableRouteBackendMetrics:           routeBackendMetrics,
+		EnableRouteCreationMetrics:          routeCreationMetrics,
 		MetricsUseExpDecaySample:            metricsUseExpDecaySample,
 		HistogramMetricBuckets:              histogramBuckets,
 		DisableMetricsCompatibilityDefaults: disableMetricsCompat,

--- a/dataclients/kubernetes/definitions.go
+++ b/dataclients/kubernetes/definitions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -18,6 +19,8 @@ type resourceId struct {
 type metadata struct {
 	Namespace   string            `json:"namespace"`
 	Name        string            `json:"name"`
+	Created     time.Time         `json:"creationTimestamp"`
+	Uid         string            `json:"uid"`
 	Annotations map[string]string `json:"annotations"`
 }
 

--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/logging/loggingtest"
@@ -361,10 +362,14 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 		expect[i].Shunt = false
 	}
 
-	sort.Sort(sortRoutes(r))
+	diffRoutes(t, expect, r)
+}
+
+func diffRoutes(t *testing.T, expect []*eskip.Route, actual []*eskip.Route) {
+	sort.Sort(sortRoutes(actual))
 	sort.Sort(sortRoutes(expect))
 
-	diff := cmp.Diff(r, expect)
+	diff := cmp.Diff(actual, expect)
 	if diff != "" {
 		t.Error(diff)
 	}
@@ -473,13 +478,7 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 		expect[i].Shunt = false
 	}
 
-	sort.Sort(sortRoutes(r))
-	sort.Sort(sortRoutes(expect))
-
-	diff := cmp.Diff(r, expect)
-	if diff != "" {
-		t.Error(diff)
-	}
+	diffRoutes(t, expect, r)
 }
 
 func TestChangeRedirectCodeFromIngress(t *testing.T) {
@@ -587,13 +586,7 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 		expect[i].Shunt = false
 	}
 
-	sort.Sort(sortRoutes(r))
-	sort.Sort(sortRoutes(expect))
-
-	diff := cmp.Diff(r, expect)
-	if diff != "" {
-		t.Error(diff)
-	}
+	diffRoutes(t, expect, r)
 }
 
 func TestEnableRedirectWithCustomCode(t *testing.T) {
@@ -692,11 +685,5 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 		expect[i].Shunt = false
 	}
 
-	sort.Sort(sortRoutes(r))
-	sort.Sort(sortRoutes(expect))
-
-	diff := cmp.Diff(r, expect)
-	if diff != "" {
-		t.Error(diff)
-	}
+	diffRoutes(t, expect, r)
 }

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -57,6 +57,7 @@ const (
 	skipperRoutesAnnotationKey         = "zalando.org/skipper-routes"
 	skipperLoadbalancerAnnotationKey   = "zalando.org/skipper-loadbalancer"
 	pathModeAnnotationKey              = "zalando.org/skipper-ingress-path-mode"
+	ingressOriginName                  = "ingress"
 )
 
 // PathMode values are used to control the ingress path interpretation. The path mode can
@@ -179,6 +180,9 @@ type Options struct {
 	// DefaultFiltersDir enables default filters mechanism and sets the location of the default filters.
 	// The provided filters are then applied to all routes.
 	DefaultFiltersDir string
+
+	// If the OriginMarker should be added as a filter
+	OriginMarker bool
 }
 
 // Client is a Skipper DataClient implementation used to create routes based on Kubernetes Ingress settings.
@@ -203,6 +207,7 @@ type Client struct {
 	pathMode                    PathMode
 	quit                        chan struct{}
 	defaultFiltersDir           string
+	originMarker                bool
 }
 
 type ingressContext struct {
@@ -312,6 +317,7 @@ func New(o Options) (*Client, error) {
 		servicesURI:                 servicesClusterURI,
 		endpointsURI:                endpointsClusterURI,
 		defaultFiltersDir:           o.DefaultFiltersDir,
+		originMarker:                o.OriginMarker,
 	}
 	if o.KubernetesNamespace != "" {
 		result.setNamespace(o.KubernetesNamespace)
@@ -840,6 +846,14 @@ func (c *Client) ingressToRoutes(state *clusterState, defaultFilters map[resourc
 		}
 	}
 
+	if c.originMarker && len(routes) > 0 {
+		//it doesn't matter which route the marker is added to
+		r := routes[0]
+		for _, i := range state.ingresses {
+			r.Filters = append(r.Filters, builtin.NewOriginMarker(ingressOriginName, i.Metadata.Uid, i.Metadata.Created))
+		}
+	}
+
 	return routes, nil
 }
 
@@ -1068,6 +1082,7 @@ func (c *Client) addCatchAllRoutes(host string, r *eskip.Route, redirect *redire
 	if redirect.disableHost[host] {
 		routes = append(routes, createIngressDisableHTTPSRedirect(catchAll))
 	}
+
 	return routes
 }
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1542,3 +1542,21 @@ Example: If a trace consists of baggage item named `foo` with a value `bar`. Add
 ```
 baggageItemToTag("foo", "baz")
 ```
+
+## originMarker
+
+This filter is used to measure the time it took to create a route. Other than that, it's a no-op.
+You can include the same origin marker when you re-create the route. As long as the `origin` and `id` are the same, the route creation time will not be measured again. 
+If there are multiple origin markers with the same origin, the earliest timestamp will be used.
+
+Parameters:
+
+* the name of the origin
+* the ID of the object that is the logical source for the route
+* the creation timestamp (rfc3339) 
+
+Example:
+
+```
+originMarker("apiUsageMonitoring", "deployment1", "2019-08-30T09:55:51Z")
+```

--- a/filters/apiusagemonitoring/filter_clientmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_clientmetrics_test.go
@@ -57,8 +57,8 @@ func Test_Filter_ClientMetrics_NoMatchingPath_RealmIsKnown(t *testing.T) {
 		realmsTrackingPattern:        "services",
 		header:                       headerUsersJoe,
 		url:                          "https://www.example.com/non/configured/path/template",
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.*.*.users.{all}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.*.*.users.{all}.",
 	})
 }
 
@@ -69,8 +69,8 @@ func Test_Filter_ClientMetrics_NoMatchingPath_RealmIsUnknown(t *testing.T) {
 		clientTrackingPattern:        s(".*"),
 		header:                       headerUsersJoe,
 		url:                          "https://www.example.com/non/configured/path/template",
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.*.*.{unknown}.{unknown}.",
 	})
 }
 

--- a/filters/apiusagemonitoring/filter_endpointmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_endpointmetrics_test.go
@@ -21,7 +21,7 @@ func Test_Filter_NoPathTemplate(t *testing.T) {
 		"https://www.example.org/a/b/c",
 		299,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*."
 			// no path matching: tracked as unknown
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
@@ -219,7 +219,7 @@ func Test_Filter_NonConfiguredPathTrackedUnderNoMatch(t *testing.T) {
 		"https://www.example.org/lapin/malin",
 		200,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.GET.{no-match}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -261,7 +261,7 @@ func Test_Filter_AllHttpMethodsAreSupported(t *testing.T) {
 				200,
 				func(pass int, m *metricstest.MockMetrics) {
 					pre := fmt.Sprintf(
-						"apiUsageMonitoring.custom.my_app.{unknown}.{unknown}.%s.{no-match}.*.*.",
+						"apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.%s.{no-match}.*.*.",
 						testCase.expectedMethodInMetric)
 					m.WithCounters(func(counters map[string]int64) {
 						assert.Equal(t,

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -77,7 +77,7 @@ func NewApiUsageMonitoring(
 	}
 	unknownPath := newPathInfo(
 		unknownPlaceholder,
-		unknownPlaceholder,
+		noTagPlaceholder,
 		unknownPlaceholder,
 		noMatchPlaceholder,
 		noMatchPlaceholder,

--- a/filters/apiusagemonitoring/spec_test.go
+++ b/filters/apiusagemonitoring/spec_test.go
@@ -47,7 +47,7 @@ func unknownPath(applicationId string) pathMatcher {
 	return pathMatcher{
 		PathTemplate:  "{no-match}",
 		ApplicationId: applicationId,
-		Tag:           "{unknown}",
+		Tag:           "{no-tag}",
 		ApiId:         "{unknown}",
 		Matcher:       nil,
 	}

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -101,6 +101,7 @@ func MakeRegistry() filters.Registry {
 		NewSetDynamicBackendHost(),
 		NewSetDynamicBackendScheme(),
 		NewSetDynamicBackendUrl(),
+		NewOriginMarkerSpec(),
 		diag.NewRandom(),
 		diag.NewLatency(),
 		diag.NewBandwidth(),

--- a/filters/builtin/creationmetrics.go
+++ b/filters/builtin/creationmetrics.go
@@ -20,6 +20,7 @@ const (
 type RouteCreationMetrics struct {
 	metrics      filters.Metrics
 	originIdAges map[string]map[string]int
+	initialized  bool
 }
 
 func NewRouteCreationMetrics(metrics filters.Metrics) *RouteCreationMetrics {
@@ -53,6 +54,12 @@ func (m *RouteCreationMetrics) startTimes(route *routing.Route) map[string]time.
 		if !exists || t.Before(old) {
 			startTimes[origin] = t
 		}
+	}
+
+	if !m.initialized {
+		//must be done after filling the cache
+		m.initialized = true
+		return nil
 	}
 
 	return startTimes

--- a/filters/builtin/creationmetrics.go
+++ b/filters/builtin/creationmetrics.go
@@ -1,0 +1,104 @@
+package builtin
+
+import (
+	"time"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/routing"
+)
+
+const (
+	maxAge        = 2
+	metricsPrefix = "routeCreationTime."
+)
+
+// RouteCreationMetrics reports metrics about the time it took to create metrics.
+// It looks for filters of type OriginMarker to determine when the source object (e.g. ingress) of the route
+// was created.
+// If an OriginMarker with the same type and id is seen again, the creation time is not reported again, because
+// a route with the same configuration already existed before.
+type RouteCreationMetrics struct {
+	metrics      filters.Metrics
+	originIdAges map[string]map[string]int
+}
+
+func NewRouteCreationMetrics(metrics filters.Metrics) *RouteCreationMetrics {
+	return &RouteCreationMetrics{metrics: metrics, originIdAges: map[string]map[string]int{}}
+}
+
+// Do implements routing.PostProcessor and records the filter creation time.
+func (m *RouteCreationMetrics) Do(routes []*routing.Route) []*routing.Route {
+	for _, r := range routes {
+		for origin, start := range m.startTimes(r) {
+			m.metrics.MeasureSince(metricsPrefix+origin, start)
+		}
+	}
+
+	m.pruneCache()
+
+	return routes
+}
+
+func (m *RouteCreationMetrics) startTimes(route *routing.Route) map[string]time.Time {
+	startTimes := map[string]time.Time{}
+
+	for _, f := range route.Filters {
+		origin, t := m.originStartTime(f.Filter)
+
+		if t.IsZero() {
+			continue
+		}
+
+		old, exists := startTimes[origin]
+		if !exists || t.Before(old) {
+			startTimes[origin] = t
+		}
+	}
+
+	return startTimes
+}
+
+func (m *RouteCreationMetrics) originStartTime(f filters.Filter) (string, time.Time) {
+	marker, ok := f.(OriginMarker)
+
+	if !ok {
+		return "", time.Time{}
+	}
+
+	origin := marker.Origin
+	id := marker.Id
+	created := marker.Created
+	if origin == "" || id == "" || created.IsZero() {
+		return "", time.Time{}
+	}
+
+	originCache := m.originIdAges[origin]
+	if originCache == nil {
+		originCache = map[string]int{}
+		m.originIdAges[origin] = originCache
+	}
+
+	_, exists := originCache[id]
+	originCache[id] = 0
+	if !exists {
+		return origin, created
+	}
+	return "", time.Time{}
+}
+
+func (m *RouteCreationMetrics) pruneCache() {
+	for origin, idAges := range m.originIdAges {
+		for id, age := range idAges {
+			age++
+			if age > maxAge {
+				delete(idAges, id)
+			} else {
+				idAges[id] = age
+			}
+		}
+
+		if len(idAges) == 0 {
+			delete(m.originIdAges, origin)
+		}
+	}
+}

--- a/filters/builtin/creationmetrics_test.go
+++ b/filters/builtin/creationmetrics_test.go
@@ -1,0 +1,163 @@
+package builtin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/metrics/metricstest"
+	"github.com/zalando/skipper/routing"
+)
+
+var time0 = time.Now().Truncate(time.Second).UTC()
+var time1 = time.Now().Add(1)
+
+func TestRouteCreationMetrics_Do(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		route           routing.Route
+		expectedMetrics []string
+	}{
+		{
+			name:  "no start time provided",
+			route: routing.Route{},
+		},
+		{
+			name:            "start time provided",
+			route:           routing.Route{Filters: []*routing.RouteFilter{{Filter: OriginMarker{Origin: "origin", Id: "config1", Created: time0}}}},
+			expectedMetrics: []string{"routeCreationTime.origin"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := metricstest.MockMetrics{}
+			NewRouteCreationMetrics(&metrics).Do([]*routing.Route{&tt.route})
+
+			metrics.WithMeasures(func(measures map[string][]time.Duration) {
+				assert.Len(t, measures, len(tt.expectedMetrics))
+
+				for _, e := range tt.expectedMetrics {
+					assert.Containsf(t, measures, e, "measure metrics do not contain %q", e)
+				}
+			})
+		})
+	}
+}
+
+func TestRouteCreationMetrics_startTimes(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		route    routing.Route
+		expected map[string]time.Time
+	}{
+		{
+			name:     "no start time provided",
+			route:    routing.Route{},
+			expected: map[string]time.Time{},
+		},
+		{
+			name: "start time from origin marker",
+			route: routing.Route{Filters: []*routing.RouteFilter{
+				{Filter: OriginMarker{Origin: "origin", Id: "config0", Created: time0}},
+				{Filter: OriginMarker{Origin: "origin", Id: "config1", Created: time1}},
+			}},
+			expected: map[string]time.Time{"origin": time0},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := metricstest.MockMetrics{}
+			s := NewRouteCreationMetrics(&metrics).startTimes(&tt.route)
+
+			assert.Equal(t, tt.expected, s)
+		})
+	}
+}
+
+func TestRouteCreationMetrics_pruneCache(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		configIds         map[string]map[string]int
+		expectedConfigIds map[string]map[string]int
+	}{
+		{
+			name:              "age increased",
+			configIds:         map[string]map[string]int{"origin": {"config0": 0, "config1": 1}},
+			expectedConfigIds: map[string]map[string]int{"origin": {"config0": 1, "config1": 2}},
+		},
+		{
+			name:              "entry pruned",
+			configIds:         map[string]map[string]int{"origin": {"config0": 0, "config1": maxAge}},
+			expectedConfigIds: map[string]map[string]int{"origin": {"config0": 1}},
+		},
+		{
+			name:              "last entry pruned",
+			configIds:         map[string]map[string]int{"origin": {"config1": maxAge}},
+			expectedConfigIds: map[string]map[string]int{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &RouteCreationMetrics{
+				originIdAges: tt.configIds,
+			}
+			m.pruneCache()
+			assert.Equal(t, tt.expectedConfigIds, m.originIdAges)
+		})
+	}
+}
+
+func TestRouteCreationMetrics_filterStartTime(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		configIds       map[string]map[string]int
+		filter          filters.Filter
+		expectedOrigin  string
+		expectedCreated time.Time
+	}{
+		{
+			name:            "not config info",
+			configIds:       map[string]map[string]int{},
+			filter:          &filtertest.Filter{},
+			expectedOrigin:  "",
+			expectedCreated: time.Time{},
+		},
+		{
+			name:            "config info with no time",
+			configIds:       map[string]map[string]int{},
+			filter:          OriginMarker{},
+			expectedOrigin:  "",
+			expectedCreated: time.Time{},
+		},
+		{
+			name:            "no config exists",
+			configIds:       map[string]map[string]int{},
+			filter:          OriginMarker{Origin: "origin", Id: "config1", Created: time0},
+			expectedOrigin:  "origin",
+			expectedCreated: time0,
+		},
+		{
+			name:            "same config",
+			configIds:       map[string]map[string]int{"origin": {"config0": 0}},
+			filter:          OriginMarker{Origin: "origin", Id: "config0", Created: time0},
+			expectedOrigin:  "",
+			expectedCreated: time.Time{},
+		},
+		{
+			name:            "new config",
+			configIds:       map[string]map[string]int{"origin": {"config0": 0}},
+			filter:          OriginMarker{Origin: "origin", Id: "config1", Created: time1},
+			expectedOrigin:  "origin",
+			expectedCreated: time1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &RouteCreationMetrics{
+				originIdAges: tt.configIds,
+			}
+			o, c := m.originStartTime(tt.filter)
+			assert.Equal(t, tt.expectedOrigin, o)
+			assert.Equal(t, tt.expectedCreated, c)
+		})
+	}
+}

--- a/filters/builtin/creationmetrics_test.go
+++ b/filters/builtin/creationmetrics_test.go
@@ -34,7 +34,9 @@ func TestRouteCreationMetrics_Do(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := metricstest.MockMetrics{}
-			NewRouteCreationMetrics(&metrics).Do([]*routing.Route{&tt.route})
+			creationMetrics := NewRouteCreationMetrics(&metrics)
+			creationMetrics.initialized = true
+			creationMetrics.Do([]*routing.Route{&tt.route})
 
 			metrics.WithMeasures(func(measures map[string][]time.Duration) {
 				assert.Len(t, measures, len(tt.expectedMetrics))

--- a/filters/builtin/originmarker.go
+++ b/filters/builtin/originmarker.go
@@ -1,0 +1,78 @@
+package builtin
+
+import (
+	"time"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters"
+)
+
+const (
+	OriginMarkerName = "originMarker"
+)
+
+type originMarkerSpec struct{}
+
+// OriginMarker carries information about the origin of a route
+type OriginMarker struct {
+	// the type of origin, e.g. ingress
+	Origin string `json:"origin"`
+	// the unique ID (within the origin) of the source object (e.g. ingress) that created the route
+	Id string `json:"id"`
+	// when the source object was created
+	Created time.Time `json:"created"`
+}
+
+// NewOriginMarkerSpec creates a filter specification whose instances
+// mark the origin an eskip.Route
+func NewOriginMarkerSpec() filters.Spec {
+	return &originMarkerSpec{}
+}
+
+func NewOriginMarker(origin string, id string, created time.Time) *eskip.Filter {
+	return &eskip.Filter{
+		Name: OriginMarkerName,
+		Args: []interface{}{origin, id, created},
+	}
+}
+
+func (s *originMarkerSpec) Name() string { return OriginMarkerName }
+
+func (s *originMarkerSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 3 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	f := &OriginMarker{}
+
+	if value, ok := args[0].(string); ok {
+		f.Origin = value
+	} else {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	if value, ok := args[1].(string); ok {
+		f.Id = value
+	} else {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	switch created := args[2].(type) {
+	case time.Time:
+		f.Created = created
+	case string:
+		if value, err := time.Parse(time.RFC3339, created); err == nil {
+			f.Created = value
+		} else {
+			return nil, filters.ErrInvalidFilterParameters
+		}
+	default:
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	return f, nil
+}
+
+func (m OriginMarker) Request(filters.FilterContext) {}
+
+func (m OriginMarker) Response(filters.FilterContext) {}

--- a/filters/builtin/originmarker_test.go
+++ b/filters/builtin/originmarker_test.go
@@ -1,0 +1,51 @@
+package builtin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_originMarkerSpec_CreateFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []interface{}
+		wantErr bool
+		want    *OriginMarker
+	}{
+		{
+			name:    "no args",
+			wantErr: true,
+		},
+		{
+			name:    "time not formatted correctly",
+			args:    []interface{}{"origin", "id", "wrong time"},
+			wantErr: true,
+		},
+		{
+			name:    "parse time",
+			args:    []interface{}{"origin", "id", time0.Format(time.RFC3339)},
+			wantErr: false,
+			want:    &OriginMarker{"origin", "id", time0},
+		},
+		{
+			name:    "pass time",
+			args:    []interface{}{"origin", "id", time0},
+			wantErr: false,
+			want:    &OriginMarker{"origin", "id", time0},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewOriginMarkerSpec().CreateFilter(tt.args)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, f)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a metric that measures the route creation time.

The end time of the measurement is the successful creation of the route.
The start time of the measurement is taken from..
1. the creation time of ingresses for the kube DataClient - this creates the `routeCreationTime.default` metric
2. a provided creation time of apiUsageMonitoring filter - this creates the `routeCreationTime.apiUsageMonitoring` metric
3. other DataClients are not supported yet 