### PR TITLE
Read and discard request body on shunt

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -1045,6 +1046,7 @@ func (p *Proxy) do(ctx *context) error {
 		p.log.Debugf("deprecated shunting detected in route: %s", ctx.route.Id)
 		return &proxyError{handled: true}
 	} else if ctx.shunted() || ctx.route.Shunt || ctx.route.BackendType == eskip.ShuntBackend {
+		io.Copy(ioutil.Discard, ctx.request.Body)
 		ctx.ensureDefaultResponse()
 	} else if ctx.route.BackendType == eskip.LoopBackend {
 		loopCTX := ctx.clone()

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -883,9 +883,11 @@ func TestNilFilterIsNotCalledAndDoesNotBreakFilterChain(t *testing.T) {
 
 func TestProcessesRequestWithShuntBackend(t *testing.T) {
 	u, _ := url.ParseRequestURI("https://www.example.org/hello")
+	reqBody := strings.NewReader("sameple request body")
 	r := &http.Request{
 		URL:    u,
-		Method: "GET",
+		Method: "POST",
+		Body:   ioutil.NopCloser(reqBody),
 		Header: http.Header{"X-Test-Header": []string{"test value"}}}
 	w := httptest.NewRecorder()
 
@@ -906,6 +908,11 @@ func TestProcessesRequestWithShuntBackend(t *testing.T) {
 	if h, ok := w.Header()["X-Test-Response-Header"]; !ok || h[0] != "response header value" {
 		t.Error("wrong response header")
 	}
+	_, err = reqBody.ReadByte()
+	if io.EOF != err {
+		t.Error("request body was not read")
+	}
+
 }
 
 func TestProcessesRequestWithPriorityRoute(t *testing.T) {


### PR DESCRIPTION
As we discussed with @aryszka , reading the request body matches better with the expected behavior of the shunt backend. In other words, default to reading the request body on any case. 

I am not sure if this is the most efficient way to read and discard the request body. 