### PR TITLE
remove reporting deprecated filter from startup

### DIFF
--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -32,7 +32,6 @@ type filter struct {
 
 // NewLocalRatelimit is *DEPRECATED*, use NewClientRatelimit, instead
 func NewLocalRatelimit() filters.Spec {
-	log.Warning("NewLocalRatelimit is deprecated, please use NewClientRatelimit")
 	return &spec{typ: ratelimit.LocalRatelimit, filterName: ratelimit.LocalRatelimitName}
 }
 


### PR DESCRIPTION
removing this warning, because it's unactionable for those users who don't compile the binary on their own. When the filter is actually referenced in the route config, a warning still will be logged.

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>