### PR TITLE
Authorization support for OIDC

### DIFF
--- a/docs/tutorials/auth.md
+++ b/docs/tutorials/auth.md
@@ -223,3 +223,25 @@ for which it needs a secret key. This key is in a file which can be rotated peri
 because it is reread by Skipper. The path to this file can be passed with the flag
 `-oidc-secret-file` when Skipper is started.
 
+### AuthZ and access control
+
+Authorization validation and access control is available by means of a subsequent filter [oidcClaimsQuery](../reference/filters.md#oidcClaimsQuery). It inspects the ID token, which exists after a successful `oauthOidc*` filter step, and validates the defined query with the request path.
+
+Given following example ID token:
+
+```json
+{
+  "email": "someone@example.org",
+  "groups": [
+    "CD-xyz",
+    "appX-Tester"
+  ],
+  "name": "Some One"
+}
+```
+
+Access to path `/` would be granted to everyone in `example.org`, however path `/login` only to those being member of `group "appX-Tester"`:
+
+```
+oauthOidcAnyClaims(...) -> oidcClaimsQuery("/login:groups.#[==\"appX-Tester\"]", "/:@_:email%\"*@example.org\"")
+```

--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -29,6 +29,7 @@ const (
 	checkOIDCUserInfo
 	checkOIDCAnyClaims
 	checkOIDCAllClaims
+	checkOIDCQueryClaims
 )
 
 type rejectReason string

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -457,92 +457,92 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 	)
 
 	r := ctx.Request()
-			oauthState, err := f.getCallbackState(ctx)
-			if err != nil {
-				if _, ok := err.(*requestError); !ok {
-					log.Errorf("Error while retrieving callback state: %v.", err)
-				}
+	oauthState, err := f.getCallbackState(ctx)
+	if err != nil {
+		if _, ok := err.(*requestError); !ok {
+			log.Errorf("Error while retrieving callback state: %v.", err)
+		}
 
-				unauthorized(
-					ctx,
-					"",
-					invalidToken,
-					r.Host,
-					fmt.Sprintf("Failed to get state from callback: %v.", err),
-				)
+		unauthorized(
+			ctx,
+			"",
+			invalidToken,
+			r.Host,
+			fmt.Sprintf("Failed to get state from callback: %v.", err),
+		)
 
-				return
-			}
+		return
+	}
 
-			oauth2Token, err = f.getTokenWithExchange(oauthState, ctx)
-			if err != nil {
-				if _, ok := err.(*requestError); !ok {
-					log.Errorf("Error while getting token in callback: %v.", err)
-				}
+	oauth2Token, err = f.getTokenWithExchange(oauthState, ctx)
+	if err != nil {
+		if _, ok := err.(*requestError); !ok {
+			log.Errorf("Error while getting token in callback: %v.", err)
+		}
 
-				unauthorized(
-					ctx,
-					"",
-					invalidClaim,
-					r.Host,
-					fmt.Sprintf("Failed to get token in callback: %v.", err),
-				)
+		unauthorized(
+			ctx,
+			"",
+			invalidClaim,
+			r.Host,
+			fmt.Sprintf("Failed to get token in callback: %v.", err),
+		)
 
-				return
-			}
+		return
+	}
 
-			switch f.typ {
-			case checkOIDCUserInfo:
+	switch f.typ {
+	case checkOIDCUserInfo:
 		userInfo, err = f.provider.UserInfo(r.Context(), oauth2.StaticTokenSource(oauth2Token))
-				if err != nil {
-					// error coming from an external library and the possible error reasons are
-					// not documented explicitly, so we assume that the cause is always rooted
-					// in the incoming request, and only log it with a debug flag, via calling
-					// unauthorized().
-					unauthorized(
-						ctx,
-						"",
-						invalidToken,
-						r.Host,
-						fmt.Sprintf("Failed to get userinfo: %v.", err),
-					)
+		if err != nil {
+			// error coming from an external library and the possible error reasons are
+			// not documented explicitly, so we assume that the cause is always rooted
+			// in the incoming request, and only log it with a debug flag, via calling
+			// unauthorized().
+			unauthorized(
+				ctx,
+				"",
+				invalidToken,
+				r.Host,
+				fmt.Sprintf("Failed to get userinfo: %v.", err),
+			)
 
-					return
-				}
+			return
+		}
 
 		sub = userInfo.Subject
 		claimsMap, _, err = f.tokenClaims(ctx, oauth2Token)
-				if err != nil {
-					unauthorized(
-						ctx,
-						"",
-						invalidToken,
-						r.Host,
-						fmt.Sprintf("Failed to get claims: %v.", err),
-					)
-					return
-				}
+		if err != nil {
+			unauthorized(
+				ctx,
+				"",
+				invalidToken,
+				r.Host,
+				fmt.Sprintf("Failed to get claims: %v.", err),
+			)
+			return
+		}
 	case checkOIDCAnyClaims, checkOIDCAllClaims:
 		claimsMap, sub, err = f.tokenClaims(ctx, oauth2Token)
-				if err != nil {
-					if _, ok := err.(*requestError); !ok {
-						log.Errorf("Failed to get claims with error: %v", err)
-					}
+		if err != nil {
+			if _, ok := err.(*requestError); !ok {
+				log.Errorf("Failed to get claims with error: %v", err)
+			}
 
-					unauthorized(
-						ctx,
-						"",
-						invalidToken,
-						r.Host,
-						fmt.Sprintf(
-							"Failed to get claims: %s, %v",
-							f.claims,
-							err,
-						),
-					)
+			unauthorized(
+				ctx,
+				"",
+				invalidToken,
+				r.Host,
+				fmt.Sprintf(
+					"Failed to get claims: %s, %v",
+					f.claims,
+					err,
+				),
+			)
 
-					return
-				}
+			return
+		}
 	}
 
 	resp = tokenContainer{
@@ -551,39 +551,39 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 		Subject:     sub,
 		Claims:      claimsMap,
 	}
-				data, err = json.Marshal(resp)
-				if err != nil {
-					log.Errorf("Failed to serialize claims: %v.", err)
-					unauthorized(
-						ctx,
-						"",
-						invalidSub,
-						r.Host,
-						"Failed to serialize claims.",
-					)
+	data, err = json.Marshal(resp)
+	if err != nil {
+		log.Errorf("Failed to serialize claims: %v.", err)
+		unauthorized(
+			ctx,
+			"",
+			invalidSub,
+			r.Host,
+			"Failed to serialize claims.",
+		)
 
-					return
-				}
+		return
+	}
 
-			compressedData, err := f.compressor.compress(data)
-			if err != nil {
-				log.Error(err)
-			}
-			encryptedData, err := f.encrypter.Encrypt(compressedData)
-			if err != nil {
-				log.Errorf("Failed to encrypt the returned oidc data: %v.", err)
-				unauthorized(
-					ctx,
-					"",
-					invalidSub,
-					r.Host,
-					"Failed to encrypt the returned oidc data.",
-				)
+	compressedData, err := f.compressor.compress(data)
+	if err != nil {
+		log.Error(err)
+	}
+	encryptedData, err := f.encrypter.Encrypt(compressedData)
+	if err != nil {
+		log.Errorf("Failed to encrypt the returned oidc data: %v.", err)
+		unauthorized(
+			ctx,
+			"",
+			invalidSub,
+			r.Host,
+			"Failed to encrypt the returned oidc data.",
+		)
 
-				return
-			}
+		return
+	}
 
-			f.doDownstreamRedirect(ctx, encryptedData, oauthState.RedirectUrl)
+	f.doDownstreamRedirect(ctx, encryptedData, oauthState.RedirectUrl)
 }
 
 func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
@@ -615,18 +615,18 @@ func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
 		return
 	}
 
-		err := json.Unmarshal([]byte(cookie), &container)
-		if err != nil {
-			unauthorized(
-				ctx,
-				"",
-				invalidToken,
-				r.Host,
-				fmt.Sprintf("Failed to deserialize cookie: %v.", err),
-			)
+	err := json.Unmarshal([]byte(cookie), &container)
+	if err != nil {
+		unauthorized(
+			ctx,
+			"",
+			invalidToken,
+			r.Host,
+			fmt.Sprintf("Failed to deserialize cookie: %v.", err),
+		)
 
-			return
-		}
+		return
+	}
 	// filter specific checks
 	switch f.typ {
 	case checkOIDCUserInfo:
@@ -653,6 +653,8 @@ func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
 		f.internalServerError(ctx)
 		return
 	}
+	// saving token info for chained filter
+	ctx.StateBag()[oidcClaimsCacheKey] = container
 	ctx.Request().Header.Add(oidcInfoHeader, string(oidcInfoJson))
 }
 

--- a/filters/auth/oidc_introspection.go
+++ b/filters/auth/oidc_introspection.go
@@ -1,0 +1,168 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/gjson"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zalando/skipper/filters"
+)
+
+const (
+	OidcClaimsQueryName = "oidcClaimsQuery"
+	oidcClaimsCacheKey  = "oidcclaimscachekey"
+)
+
+type (
+	oidcIntrospectionSpec struct {
+		typ roleCheckType
+	}
+	oidcIntrospectionFilter struct {
+		typ   roleCheckType
+		paths []pathQuery
+	}
+
+	pathQuery struct {
+		path    string
+		queries []string
+	}
+)
+
+func NewOIDCQueryClaimsFilter() filters.Spec {
+	return &oidcIntrospectionSpec{
+		typ: checkOIDCQueryClaims,
+	}
+}
+
+func (spec *oidcIntrospectionSpec) Name() string {
+	switch spec.typ {
+	case checkOIDCQueryClaims:
+		return OidcClaimsQueryName
+	}
+	return AuthUnknown
+}
+
+func (spec *oidcIntrospectionSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	sargs, err := getStrings(args)
+	if err != nil {
+		return nil, err
+	}
+	if len(sargs) == 0 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	filter := &oidcIntrospectionFilter{typ: spec.typ}
+
+	switch filter.typ {
+	case checkOIDCQueryClaims:
+		for _, arg := range sargs {
+			slice := strings.SplitN(arg, ":", 2)
+			if len(slice) != 2 {
+				return nil, fmt.Errorf("%v: malformatted filter arg %s", filters.ErrInvalidFilterParameters, arg)
+			}
+			pq := pathQuery{path: slice[0]}
+			for _, query := range strings.Split(slice[1], " ") {
+				if query == "" {
+					return nil, fmt.Errorf("%v: %s", errUnsupportedClaimSpecified, arg)
+				}
+				pq.queries = append(pq.queries, trimQuotes(query))
+			}
+			if len(pq.queries) == 0 {
+				return nil, fmt.Errorf("%v: %s", errUnsupportedClaimSpecified, arg)
+			}
+			filter.paths = append(filter.paths, pq)
+		}
+		if len(filter.paths) == 0 {
+			return nil, fmt.Errorf("%v: no queries could be parsed", errUnsupportedClaimSpecified)
+		}
+	default:
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	return filter, nil
+}
+
+func (filter *oidcIntrospectionFilter) String() string {
+	var str []string
+	for _, query := range filter.paths {
+		str = append(str, query.String())
+	}
+	return fmt.Sprintf("%s(%s)", OidcClaimsQueryName, strings.Join(str, "; "))
+}
+
+func (filter *oidcIntrospectionFilter) Request(ctx filters.FilterContext) {
+	r := ctx.Request()
+
+	token, ok := ctx.StateBag()[oidcClaimsCacheKey].(tokenContainer)
+	if !ok || &token == (&tokenContainer{}) || len(token.Claims) == 0 {
+		log.Errorf("Error retrieving %s for OIDC token introspection", oidcClaimsCacheKey)
+		unauthorized(ctx, "", missingToken, r.Host, oidcClaimsCacheKey+" is unavailable in StateBag")
+		return
+	}
+
+	switch filter.typ {
+	case checkOIDCQueryClaims:
+		if !filter.validateClaimsQuery(r.URL.Path, token.Claims) {
+			unauthorized(ctx, "", invalidAccess, r.Host, "Path not permitted")
+			return
+		}
+	default:
+		unauthorized(ctx, string(filter.typ), invalidClaim, r.Host, "Wrong oidcIntrospectionFilter type")
+		return
+	}
+
+	sub := token.Claims["sub"].(string)
+	authorized(ctx, sub)
+}
+
+func (filter *oidcIntrospectionFilter) Response(filters.FilterContext) {}
+
+func (filter *oidcIntrospectionFilter) validateClaimsQuery(reqPath string, gotToken map[string]interface{}) bool {
+	gjson.AddModifier("_", func(json, arg string) string {
+		return gjson.Get(json, "[@this].#("+arg+")").Raw
+	})
+
+	l := len(filter.paths)
+	if l == 0 {
+		return false
+	}
+
+	json, err := json.Marshal(gotToken)
+	if err != nil || !gjson.ValidBytes(json) {
+		log.Errorf("Failed to serialize in validateClaimsQuery: %v", err)
+		return false
+	}
+	parsed := gjson.ParseBytes(json)
+
+	for _, path := range filter.paths {
+		if !strings.HasPrefix(reqPath, path.path) {
+			continue
+		}
+
+		for _, query := range path.queries {
+			match := parsed.Get(query)
+			log.Debugf("claim: %s results:%s", query, match.String())
+			if match.Exists() {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func (p pathQuery) String() string {
+	return fmt.Sprintf("path: '%s*', matching: %s", p.path, strings.Join(p.queries, " ,"))
+}
+
+func trimQuotes(s string) string {
+	if len(s) >= 2 {
+		if c := s[len(s)-1]; s[0] == c && (c == '"' || c == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/filters/auth/oidc_introspection_test.go
+++ b/filters/auth/oidc_introspection_test.go
@@ -1,0 +1,325 @@
+package auth
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/logging/loggingtest"
+	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/routing"
+	"github.com/zalando/skipper/routing/testdataclient"
+	"github.com/zalando/skipper/secrets/secrettest"
+)
+
+func TestCreateOIDCQueryClaimsFilter(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		args    []interface{}
+		want    interface{}
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "no args",
+			args:    nil,
+			wantErr: assert.Error,
+		},
+		{
+			name:    "bogus formatted",
+			args:    []interface{}{"s"},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "several bogus formatted",
+			args:    []interface{}{"s", "d", "easdf:"},
+			wantErr: assert.Error,
+		},
+		{
+			name: "one path query",
+			args: []interface{}{"/:[@this].#(sub==\"somesub\")"},
+			want: &oidcIntrospectionFilter{
+				typ: checkOIDCQueryClaims,
+				paths: []pathQuery{
+					{
+						path:    "/",
+						queries: []string{"[@this].#(sub==\"somesub\")"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "several path queries",
+			args: []interface{}{
+				"/some/path:[@this].#(sub==\"somesub\")",
+				"/another/path:groups.#(%\"CD-*\")",
+				"/asdf/:groups.#(%\"CD-*\") 'groups.#(%\"*-Test-Users\")' groups.#(%\"Purchasing-Department\")",
+				"/:groups.#(%\"Purchasing-Department\")",
+			},
+			want: &oidcIntrospectionFilter{
+				typ: checkOIDCQueryClaims,
+				paths: []pathQuery{
+					{
+						path:    "/some/path",
+						queries: []string{"[@this].#(sub==\"somesub\")"},
+					},
+					{
+						path:    "/another/path",
+						queries: []string{"groups.#(%\"CD-*\")"},
+					},
+					{
+						path: "/asdf/",
+						queries: []string{
+							"groups.#(%\"CD-*\")",
+							"groups.#(%\"*-Test-Users\")",
+							"groups.#(%\"Purchasing-Department\")",
+						},
+					},
+					{
+						path: "/",
+						queries: []string{
+							"groups.#(%\"Purchasing-Department\")",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := NewOIDCQueryClaimsFilter()
+			got, err := spec.CreateFilter(tt.args)
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+}
+
+func TestOIDCQueryClaimsFilter(t *testing.T) {
+	for _, tc := range []struct {
+		msg       string
+		path      string
+		expected  int
+		expectErr bool
+		args      []interface{}
+	}{
+		{
+			msg: "secure sub/path not permitted",
+			args: []interface{}{
+				"/login:groups.#[==\"appY-Tester\"]",
+				"/:@_:email%\"*@example.org\"",
+			},
+			path:      "/login/page",
+			expected:  401,
+			expectErr: false,
+		},
+		{
+			msg: "secure sub/path is permitted",
+			args: []interface{}{
+				"/login:groups.#[==\"AppX-Test-Users\"]",
+				"/:@_:email%\"*@example.org\"",
+			},
+			path:      "/login/page",
+			expected:  200,
+			expectErr: false,
+		},
+		{
+			msg: "generic user path permitted",
+			args: []interface{}{
+				"/login:groups.#[==\"Arbitrary-Group\"]",
+				"/:@_:email%\"*@example.org\"",
+			},
+			path:      "/notsecured",
+			expected:  200,
+			expectErr: false,
+		},
+		{
+			msg: "using modifier, path matching",
+			args: []interface{}{
+				`/path:@_:sub=="somesub"`,
+			},
+			path:      "/path/asdf",
+			expected:  200,
+			expectErr: false,
+		},
+		{
+			msg: "using escape character",
+			args: []interface{}{
+				"/path:@_:sub==\"somesub\"",
+			},
+			path:      "/path/asdf",
+			expected:  200,
+			expectErr: false,
+		},
+		{
+			msg: "path / permitted for group Purchasing-Department",
+			args: []interface{}{
+				"/:groups.#(%\"Purchasing-Department\")",
+			},
+			path:      "/",
+			expected:  200,
+			expectErr: false,
+		},
+		{
+			msg: "path /some/path permitted",
+			args: []interface{}{
+				"/some/path:groups.#(%\"Purchasing-Department\")",
+			},
+			path:      "/some/path/down/there",
+			expected:  200,
+			expectErr: false,
+		},
+		{
+			msg: "path /some/otherpath denied",
+			args: []interface{}{
+				"/some/path:groups.#(%\"Purchasing-Department\")",
+			},
+			path:      "/some/otherpath",
+			expected:  401,
+			expectErr: false,
+		},
+		{
+			msg: "wrong group denied",
+			args: []interface{}{
+				"/some/path:groups.#(%\"Shipping-Department\")",
+			},
+			path:      "/some/path",
+			expected:  401,
+			expectErr: false,
+		},
+		{
+			msg: "several queries, path matching",
+			args: []interface{}{
+				"/some/path:[@this].#(sub==\"somesub\")",
+				"/another/path:groups.#(%\"CD-*\")",
+				"/asdf/:groups.#(%\"CD-*\") 'groups.#(%\"*-Test-Users\")' groups.#(%\"Purchasing-Department\")",
+				"/:groups.#(%\"Purchasing-Department\")",
+			},
+			path:      "/asdf/asdf",
+			expected:  200,
+			expectErr: false,
+		},
+		{
+			msg: "several queries, no path matching",
+			args: []interface{}{
+				"/some/path:[@this].#(sub==\"somesub\")",
+				"/another/path:groups.#(%\"CD-*\")",
+				"/asdf/:groups.#(%\"CD-*\") 'groups.#(%\"*-Test-Users\")' groups.#(%\"Purchasing-Department\")",
+				"/abc:groups.#(%\"Purchasing-Department\")",
+			},
+			path:      "/xyz",
+			expected:  401,
+			expectErr: false,
+		},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Logf("backend got request: %+v", r)
+				w.Write([]byte("OK"))
+			}))
+			defer backend.Close()
+			t.Logf("backend URL: %s", backend.URL)
+
+			spec := &tokenOidcSpec{
+				typ:             checkOIDCAnyClaims,
+				SecretsFile:     "/tmp/foo",
+				secretsRegistry: secrettest.NewTestRegistry(),
+			}
+			fr := make(filters.Registry)
+			fr.Register(spec)
+			dc := testdataclient.New(nil)
+			proxy := proxytest.WithRoutingOptions(fr, routing.Options{
+				DataClients: []routing.DataClient{dc},
+				Log:         loggingtest.New(),
+			})
+			defer proxy.Close()
+			reqURL, err := url.Parse(proxy.URL)
+			if err != nil {
+				t.Errorf("Failed to parse url %s: %v", proxy.URL, err)
+			}
+			reqURL.Path = tc.path
+			oidcServer := createOIDCServer(proxy.URL+"/redirect", validClient, "mysec")
+			defer oidcServer.Close()
+			t.Logf("oidc/auth server URL: %s", oidcServer.URL)
+			// create filter
+			sargs := []interface{}{
+				oidcServer.URL,
+				validClient,
+				"mysec",
+				proxy.URL + "/redirect",
+				testKey,
+				testKey,
+			}
+			f, err := spec.CreateFilter(sargs)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("Want error but got filter: %v", f)
+				}
+				return //OK
+			} else if err != nil {
+				t.Fatalf("Unexpected error while creating filter: %v", err)
+			}
+			fOIDC := f.(*tokenOidcFilter)
+			defer fOIDC.Close()
+
+			// adding the OIDCQueryClaimsFilter to the route
+			querySpec := NewOIDCQueryClaimsFilter()
+			fr.Register(querySpec)
+			r := &eskip.Route{
+				Filters: []*eskip.Filter{
+					{
+						Name: spec.Name(),
+						Args: sargs,
+					},
+					{
+						Name: querySpec.Name(),
+						Args: tc.args,
+					},
+				},
+				Backend: backend.URL,
+			}
+
+			proxy.Log.Reset()
+			dc.Update([]*eskip.Route{r}, nil)
+			if err = proxy.Log.WaitFor("route settings applied", 1*time.Second); err != nil {
+				t.Fatalf("Failed to get update: %v", err)
+			}
+
+			// do request through proxy
+			req, err := http.NewRequest("GET", reqURL.String(), nil)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			req.Header.Set(authHeaderName, authHeaderPrefix+testToken)
+
+			// client with cookie handling to support 127.0.0.1 with ports
+			client := http.Client{
+				Timeout: 1 * time.Second,
+				Jar:     newInsecureCookieJar(),
+			}
+
+			// trigger OpenID Connect Authorization Code Flow
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Errorf("req: %+v: %v", req, err)
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.expected {
+				t.Logf("response: %+v", resp)
+				t.Errorf("auth filter failed got=%d, expected=%d, route=%s", resp.StatusCode, tc.expected, r)
+				b, _ := ioutil.ReadAll(resp.Body)
+				t.Fatalf("Response body: %s", string(b))
+			}
+		})
+	}
+}

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -224,6 +224,12 @@ func createOIDCServer(cb, client, clientsecret string) *httptest.Server {
 					"aud":   validClient,
 					"iat":   time.Now().Add(-time.Minute).UTC().Unix(),
 					"exp":   time.Now().Add(time.Hour).UTC().Unix(),
+					"groups": []string{
+						"CD-Administrators",
+						"Purchasing-Department",
+						"AppX-Test-Users",
+					},
+					"email": "someone@example.org",
 				})
 
 				privKey, err := ioutil.ReadFile(keyPath)

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/sony/gobreaker v0.4.1
 	github.com/stretchr/testify v1.3.0
 	github.com/szuecs/rate-limit-buffer v0.7.1
+	github.com/tidwall/gjson v1.4.0
+	github.com/tidwall/pretty v1.0.1 // indirect
 	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	github.com/uber/jaeger-lib v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,14 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/szuecs/rate-limit-buffer v0.7.1 h1:kpVLwDvpCTFQi8uhiXQrhAKWzNUaEKhArFdjb4GQ8F4=
 github.com/szuecs/rate-limit-buffer v0.7.1/go.mod h1:BxqrsmnHsCnWcvbtdcaDLEBmjNEvRFU5LQ8edoZ9B0M=
+github.com/tidwall/gjson v1.4.0 h1:w6iOJZt9BJOzz4VD9CSnRCX/oleCsAZWi+1FFzZA+SA=
+github.com/tidwall/gjson v1.4.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.0.1 h1:WE4RBSZ1x6McVVC8S/Md+Qse8YUv6HRObAx6ke00NY8=
+github.com/tidwall/pretty v1.0.1/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=
 github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber/jaeger-client-go v2.16.0+incompatible h1:Q2Pp6v3QYiocMxomCaJuwQGFt7E53bPYqEgug/AoBtY=

--- a/skipper.go
+++ b/skipper.go
@@ -1066,6 +1066,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		auth.NewOAuthOidcUserInfos(o.OIDCSecretsFile, o.SecretsRegistry),
 		auth.NewOAuthOidcAnyClaims(o.OIDCSecretsFile, o.SecretsRegistry),
 		auth.NewOAuthOidcAllClaims(o.OIDCSecretsFile, o.SecretsRegistry),
+		auth.NewOIDCQueryClaimsFilter(),
 		apiusagemonitoring.NewApiUsageMonitoring(
 			o.ApiUsageMonitoringEnable,
 			o.ApiUsageMonitoringRealmKeys,


### PR DESCRIPTION
# AuthZ filter OIDCQueryClaimsFilter

This filter is intended to be chained after one of `OAuthOidc*Claims` OIDC flow provider, making use of the token information saved in `stateBag` to classify **authorization**

* It leverages the query syntax of `GJSON` to express a matching of the token.
* It allows validation per path request, matching one or more queries.
* Each argument of the filter expresses a path/query relation, one or several paths can be defined
* The first positive match wins

Format:
`<path>:[<query>]`

Following example statements would be possible:
```
"/some/path:@_:sub==\"somesub\")"
"/some/path:[@this].#(sub==\"somesub\")"
"/another/path:groups.#(%\"CD-*\")"
"/asdf/:groups.#(%\"CD-*\") 'groups.#(%\"*-Test-Users\")' groups.#(%\"Purchasing-Department\")"
"/:groups.#(%\"Purchasing-Department\")"
```

These would match each one of these:
```json
{
    "sub": "somesub",
    "groups": [
        "CD-Administrators",
        "Purchasing-Department",
        "AppX-Test-Users",
    ]
}
```
ref: https://github.com/tidwall/gjson/issues/151

## generalize and remove cognitive challenge

 * Cognitive challenge reduced by splitting out the stage 5 of the OIDC flow into distinct method
 * generlizing duplicate code paths
 * making use of one struct `tokenContainer` as they can be united through `omitempty` annotation. This is necessary for later filter chain parsing of the statebag
