### PR TITLE
Add modRequestHeader filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -63,17 +63,9 @@ Example:
 foo: * -> setRequestHeader("X-Passed-Skipper", "true") -> "https://backend.example.org";
 ```
 
-## setResponseHeader
-
-Same as [setRequestHeader](#setrequestheader), only for responses
-
 ## appendRequestHeader
 
 Same as [setRequestHeader](#setrequestheader), does not remove a possibly existing value, but adds a new header value
-
-## appendResponseHeader
-
-Same as [appendRequestHeader](#appendrequestheader), only for responses
 
 ## dropRequestHeader
 
@@ -88,6 +80,14 @@ Example:
 ```
 foo: * -> dropRequestHeader("User-Agent") -> "https://backend.example.org";
 ```
+
+## setResponseHeader
+
+Same as [setRequestHeader](#setrequestheader), only for responses
+
+## appendResponseHeader
+
+Same as [appendRequestHeader](#appendrequestheader), only for responses
 
 ## dropResponseHeader
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -48,6 +48,22 @@ foo3:
   -> <dynamic>;
 ```
 
+## modRequestHeader
+
+Replace all matched regex expressions in the given header.
+
+Parameters:
+
+* header name (string)
+* the expression to match (regex)
+* the replacement (string)
+
+Example:
+
+```
+enforce_www: * -> modRequestHeader("Host", "^zalando\.(\w+)$", "www.zalando.$1") -> redirectTo(301);
+```
+
 ## setRequestHeader
 
 Set headers for requests.

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -45,21 +45,22 @@ const (
 	SetDynamicBackendScheme           = "setDynamicBackendScheme"
 	SetDynamicBackendUrl              = "setDynamicBackendUrl"
 
-	HealthCheckName     = "healthcheck"
-	ModPathName         = "modPath"
-	SetPathName         = "setPath"
-	RedirectToName      = "redirectTo"
-	RedirectToLowerName = "redirectToLower"
-	StaticName          = "static"
-	StripQueryName      = "stripQuery"
-	PreserveHostName    = "preserveHost"
-	StatusName          = "status"
-	CompressName        = "compress"
-	SetQueryName        = "setQuery"
-	DropQueryName       = "dropQuery"
-	InlineContentName   = "inlineContent"
-	HeaderToQueryName   = "headerToQuery"
-	QueryToHeaderName   = "queryToHeader"
+	HealthCheckName      = "healthcheck"
+	ModPathName          = "modPath"
+	SetPathName          = "setPath"
+	ModRequestHeaderName = "modRequestHeader"
+	RedirectToName       = "redirectTo"
+	RedirectToLowerName  = "redirectToLower"
+	StaticName           = "static"
+	StripQueryName       = "stripQuery"
+	PreserveHostName     = "preserveHost"
+	StatusName           = "status"
+	CompressName         = "compress"
+	SetQueryName         = "setQuery"
+	DropQueryName        = "dropQuery"
+	InlineContentName    = "inlineContent"
+	HeaderToQueryName    = "headerToQuery"
+	QueryToHeaderName    = "queryToHeader"
 )
 
 // Returns a Registry object initialized with the default set of filter
@@ -79,6 +80,7 @@ func MakeRegistry() filters.Registry {
 		NewDropResponseHeader(),
 		NewModPath(),
 		NewSetPath(),
+		NewModRequestHeader(),
 		NewDropQuery(),
 		NewSetQuery(),
 		NewHealthCheck(),

--- a/filters/builtin/mod_header.go
+++ b/filters/builtin/mod_header.go
@@ -1,0 +1,75 @@
+package builtin
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/zalando/skipper/filters"
+)
+
+type modRequestHeader struct {
+	headerName  string
+	rx          *regexp.Regexp
+	replacement string
+}
+
+// NewModRequestHeader returns a new filter Spec, whose instances execute
+// regexp.ReplaceAllString on the request host. Instances expect three
+// parameters: the header name, the expression to match and the replacement string.
+// Name: "modRequestHeader".
+func NewModRequestHeader() filters.Spec { return &modRequestHeader{} }
+
+func (spec *modRequestHeader) Name() string {
+	return ModRequestHeaderName
+}
+
+//lint:ignore ST1016 "spec" makes sense here and we reuse the type for the filter
+func (spec *modRequestHeader) CreateFilter(config []interface{}) (filters.Filter, error) {
+	if len(config) != 3 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	headerName, ok := config[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	expr, ok := config[1].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	replacement, ok := config[2].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	rx, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &modRequestHeader{headerName: headerName, rx: rx, replacement: replacement}, nil
+}
+
+func (f *modRequestHeader) Request(ctx filters.FilterContext) {
+	req := ctx.Request()
+
+	if strings.ToLower(f.headerName) == "host" {
+		nh := f.rx.ReplaceAllString(getRequestHost(req), f.replacement)
+
+		req.Header.Set(f.headerName, nh)
+		ctx.SetOutgoingHost(nh)
+
+		return
+	}
+
+	if _, ok := req.Header[http.CanonicalHeaderKey(f.headerName)]; !ok {
+		return
+	}
+
+	req.Header.Set(f.headerName, f.rx.ReplaceAllString(req.Header.Get(f.headerName), f.replacement))
+}
+
+func (*modRequestHeader) Response(filters.FilterContext) {}

--- a/filters/builtin/mod_header_test.go
+++ b/filters/builtin/mod_header_test.go
@@ -1,0 +1,216 @@
+package builtin
+
+import (
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"net/http"
+	"testing"
+)
+
+type createTestItemHost struct {
+	msg  string
+	args []interface{}
+	err  bool
+}
+
+func TestModRequestHostHeader(t *testing.T) {
+	for _, tt := range []struct {
+		msg           string
+		expression    string
+		replacement   string
+		url           string
+		requestHeader http.Header
+		expectedHost  string
+	}{{
+		"replace when Host header is provided and pattern matches",
+		`^(example\.\w+)$`,
+		`www.$1`,
+		"https://example.org/path/yo",
+		http.Header{"Host": []string{"example.org"}},
+		"www.example.org",
+	}, {
+		"replace when Host header is not provided and pattern matches url host",
+		`^(example\.\w+)$`,
+		`www.$1`,
+		"https://example.org/path/yo",
+		http.Header{},
+		"www.example.org",
+	}, {
+		"replace when Host header is not provided and pattern does not match url host",
+		`^(example\.\w+)$`,
+		`www.$1`,
+		"https://zalando.de/path/yo",
+		http.Header{},
+		"zalando.de",
+	}, {
+		"replace when Host header is provided and pattern does not match",
+		`^zalando\.de$`,
+		`zalando.com`,
+		"https://example.org/path/yo",
+		http.Header{"Host": []string{"example.org"}},
+		"example.org",
+	}} {
+		t.Run(tt.msg, func(t *testing.T) {
+			spec := NewModRequestHeader()
+			f, err := spec.CreateFilter([]interface{}{"Host", tt.expression, tt.replacement})
+			if err != nil {
+				t.Error(err)
+			}
+
+			req, err := http.NewRequest("GET", tt.url, nil)
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			for n, vs := range tt.requestHeader {
+				req.Header[n] = vs
+			}
+
+			ctx := &filtertest.Context{FRequest: req}
+			f.Request(ctx)
+
+			if ctx.OutgoingHost() != tt.expectedHost {
+				t.Errorf(`failed to modify OutgoingHost to "%s". Got: "%s"`, tt.expectedHost, ctx.OutgoingHost())
+			}
+
+			hv := req.Header.Get("Host")
+			if hv != tt.expectedHost {
+				t.Errorf(`failed to modify Host header to "%s". Got: "%s"`, tt.expectedHost, hv)
+			}
+		})
+	}
+}
+
+func TestModRequestHeader(t *testing.T) {
+	for _, tt := range []struct {
+		msg                    string
+		headerName             string
+		expression             string
+		replacement            string
+		requestHeader          http.Header
+		expectedHeader         string
+		expectHeaderToNotExist bool
+	}{{
+		"replace when header is provided and pattern matches",
+		"Accept-Language",
+		`^nl\-NL$`,
+		`en`,
+		http.Header{"Accept-Language": []string{"nl-NL"}},
+		"en",
+		false,
+	}, {
+		"replace when header is provided and pattern matches anything",
+		"Accept-Language",
+		`^.*`,
+		`en`,
+		http.Header{"Accept-Language": []string{"nl-NL"}},
+		"en",
+		false,
+	}, {
+		"replace when header is not provided and pattern matches anything",
+		"Accept-Language",
+		`^.*`,
+		`en`,
+		http.Header{},
+		"",
+		true,
+	}, {
+		"do not replace when header is not provided and pattern does not match",
+		"Accept-Language",
+		`fr`,
+		`en`,
+		http.Header{},
+		"",
+		true,
+	}} {
+		t.Run(tt.msg, func(t *testing.T) {
+			spec := NewModRequestHeader()
+			f, err := spec.CreateFilter([]interface{}{tt.headerName, tt.expression, tt.replacement})
+			if err != nil {
+				t.Error(err)
+			}
+
+			req, err := http.NewRequest("GET", "https://example.org/path/yo", nil)
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			for n, vs := range tt.requestHeader {
+				req.Header[n] = vs
+			}
+
+			ctx := &filtertest.Context{FRequest: req}
+			f.Request(ctx)
+
+			hv := req.Header.Get(tt.headerName)
+			if hv != tt.expectedHeader {
+				t.Errorf(`failed to modify request header %s to "%s". Got: "%s"`, tt.headerName, tt.expectedHeader, hv)
+			}
+
+			if tt.expectHeaderToNotExist && len(req.Header.Values(tt.headerName)) != 0 {
+				t.Errorf(`expected header %s to not exist, but it does`, tt.headerName)
+			}
+		})
+	}
+}
+
+func TestModifyHostWithInvalidExpression(t *testing.T) {
+	spec := NewModRequestHeader()
+	if f, err := spec.CreateFilter([]interface{}{"Host", "(?=;)", "foo"}); err == nil || f != nil {
+		t.Error("Expected error for invalid regular expression parameter")
+	}
+}
+
+func testCreateHost(t *testing.T, spec func() filters.Spec, items []createTestItemHost) {
+	for _, ti := range items {
+		func() {
+			f, err := spec().CreateFilter(ti.args)
+			switch {
+			case ti.err && err == nil:
+				t.Error(ti.msg, "failed to fail")
+			case !ti.err && err != nil:
+				t.Error(ti.msg, err)
+			case err == nil && f == nil:
+				t.Error(ti.msg, "failed to create filter")
+			}
+		}()
+	}
+}
+
+func TestCreateModHost(t *testing.T) {
+	testCreateHost(t, NewModRequestHeader, []createTestItemHost{{
+		"no args",
+		nil,
+		true,
+	}, {
+		"single arg",
+		[]interface{}{"Host"},
+		true,
+	}, {
+		"two args",
+		[]interface{}{"Host", ".*"},
+		true,
+	}, {
+		"non-string arg, pos 1",
+		[]interface{}{3.14, ".*", "/foo"},
+		true,
+	}, {
+		"non-string arg, pos 2",
+		[]interface{}{"Host", 2.72, "/foo"},
+		true,
+	}, {
+		"non-string arg, pos 3",
+		[]interface{}{"Host", ".*", 2.72},
+		true,
+	}, {
+		"more than three args",
+		[]interface{}{"Host", ".*", "/foo", "/bar"},
+		true,
+	}, {
+		"create",
+		[]interface{}{"Host", ".*", "/foo"},
+		false,
+	}})
+}


### PR DESCRIPTION
This allows you to do things like this:
```
add_www: Host("^example\.") -> modHost("example.(\w+)", "www.example.$1") -> redirectTo(301) -> <shunt>;
```
or
```
add_www: Host("^example\.") -> modHost("(.*)", "www.$1") -> redirectTo(301) -> <shunt>;
```

```
curl -I -H 'Host: example.com' localhost:9090/hello
HTTP/1.1 301 Moved Permanently
Location: https://www.example.com/hello
Server: Skipper
Date: Sat, 29 Feb 2020 10:26:56 GMT
```

## Todo

- [x] Add more tests
- [x] Add documentation