### PR TITLE
Allowed origin header should be a single value, not a list

### DIFF
--- a/filters/cors/cors.go
+++ b/filters/cors/cors.go
@@ -26,7 +26,7 @@ func NewOrigin() filters.Spec {
 // otherwise it just sets '*' as the value
 func (a filter) Response(ctx filters.FilterContext) {
 	if len(a.allowedOrigins) == 0 {
-		ctx.Response().Header.Add(allowOriginHeader, "*")
+		ctx.Response().Header.Set(allowOriginHeader, "*")
 		return
 	}
 

--- a/filters/cors/cors.go
+++ b/filters/cors/cors.go
@@ -36,7 +36,7 @@ func (a filter) Response(ctx filters.FilterContext) {
 	}
 	for _, o := range a.allowedOrigins {
 		if o == origin {
-			ctx.Response().Header.Add(allowOriginHeader, o)
+			ctx.Response().Header.Set(allowOriginHeader, o)
 			return
 		}
 	}

--- a/filters/cors/cors_test.go
+++ b/filters/cors/cors_test.go
@@ -66,3 +66,34 @@ func TestWithOriginHeader(t *testing.T) {
 		t.Error("origin header wrong/missing")
 	}
 }
+
+func TestSingleHeader(t *testing.T) {
+	spec := NewOrigin()
+	f, err := spec.CreateFilter([]interface{}{"https://www.example.org"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	req, err := http.NewRequest("GET", "https://www.example.org/", nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	req.Header.Set("Origin", "https://www.example.org")
+
+	ctx := &filtertest.Context{
+		FRequest:  req,
+		FResponse: &http.Response{Header: http.Header{allowOriginHeader: []string{"https://www.other-example.org"}}},
+	}
+
+	expectedHeaderValue := "https://www.example.org"
+
+	f.Response(ctx)
+	headers := ctx.Response().Header[allowOriginHeader]
+	if len(headers) != 1 {
+		t.Error("header should only contain one value")
+	}
+	if headers[0] != expectedHeaderValue {
+		t.Error("backend header value should have been overwritten")
+	}
+}


### PR DESCRIPTION
If the backend sets the `Access-Control-Allow-Origin` header, the current corsOrigin filter appends another value. This pr makes it override the value instead.

Example chrome error from having multiple values in the allowed origin header: 

```
Access to XMLHttpRequest at 'https://4ce88b85.ngrok.io' from origin 'https://59298408.ngrok.io' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values 'https://nsns.ngrok.io, https://59298408.ngrok.io', but only one is allowed.
```