### PR TITLE
keep the trailing slash in the path for regexp matching

### DIFF
--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -11,8 +11,9 @@ import (
 )
 
 type leafRequestMatcher struct {
-	r    *http.Request
-	path string
+	r         *http.Request
+	path      string
+	exactPath string
 }
 
 func (m *leafRequestMatcher) Match(value interface{}) (bool, interface{}) {
@@ -21,7 +22,7 @@ func (m *leafRequestMatcher) Match(value interface{}) (bool, interface{}) {
 		return false, nil
 	}
 
-	l := matchLeaves(v.leaves, m.r, m.path)
+	l := matchLeaves(v.leaves, m.r, m.path, m.exactPath)
 
 	return l != nil, l
 }
@@ -190,13 +191,15 @@ func trimTrailingSlash(path string) string {
 	return path
 }
 
-func cleanPath(path string, o MatchingOptions) string {
-	path = httppath.Clean(path)
+func cleanPath(path string, o MatchingOptions) (clean, cleanExact string) {
+	cleanExact = httppath.Clean(path)
 	if o.ignoreTrailingSlash() {
-		path = trimTrailingSlash(path)
+		clean = trimTrailingSlash(cleanExact)
+	} else {
+		clean = cleanExact
 	}
 
-	return path
+	return
 }
 
 // add all required tree entries for a subtree with patching the path and
@@ -323,7 +326,7 @@ func newMatcher(rs []*Route, o MatchingOptions) (*matcher, []*definitionError) {
 		}
 
 		if r.pathSubtree != "" {
-			path := cleanPath(r.pathSubtree, o|IgnoreTrailingSlash)
+			path, _ := cleanPath(r.pathSubtree, o|IgnoreTrailingSlash)
 			addLeafToPath(subtreeMatchers, path, l)
 			continue
 		}
@@ -333,7 +336,7 @@ func newMatcher(rs []*Route, o MatchingOptions) (*matcher, []*definitionError) {
 			continue
 		}
 
-		path := cleanPath(r.path, o)
+		path, _ := cleanPath(r.path, o)
 		addLeafToPath(pathMatchers, path, l)
 	}
 
@@ -425,7 +428,7 @@ func matchPredicates(cps []Predicate, req *http.Request) bool {
 }
 
 // matches a request to the conditions in a leaf matcher
-func matchLeaf(l *leafMatcher, req *http.Request, path string) bool {
+func matchLeaf(l *leafMatcher, req *http.Request, path, exactPath string) bool {
 	if l.exactPath != "" && l.exactPath != path {
 		return false
 	}
@@ -438,7 +441,7 @@ func matchLeaf(l *leafMatcher, req *http.Request, path string) bool {
 		return false
 	}
 
-	if !matchRegexps(l.pathRxs, path) {
+	if !matchRegexps(l.pathRxs, exactPath) {
 		return false
 	}
 
@@ -454,9 +457,9 @@ func matchLeaf(l *leafMatcher, req *http.Request, path string) bool {
 }
 
 // matches a request to a set of leaf matchers
-func matchLeaves(leaves leafMatchers, req *http.Request, path string) *leafMatcher {
+func matchLeaves(leaves leafMatchers, req *http.Request, path, exactPath string) *leafMatcher {
 	for _, l := range leaves {
-		if matchLeaf(l, req, path) {
+		if matchLeaf(l, req, path, exactPath) {
 			return l
 		}
 	}
@@ -470,8 +473,8 @@ func matchLeaves(leaves leafMatchers, req *http.Request, path string) *leafMatch
 func (m *matcher) match(r *http.Request) (*Route, map[string]string) {
 	// normalize path before matching
 	// in case ignoring trailing slashes, match without the trailing slash
-	path := cleanPath(r.URL.Path, m.matchingOptions)
-	lrm := &leafRequestMatcher{r, path}
+	path, exact := cleanPath(r.URL.Path, m.matchingOptions)
+	lrm := &leafRequestMatcher{r: r, path: path, exactPath: exact}
 
 	// first match fixed and wildcard paths
 	params, l := matchPathTree(m.paths, path, lrm)
@@ -481,7 +484,7 @@ func (m *matcher) match(r *http.Request) (*Route, map[string]string) {
 	}
 
 	// if no path match, match root leaves for other conditions
-	l = matchLeaves(m.rootLeaves, r, path)
+	l = matchLeaves(m.rootLeaves, r, path, exact)
 	if l != nil {
 		return l.route, nil
 	}

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -326,7 +326,6 @@ func newMatcher(rs []*Route, o MatchingOptions) (*matcher, []*definitionError) {
 			continue
 		}
 
-
 		path := httppath.Clean(r.path)
 		if o.ignoreTrailingSlash() {
 			path = trimTrailingSlash(path)


### PR DESCRIPTION
Fixing: #1210 

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>