### PR TITLE
Added option to disable HTTP keepalives

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -178,6 +178,7 @@ type Config struct {
 	ResponseHeaderTimeoutBackend time.Duration `yaml:"response-header-timeout-backend"`
 	ExpectContinueTimeoutBackend time.Duration `yaml:"expect-continue-timeout-backend"`
 	MaxIdleConnsBackend          int           `yaml:"max-idle-connection-backend"`
+	DisableHTTPKeepalives        bool          `yaml:"disable-http-keepalives"`
 
 	// swarm:
 	EnableSwarm bool `yaml:"enable-swarm"`
@@ -381,6 +382,7 @@ const (
 	responseHeaderTimeoutBackendUsage = "sets the HTTP response header timeout for backend connections"
 	expectContinueTimeoutBackendUsage = "sets the HTTP expect continue timeout for backend connections"
 	maxIdleConnsBackendUsage          = "sets the maximum idle connections for all backend connections"
+	disableHTTPKeepalivesUsage        = "forces backend to always create a new connection"
 
 	// swarm:
 	enableSwarmUsage                       = "enable swarm communication between nodes in a skipper fleet"
@@ -561,6 +563,7 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.ResponseHeaderTimeoutBackend, "response-header-timeout-backend", defaultResponseHeaderTimeoutBackend, responseHeaderTimeoutBackendUsage)
 	flag.DurationVar(&cfg.ExpectContinueTimeoutBackend, "expect-continue-timeout-backend", defaultExpectContinueTimeoutBackend, expectContinueTimeoutBackendUsage)
 	flag.IntVar(&cfg.MaxIdleConnsBackend, "max-idle-connection-backend", defaultMaxIdleConnsBackend, maxIdleConnsBackendUsage)
+	flag.BoolVar(&cfg.DisableHTTPKeepalives, "disable-http-keepalives", false, disableHTTPKeepalivesUsage)
 
 	// Swarm:
 	flag.BoolVar(&cfg.EnableSwarm, "enable-swarm", false, enableSwarmUsage)
@@ -797,6 +800,7 @@ func (c *Config) ToOptions() skipper.Options {
 		ResponseHeaderTimeoutBackend: c.ResponseHeaderTimeoutBackend,
 		ExpectContinueTimeoutBackend: c.ExpectContinueTimeoutBackend,
 		MaxIdleConnsBackend:          c.MaxIdleConnsBackend,
+		DisableHTTPKeepalives:        c.DisableHTTPKeepalives,
 
 		// swarm:
 		EnableSwarm: c.EnableSwarm,

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -44,6 +44,13 @@ This will set MaxIdleConns on the
 [http.Transport](https://golang.org/pkg/net/http/#Transport) to limit
 the number for all backends such that we do not run out of sockets.
 
+    -disable-http-keepalives bool
+        forces backend to always create a new connection
+
+This will set DisableKeepAlives on the
+[http.Transport](https://golang.org/pkg/net/http/#Transport) to disable
+HTTP keep-alives and to only use the connection for single request.
+
     -max-idle-connection-backend int
         sets the maximum idle connections for all backend connections
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -176,6 +176,9 @@ type Params struct {
 	// MaxIdleConns limits the number of idle connections to all backends, 0 means no limit
 	MaxIdleConns int
 
+	// DisableHTTPKeepalives forces backend to always create a new connection
+	DisableHTTPKeepalives bool
+
 	// CircuitBreakers provides a registry that skipper can use to
 	// find the matching circuit breaker for backend requests. If not
 	// set, no circuit breakers are used.
@@ -587,6 +590,7 @@ func WithParams(p Params) *Proxy {
 		MaxIdleConns:          p.MaxIdleConns,
 		MaxIdleConnsPerHost:   p.IdleConnectionsPerHost,
 		IdleConnTimeout:       p.CloseIdleConnsPeriod,
+		DisableKeepAlives:     p.DisableHTTPKeepalives,
 	}
 
 	if p.ClientTLS != nil {

--- a/skipper.go
+++ b/skipper.go
@@ -284,6 +284,10 @@ type Options struct {
 	// limit.
 	MaxIdleConnsBackend int
 
+	// DisableHTTPKeepalives sets DisableKeepAlives, which forces
+	// a backend to always create a new connection.
+	DisableHTTPKeepalives bool
+
 	// Flag indicating to ignore trailing slashes in paths during route
 	// lookup.
 	IgnoreTrailingSlash bool
@@ -1138,6 +1142,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		DualStack:                o.DualStackBackend,
 		TLSHandshakeTimeout:      o.TLSHandshakeTimeoutBackend,
 		MaxIdleConns:             o.MaxIdleConnsBackend,
+		DisableHTTPKeepalives:    o.DisableHTTPKeepalives,
 		AccessLogDisabled:        o.AccessLogDisabled,
 		ClientTLS:                o.ClientTLS,
 	}


### PR DESCRIPTION
A new skipper argument/config option was added.
`-disable-http-keepalives` makes each request use new connection to the
backend.