### PR TITLE
RedirectTo > Make location argument optional

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -126,13 +126,13 @@ Creates an HTTP redirect response.
 Parameters:
 
 * redirect status code (int)
-* location (string)
+* location (string) - optional
 
 Example:
 
 ```
 redirect1: PathRegexp(/^\/foo\/bar/) -> redirectTo(302, "/foo/newBar") -> <shunt>;
-redirect2: * -> redirectTo(301, "") -> <shunt>;
+redirect2: * -> redirectTo(301) -> <shunt>;
 ```
 
 - Route redirect1 will do a redirect with status code 302 to https

--- a/filters/builtin/redirect.go
+++ b/filters/builtin/redirect.go
@@ -78,6 +78,10 @@ func (spec *redirect) CreateFilter(config []interface{}) (filters.Filter, error)
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
+	if len(config) == 1 {
+		config = append(config, "")
+	}
+
 	if len(config) != 2 {
 		return invalidArgs()
 	}


### PR DESCRIPTION
This allows you to skip the `location` argument to `redirectTo`:
```diff
-redirectTo(301, "")
+redirectTo(301)
```

Much nicer, right? :) 