### PR TITLE
set origin markers only when there were any changes to the routes

### DIFF
--- a/dataclients/kubernetes/update_test.go
+++ b/dataclients/kubernetes/update_test.go
@@ -1,6 +1,10 @@
 package kubernetes
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/zalando/skipper/eskip"
+)
 
 func TestUpdateOnlyChangedRoutes(t *testing.T) {
 	api := newTestAPIWithEndpoints(t, &serviceList{}, &ingressList{}, &endpointList{})
@@ -35,4 +39,110 @@ func TestUpdateOnlyChangedRoutes(t *testing.T) {
 			t.Fatal("unexpected udpate received")
 		}
 	}
+}
+
+func TestOriginMarkerNotStored(t *testing.T) {
+	expectOriginMarker := func(r []*eskip.Route) {
+		for _, ri := range r {
+			for _, f := range ri.Filters {
+				if f.Name == "originMarker" {
+					return
+				}
+			}
+		}
+
+		t.Fatal("origin marker not found")
+	}
+
+	expectNoOriginMarker := func(r map[string]*eskip.Route) {
+		for _, ri := range r {
+			for _, f := range ri.Filters {
+				if f.Name == "originMarker" {
+					t.Fatal("unexpected origin marker found in stored routes")
+				}
+			}
+		}
+	}
+
+	api := newTestAPI(t,
+		&serviceList{
+			Items: []*service{
+				testService(
+					"namespace1",
+					"service1",
+					"1.2.3.4",
+					map[string]int{"port1": 8080},
+				),
+			}},
+		&ingressList{
+			Items: []*ingressItem{
+				testIngressSimple(
+					"namespace1",
+					"ingress1",
+					"service1",
+					backendPort{8080},
+					testRule(
+						"example.org",
+						testPathRule("/", "service1", backendPort{8080}),
+					),
+				),
+			},
+		},
+	)
+	defer api.Close()
+
+	k, err := New(Options{
+		KubernetesURL:      api.server.URL,
+		ProvideHealthcheck: true,
+		OriginMarker:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer k.Close()
+
+	// receive initial routes
+	r, err := k.LoadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectOriginMarker(r)
+	expectNoOriginMarker(k.current)
+
+	// check for an update, expect none
+	r, d, err := k.LoadUpdate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(r) != 0 || len(d) != 0 {
+		t.Fatal("unexpected route update received")
+	}
+
+	expectNoOriginMarker(k.current)
+
+	// make an update and receive it
+	api.ingresses.Items = append(
+		api.ingresses.Items,
+		testIngressSimple(
+			"namespace1",
+			"ingress2",
+			"service1",
+			backendPort{8080},
+			testRule(
+				"api.example.org",
+				testPathRule("/v1", "service1", backendPort{8080}),
+			),
+		),
+	)
+
+	r, _, err = k.LoadUpdate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectOriginMarker(r)
+	expectNoOriginMarker(k.current)
 }


### PR DESCRIPTION
attempt 2

previous attempt: https://github.com/zalando/skipper/pull/1197

**The problem:**

The `DataClient.LoadUpdate()` should return any routes only when there were any changes, but only the changes: updated routes, or new routes, and it should return the IDs of the deleted routes. Otherwise, it should return nil for each return argument. When there are any changes, the routing tree is recreated. When there are no changes, there's no new routing tree created.

See also: https://godoc.org/github.com/zalando/skipper/routing#hdr-Data_Clients

The Kubernetes DataClient, in order to be able to detect the changes, stores the current generation of routes, and when the Kubernetes API is polled again, it compares the new routes with the old ones, to see if there were any changes.

The Kubernetes DataClient appends origin markers for each ingress (it appends them to a single route, which is fine), when enabled. When the LoadUpdate is called, it appends them again to the new routes. It uses the first one of the loaded routes, but since the routes are not sorted, this route will be most often a different route. The comparison with the old generation is executed only after this, and therefor, on every call to LoadUpdate, it will return changes, that are not caused by real changes to the ingress specifications. As a result of this, the routing tree is recreated in every cluster where this feature is enabled, in every instance, every 3 seconds.

**Change:**

To fix this, this PR doesn't append the origin markers to the routes that are stored in the data client, but copies them, and appends it to a route in the copied set, and returns the copies. The comparison happens before taking the copy. This way the data client returns updates only when there were real updates, and always adds the origin markers to the returned set of routes (one of them, as before).

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>