### PR TITLE
Clarify that flowIds must be of a certain format to be reusable

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -264,8 +264,9 @@ Sets an X-Flow-Id header, if it's not already in the request.
 This allows you to have a trace in your logs, that traces from
 the incoming request on the edge to all backend services.
 
-Flow IDs must be in a [certain format][flowid_validation] to be reusable in
-skipper.
+Flow IDs must be in a certain format to be reusable in skipper. Valid formats
+depend on the generator used in skipper. Default generator creates IDs of
+length 16 matching the following regex: `^[0-9a-zA-Z+-]+$`
 
 Paramters:
 
@@ -278,8 +279,6 @@ Example:
 * -> flowId() -> "https://some-backend.example.org";
 * -> flowId("reuse") -> "https://some-backend.example.org";
 ```
-
-[flowid_validation]: https://github.com/zalando/skipper/blob/b2d74584a5753b21034be452743ae242f86fd513/filters/flowid/ulid.go#L55-L58
 
 ## randomContent
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -264,10 +264,13 @@ Sets an X-Flow-Id header, if it's not already in the request.
 This allows you to have a trace in your logs, that traces from
 the incoming request on the edge to all backend services.
 
+Flow IDs must be in a [certain format][flowid_validation] to be reusable in
+skipper.
+
 Paramters:
 
 * no parameter: resets always the X-Flow-Id header to a new value
-* "reuse": only create X-Flow-Id header if not set in the request
+* `"reuse"`: only create X-Flow-Id header if not already set or if the value is invalid in the request
 
 Example:
 
@@ -275,6 +278,8 @@ Example:
 * -> flowId() -> "https://some-backend.example.org";
 * -> flowId("reuse") -> "https://some-backend.example.org";
 ```
+
+[flowid_validation]: https://github.com/zalando/skipper/blob/b2d74584a5753b21034be452743ae242f86fd513/filters/flowid/ulid.go#L55-L58
 
 ## randomContent
 

--- a/filters/flowid/ulid.go
+++ b/filters/flowid/ulid.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+const (
+	flowIDLength = 26
+)
+
 type ulidGenerator struct {
 	sync.Mutex
 	r io.Reader
@@ -54,5 +58,5 @@ func (g *ulidGenerator) MustGenerate() string {
 
 // IsValid checks if the given flowId follows the format of this generator
 func (g *ulidGenerator) IsValid(flowId string) bool {
-	return len(flowId) >= MinLength && len(flowId) <= MaxLength && ulidFlowIDRegex.MatchString(flowId)
+	return len(flowId) == flowIDLength && ulidFlowIDRegex.MatchString(flowId)
 }


### PR DESCRIPTION
Clarify that flowIds must be of a certain format to be reusable