### PR TITLE
fix: SecretPaths should support symlink to file for Kubernetes secrets

### DIFF
--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -132,7 +132,17 @@ func newClusterClient(o Options, apiURL, ingCls string, quit <-chan struct{}) (*
 
 	if o.KubernetesInCluster {
 		c.tokenProvider = secrets.NewSecretPaths(time.Minute)
-		c.tokenProvider.Add(serviceAccountDir + serviceAccountTokenKey)
+		err := c.tokenProvider.Add(serviceAccountDir + serviceAccountTokenKey)
+		if err != nil {
+			log.Errorf("Failed to Add secret %s: %v", serviceAccountDir+serviceAccountTokenKey, err)
+			return nil, err
+		}
+
+		b, ok := c.tokenProvider.GetSecret(serviceAccountDir + serviceAccountTokenKey)
+		if !ok {
+			return nil, fmt.Errorf("Failed to GetSecret: %s", serviceAccountDir+serviceAccountTokenKey)
+		}
+		log.Debugf("Got secret %d bytes", len(b))
 	}
 
 	if o.KubernetesNamespace != "" {
@@ -156,9 +166,9 @@ func (c *clusterClient) createRequest(uri string, body io.Reader) (*http.Request
 	}
 
 	if c.tokenProvider != nil {
-		token, ok := c.tokenProvider.GetSecret(serviceAccountTokenKey)
+		token, ok := c.tokenProvider.GetSecret(serviceAccountDir + serviceAccountTokenKey)
 		if !ok {
-			return nil, fmt.Errorf("secret not found: %v", serviceAccountTokenKey)
+			return nil, fmt.Errorf("secret not found: %v", serviceAccountDir+serviceAccountTokenKey)
 		}
 		req.Header.Set("Authorization", "Bearer "+string(token))
 	}

--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -140,7 +140,7 @@ func newClusterClient(o Options, apiURL, ingCls string, quit <-chan struct{}) (*
 
 		b, ok := c.tokenProvider.GetSecret(serviceAccountDir + serviceAccountTokenKey)
 		if !ok {
-			return nil, fmt.Errorf("Failed to GetSecret: %s", serviceAccountDir+serviceAccountTokenKey)
+			return nil, fmt.Errorf("failed to GetSecret: %s", serviceAccountDir+serviceAccountTokenKey)
 		}
 		log.Debugf("Got secret %d bytes", len(b))
 	}

--- a/secrets/file.go
+++ b/secrets/file.go
@@ -126,14 +126,6 @@ func (sp *SecretPaths) handleDir(p string) error {
 	return nil
 }
 
-func (sp *SecretPaths) tryDir(p string) error {
-	_, err := filepath.Glob(p + "/*")
-	if err != nil {
-		return ErrWrongFileType
-	}
-	return sp.handleDir(p)
-}
-
 func (sp *SecretPaths) registerSecretFile(p string) error {
 	if _, ok := sp.GetSecret(p); ok {
 		return ErrAlreadyExists

--- a/secrets/file.go
+++ b/secrets/file.go
@@ -100,16 +100,8 @@ func (sp *SecretPaths) Add(p string) error {
 	case mode.IsDir():
 		return sp.handleDir(p)
 
-	case mode&os.ModeSymlink != 0: // TODO(sszuecs) do we want to support symlinks or not?
-		newp, err := os.Readlink(p)
-		if err != nil {
-			return err
-		}
-		err = sp.registerSecretFile(newp) // link to regular file
-		if err != nil {
-			return sp.tryDir(newp)
-		}
-		return nil
+	case mode&os.ModeSymlink != 0: // Kubernetes use symlink to file
+		return sp.registerSecretFile(p)
 	}
 
 	return ErrWrongFileType

--- a/secrets/file_test.go
+++ b/secrets/file_test.go
@@ -84,9 +84,6 @@ func Test_SecretPaths_Add(t *testing.T) {
 	if err := os.Symlink(watchit+filename, watchit+"/mysymlink"); err != nil {
 		t.Errorf("Failed to create symlink")
 	}
-	if err := os.Symlink(watchit, watchit+"/mysymlinktodir"); err != nil {
-		t.Errorf("Failed to create symlink to dir")
-	}
 
 	for _, tt := range []struct {
 		name      string
@@ -113,19 +110,9 @@ func Test_SecretPaths_Add(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-
 			name:      "Should GetSecret after write to watched symlink",
 			addFile:   watchit + "/mysymlink",
-			writeFile: watchit + filename,
-			want:      dat,
-			wantOk:    true,
-			wantErr:   false,
-		},
-		{
-
-			name:      "Should GetSecret after write to watched symlinked directory",
-			addFile:   watchit + "/mysymlinktodir",
-			writeFile: watchit + filename + "3",
+			writeFile: watchit + "/mysymlink",
 			want:      dat,
 			wantOk:    true,
 			wantErr:   false,
@@ -148,6 +135,7 @@ func Test_SecretPaths_Add(t *testing.T) {
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			sp := NewSecretPaths(60 * time.Millisecond)
+			defer sp.Close()
 			err := ioutil.WriteFile(tt.writeFile, []byte(""), 0644)
 			if err != nil {
 				t.Errorf("Failed to create file: %v", err)
@@ -219,7 +207,7 @@ func Test_SecretPaths_Close(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to write to file: %v", err)
 	}
-	time.Sleep(100 * time.Millisecond) // wait for fsnotify
+	time.Sleep(100 * time.Millisecond) // wait for refresher
 	got, ok = sp.GetSecret(afile)
 	if !ok {
 		t.Errorf("Should have former secret: %v", ok)


### PR DESCRIPTION
fix https://github.com/zalando/skipper/issues/1305 validated in a dev cluster
fix: SecretPaths should support symlink to file for Kubernetes secrets and clusterclient should report errors for this more clearly

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>