### PR TITLE
Use Errorf when port defition is wrong

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -681,7 +681,7 @@ func (c *Client) convertPathRule(
 	targetPort, err := svc.GetTargetPort(svcPort)
 	if err != nil {
 		// fallback to service, but service definition is wrong or no pods
-		log.Debugf("Failed to find target port for service %s, fallback to service: %v", svcName, err)
+		log.Errorf("Failed to find target port for service %s, fallback to service: %v", svcName, err)
 		err = nil
 	} else if svc.Spec.Type == "ExternalName" {
 		scheme := "https"


### PR DESCRIPTION
I spend 2 hours yesterday fighting with Skipper because it didn't log this error:
```
Failed to find target port for service xx, fallback to service: GetTargetPort: target port not found [xx 80 http] given http
```

Only after enabling debug mode I discovered it.