### PR TITLE
Fix: CPU hot busyloop by setting a default timeout to 30s, if not set

### DIFF
--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -10,6 +10,10 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+const (
+	defaultTimeout = 30 * time.Second
+)
+
 // Options are mostly passed to the http.Transport of the same
 // name. Options.Timeout can be used as default for all timeouts, that
 // are not set. You can pass an opentracing.Tracer
@@ -78,6 +82,10 @@ func NewTransport(options Options) *Transport {
 	// set default tracer
 	if options.Tracer == nil {
 		options.Tracer = &opentracing.NoopTracer{}
+	}
+
+	if options.Timeout == 0 {
+		options.Timeout = defaultTimeout
 	}
 
 	// set timeout defaults

--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	defaultTimeout = 30 * time.Second
+	defaultIdleConnTimeout = 30 * time.Second
 )
 
 // Options are mostly passed to the http.Transport of the same
@@ -84,16 +84,16 @@ func NewTransport(options Options) *Transport {
 		options.Tracer = &opentracing.NoopTracer{}
 	}
 
-	if options.Timeout == 0 {
-		options.Timeout = defaultTimeout
-	}
-
 	// set timeout defaults
 	if options.TLSHandshakeTimeout == 0 {
 		options.TLSHandshakeTimeout = options.Timeout
 	}
 	if options.IdleConnTimeout == 0 {
-		options.IdleConnTimeout = options.Timeout
+		if options.Timeout != 0 {
+			options.IdleConnTimeout = options.Timeout
+		} else {
+			options.IdleConnTimeout = defaultIdleConnTimeout
+		}
 	}
 	if options.ResponseHeaderTimeout == 0 {
 		options.ResponseHeaderTimeout = options.Timeout


### PR DESCRIPTION
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>