### PR TITLE
feat: Add baggageItemToTag filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1503,7 +1503,7 @@ It is also possible to enable this behavior centrally for a Skipper instance wit
 the -rfc-patch-path flag. See
 [URI standards interpretation](../../operation/operation/#uri-standards-interpretation).
 
-## Bearerinjector
+## bearerinjector
 
 This filter injects `Bearer` tokens into `Authorization` headers read
 from file providing the token as content. This is only for use cases
@@ -1528,3 +1528,17 @@ directory, but it won't walk subtrees. For the example case, there
 have to be filenames `write-token` and `read-token` within the
 specified credential paths `/tmp/secrets/`, resulting in
 `/tmp/secrets/write-token` and `/tmp/secrets/read-token`.
+
+## baggageItemToTag
+
+This filter adds an opentracing tag for a given baggage item in the trace. 
+
+Syntax:
+```
+baggageItemToTag("<baggage_item_name>", "<tag_name>")
+```
+
+Example: If a trace consists of baggage item named `foo` with a value `bar`. Adding below filter will add a tag named `baz` with value `bar` 
+```
+baggageItemToTag("foo", "baz")
+```

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -128,6 +128,7 @@ func MakeRegistry() filters.Registry {
 		cors.NewOrigin(),
 		logfilter.NewUnverifiedAuditLog(),
 		tracing.NewSpanName(),
+		tracing.NewBaggageToTagFilter(),
 		accesslog.NewAccessLogDisabled(),
 		accesslog.NewDisableAccessLog(),
 		accesslog.NewEnableAccessLog(),

--- a/filters/tracing/baggagetotag.go
+++ b/filters/tracing/baggagetotag.go
@@ -1,0 +1,67 @@
+package tracing
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/zalando/skipper/filters"
+)
+
+const (
+	BaggageToTagFilterName = "baggageItemToTag"
+)
+
+type baggageToTagSpec struct{}
+
+type baggageToTagFilter struct {
+	baggageItemName string
+	tagName         string
+}
+
+func (baggageToTagSpec) Name() string {
+	return BaggageToTagFilterName
+}
+
+func (baggageToTagSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) < 1 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	baggageItemName, ok := args[0].(string)
+	if !ok || baggageItemName == "" {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	tagName := baggageItemName
+	if len(args) > 1 {
+		tagNameArg, ok := args[1].(string)
+		if !ok || tagNameArg == "" {
+			return nil, filters.ErrInvalidFilterParameters
+		}
+		tagName = tagNameArg
+	}
+
+	return baggageToTagFilter{
+		baggageItemName,
+		tagName,
+	}, nil
+}
+
+func NewBaggageToTagFilter() filters.Spec {
+	return baggageToTagSpec{}
+}
+
+func (f baggageToTagFilter) Request(ctx filters.FilterContext) {
+
+	span := opentracing.SpanFromContext(ctx.Request().Context())
+	if span == nil {
+		return
+	}
+	baggageItem := span.BaggageItem(f.baggageItemName)
+
+	if baggageItem == "" {
+		return
+	}
+
+	span.SetTag(f.tagName, baggageItem)
+}
+
+func (baggageToTagFilter) Response(ctx filters.FilterContext) {}

--- a/filters/tracing/baggagetotag_test.go
+++ b/filters/tracing/baggagetotag_test.go
@@ -1,0 +1,119 @@
+package tracing
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/tracing/tracingtest"
+	"net/http"
+	"testing"
+)
+
+func TestBaggageItemNameToTag(t *testing.T) {
+	for _, ti := range []struct {
+		msg              string
+		baggageItemName  string
+		baggageItemValue string
+		tagName          string
+	}{{
+		"should add span tag for baggage item",
+		"baggage_name",
+		"push",
+		"tag_name",
+	}} {
+		t.Run(ti.msg, func(t *testing.T) {
+			req := &http.Request{Header: http.Header{}}
+
+			span := tracingtest.NewSpan("start_span")
+			span.SetBaggageItem(ti.baggageItemName, ti.baggageItemValue)
+			req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
+			ctx := &filtertest.Context{FRequest: req}
+
+			f, err := NewBaggageToTagFilter().CreateFilter([]interface{}{ti.baggageItemName, ti.tagName})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			f.Request(ctx)
+
+			if tagValue := span.Tags[ti.tagName]; ti.baggageItemValue != tagValue {
+				t.Error("couldn't set span tag from baggage item")
+			}
+		})
+	}
+}
+
+func TestCreateFilter(t *testing.T) {
+	for _, ti := range []struct {
+		msg             string
+		baggageItemName string
+		tagName         string
+		err             error
+	}{{
+		"should create filter with baggage item and span tag names",
+		"baggage_name",
+		"tag_name",
+		nil,
+	}, {
+		"should not have empty baggage name or tag name",
+		"",
+		"",
+		filters.ErrInvalidFilterParameters,
+	}} {
+		t.Run(ti.msg, func(t *testing.T) {
+			var err error
+			if ti.tagName == "" {
+				_, err = NewBaggageToTagFilter().CreateFilter([]interface{}{
+					ti.baggageItemName,
+				})
+			} else {
+				_, err = NewBaggageToTagFilter().CreateFilter([]interface{}{
+					ti.baggageItemName,
+					ti.tagName,
+				})
+			}
+
+			if err != ti.err {
+				t.Error(err)
+				return
+			}
+
+		})
+	}
+}
+
+func TestFallbackToBaggageNameForTag(t *testing.T) {
+	for _, ti := range []struct {
+		msg              string
+		baggageItemName  string
+		baggageItemValue string
+		err              error
+	}{{
+		"should create filter and use baggage name when tag name is not provided",
+		"baggage_name",
+		"baggageValue",
+		nil,
+	}} {
+		t.Run(ti.msg, func(t *testing.T) {
+			req := &http.Request{Header: http.Header{}}
+
+			span := tracingtest.NewSpan("start_span")
+			span.SetBaggageItem(ti.baggageItemName, ti.baggageItemValue)
+			req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
+			ctx := &filtertest.Context{FRequest: req}
+
+			f, err := NewBaggageToTagFilter().CreateFilter([]interface{}{ti.baggageItemName})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			f.Request(ctx)
+
+			if tagValue := span.Tags[ti.baggageItemName]; ti.baggageItemValue != tagValue {
+				t.Error("couldn't set span tag from baggage item")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add baggageItemToTag filter

This filter adds an opentracing tag for a given baggage item in the trace. 

Syntax:
```
baggageItemToTag("<baggage_item_name>", "<tag_name>")
```

Example: If a trace consists of baggage item named `foo` with a value `bar`. Adding below filter will add a tag named `baz` with value `bar` 
```
baggageItemToTag("foo", "baz")
```