### PR TITLE
Added new filter backendIsProxy

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -18,18 +18,15 @@ all: * -> filter1 -> filter2 -> "http://127.0.0.1:1234/";
 
 ## backendIsProxy
 
-Notifies the proxy that the backend this request is going to be sent to is also
-proxy. This means that the request is going to be sent the usual proxy way:
+Notifies the proxy that the backend handling this request is also a
+proxy. The proxy type is based in the URL scheme which can be either
+`http`, `https` or `socks5`.
 
-```
-# HTTP request
-GET http://example.com HTTP/1.1
-...
+Keep in mind that Skipper currently cannot handle `CONNECT` requests
+by tunneling the traffic to the target destination, however, the
+`CONNECT` requests can be forwarded to a different proxy using this
+filter.
 
-# HTTPS request
-CONNECT https://example.com HTTP/1.1
-...
-```
 
 Example:
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -16,6 +16,41 @@ Example route with a match all, 2 filters and a backend:
 all: * -> filter1 -> filter2 -> "http://127.0.0.1:1234/";
 ```
 
+## backendIsProxy
+
+Notifies the proxy that the backend this request is going to be sent to is also
+proxy. This means that the request is going to be sent the usual proxy way:
+
+```
+# HTTP request
+GET http://example.com HTTP/1.1
+...
+
+# HTTPS request
+CONNECT https://example.com HTTP/1.1
+...
+```
+
+Example:
+
+```
+foo1:
+  *
+  -> backendIsProxy()
+  -> "http://proxy.example.com";
+
+foo2:
+  *
+  -> backendIsProxy()
+  -> <roundRobin, "http://proxy1.example.com", "http://proxy2.example.com">;
+
+foo3:
+  *
+  -> setDynamicBackendUrl("http://proxy.example.com")
+  -> backendIsProxy()
+  -> <dynamic>;
+```
+
 ## setRequestHeader
 
 Set headers for requests.

--- a/filters/builtin/backendisproxy.go
+++ b/filters/builtin/backendisproxy.go
@@ -1,0 +1,27 @@
+package builtin
+
+import "github.com/zalando/skipper/filters"
+
+type backendIsProxySpec struct{}
+
+type backendIsProxyFilter struct{}
+
+// NewBackendIsProxy returns a filter specification that is used to specify that the backend is also a proxy.
+func NewBackendIsProxy() filters.Spec {
+	return &backendIsProxySpec{}
+}
+
+func (s *backendIsProxySpec) Name() string {
+	return "backendIsProxy"
+}
+
+func (s *backendIsProxySpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	return &backendIsProxyFilter{}, nil
+}
+
+func (f *backendIsProxyFilter) Request(ctx filters.FilterContext) {
+	ctx.StateBag()[filters.BackendIsProxyKey] = true
+}
+
+func (f *backendIsProxyFilter) Response(ctx filters.FilterContext) {
+}

--- a/filters/builtin/backendisproxy.go
+++ b/filters/builtin/backendisproxy.go
@@ -20,7 +20,7 @@ func (s *backendIsProxySpec) CreateFilter(args []interface{}) (filters.Filter, e
 }
 
 func (f *backendIsProxyFilter) Request(ctx filters.FilterContext) {
-	ctx.StateBag()[filters.BackendIsProxyKey] = true
+	ctx.StateBag()[filters.BackendIsProxyKey] = struct{}{}
 }
 
 func (f *backendIsProxyFilter) Response(ctx filters.FilterContext) {

--- a/filters/builtin/backendisproxy_test.go
+++ b/filters/builtin/backendisproxy_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestBackendIsProxyFilter(t *testing.T) {
 	expectedStateBag := map[string]interface{}{
-		filters.BackendIsProxyKey: true,
+		filters.BackendIsProxyKey: struct{}{},
 	}
 
 	ctx := &filtertest.Context{

--- a/filters/builtin/backendisproxy_test.go
+++ b/filters/builtin/backendisproxy_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Zalando SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builtin
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func TestBackendIsProxyFilter(t *testing.T) {
+	expectedStateBag := map[string]interface{}{
+		filters.BackendIsProxyKey: true,
+	}
+
+	ctx := &filtertest.Context{
+		FRequest:  &http.Request{},
+		FStateBag: map[string]interface{}{},
+	}
+
+	f, _ := NewBackendIsProxy().CreateFilter(nil)
+	f.Request(ctx)
+
+	if !reflect.DeepEqual(expectedStateBag, ctx.FStateBag) {
+		t.Error("StateBags are not equal", expectedStateBag, ctx.FStateBag)
+	}
+}

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -68,6 +68,7 @@ const (
 func MakeRegistry() filters.Registry {
 	r := make(filters.Registry)
 	for _, s := range []filters.Spec{
+		NewBackendIsProxy(),
 		NewRequestHeader(),
 		NewSetRequestHeader(),
 		NewAppendRequestHeader(),

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -17,6 +17,9 @@ const (
 
 	// DynamicBackendURLKey is the key used in the state bag to pass url to the proxy.
 	DynamicBackendURLKey = "backend:dynamic:url"
+
+	// BackendIsProxyKey is the key used in the state bag to notify proxy that the backend is also a proxy.
+	BackendIsProxyKey = "backend:isproxy"
 )
 
 // Context object providing state and information that is unique to a request.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -521,7 +521,7 @@ func forwardToProxy(incoming, outgoing *http.Request) {
 		Host:   outgoing.URL.Host,
 	}
 
-	outgoing.URL.Host = outgoing.Host
+	outgoing.URL.Host = incoming.Host
 	outgoing.URL.Scheme = schemeFromRequest(incoming)
 
 	outgoing.Header.Set("X-Skipper-Proxy", proxyURL.String())

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -523,6 +523,7 @@ func forwardToProxy(incoming, outgoing *http.Request) {
 
 	outgoing.URL.Host = outgoing.Host
 	outgoing.URL.Scheme = schemeFromRequest(incoming)
+
 	outgoing.Header.Set("X-Skipper-Proxy", proxyURL.String())
 }
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2030,7 +2030,7 @@ func TestForwardToProxy(t *testing.T) {
 				ti.expectedRequestURL, outgoing.URL.String())
 		}
 
-		proxyURL := outgoing.Header.Get("X-Skipper-Proxy")
+		proxyURL := outgoing.Header.Get(backendIsProxyHeader)
 
 		if proxyURL != ti.expectedProxyURL {
 			t.Errorf("proxy URLs are not equal, expected %s got %s",
@@ -2052,7 +2052,7 @@ func TestProxyFromHeader(t *testing.T) {
 
 	u2, err := proxyFromHeader(&http.Request{
 		Header: http.Header{
-			"X-Skipper-Proxy": []string{expectedProxyURL},
+			backendIsProxyHeader: []string{expectedProxyURL},
 		},
 	})
 	if err != nil {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1988,39 +1988,39 @@ func benchmarkAccessLog(b *testing.B, filter string, responseCode int) {
 func TestForwardToProxy(t *testing.T) {
 	for _, ti := range []struct {
 		tls                *tls.ConnectionState
-		requestURL         string
-		requestHost        string
+		outgoingURL        string
+		incomingHost       string
 		expectedProxyURL   string
 		expectedRequestURL string
 	}{{
 		tls:                nil,
-		requestURL:         "http://proxy.example.com/anything?key=val",
-		requestHost:        "example.com",
+		outgoingURL:        "http://proxy.example.com/anything?key=val",
+		incomingHost:       "example.com",
 		expectedProxyURL:   "http://proxy.example.com",
 		expectedRequestURL: "http://example.com/anything?key=val",
 	}, {
 		tls:                nil,
-		requestURL:         "https://proxy.example.com/anything?key=val",
-		requestHost:        "example.com",
+		outgoingURL:        "https://proxy.example.com/anything?key=val",
+		incomingHost:       "example.com",
 		expectedProxyURL:   "https://proxy.example.com",
 		expectedRequestURL: "http://example.com/anything?key=val",
 	}, {
 		tls:                &tls.ConnectionState{},
-		requestURL:         "http://proxy.example.com/anything?key=val",
-		requestHost:        "example.com",
+		outgoingURL:        "http://proxy.example.com/anything?key=val",
+		incomingHost:       "example.com",
 		expectedProxyURL:   "http://proxy.example.com",
 		expectedRequestURL: "https://example.com/anything?key=val",
 	}} {
-		reqURL, _ := url.Parse(ti.requestURL)
+		outgoingURL, _ := url.Parse(ti.outgoingURL)
 
 		outgoing := &http.Request{
-			URL:    reqURL,
-			Host:   ti.requestHost,
+			URL:    outgoingURL,
 			Header: make(http.Header),
 		}
 
 		incoming := &http.Request{
-			TLS: ti.tls,
+			Host: ti.incomingHost,
+			TLS:  ti.tls,
 		}
 
 		forwardToProxy(incoming, outgoing)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2014,8 +2014,9 @@ func TestForwardToProxy(t *testing.T) {
 		reqURL, _ := url.Parse(ti.requestURL)
 
 		outgoing := &http.Request{
-			URL:  reqURL,
-			Host: ti.requestHost,
+			URL:    reqURL,
+			Host:   ti.requestHost,
+			Header: make(http.Header),
 		}
 
 		incoming := &http.Request{


### PR DESCRIPTION
The filter notifies the proxy that the backend this request is going to be sent to is also
proxy. This means that the request is going to be sent the usual proxy way:

    // HTTP request
    GET http://example.com HTTP/1.1
    ...

    // HTTPS request
    CONNECT https://example.com HTTP/1.1
    ...

Example:

    foo1:
      *
      -> backendIsProxy()
      -> "http://proxy.example.com";

    foo2:
      *
      -> backendIsProxy()
      -> <roundRobin, "http://proxy1.example.com", "http://proxy2.example.com">;

    foo3:
      *
      -> setDynamicBackendUrl("http://proxy.example.com")
      -> backendIsProxy()
      -> <dynamic>;

Signed-off-by: Stepan Bujnak <stepan.bujnak@gmail.com>