### PR TITLE
trim origin markers after evaluated

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -132,7 +132,9 @@ type Options struct {
 // purpose.
 type RouteFilter struct {
 	filters.Filter
-	Name  string
+	Name string
+
+	// Deprecated: currently not used, and post-processors may not maintain a correct value
 	Index int
 }
 


### PR DESCRIPTION
the origin markers are used to measure the time when the incoming routes were applied but they don't change the request flow. Therefore, it is possible to remove them after the metrics were updated.

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>