### PR TITLE
Close request body on shunted requests

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -96,6 +96,9 @@ type FilterContext interface {
 
 	// Allow filters to create their own spans
 	ParentSpan() opentracing.Span
+
+	// Returns if the current response is shunted.
+	Shunted() bool
 }
 
 // Metrics provides possibility to use custom metrics from filter implementations. The custom metrics will

--- a/filters/tee/tee.go
+++ b/filters/tee/tee.go
@@ -160,6 +160,12 @@ func (r *tee) Request(fc filters.FilterContext) {
 		}()
 
 		rsp, err := r.client.Do(copyOfRequest)
+
+		// Prevent to leak goroutines when request body is never read.
+		if fc.Shunted() {
+			defer copyOfRequest.Body.Close()
+		}
+
 		if err != nil {
 			log.Warn("tee: error while tee request", err)
 			return

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -185,6 +185,7 @@ func (c *context) setResponse(r *http.Response, preserveOriginal bool) {
 	}
 }
 
+func (c *context) Shunted() bool                       { return c.shunted() || c.deprecatedShunted() }
 func (c *context) ResponseWriter() http.ResponseWriter { return c.responseWriter }
 func (c *context) Request() *http.Request              { return c.request }
 func (c *context) Response() *http.Response            { return c.response }


### PR DESCRIPTION
Exposes Shunt() in the filter context. This method is used to check is the route is shunted in the tee filter. If that is the case then we close the req.body to prevent leaks.

Fixes: https://github.com/zalando/skipper/issues/1310