### PR TITLE
remove deprecated certificate naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ vet: $(SOURCES)
 # -ST1021 too many wrong comments on exported functions to fix right away
 # -ST1022 too many wrong comments on exported functions to fix right away
 staticcheck: $(SOURCES)
-	GO111MODULE=$(GO111) staticcheck -checks "all,-ST1000,-ST1003,-ST1012,-ST1020,-ST1021,-ST1022,-SA1019" $(PACKAGES)
+	GO111MODULE=$(GO111) staticcheck -checks "all,-ST1000,-ST1003,-ST1012,-ST1020,-ST1021,-ST1022" $(PACKAGES)
 
 # TODO(sszuecs) review disabling these checks, f.e.:
 # G101 find by variable name match "oauth" are not hardcoded credentials

--- a/skipper.go
+++ b/skipper.go
@@ -857,7 +857,6 @@ func listenAndServeQuit(
 				}
 				tlsCfg.Certificates = append(tlsCfg.Certificates, kp)
 			}
-			tlsCfg.BuildNameToCertificate()
 			o.CertPathTLS = ""
 			o.KeyPathTLS = ""
 			srv.TLSConfig = tlsCfg


### PR DESCRIPTION
removing deprecated certificate naming

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>