### PR TITLE
fix bug when having at least 3 prepend filters

### DIFF
--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -31,12 +31,31 @@ type DefaultFilters struct {
 // prepends filters stored to incoming routes and returns the modified
 // version of routes.
 func (df *DefaultFilters) Do(routes []*Route) []*Route {
+	pn := len(df.Prepend)
+	an := len(df.Append)
+	if pn == 0 && an == 0 {
+		return routes
+	}
+
 	nextRoutes := make([]*Route, len(routes))
 	for i, r := range routes {
 		nextRoutes[i] = new(Route)
 		*nextRoutes[i] = *r
-		nextRoutes[i].Filters = append(df.Prepend, nextRoutes[i].Filters...)
-		nextRoutes[i].Filters = append(nextRoutes[i].Filters, df.Append...)
+
+		fn := len(r.Filters)
+
+		filters := make([]*Filter, fn+pn+an)
+		for i, f := range df.Prepend {
+			filters[i] = f
+		}
+		for i, f := range r.Filters {
+			filters[i+pn] = f
+		}
+		for i, f := range df.Append {
+			filters[i+pn+fn] = f
+		}
+
+		nextRoutes[i].Filters = filters
 	}
 
 	return nextRoutes

--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -45,15 +45,9 @@ func (df *DefaultFilters) Do(routes []*Route) []*Route {
 		fn := len(r.Filters)
 
 		filters := make([]*Filter, fn+pn+an)
-		for i, f := range df.Prepend {
-			filters[i] = f
-		}
-		for i, f := range r.Filters {
-			filters[i+pn] = f
-		}
-		for i, f := range df.Append {
-			filters[i+pn+fn] = f
-		}
+		copy(filters[:pn], df.Prepend)
+		copy(filters[pn:pn+fn], r.Filters)
+		copy(filters[pn+fn:], df.Append)
 
 		nextRoutes[i].Filters = filters
 	}

--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -562,3 +562,27 @@ func TestDefaultFiltersDo(t *testing.T) {
 	}
 
 }
+
+func TestDefaultFiltersDoCorrectPrependFilters(t *testing.T) {
+	filters, err := ParseFilters("status(1) -> status(2) -> status(3)")
+	if err != nil {
+		t.Errorf("Failed to parse filter: %v", err)
+	}
+
+	routes, err := Parse(`
+r1: Method("GET") -> inlineContent("r1") -> <shunt>;
+r2: Method("POST") -> inlineContent("r2") -> <shunt>;
+`)
+	if err != nil {
+		t.Errorf("Failed to parse route: %v", err)
+	}
+
+	df := &DefaultFilters{Prepend: filters}
+
+	finalRoutes := df.Do(routes)
+	for _, route := range finalRoutes {
+		if route.Id != route.Filters[len(route.Filters)-1].Args[0].(string) {
+			t.Errorf("Route %v has incorrect filters: %v", route.Id, route.Filters[3])
+		}
+	}
+}


### PR DESCRIPTION
The issue is that as soon as one has at least 3 prepend filters, all routes get the filters from the last route.