### PR TITLE
doc: update deployment manifests to enable routegroups via rbac.

### DIFF
--- a/docs/kubernetes/deploy/deployment/deployment.yaml
+++ b/docs/kubernetes/deploy/deployment/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.1
+    version: v0.11.40
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.1
+        version: v0.11.40
         component: ingress
     spec:
       affinity:
@@ -39,7 +39,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.1
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.40
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/docs/kubernetes/deploy/deployment/rbac.yaml
+++ b/docs/kubernetes/deploy/deployment/rbac.yaml
@@ -33,12 +33,29 @@ kind: ClusterRole
 metadata:
   name: skipper-ingress
 rules:
-- apiGroups: ["extensions"]
-  resources: ["ingresses", ]
-  verbs: ["get", "list"]
+- apiGroups:
+    - extensions
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - list
 - apiGroups: [""]
-  resources: ["namespaces", "services", "endpoints", "pods"]
-  verbs: ["get", "list"]
+  resources:
+    - namespaces
+    - services
+    - endpoints
+    - pods
+  verbs:
+    - get
+    - list
+- apiGroups:
+  - zalando.org
+  resources:
+  - routegroups
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -322,8 +322,9 @@ To deploy the demo application, you have to run:
 kubectl create -f docs/kubernetes/deploy/demo/
 ```
 
-Now we have a skipper-ingress running as daemonset exposing the TCP
-port 9999 on each worker node, a backend application running with 2
+Now we have a skipper-ingress running as daemonset or deployment
+exposing the TCP port 9999 on each worker nodes, which has a running
+skipper-ingress instance, a backend application running with 2
 replicas that serves some html on TCP port 9090, and we expose a
 cluster service on TCP port 80. Besides skipper-ingress, deployment
 and service can not be reached from outside the cluster. Now we expose
@@ -362,7 +363,9 @@ The next question you may ask is: how to expose this to your customers?
 The answer depends on your setup and complexity requirements. In the
 simplest case you could add one A record in your DNS `*.<mydomain.org>`
 to your frontend load balancer IP that directs all traffic from `*.<mydomain.org>`
-to all Kubernetes worker nodes on TCP port 9999.
+to all Kubernetes worker nodes on TCP port 9999. The load balancer
+health check should make sure, that only nodes with ready skipper-ingress
+instances will get traffic.
 
 A more complex setup we use in production and can be done with
 something that configures your frontend load balancer, for example


### PR DESCRIPTION
doc: update deployment manifests to enable routegroups via rbac.

https://github.com/zalando/skipper/pull/1300 should be merged before this one, because we reference the v0.11.40, which fixes the log spam

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>