### PR TITLE
Forward headers from webhook filter responses

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -453,13 +453,17 @@ The `webhook` filter makes it possible to have your own authentication and
 authorization endpoint as a filter.
 
 Headers from the incoming request will be copied into the request that
-is being done to the webhook endpoint. Responses from the webhook with
-status code less than 300 will be authorized, rest unauthorized.
+is being done to the webhook endpoint. It is possible to copy headers
+from the webhook response into the continuing request by specifying the
+headers to copy as a second argument to the filter.
+
+Responses from the webhook with status code less than 300 will be
+authorized, the rest will be unauthorized.
 
 Examples:
 
 ```
-webhook("https://custom-webhook.example.org/auth")
+webhook("https://custom-webhook.example.org/auth", "X-Copy-Webhook-Header,X-Copy-Another-Header")
 ```
 
 The webhook timeout has a default of 2 seconds and can be globally

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -455,7 +455,7 @@ authorization endpoint as a filter.
 Headers from the incoming request will be copied into the request that
 is being done to the webhook endpoint. It is possible to copy headers
 from the webhook response into the continuing request by specifying the
-headers to copy as a second argument to the filter.
+headers to copy as an optional second argument to the filter.
 
 Responses from the webhook with status code less than 300 will be
 authorized, the rest will be unauthorized.
@@ -463,6 +463,7 @@ authorized, the rest will be unauthorized.
 Examples:
 
 ```
+webhook("https://custom-webhook.example.org/auth")
 webhook("https://custom-webhook.example.org/auth", "X-Copy-Webhook-Header,X-Copy-Another-Header")
 ```
 

--- a/filters/auth/authclient.go
+++ b/filters/auth/authclient.go
@@ -118,18 +118,18 @@ func (ac *authClient) getTokeninfo(token string, ctx filters.FilterContext) (map
 	return doc, err
 }
 
-func (ac *authClient) getWebhook(ctx filters.FilterContext) (int, error) {
+func (ac *authClient) getWebhook(ctx filters.FilterContext) (*http.Response, error) {
 	req, err := http.NewRequest("GET", ac.url.String(), nil)
 	if err != nil {
-		return -1, err
+		return nil, err
 	}
 	copyHeader(req.Header, ctx.Request().Header)
 
 	rsp, err := ac.tr.RoundTrip(req)
 	if err != nil {
-		return -1, err
+		return nil, err
 	}
 	defer rsp.Body.Close()
 
-	return rsp.StatusCode, nil
+	return rsp, nil
 }

--- a/filters/auth/doc.go
+++ b/filters/auth/doc.go
@@ -355,9 +355,12 @@ filter after the auth filter.
 Webhook - webhook() filter
 
 The filter webhook allows you to have a custom authentication and
-authorization endpoint for a route.
+authorization endpoint for a route. Headers from the webhook response
+can be copyied into the continuing request by specifying the
+headers to copy as a second argument to the filter
 
     a: Path("/only-allowed-by-webhook") -> webhook("https://custom-webhook.example.org/auth") -> "https://protected-backend.example.org/";
+    b: Path("/copy-webhook-headers") -> webhook("https://custom-webhook.example.org/auth", "X-Copy-This-Header") -> "https://protected-backend.example.org/";
 
 Forward Token - forwardToken() filter
 

--- a/filters/auth/doc.go
+++ b/filters/auth/doc.go
@@ -357,7 +357,7 @@ Webhook - webhook() filter
 The filter webhook allows you to have a custom authentication and
 authorization endpoint for a route. Headers from the webhook response
 can be copyied into the continuing request by specifying the
-headers to copy as a second argument to the filter
+headers to copy as an optional second argument to the filter
 
     a: Path("/only-allowed-by-webhook") -> webhook("https://custom-webhook.example.org/auth") -> "https://protected-backend.example.org/";
     b: Path("/copy-webhook-headers") -> webhook("https://custom-webhook.example.org/auth", "X-Copy-This-Header") -> "https://protected-backend.example.org/";

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -1,11 +1,14 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/http/httpguts"
 
 	"github.com/zalando/skipper/filters"
 )
@@ -25,7 +28,8 @@ type (
 		options WebhookOptions
 	}
 	webhookFilter struct {
-		authClient *authClient
+		authClient                *authClient
+		forwardResponseHeaderKeys []string
 	}
 )
 
@@ -48,9 +52,10 @@ func (*webhookSpec) Name() string {
 }
 
 // CreateFilter creates an auth filter. The first argument is an URL
-// string.
+// string. The second, optional, argument is a comma separated list of
+// headers to forward from from webhook response.
 //
-//     s.CreateFilter("https://my-auth-service.example.org/auth")
+//     s.CreateFilter("https://my-auth-service.example.org/auth", "X-Auth-User,X-Auth-User-Roles")
 //
 func (ws *webhookSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 	if l := len(args); l == 0 || l > 2 {
@@ -62,12 +67,32 @@ func (ws *webhookSpec) CreateFilter(args []interface{}) (filters.Filter, error) 
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
+	forwardResponseHeaderKeys := make([]string, 0)
+
+	if len(args) > 1 {
+		// Capture headers that should be forwarded from webhook responses.
+		headerKeysOption, ok := args[1].(string)
+		if !ok {
+			return nil, filters.ErrInvalidFilterParameters
+		}
+
+		headerKeys := strings.Split(headerKeysOption, ",")
+
+		for _, header := range headerKeys {
+			valid := httpguts.ValidHeaderFieldName(header)
+			if !valid {
+				return nil, fmt.Errorf("header %s is invalid", header)
+			}
+			forwardResponseHeaderKeys = append(forwardResponseHeaderKeys, http.CanonicalHeaderKey(header))
+		}
+	}
+
 	ac, err := newAuthClient(s, webhookSpanName, ws.options.Timeout, ws.options.MaxIdleConns, ws.options.Tracer)
 	if err != nil {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
-	return &webhookFilter{authClient: ac}, nil
+	return &webhookFilter{authClient: ac, forwardResponseHeaderKeys: forwardResponseHeaderKeys}, nil
 }
 
 func copyHeader(to, from http.Header) {
@@ -77,15 +102,22 @@ func copyHeader(to, from http.Header) {
 }
 
 func (f *webhookFilter) Request(ctx filters.FilterContext) {
-	statusCode, err := f.authClient.getWebhook(ctx)
+	resp, err := f.authClient.getWebhook(ctx)
 	if err != nil {
 		log.Errorf("Failed to make authentication webhook request: %v.", err)
 	}
 
 	// errors, redirects, auth errors, webhook errors
-	if err != nil || statusCode >= 300 {
+	if err != nil || resp.StatusCode >= 300 {
 		unauthorized(ctx, "", invalidAccess, f.authClient.url.Hostname(), WebhookName)
 		return
+	}
+
+	// copy required headers from webhook response into the current request
+	for _, hk := range f.forwardResponseHeaderKeys {
+		if h, ok := resp.Header[hk]; ok {
+			ctx.Request().Header[hk] = h
+		}
 	}
 
 	authorized(ctx, WebhookName)

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -55,6 +55,7 @@ func (*webhookSpec) Name() string {
 // string. The second, optional, argument is a comma separated list of
 // headers to forward from from webhook response.
 //
+//     s.CreateFilter("https://my-auth-service.example.org/auth")
 //     s.CreateFilter("https://my-auth-service.example.org/auth", "X-Auth-User,X-Auth-User-Roles")
 //
 func (ws *webhookSpec) CreateFilter(args []interface{}) (filters.Filter, error) {


### PR DESCRIPTION
Update the `webhook` filter so that it can take a second argument, a comma-separated list of header names, that should be copied from the webhook response to the continuing request, if the webhook response is authorized.

i.e. `webhook("auth-endpoint", "Headers-To-Copy,And-More")`