### PR TITLE
Feature/skipper http client

### DIFF
--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -3939,10 +3939,12 @@ func TestSkipperDefaultFilters(t *testing.T) {
 
 type mockSecretProvider string
 
-func (sp mockSecretProvider) GetSecret(_ string) ([]byte, bool) {
+func (sp mockSecretProvider) GetSecret(string) ([]byte, bool) {
 	return []byte(sp), true
 }
 
-func (sp mockSecretProvider) Add(_ string) error {
+func (mockSecretProvider) Add(string) error {
 	return nil
 }
+
+func (mockSecretProvider) Close() {}

--- a/filters/auth/bearer_test.go
+++ b/filters/auth/bearer_test.go
@@ -73,6 +73,8 @@ func (tsr *testSecretsReader) GetSecret(name string) ([]byte, bool) {
 	return nil, false
 }
 
+func (*testSecretsReader) Close() {}
+
 func Test_bearerInjectorFilter_Request(t *testing.T) {
 	goodtoken := "goodtoken"
 	goodsecret := "goodsecret"

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FY
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/logging/log.go
+++ b/logging/log.go
@@ -1,9 +1,10 @@
 package logging
 
 import (
-	"github.com/sirupsen/logrus"
 	"io"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
 type prefixFormatter struct {

--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -2,17 +2,129 @@ package net
 
 import (
 	"crypto/tls"
+	"io"
 	"net/http"
 	"net/http/httptrace"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/zalando/skipper/logging"
+	"github.com/zalando/skipper/secrets"
 )
 
 const (
 	defaultIdleConnTimeout = 30 * time.Second
+	defaultRefreshInterval = 5 * time.Minute
 )
+
+// Client adds additional features like Bearer token injection, and
+// opentracing to the wrapped http.Client with the same interface as
+// http.Client from the stdlib.
+type Client struct {
+	client http.Client
+	tr     *Transport
+	log    logging.Logger
+	sr     secrets.SecretsReader
+}
+
+// NewClient creates a wrapped http.Client and uses Transport to
+// support OpenTracing. On teardown you have to use Close() to
+// not leak a goroutine.
+//
+// If secrets.SecretsReader is nil, but BearerTokenFile is not empty
+// string, it creates StaticDelegateSecret with a wrapped
+// secrets.SecretPaths, which can be used with Kubernetes secrets to
+// read from the secret an automatically updated Bearer token.
+func NewClient(o Options) *Client {
+	if o.Log == nil {
+		o.Log = &logging.DefaultLog{}
+	}
+
+	tr := NewTransport(o)
+
+	sr := o.SecretsReader
+	if sr == nil && o.BearerTokenFile != "" {
+		if o.BearerTokenRefreshInterval == 0 {
+			o.BearerTokenRefreshInterval = defaultRefreshInterval
+		}
+		sp := secrets.NewSecretPaths(o.BearerTokenRefreshInterval)
+		if err := sp.Add(o.BearerTokenFile); err != nil {
+			o.Log.Errorf("failed to read secret: %v", err)
+		}
+		sr = secrets.NewStaticDelegateSecret(sp, o.BearerTokenFile)
+	}
+
+	c := &Client{
+		client: http.Client{
+			Transport: tr,
+		},
+		tr:  tr,
+		log: o.Log,
+		sr:  sr,
+	}
+
+	return c
+}
+
+func (c *Client) Close() {
+	c.tr.Close()
+	if c.sr != nil {
+		c.sr.Close()
+	}
+}
+
+func (c *Client) Head(url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req)
+}
+
+func (c *Client) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
+}
+
+func (c *Client) Post(url, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	return c.Do(req)
+}
+
+func (c *Client) PostForm(url string, data url.Values) (*http.Response, error) {
+	return c.Post(url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}
+
+// Do delegates the given http.Request to the underlying http.Client
+// and adds a Bearer token to the authorization header, if Client has
+// a secrets.SecretsReader and the request does not contain an
+// Authorization header.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if c.sr != nil && req.Header.Get("Authorization") == "" {
+		if b, ok := c.sr.GetSecret(req.URL.String()); ok {
+			req.Header.Set("Authorization", "Bearer "+string(b))
+		}
+	}
+	return c.client.Do(req)
+}
+
+// CloseIdleConnections delegates the call to the underlying
+// http.Client.
+func (c *Client) CloseIdleConnections() {
+	c.client.CloseIdleConnections()
+}
 
 // Options are mostly passed to the http.Transport of the same
 // name. Options.Timeout can be used as default for all timeouts, that
@@ -61,6 +173,25 @@ type Options struct {
 	ExpectContinueTimeout time.Duration
 	// Tracer instance, can be nil to not enable tracing
 	Tracer opentracing.Tracer
+
+	// BearerTokenFile injects bearer token read from file, which
+	// file path is the given string. In case SecretsReader is
+	// provided, BearerTokenFile will be ignored.
+	BearerTokenFile string
+	// BearerTokenRefreshInterval refresh bearer from
+	// BearerTokenFile. In case SecretsReader is provided,
+	// BearerTokenFile will be ignored.
+	BearerTokenRefreshInterval time.Duration
+	// SecretsReader is used to read and refresh bearer tokens
+	SecretsReader secrets.SecretsReader
+
+	// Log is used for error logging
+	Log logging.Logger
+
+	// OpentracingComponentTag sets component tag for all requests
+	OpentracingComponentTag string
+	// OpentracingSpanName sets span name for all requests
+	OpentracingSpanName string
 }
 
 // Transport wraps an http.Transport and adds support for tracing and
@@ -124,6 +255,15 @@ func NewTransport(options Options) *Transport {
 		tracer: options.Tracer,
 	}
 
+	if t.tracer != nil {
+		if options.OpentracingComponentTag != "" {
+			t = WithComponentTag(t, options.OpentracingComponentTag)
+		}
+		if options.OpentracingSpanName != "" {
+			t = WithSpanName(t, options.OpentracingSpanName)
+		}
+	}
+
 	go func() {
 		for {
 			select {
@@ -170,7 +310,11 @@ func (t *Transport) shallowCopy() *Transport {
 }
 
 func (t *Transport) Close() {
-	t.quit <- struct{}{}
+	close(t.quit)
+}
+
+func (t *Transport) CloseIdleConnections() {
+	t.tr.CloseIdleConnections()
 }
 
 // RoundTrip the request with tracing, bearer token injection and add client

--- a/net/httpclient_example_test.go
+++ b/net/httpclient_example_test.go
@@ -3,9 +3,12 @@ package net_test
 import (
 	"log"
 	"net/http"
+	"net/http/httptest"
+	"time"
 
 	"github.com/lightstep/lightstep-tracer-go"
 	"github.com/zalando/skipper/net"
+	"github.com/zalando/skipper/secrets"
 )
 
 func ExampleTransport() {
@@ -18,7 +21,16 @@ func ExampleTransport() {
 	cli = net.WithSpanName(cli, "myspan")
 	cli = net.WithBearerToken(cli, "mytoken")
 
-	u := "http://127.0.0.1:12345/foo"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Authorization: %s", r.Header.Get("Authorization"))
+		log.Printf("Ot-Tracer-Sampled: %s", r.Header.Get("Ot-Tracer-Sampled"))
+		log.Printf("Ot-Tracer-Traceid: %s", r.Header.Get("Ot-Tracer-Traceid"))
+		log.Printf("Ot-Tracer-Spanid: %s", r.Header.Get("Ot-Tracer-Spanid"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u := "http://" + srv.Listener.Addr().String() + "/"
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		log.Fatalf("Failed to create request: %v", err)
@@ -29,4 +41,209 @@ func ExampleTransport() {
 		log.Fatalf("Failed to do request: %v", err)
 	}
 	log.Printf("rsp code: %v", rsp.StatusCode)
+}
+
+func ExampleClient() {
+	tracer := lightstep.NewTracer(lightstep.Options{})
+
+	cli := net.NewClient(net.Options{
+		Tracer:                     tracer,
+		OpentracingComponentTag:    "testclient",
+		OpentracingSpanName:        "clientSpan",
+		BearerTokenRefreshInterval: 10 * time.Second,
+		BearerTokenFile:            "/tmp/foo.token",
+		IdleConnTimeout:            2 * time.Second,
+	})
+	defer cli.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Authorization: %s", r.Header.Get("Authorization"))
+		log.Printf("Ot-Tracer-Sampled: %s", r.Header.Get("Ot-Tracer-Sampled"))
+		log.Printf("Ot-Tracer-Traceid: %s", r.Header.Get("Ot-Tracer-Traceid"))
+		log.Printf("Ot-Tracer-Spanid: %s", r.Header.Get("Ot-Tracer-Spanid"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u := "http://" + srv.Listener.Addr().String() + "/"
+
+	for i := 0; i < 15; i++ {
+		rsp, err := cli.Get(u)
+		if err != nil {
+			log.Fatalf("Failed to do request: %v", err)
+		}
+		log.Printf("rsp code: %v", rsp.StatusCode)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func ExampleClient_fileSecretsReader() {
+	tracer := lightstep.NewTracer(lightstep.Options{})
+
+	sp := secrets.NewSecretPaths(10 * time.Second)
+	if err := sp.Add("/tmp/bar.token"); err != nil {
+		log.Fatalf("failed to read secret: %v", err)
+	}
+
+	cli := net.NewClient(net.Options{
+		Tracer:                  tracer,
+		OpentracingComponentTag: "testclient",
+		OpentracingSpanName:     "clientSpan",
+		SecretsReader:           sp,
+		IdleConnTimeout:         2 * time.Second,
+	})
+	defer cli.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Authorization: %s", r.Header.Get("Authorization"))
+		log.Printf("Ot-Tracer-Sampled: %s", r.Header.Get("Ot-Tracer-Sampled"))
+		log.Printf("Ot-Tracer-Traceid: %s", r.Header.Get("Ot-Tracer-Traceid"))
+		log.Printf("Ot-Tracer-Spanid: %s", r.Header.Get("Ot-Tracer-Spanid"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u := "http://" + srv.Listener.Addr().String() + "/"
+
+	for i := 0; i < 15; i++ {
+		rsp, err := cli.Get(u)
+		if err != nil {
+			log.Fatalf("Failed to do request: %v", err)
+		}
+		log.Printf("rsp code: %v", rsp.StatusCode)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func ExampleClient_staticSecret() {
+	tracer := lightstep.NewTracer(lightstep.Options{})
+	sec := []byte("mysecret")
+	cli := net.NewClient(net.Options{
+		Tracer:                  tracer,
+		OpentracingComponentTag: "testclient",
+		OpentracingSpanName:     "clientSpan",
+		SecretsReader:           secrets.StaticSecret(sec),
+		IdleConnTimeout:         2 * time.Second,
+	})
+	defer cli.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Authorization: %s", r.Header.Get("Authorization"))
+		log.Printf("Ot-Tracer-Sampled: %s", r.Header.Get("Ot-Tracer-Sampled"))
+		log.Printf("Ot-Tracer-Traceid: %s", r.Header.Get("Ot-Tracer-Traceid"))
+		log.Printf("Ot-Tracer-Spanid: %s", r.Header.Get("Ot-Tracer-Spanid"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u := "http://" + srv.Listener.Addr().String() + "/"
+
+	for i := 0; i < 15; i++ {
+		rsp, err := cli.Get(u)
+		if err != nil {
+			log.Fatalf("Failed to do request: %v", err)
+		}
+		log.Printf("rsp code: %v", rsp.StatusCode)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+type testSecretsReader struct {
+	h map[string][]byte
+}
+
+func newTestSecretsReader(m map[string][]byte) *testSecretsReader {
+	return &testSecretsReader{
+		h: m,
+	}
+}
+
+func (*testSecretsReader) Close() {}
+func (tsr *testSecretsReader) GetSecret(k string) ([]byte, bool) {
+	b, ok := tsr.h[k]
+	return b, ok
+}
+
+func ExampleClient_staticDelegateSecret() {
+	tracer := lightstep.NewTracer(lightstep.Options{})
+	sec := []byte("mysecret")
+
+	cli := net.NewClient(net.Options{
+		Tracer:                  tracer,
+		OpentracingComponentTag: "testclient",
+		OpentracingSpanName:     "clientSpan",
+		SecretsReader: secrets.NewStaticDelegateSecret(
+			newTestSecretsReader(
+				map[string][]byte{
+					"key": sec,
+				},
+			),
+			"key",
+		),
+		IdleConnTimeout: 2 * time.Second,
+	})
+	defer cli.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Authorization: %s", r.Header.Get("Authorization"))
+		log.Printf("Ot-Tracer-Sampled: %s", r.Header.Get("Ot-Tracer-Sampled"))
+		log.Printf("Ot-Tracer-Traceid: %s", r.Header.Get("Ot-Tracer-Traceid"))
+		log.Printf("Ot-Tracer-Spanid: %s", r.Header.Get("Ot-Tracer-Spanid"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u := "http://" + srv.Listener.Addr().String() + "/"
+
+	for i := 0; i < 15; i++ {
+		rsp, err := cli.Get(u)
+		if err != nil {
+			log.Fatalf("Failed to do request: %v", err)
+		}
+		log.Printf("rsp code: %v", rsp.StatusCode)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func ExampleClient_hostSecret() {
+	tracer := lightstep.NewTracer(lightstep.Options{})
+	sec := []byte("mysecret")
+
+	cli := net.NewClient(net.Options{
+		Tracer:                  tracer,
+		OpentracingComponentTag: "testclient",
+		OpentracingSpanName:     "clientSpan",
+		SecretsReader: secrets.NewHostSecret(
+			newTestSecretsReader(
+				map[string][]byte{
+					"key": sec,
+				},
+			),
+			map[string]string{
+				"127.0.0.1": "key",
+			},
+		),
+		IdleConnTimeout: 2 * time.Second,
+	})
+	defer cli.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Authorization: %s", r.Header.Get("Authorization"))
+		log.Printf("Ot-Tracer-Sampled: %s", r.Header.Get("Ot-Tracer-Sampled"))
+		log.Printf("Ot-Tracer-Traceid: %s", r.Header.Get("Ot-Tracer-Traceid"))
+		log.Printf("Ot-Tracer-Spanid: %s", r.Header.Get("Ot-Tracer-Spanid"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u := "http://" + srv.Listener.Addr().String() + "/"
+
+	for i := 0; i < 15; i++ {
+		rsp, err := cli.Get(u)
+		if err != nil {
+			log.Fatalf("Failed to do request: %v", err)
+		}
+		log.Printf("rsp code: %v", rsp.StatusCode)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/net/httpclient_test.go
+++ b/net/httpclient_test.go
@@ -1,12 +1,184 @@
 package net
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/zalando/skipper/secrets"
 	"github.com/zalando/skipper/tracing/tracers/basic"
 )
+
+var testToken = []byte("mytoken1")
+
+type testSecretsReader struct {
+	h map[string][]byte
+}
+
+func newTestSecretsReader(m map[string][]byte) *testSecretsReader {
+	return &testSecretsReader{
+		h: m,
+	}
+}
+
+func (*testSecretsReader) Close() {}
+func (tsr *testSecretsReader) GetSecret(k string) ([]byte, bool) {
+	b, ok := tsr.h[k]
+	return b, ok
+}
+
+func TestClient(t *testing.T) {
+	tracer, err := basic.InitTracer([]string{"recorder=in-memory"})
+	if err != nil {
+		t.Fatalf("Failed to get a tracer: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name      string
+		options   Options
+		tokenFile string
+		wantErr   bool
+	}{
+		{
+			name:    "All defaults, with request should have a response",
+			wantErr: false,
+		},
+		{
+			name: "With tracer",
+			options: Options{
+				Tracer: tracer,
+			},
+			wantErr: false,
+		},
+		{
+			name: "With tracer and span name",
+			options: Options{
+				Tracer:                  tracer,
+				OpentracingComponentTag: "mytag",
+				OpentracingSpanName:     "foo",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "With token",
+			options:   Options{},
+			tokenFile: "token",
+			wantErr:   false,
+		},
+		{
+			name: "With static secrets reader",
+			options: Options{
+				SecretsReader: secrets.StaticSecret(testToken),
+			},
+			wantErr: false,
+		},
+		{
+			name: "With static delegate secrets reader",
+			options: Options{
+				SecretsReader: secrets.NewStaticDelegateSecret(newTestSecretsReader(map[string][]byte{
+					"key": testToken,
+				}), "key"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "With HostSecret secrets reader",
+			options: Options{
+				SecretsReader: secrets.NewHostSecret(
+					newTestSecretsReader(map[string][]byte{
+						"key": testToken,
+					}),
+					map[string]string{
+						"127.0.0.1": "key",
+					},
+				),
+			},
+			wantErr: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := startTestServer(func(r *http.Request) {
+				if tt.options.OpentracingSpanName != "" && tt.options.Tracer != nil {
+					if r.Header.Get("Ot-Tracer-Sampled") == "" ||
+						r.Header.Get("Ot-Tracer-Traceid") == "" ||
+						r.Header.Get("Ot-Tracer-Spanid") == "" {
+						t.Errorf("One of the OT Tracer headers are missing: %v", r.Header)
+					}
+				}
+
+				if tt.tokenFile != "" || tt.options.SecretsReader != nil {
+					switch auth := r.Header.Get("Authorization"); auth {
+					case "Bearer " + string(testToken):
+						if tt.wantErr {
+							t.Error("Want error and not an Authorization header")
+						}
+					default:
+						if !tt.wantErr {
+							t.Errorf("Wrong Authorization header '%s'", auth)
+						}
+					}
+				} else if r.Header.Get("Authorization") != "" {
+					t.Errorf("Client should not have an authorization header: %s", r.Header.Get("Authorization"))
+				}
+			})
+			defer s.Close()
+
+			if tt.tokenFile != "" {
+				dir, err := ioutil.TempDir("/tmp", "skipper-httpclient-test")
+				if err != nil {
+					t.Fatalf("Failed to create temp dir: %v", err)
+				}
+				defer os.RemoveAll(dir) // clean up
+				tokenFile := filepath.Join(dir, tt.tokenFile)
+				if err := ioutil.WriteFile(tokenFile, []byte(testToken), 0600); err != nil {
+					t.Fatalf("Failed to create token file: %v", err)
+				}
+				tt.options.BearerTokenFile = tokenFile
+			}
+
+			cli := NewClient(tt.options)
+			defer cli.Close()
+
+			u := "http://" + s.Listener.Addr().String() + "/"
+
+			_, err = cli.Get(u)
+			if err != nil {
+				t.Errorf("Failed to do GET request error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			_, err = cli.Head(u)
+			if err != nil {
+				t.Errorf("Failed to do HEAD request error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			_, err = cli.Post(u, "", nil)
+			if err != nil {
+				t.Errorf("Failed to do POST request error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			_, err = cli.PostForm(u, url.Values{})
+			if err != nil {
+				t.Errorf("Failed to do POST form request error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			req, err := http.NewRequest("DELETE", u, nil)
+			if err != nil {
+				t.Errorf("Failed to create DELETE request: %v", err)
+			}
+			_, err = cli.Do(req)
+			if err != nil {
+				t.Errorf("Failed to do DELETE request error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+		})
+	}
+}
 
 func TestTransport(t *testing.T) {
 	tracer, err := basic.InitTracer(nil)
@@ -38,7 +210,7 @@ func TestTransport(t *testing.T) {
 		},
 		{
 			name:        "With bearer token request should have a token in the request observed by the endpoint",
-			bearerToken: "my-token",
+			bearerToken: string(testToken),
 			req:         httptest.NewRequest("GET", "http://example.com/", nil),
 			wantErr:     false,
 		},
@@ -62,7 +234,7 @@ func TestTransport(t *testing.T) {
 				}
 
 				if tt.bearerToken != "" {
-					if r.Header.Get("Authorization") != "Bearer my-token" {
+					if r.Header.Get("Authorization") != "Bearer "+string(testToken) {
 						t.Errorf("Failed to have a token, but want to have it, got: %v, want: %v", r.Header.Get("Authorization"), "Bearer "+tt.bearerToken)
 					}
 				}

--- a/secrets/readers.go
+++ b/secrets/readers.go
@@ -1,0 +1,96 @@
+package secrets
+
+import "net/url"
+
+// SecretsReader is able to get a secret
+type SecretsReader interface {
+	// GetSecret finds secret by name and returns secret and if found or not
+	GetSecret(string) ([]byte, bool)
+	// Close should be used on teardown to cleanup a refresher
+	// goroutine. Implementers should check of this interface
+	// should check nil pointer, such that caller do not need to
+	// check.
+	Close()
+}
+
+// StaticSecret implements SecretsReader interface. Example:
+//
+//    sec := []byte("mysecret")
+//    sss := StaticSecret(sec)
+//    b,_ := sss.GetSecret("")
+//    string(b) == sec // true
+type StaticSecret []byte
+
+// GetSecret returns the static secret
+func (st StaticSecret) GetSecret(string) ([]byte, bool) {
+	return st, true
+}
+
+// Close implements SecretsReader.
+func (st StaticSecret) Close() {}
+
+// StaticDelegateSecret delegates with a static string to the wrapped
+// SecretsReader
+type StaticDelegateSecret struct {
+	sr  SecretsReader
+	key string
+}
+
+// NewStaticDelegateSecret creates a wrapped SecretsReader,
+// that use given s to the underlying SecretsReader to return
+// the secret.
+func NewStaticDelegateSecret(sr SecretsReader, s string) *StaticDelegateSecret {
+	return &StaticDelegateSecret{
+		sr:  sr,
+		key: s,
+	}
+}
+
+// GetSecret returns the secret looked up by the static key via
+// delegated SecretsReader.
+func (sds *StaticDelegateSecret) GetSecret(string) ([]byte, bool) {
+	return sds.sr.GetSecret(sds.key)
+}
+
+// Close delegates to the wrapped SecretsReader.
+func (sds *StaticDelegateSecret) Close() {
+	sds.sr.Close()
+}
+
+// HostSecret can be used to get secrets by hostnames.
+type HostSecret struct {
+	sr     SecretsReader
+	secMap map[string]string
+}
+
+// NewHostSecret create a SecretsReader that returns a secret for
+// given host. The given map is used to map hostname to the secrets
+// reader key to read the secret from.
+func NewHostSecret(sr SecretsReader, h map[string]string) *HostSecret {
+	return &HostSecret{
+		sr:     sr,
+		secMap: h,
+	}
+}
+
+// GetSecret returns secret for given URL string using the hostname.
+func (hs *HostSecret) GetSecret(s string) ([]byte, bool) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, false
+	}
+	hostname := u.Hostname()
+	k, ok := hs.secMap[hostname]
+	if !ok {
+		return nil, false
+	}
+	b, ok := hs.sr.GetSecret(k)
+	if !ok {
+		return nil, false
+	}
+	return b, true
+}
+
+func (hs *HostSecret) Close() {
+	hs.sr.Close()
+}


### PR DESCRIPTION
net.Client implements the current net/http.Ciient interface with skipper's net.Transport with opentracing and secrets injection on top.
I changed the secrets module interface to simplify the implementation. I think it's fine to do, because no one should have used this besides our OpenIDConnect filters.