### PR TITLE
set the go.mod go version to the automatically applied one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,4 +46,4 @@ require (
 	layeh.com/gopher-json v0.0.0-20190114024228-97fed8db8427
 )
 
-go 1.13.1
+go 1.13


### PR DESCRIPTION
revert the go version in go.mod, as it is set automatically by go.

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>