### PR TITLE
feature: add optional startup checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	DebugListener                   string         `yaml:"debug-listener"`
 	CertPathTLS                     string         `yaml:"tls-cert"`
 	KeyPathTLS                      string         `yaml:"tls-key"`
+	StartupChecks                   *listFlag      `yaml:"startup-checks"`
 	PrintVersion                    bool           `yaml:"version"`
 	MaxLoopbacks                    int            `yaml:"max-loopbacks"`
 	DefaultHTTPStatus               int            `yaml:"default-http-status"`
@@ -247,6 +248,7 @@ const (
 
 	// generic:
 	addressUsage                         = "network address that skipper should listen on"
+	startupChecksUsage                   = "URLs to check before reporting healthy on startup"
 	enableTCPQueueUsage                  = "enable experimental TCP listener queue"
 	expectedBytesPerRequestUsage         = "bytes per request, that is used to calculate concurrency limits to buffer connection spikes"
 	maxTCPListenerConcurrencyUsage       = "sets hardcoded max for TCP listener concurrency, normally calculated based on available memory cgroups with max TODO"
@@ -405,6 +407,7 @@ const (
 func NewConfig() *Config {
 	cfg := new(Config)
 	cfg.MetricsFlavour = commaListFlag("codahale", "prometheus")
+	cfg.StartupChecks = commaListFlag()
 	cfg.FilterPlugins = newPluginFlag()
 	cfg.PredicatePlugins = newPluginFlag()
 	cfg.DataclientPlugins = newPluginFlag()
@@ -430,6 +433,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.DebugListener, "debug-listener", "", debugEndpointUsage)
 	flag.StringVar(&cfg.CertPathTLS, "tls-cert", "", certPathTLSUsage)
 	flag.StringVar(&cfg.KeyPathTLS, "tls-key", "", keyPathTLSUsage)
+	flag.Var(cfg.StartupChecks, "startup-checks", startupChecksUsage)
 	flag.BoolVar(&cfg.PrintVersion, "version", false, versionUsage)
 	flag.IntVar(&cfg.MaxLoopbacks, "max-loopbacks", proxy.DefaultMaxLoopbacks, maxLoopbacksUsage)
 	flag.IntVar(&cfg.DefaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
@@ -664,6 +668,7 @@ func (c *Config) ToOptions() skipper.Options {
 	options := skipper.Options{
 		// generic:
 		Address:                         c.Address,
+		StartupChecks:                   c.StartupChecks.values,
 		EnableTCPQueue:                  c.EnableTCPQueue,
 		ExpectedBytesPerRequest:         c.ExpectedBytesPerRequest,
 		MaxTCPListenerConcurrency:       c.MaxTCPListenerConcurrency,

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	DebugListener                   string         `yaml:"debug-listener"`
 	CertPathTLS                     string         `yaml:"tls-cert"`
 	KeyPathTLS                      string         `yaml:"tls-key"`
-	StatusChecks                   *listFlag      `yaml:"status-checks"`
+	StatusChecks                    *listFlag      `yaml:"status-checks"`
 	PrintVersion                    bool           `yaml:"version"`
 	MaxLoopbacks                    int            `yaml:"max-loopbacks"`
 	DefaultHTTPStatus               int            `yaml:"default-http-status"`
@@ -668,7 +668,7 @@ func (c *Config) ToOptions() skipper.Options {
 	options := skipper.Options{
 		// generic:
 		Address:                         c.Address,
-		StatusChecks:                   c.StatusChecks.values,
+		StatusChecks:                    c.StatusChecks.values,
 		EnableTCPQueue:                  c.EnableTCPQueue,
 		ExpectedBytesPerRequest:         c.ExpectedBytesPerRequest,
 		MaxTCPListenerConcurrency:       c.MaxTCPListenerConcurrency,

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	DebugListener                   string         `yaml:"debug-listener"`
 	CertPathTLS                     string         `yaml:"tls-cert"`
 	KeyPathTLS                      string         `yaml:"tls-key"`
-	StartupChecks                   *listFlag      `yaml:"startup-checks"`
+	StatusChecks                   *listFlag      `yaml:"status-checks"`
 	PrintVersion                    bool           `yaml:"version"`
 	MaxLoopbacks                    int            `yaml:"max-loopbacks"`
 	DefaultHTTPStatus               int            `yaml:"default-http-status"`
@@ -407,7 +407,7 @@ const (
 func NewConfig() *Config {
 	cfg := new(Config)
 	cfg.MetricsFlavour = commaListFlag("codahale", "prometheus")
-	cfg.StartupChecks = commaListFlag()
+	cfg.StatusChecks = commaListFlag()
 	cfg.FilterPlugins = newPluginFlag()
 	cfg.PredicatePlugins = newPluginFlag()
 	cfg.DataclientPlugins = newPluginFlag()
@@ -433,7 +433,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.DebugListener, "debug-listener", "", debugEndpointUsage)
 	flag.StringVar(&cfg.CertPathTLS, "tls-cert", "", certPathTLSUsage)
 	flag.StringVar(&cfg.KeyPathTLS, "tls-key", "", keyPathTLSUsage)
-	flag.Var(cfg.StartupChecks, "startup-checks", startupChecksUsage)
+	flag.Var(cfg.StatusChecks, "status-checks", startupChecksUsage)
 	flag.BoolVar(&cfg.PrintVersion, "version", false, versionUsage)
 	flag.IntVar(&cfg.MaxLoopbacks, "max-loopbacks", proxy.DefaultMaxLoopbacks, maxLoopbacksUsage)
 	flag.IntVar(&cfg.DefaultHTTPStatus, "default-http-status", http.StatusNotFound, defaultHTTPStatusUsage)
@@ -668,7 +668,7 @@ func (c *Config) ToOptions() skipper.Options {
 	options := skipper.Options{
 		// generic:
 		Address:                         c.Address,
-		StartupChecks:                   c.StartupChecks.values,
+		StatusChecks:                   c.StatusChecks.values,
 		EnableTCPQueue:                  c.EnableTCPQueue,
 		ExpectedBytesPerRequest:         c.ExpectedBytesPerRequest,
 		MaxTCPListenerConcurrency:       c.MaxTCPListenerConcurrency,

--- a/config/config.go
+++ b/config/config.go
@@ -248,7 +248,7 @@ const (
 
 	// generic:
 	addressUsage                         = "network address that skipper should listen on"
-	startupChecksUsage                   = "URLs to check before reporting healthy on startup"
+	startupChecksUsage                   = "experimental URLs to check before reporting healthy on startup"
 	enableTCPQueueUsage                  = "enable experimental TCP listener queue"
 	expectedBytesPerRequestUsage         = "bytes per request, that is used to calculate concurrency limits to buffer connection spikes"
 	maxTCPListenerConcurrencyUsage       = "sets hardcoded max for TCP listener concurrency, normally calculated based on available memory cgroups with max TODO"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,7 @@ func Test_NewConfig(t *testing.T) {
 			want: &Config{
 				ConfigFile:                              "test.yaml",
 				Address:                                 "localhost:8080",
+				StartupChecks:                           nil,
 				ExpectedBytesPerRequest:                 50 * 1024,
 				SupportListener:                         ":9911",
 				MaxLoopbacks:                            12,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,7 +36,7 @@ func Test_NewConfig(t *testing.T) {
 			want: &Config{
 				ConfigFile:                              "test.yaml",
 				Address:                                 "localhost:8080",
-				StartupChecks:                           nil,
+				StatusChecks:                           nil,
 				ExpectedBytesPerRequest:                 50 * 1024,
 				SupportListener:                         ":9911",
 				MaxLoopbacks:                            12,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,7 +36,7 @@ func Test_NewConfig(t *testing.T) {
 			want: &Config{
 				ConfigFile:                              "test.yaml",
 				Address:                                 "localhost:8080",
-				StatusChecks:                           nil,
+				StatusChecks:                            nil,
 				ExpectedBytesPerRequest:                 50 * 1024,
 				SupportListener:                         ":9911",
 				MaxLoopbacks:                            12,

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,3 +1,4 @@
 address: localhost:9090
 max-loopbacks: 12
 etcd-timeout: 2s
+startup-checks:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,4 +1,4 @@
 address: localhost:9090
 max-loopbacks: 12
 etcd-timeout: 2s
-startup-checks:
+status-checks:

--- a/skipper.go
+++ b/skipper.go
@@ -71,10 +71,10 @@ type Options struct {
 	// to 0.
 	WaitForHealthcheckInterval time.Duration
 
-	// StartupChecks is an experimental feature. It defines a
+	// StatusChecks is an experimental feature. It defines a
 	// comma separated list of HTTP URLs to do GET requests to,
 	// that have to return 200 before skipper becomes ready
-	StartupChecks []string
+	StatusChecks []string
 
 	// WhitelistedHealthcheckCIDR appends the whitelisted IP Range to the inernalIPS range for healthcheck purposes
 	WhitelistedHealthCheckCIDR []string
@@ -1293,7 +1293,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	proxy := proxy.WithParams(proxyParams)
 	defer proxy.Close()
 
-	for _, startupCheckURL := range o.StartupChecks {
+	for _, startupCheckURL := range o.StatusChecks {
 		for {
 			/* #nosec */
 			resp, err := http.Get(startupCheckURL)

--- a/skipper.go
+++ b/skipper.go
@@ -71,6 +71,9 @@ type Options struct {
 	// to 0.
 	WaitForHealthcheckInterval time.Duration
 
+	// StartupChecks defines a comma separated list of HTTP URLs to do GET requests to, that have to return 200 before skipper becomes ready
+	StartupChecks []string
+
 	// WhitelistedHealthcheckCIDR appends the whitelisted IP Range to the inernalIPS range for healthcheck purposes
 	WhitelistedHealthCheckCIDR []string
 
@@ -1287,6 +1290,23 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	// create the proxy
 	proxy := proxy.WithParams(proxyParams)
 	defer proxy.Close()
+
+	for _, startupCheckURL := range o.StartupChecks {
+		for {
+			resp, err := http.Get(startupCheckURL)
+			if err != nil {
+				log.Infof("%s unhealthy", startupCheckURL)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			if resp.StatusCode == 200 {
+				log.Infof("%s got healthy", startupCheckURL)
+				break
+			}
+			log.Infof("%s unhealthy", startupCheckURL)
+			time.Sleep(1 * time.Second)
+		}
+	}
 
 	// wait for the first route configuration to be loaded if enabled:
 	<-routing.FirstLoad()

--- a/skipper.go
+++ b/skipper.go
@@ -1293,6 +1293,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	for _, startupCheckURL := range o.StartupChecks {
 		for {
+			/* #nosec */
 			resp, err := http.Get(startupCheckURL)
 			if err != nil {
 				log.Infof("%s unhealthy", startupCheckURL)

--- a/skipper.go
+++ b/skipper.go
@@ -71,7 +71,9 @@ type Options struct {
 	// to 0.
 	WaitForHealthcheckInterval time.Duration
 
-	// StartupChecks defines a comma separated list of HTTP URLs to do GET requests to, that have to return 200 before skipper becomes ready
+	// StartupChecks is an experimental feature. It defines a
+	// comma separated list of HTTP URLs to do GET requests to,
+	// that have to return 200 before skipper becomes ready
 	StartupChecks []string
 
 	// WhitelistedHealthcheckCIDR appends the whitelisted IP Range to the inernalIPS range for healthcheck purposes
@@ -1301,7 +1303,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 				continue
 			}
 			if resp.StatusCode == 200 {
-				log.Infof("%s got healthy", startupCheckURL)
+				log.Infof("%s healthy", startupCheckURL)
 				break
 			}
 			log.Infof("%s unhealthy", startupCheckURL)


### PR DESCRIPTION
feature: add optional startup checks, that are checked to return 200 before we start listener -startup-checks="https://www.zalando.de/,https://www.google.com/,http://127.0.0.1:12345/health"

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>