### PR TITLE
Forward body from backend on connection upgrade errors

### DIFF
--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -124,7 +124,12 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		log.Debugf("Got invalid status code from backend: %d", resp.StatusCode)
 		w.WriteHeader(resp.StatusCode)
-		w.Write([]byte(http.StatusText(resp.StatusCode)))
+		_, err := io.Copy(w, resp.Body)
+		if err != nil {
+			log.Errorf("Error writing body to client: %s", err)
+			return
+		}
+		resp.Body.Close()
 		return
 	}
 

--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -113,6 +113,7 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
 		return
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		log.Debugf("Got unauthorized error from backend for: %s %s", req.Method, req.URL)
@@ -129,7 +130,6 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 			log.Errorf("Error writing body to client: %s", err)
 			return
 		}
-		resp.Body.Close()
 		return
 	}
 


### PR DESCRIPTION
In case the backend rejects a connection upgrade and returns something other than `101` we just responded with the HTTP status code as the body e.g. `Bad Request`

Instead we should respond with the body of the response which may have important information on why it failed.