### PR TITLE
Note that inlineContent filter is special

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -254,6 +254,9 @@ Example:
 * -> inlineContent("<h1>Hello</h1>") -> <shunt>
 ```
 
+!!! note
+    `inlineContent` filter is special and must be the last in the filter chain.
+
 ## flowId
 
 Sets an X-Flow-Id header, if it's not already in the request.


### PR DESCRIPTION
Note in the docs that `inlineContent` filter is special and must be last in the chain.