### PR TITLE
use fixed version of staticcheck for Go1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ clean:
 deps:
 	go env
 	./etcd/install.sh $(TEST_ETCD_VERSION)
-	@curl -o /tmp/staticcheck_linux_amd64.tar.gz -LO https://github.com/dominikh/go-tools/releases/download/2019.2.2/staticcheck_linux_amd64.tar.gz
-	@sha256sum /tmp/staticcheck_linux_amd64.tar.gz | grep -q fd998bed64033e585ffe5cb3915d0822f3352e96c7281df56da92d7132225e51
+	@curl -o /tmp/staticcheck_linux_amd64.tar.gz -LO https://github.com/dominikh/go-tools/releases/download/2019.2.3/staticcheck_linux_amd64.tar.gz
+	@sha256sum /tmp/staticcheck_linux_amd64.tar.gz | grep -q 93f7780f8710380037cecee8a49178de01c6153f19587c082abec4cc8637016c
 	@tar -C /tmp -xzf /tmp/staticcheck_linux_amd64.tar.gz
 	@mkdir -p $(GOPATH)/bin
 	@mv /tmp/staticcheck/staticcheck $(GOPATH)/bin/
@@ -141,7 +141,7 @@ vet: $(SOURCES)
 # -ST1021 too many wrong comments on exported functions to fix right away
 # -ST1022 too many wrong comments on exported functions to fix right away
 staticcheck: $(SOURCES)
-	#GO111MODULE=$(GO111) staticcheck -checks "all,-ST1000,-ST1003,-ST1012,-ST1020,-ST1021,-ST1022" $(PACKAGES)
+	GO111MODULE=$(GO111) staticcheck -checks "all,-ST1000,-ST1003,-ST1012,-ST1020,-ST1021,-ST1022" $(PACKAGES)
 
 # TODO(sszuecs) review disabling these checks, f.e.:
 # G101 find by variable name match "oauth" are not hardcoded credentials


### PR DESCRIPTION
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>