### PR TITLE
add helm chart

### DIFF
--- a/packaging/helm/skipper-aws/.helmignore
+++ b/packaging/helm/skipper-aws/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packaging/helm/skipper-aws/Chart.yaml
+++ b/packaging/helm/skipper-aws/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v3
+name: skipper-simple-aws
+description: A Helm chart for Skipper load balancer stack AWS
+type: application
+version: 0.1.0

--- a/packaging/helm/skipper-aws/README.md
+++ b/packaging/helm/skipper-aws/README.md
@@ -1,0 +1,126 @@
+# Helm chart
+
+## Pre-requisites
+
+### IAM Policies
+
+If using [Kube2IAM](https://github.com/jtblin/kube2iam) make sure you read their documentation on IAM roles (specifically about trust relationships) on how to create the roles needed for these policies.
+
+If using IAM Roles for Service Accounts please take a look at the [AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html) on how to create the roles needed for these policies.
+
+**external-dns**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": "route53:ChangeResourceRecordSets",
+          "Resource": "arn:aws:route53:::hostedzone/*"
+      },
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": [
+              "route53:ListResourceRecordSets",
+              "route53:ListHostedZones"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+```
+
+**kube-ingress-aws-controller**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": [
+              "iam:ListServerCertificates",
+              "iam:GetServerCertificate",
+              "iam:CreateServiceLinkedRole",
+              "elasticloadbalancingv2:*",
+              "elasticloadbalancing:*",
+              "ec2:DescribeVpcs",
+              "ec2:DescribeSubnets",
+              "ec2:DescribeSecurityGroups",
+              "ec2:DescribeRouteTables",
+              "ec2:DescribeInternetGateways",
+              "ec2:DescribeInstances",
+              "ec2:DescribeAccountAttributes",
+              "cloudformation:*",
+              "autoscaling:DetachLoadBalancers",
+              "autoscaling:DetachLoadBalancerTargetGroups",
+              "autoscaling:DescribeLoadBalancerTargetGroups",
+              "autoscaling:DescribeAutoScalingGroups",
+              "autoscaling:AttachLoadBalancers",
+              "autoscaling:AttachLoadBalancerTargetGroups",
+              "acm:ListCertificates",
+              "acm:GetCertificate",
+              "acm:DescribeCertificate"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+```
+
+## Installation
+
+```sh
+git clone https://github.com/zalando/skipper.git
+cd skipper/packaging/helm/skipper-aws
+helm install --name skipper-aws .
+```
+
+## Values
+
+| Value | Description | Default |
+| --- | --- | --- |
+| clusterID | The name of your Kubernetes cluster | mycluster |
+| region | The region in which your Kubernetes cluster resides | eu-central-1 |
+| vpa | Enable vertical pod autoscaling | false |
+| kube2iam.install | Install kube2iam | true |
+| kube2iam.enable | Make use of kube2iam | true |
+| kube2iam.aws_role | The kube2iam role that can assume other roles | kube2iam-role |
+| kube2iam.version | The version of kube2iam to install | 0.10.7 |
+| kube2iam.image | The image of kube2iam to install | registry.opensource.zalan.do/teapot/kube2iam |
+| kube_aws_iam_controller.enable | Enable use of kube-aws-iam-controller | false |
+| kube_aws_iam_controller.install | Enable installation of kube-aws-iam-controller | false |
+| kube_aws_iam_controller.aws_role | The role used by kube-aws-iam-controller | kube-aws-iam-controller-role |
+| kube_aws_iam_controller.version | The version of kube_aws_iam_controller  to install | 0.10.7 |
+| kube_aws_iam_controller.image | The image of kube_aws_iam_controller to install | registry.opensource.zalan.do/teapot/kube2iam |
+| external_dns.ownership_prefix | The txt prefix to use for DNS entries | skipper-test |
+| external_dns.aws_role | The role created for the external-dns IAM policy | external-dns-role |
+| external_dns.version | The version of external-dns to use | 0.5.18 |
+| external_dns.image | The image of external-dns to use | registry.opensource.zalan.do/teapot/external-dns |
+| kube_ingress_aws_controller.idle_timeout | The idle connection timeout for kube-ingress-aws-controller | 60s |
+| kube_ingress_aws_controller.aws_role | The role used by kube-ingress-aws-controller | kube-ingress-aws-controller-role |
+| kube_ingress_aws_controller.version | The version of kube-ingress-aws-controller to install | 0.10.1 |
+| kube_ingress_aws_controller.image | The image of kube-ingress-aws-controller to install | registry.opensource.zalan.do/teapot/kube-ingress-aws-controller |
+| kube_ingress_aws_controller.ssl_policy | The SSL policy to use | ELBSecurityPolicy-TLS-1-2-2017-01 |
+| skipper.version | The version of Skipper to install | 0.11.48 |
+| skipper.image | The image of Skipper to install | registry.opensource.zalan.do/pathfinder/skipper |
+| skipper.cluster_ratelimit | Enable rate limiting in Skipper | false |
+| skipper.redis.version | The version of Redis to install | 4.0.9-master-6 |
+| skipper.redis.image | The image of Redis to install | registry.opensource.zalan.do/zmon/redis |
+| skipper.svc_ip |  | 10.3.11.28 |
+| skipper.east_west | Enable East-West support in Skipper | false |
+| skipper.east_west_domain | The East-West domain to use | .ingress.cluster.local |
+
+See [values.yaml](values.yaml) for more.
+
+
+## Documentation
+
+Before running production you should consider reading all important
+[tutorials](https://opensource.zalando.com/skipper/tutorials/basics/)
+and check the [operations
+reference](https://opensource.zalando.com/skipper/operation/operation/).

--- a/packaging/helm/skipper-aws/README.md
+++ b/packaging/helm/skipper-aws/README.md
@@ -87,6 +87,8 @@ helm install --name skipper-aws .
 | clusterID | The name of your Kubernetes cluster | mycluster |
 | region | The region in which your Kubernetes cluster resides | eu-central-1 |
 | vpa | Enable vertical pod autoscaling | false |
+| namespace | Namespace to install all components into (kube-system will add reasonable `priorityClassName`) | kube-system |
+| eks_iam | Enable EKS IAM with service account integration | false
 | kube2iam.install | Install kube2iam | true |
 | kube2iam.enable | Make use of kube2iam | true |
 | kube2iam.aws_role | The kube2iam role that can assume other roles | kube2iam-role |

--- a/packaging/helm/skipper-aws/crds/awsiamroles.yaml
+++ b/packaging/helm/skipper-aws/crds/awsiamroles.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: awsiamroles.zalando.org
+spec:
+  group: zalando.org
+  scope: Namespaced
+  names:
+    kind: AWSIAMRole
+    singular: awsiamrole
+    plural: awsiamroles
+    categories:
+    - all
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: RoleARN
+      type: string
+      description: Full RoleARN
+      jsonPath: .status.roleARN
+    - name: Expiration
+      type: string
+      description: Expiration time of the current credentials provisioned for the role
+      jsonPath: .status.expiration
+    subresources:
+      # status enables the status subresource.
+      status: {}
+    # validation depends on Kubernetes >= v1.11.0
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              roleReference:
+                description: |
+                  Reference to an AWS IAM role which can either be a role name
+                  or a full IAM role ARN.
+                type: string
+                minLength: 3
+              roleSessionDuration:
+                description: |
+                  Specify the role session duration in seconds. Defaults to 3600
+                  seconds (1 hour). This value must be less than or equal to the
+                  `MaxSessionDuration` value of the IAM role.
+                type: integer
+                minimum: 900   # 15 minutes
+                maximum: 43200 # 12 hours
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              roleARN:
+                type: string
+              expiration:
+                type: string
+        required:
+        - spec

--- a/packaging/helm/skipper-aws/crds/routegroups.yaml
+++ b/packaging/helm/skipper-aws/crds/routegroups.yaml
@@ -1,0 +1,118 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: routegroups.zalando.org
+spec:
+  group: zalando.org
+  version: v1
+  scope: Namespaced
+  names:
+    kind: RouteGroup
+    singular: routegroup
+    plural: routegroups
+    categories:
+    - all
+    shortNames:
+    - rg
+    - rgs
+  additionalPrinterColumns:
+  - name: Hosts
+    type: string
+    description: Hostnames expecting requests to
+    JSONPath: .spec.hosts
+  - name: Backends
+    type: string
+    description: Backends forwarding traffic to
+    JSONPath: .spec.backends
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - backends
+          - routes
+          properties:
+            hosts:
+              type: array
+              items:
+                type: string
+            backends:
+              type: array
+              minLength: 1
+              items:
+                required:
+                - type
+                - name
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - service
+                    - shunt
+                    - loopback
+                    - dynamic
+                    - lb
+                    - network
+                  name:
+                    type: string
+                  serviceName:
+                    type: string
+                  servicePort:
+                    type: integer
+                  algorithm:
+                    type: string
+                    enum:
+                    - roundrobin
+                    - random
+                    - consistent-hash
+                  endpoints:
+                    type: array
+                    minLength: 1
+                    items:
+                      type: string
+                  address:
+                    type: string
+            defaultBackends:
+              type: array
+              items:
+                properties:
+                  backendName:
+                    type: string
+                  weight:
+                    type: integer
+                    minimum: 0
+            routes:
+              type: array
+              minLength: 1
+              items:
+                properties:
+                  path:
+                    type: string
+                  pathSubtree:
+                    type: string
+                  pathRegexp:
+                    type: string
+                  backends:
+                    type: array
+                    items:
+                      properties:
+                        backendName:
+                          type: string
+                        weight:
+                          type: integer
+                          minimum: 0
+                  filters:
+                    type: array
+                    items:
+                      type: string
+                  predicates:
+                    type: array
+                    items:
+                      type: string
+                  methods:
+                    type: array
+                    items:
+                      type: string

--- a/packaging/helm/skipper-aws/templates/external-dns/aws-iam-role.yaml
+++ b/packaging/helm/skipper-aws/templates/external-dns/aws-iam-role.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.kube_aws_iam_controller.enabled }}
+apiVersion: zalando.org/v1
+kind: AWSIAMRole
+metadata:
+  name: {{ .Release.Name }}-external-dns-aws-iam-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+spec:
+  roleReference: {{ .Values.external_dns.aws_role }}
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/external-dns/deployment.yaml
+++ b/packaging/helm/skipper-aws/templates/external-dns/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: external-dns
+    version: {{ .Values.external_dns.version }}
+    chart: {{ .Chart.Version }}
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      application: external-dns
+  template:
+    metadata:
+      labels:
+        application: external-dns
+        version: {{ .Values.external_dns.version }}
+{{- if .Values.kube2iam.enabled }}
+      annotations:
+        iam.amazonaws.com/role: "{{ .Values.external_dns.aws_role }}"
+{{- end }}
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+{{- if eq .Values.namespace "kube-system" }}
+      priorityClassName: system-cluster-critical
+{{- end }}
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: {{ .Values.external_dns.image }}:{{ .Values.external_dns.version }}
+        args:
+        - --source=service
+        - --source=ingress
+        - --provider=aws
+        - --registry=txt
+        - --txt-owner-id={{ .Values.region }}:{{ .Values.clusterID }}
+        - --txt-prefix={{ .Values.external_dns.ownership_prefix }}
+        - --aws-batch-change-size=100
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7979
+{{- if .Values.kube_aws_iam_controller.enabled }}
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
+          value: /meta/aws-iam/credentials.process
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+{{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop: ["ALL"]
+      securityContext:
+        fsGroup: 65534
+{{- if .Values.kube_aws_iam_controller.enabled }}
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          secretName: external-dns-aws-iam-credentials
+{{- end }}

--- a/packaging/helm/skipper-aws/templates/external-dns/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/external-dns/rbac.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: external-dns
+    chart: {{ .Chart.Version }}
+---
+# allows to list services and ingresses
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+  labels:
+    application: external-dns
+    chart: {{ .Chart.Version }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["list"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns
+  labels:
+    application: external-dns
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: {{ .Values.namespace }}

--- a/packaging/helm/skipper-aws/templates/external-dns/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/external-dns/rbac.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     application: external-dns
     chart: {{ .Chart.Version }}
+{{- if .Values.eks_iam }}
+  annotations:
+    eks.amazonaws.com/role-arn:
+      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.external_dns.aws_role }}
+{{- end }}
 ---
 # allows to list services and ingresses
 apiVersion: rbac.authorization.k8s.io/v1

--- a/packaging/helm/skipper-aws/templates/external-dns/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/external-dns/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- if .Values.eks_iam }}
   annotations:
     eks.amazonaws.com/role-arn:
-      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.external_dns.aws_role }}
+      arn:aws:iam::{{ .Values.awsAccountID }}:role/{{ .Values.external_dns.aws_role }}
 {{- end }}
 ---
 # allows to list services and ingresses

--- a/packaging/helm/skipper-aws/templates/external-dns/svc.yaml
+++ b/packaging/helm/skipper-aws/templates/external-dns/svc.yaml
@@ -1,0 +1,23 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: external-dns
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: external-dns
+    chart: {{ .Chart.Version }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "ExternalDNS"
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "7979"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    application: external-dns
+  type: ClusterIP
+  ports:
+  - name: monitor
+    port: 7979
+    targetPort: 7979
+    protocol: TCP

--- a/packaging/helm/skipper-aws/templates/external-dns/vpa.yaml
+++ b/packaging/helm/skipper-aws/templates/external-dns/vpa.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.vpa }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: external-dns
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: external-dns
+    chart: {{ .Chart.Version }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: external-dns
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: external-dns
+      maxAllowed:
+        cpu: 500m
+        memory: 2Gi
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/ingress-controller/aws-iam-role.yaml
+++ b/packaging/helm/skipper-aws/templates/ingress-controller/aws-iam-role.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.kube_aws_iam_controller.enabled }}
+apiVersion: zalando.org/v1
+kind: AWSIAMRole
+metadata:
+  name: kube-ingress-aws-controller-aws-iam-credentials
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+spec:
+  roleReference: {{ .Values.kube_ingress_aws_controller.aws_role }}
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/ingress-controller/deployment.yaml
+++ b/packaging/helm/skipper-aws/templates/ingress-controller/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-ingress-aws-controller
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: kube-ingress-aws-controller
+    version: {{ .Values.kube_ingress_aws_controller.version }}
+    chart: {{ .Chart.Version }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-ingress-aws-controller
+  template:
+    metadata:
+      labels:
+        application: kube-ingress-aws-controller
+        version: {{ .Values.kube_ingress_aws_controller.version }}
+{{- if .Values.kube2iam.enabled }}
+      annotations:
+        iam.amazonaws.com/role: {{ .Values.kube_ingress_aws_controller.aws_role }}
+{{- end }}
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+{{- if eq .Values.namespace "kube-system" }}
+      priorityClassName: system-cluster-critical
+{{- end }}
+      serviceAccountName: kube-ingress-aws-controller
+      containers:
+      - name: controller
+        image: {{ .Values.kube_ingress_aws_controller.image }}:{{ .Values.kube_ingress_aws_controller.version }}
+        args:
+        - --stack-termination-protection
+        - --ssl-policy={{ .Values.kube_ingress_aws_controller.ssl_policy }}
+        - --idle-connection-timeout={{ .Values.kube_ingress_aws_controller.idle_timeout }}
+        - --nlb-cross-zone
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 50m
+            memory: 100Mi
+        env:
+        - name: CUSTOM_FILTERS
+          value: "tag:kubernetes.io/cluster/{{ .Values.clusterID }}=owned tag:node.kubernetes.io/role=worker"
+        - name: AWS_REGION
+          value: {{ .Values.region }}
+{{- if .Values.kube_aws_iam_controller.enabled }}
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
+          value: /meta/aws-iam/credentials.process
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          secretName: kube-ingress-aws-controller-aws-iam-credentials
+{{- end }}

--- a/packaging/helm/skipper-aws/templates/ingress-controller/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/ingress-controller/rbac.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     chart: {{ .Chart.Version }}
+{{- if .Values.eks_iam }}
+  annotations:
+    eks.amazonaws.com/role-arn:
+      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.kube_ingress_aws_controller.aws_role }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/packaging/helm/skipper-aws/templates/ingress-controller/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/ingress-controller/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- if .Values.eks_iam }}
   annotations:
     eks.amazonaws.com/role-arn:
-      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.kube_ingress_aws_controller.aws_role }}
+      arn:aws:iam::{{ .Values.awsAccountID }}:role/{{ .Values.kube_ingress_aws_controller.aws_role }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/packaging/helm/skipper-aws/templates/ingress-controller/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/ingress-controller/rbac.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ingress-aws-controller
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-ingress-aws-controller
+  labels:
+    chart: {{ .Chart.Version }}
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-ingress-aws-controller
+  labels:
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-ingress-aws-controller
+subjects:
+- kind: ServiceAccount
+  name: kube-ingress-aws-controller
+  namespace: {{ .Values.namespace }}

--- a/packaging/helm/skipper-aws/templates/ingress-controller/vpa.yaml
+++ b/packaging/helm/skipper-aws/templates/ingress-controller/vpa.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.vpa }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-ingress-aws-controller
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: kube-ingress-aws-controller
+    chart: {{ .Chart.Version }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kube-ingress-aws-controller
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: kube-ingress-aws-controller
+      maxAllowed:
+        cpu: 250m
+        memory: 1Gi
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/deployment.yaml
+++ b/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/deployment.yaml
@@ -1,0 +1,49 @@
+{{ if .Values.kube_aws_iam_controller.install }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-aws-iam-controller
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: kube-aws-iam-controller
+    version: {{ .Values.kube_aws_iam_controller.version }}
+    chart: {{ .Chart.Version }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-aws-iam-controller
+  template:
+    metadata:
+      labels:
+        application: kube-aws-iam-controller
+        version: {{ .Values.kube_aws_iam_controller.version }}
+    spec:
+      serviceAccountName: kube-aws-iam-controller
+{{- if eq .Values.namespace "kube-system" }}
+      priorityClassName: system-cluster-critical
+{{ end }}
+      # running with hostNetwork to bypass metadata service block from pod
+      # network.
+      hostNetwork: true
+      containers:
+      - name: kube-aws-iam-controller
+        image:
+          {{ .Values.kube_aws_iam_controller.image }}:{{ .Values.kube_aws_iam_controller.version }}
+        args:
+        - --debug
+        - "--assume-role={{ .Values.kube_aws_iam_controller.aws_role }}"
+        resources:
+          limits:
+            cpu: "5m"
+            memory: "50Mi"
+          requests:
+            cpu: "5m"
+            memory: "50Mi"
+      tolerations:
+      - key: node.kubernetes.io/role
+        value: master
+        effect: NoSchedule
+      nodeSelector:
+        node.kubernetes.io/role: master
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/rbac.yaml
@@ -60,6 +60,11 @@ subjects:
 - kind: ServiceAccount
   name: kube-aws-iam-controller
   namespace: {{ .Values.namespace }}
+{{- if .Values.eks_iam }}
+  annotations:
+    eks.amazonaws.com/role-arn:
+      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.kube_aws_iam_controller.aws_role }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/rbac.yaml
@@ -63,7 +63,7 @@ subjects:
 {{- if .Values.eks_iam }}
   annotations:
     eks.amazonaws.com/role-arn:
-      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.kube_aws_iam_controller.aws_role }}
+      arn:aws:iam::{{ .Values.awsAccountID }}:role/{{ .Values.kube_aws_iam_controller.aws_role }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/rbac.yaml
@@ -1,0 +1,79 @@
+{{ if .Values.kube_aws_iam_controller.install }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kube-aws-iam-controller
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-aws-iam-controller
+  labels:
+    chart: {{ .Chart.Version }}
+rules:
+- apiGroups:
+  - "zalando.org"
+  resources:
+  - awsiamroles
+  - awsiamroles/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-aws-iam-controller
+  labels:
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-aws-iam-controller
+subjects:
+- kind: ServiceAccount
+  name: kube-aws-iam-controller
+  namespace: {{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-aws-iam-controller-hostnetwork-psp
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hostnetwork-psp
+subjects:
+- kind: ServiceAccount
+  name: kube-aws-iam-controller
+  namespace: {{ .Values.namespace }}
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/vpa.yaml
+++ b/packaging/helm/skipper-aws/templates/kube-aws-iam-controller/vpa.yaml
@@ -1,0 +1,21 @@
+{{ if and (.Values.kube_aws_iam_controller.install) (.Values.vpa) }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-aws-iam-controller
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kube-aws-iam-controller
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: kube-aws-iam-controller
+      maxAllowed:
+        memory: 1Gi
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/kube2iam/daemonset.yaml
+++ b/packaging/helm/skipper-aws/templates/kube2iam/daemonset.yaml
@@ -1,0 +1,70 @@
+{{ if .Values.kube2iam.install }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube2iam
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: kube2iam
+    version: {{ .Values.kube2iam.version }}
+    chart: {{ .Chart.Version }}
+spec:
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      application: kube2iam
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        application: kube2iam
+        version: {{ .Values.kube2iam.version }}
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+{{- if eq .Values.namespace "kube-system" }}
+      priorityClassName: system-node-critical
+{{- end }}
+      serviceAccountName: kube2iam
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      hostNetwork: true
+      containers:
+      - image: {{ .Values.kube2iam.image }}:{{ .Values.kube2iam.version }}
+        name: kube2iam
+        args:
+        - --auto-discover-base-arn
+        - --verbose
+        - --node=$(NODE_NAME)
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - containerPort: 8181
+          hostPort: 8181
+          name: http
+        securityContext:
+          privileged: true
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8181
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 25m
+            memory: 100Mi
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: 25m
+            memory: 100Mi
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/kube2iam/psp.yaml
+++ b/packaging/helm/skipper-aws/templates/kube2iam/psp.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.kube2iam.install }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  labels:
+    chart: {{ .Chart.Version }}
+spec:
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  allowPrivilegeEscalation: true
+  hostPID: true
+  hostNetwork: true
+  hostIPC: true
+  hostPorts:
+  - max: 10000
+    min: 50
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+  labels:
+    chart: {{ .Chart.Version }}
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - emptyDir
+  - awsElasticBlockStore
+  - secret
+  - persistentVolumeClaim
+  - downwardAPI
+  - configMap
+  - projected
+{{- end }}

--- a/packaging/helm/skipper-aws/templates/kube2iam/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/kube2iam/rbac.yaml
@@ -1,0 +1,51 @@
+{{ if .Values.kube2iam.install }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube2iam
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube2iam
+  labels:
+    chart: {{ .Chart.Version }}
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube2iam
+  labels:
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube2iam
+subjects:
+- kind: ServiceAccount
+  name: kube2iam
+  namespace: {{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube2iam-privileged-psp
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: kube2iam
+  namespace: {{ .Values.namespace }}
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/kube2iam/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/kube2iam/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 {{- if .Values.eks_iam }}
   annotations:
     eks.amazonaws.com/role-arn:
-      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.kube2iam.aws_role }}
+      arn:aws:iam::{{ .Values.awsAccountID }}:role/{{ .Values.kube2iam.aws_role }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/packaging/helm/skipper-aws/templates/kube2iam/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/kube2iam/rbac.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     chart: {{ .Chart.Version }}
+{{- if .Values.eks_iam }}
+  annotations:
+    eks.amazonaws.com/role-arn:
+      arn:aws:iam::AWS_ACCOUNT_ID:role/{{ .Values.kube2iam.aws_role }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/packaging/helm/skipper-aws/templates/skipper/deployment.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skipper-ingress
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: skipper-ingress
+    version: {{ .Values.skipper.version }}
+    component: ingress
+    chart: {{ .Chart.Version }}
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+  selector:
+    matchLabels:
+      application: skipper-ingress
+  template:
+    metadata:
+      labels:
+        application: skipper-ingress
+        version: {{ .Values.skipper.version }}
+        component: ingress
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: application
+                  operator: In
+                  values:
+                  - skipper-ingress
+              topologyKey: kubernetes.io/hostname
+{{- if eq .Values.namespace "kube-system" }}
+      priorityClassName: system-cluster-critical
+{{- end }}
+      serviceAccountName: skipper-ingress
+      nodeSelector:
+        node.kubernetes.io/role: worker
+      dnsPolicy: ClusterFirstWithHostNet
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      hostNetwork: true
+      containers:
+      - name: skipper-ingress
+        image: {{ .Values.skipper.image }}:{{ .Values.skipper.version }}
+        ports:
+        - name: ingress-port
+          containerPort: 9999
+          hostPort: 9999
+        args:
+          - "skipper"
+          - "-kubernetes"
+          - "-kubernetes-in-cluster"
+          - "-kubernetes-path-mode=path-prefix"
+          - "-address=:9999"
+          - "-wait-first-route-load"
+          - "-proxy-preserve-host"
+          - "-serve-host-metrics"
+          - "-disable-metrics-compat"
+          - "-enable-profile"
+          - "-debug-listener=:9922"
+          - "-enable-ratelimits"
+          - "-experimental-upgrade"
+          - "-metrics-exp-decay-sample"
+          - "-reverse-source-predicate"
+          - "-lb-healthcheck-interval=3s"
+          - "-metrics-flavour=prometheus"
+          - "-enable-connection-metrics"
+          - "-enable-route-lifo-metrics"
+          - "-max-audit-body=0"
+          - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
+          - "-expect-continue-timeout-backend=30s"
+          - "-keepalive-backend=30s"
+          - "-max-idle-connection-backend=0"
+          - "-response-header-timeout-backend=1m"
+          - "-timeout-backend=1m"
+          - "-tls-timeout-backend=1m"
+          - "-close-idle-conns-period=20s"
+          - "-idle-timeout-server=62s"
+          - "-read-timeout-server=5m"
+          - "-write-timeout-server=60s"
+          - '-default-filters-prepend=enableAccessLog(4,5) -> lifo(2000,20000,"3s")'
+          - "-route-creation-metrics"
+          - "-enable-tcp-queue"
+          - "-expected-bytes-per-request=51200"
+          - "-max-tcp-listener-concurrency=-1"
+          - "-max-tcp-listener-queue=-1"
+{{- if .Values.skipper.cluster_ratelimit }}
+          - "-enable-swarm"
+          - "-swarm-redis-urls=skipper-ingress-redis-0.skipper-ingress-redis.{{ .Values.namespace }}.svc.cluster.local:6379,skipper-ingress-redis-1.skipper-ingress-redis.{{ .Values.namespace }}.svc.cluster.local:6379"
+{{- end }}
+{{- if .Values.skipper.east_west }}
+          - "-enable-kubernetes-east-west"
+          - "-kubernetes-east-west-domain={{ .Values.skipper.east_west_domain }}"
+{{- end }}
+        resources:
+          limits:
+            cpu: "2"
+            memory: "1Gi"
+          requests:
+            cpu: "2"
+            memory: "1Gi"
+        readinessProbe:
+          httpGet:
+            path: /kube-system/healthz
+            port: 9999
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000

--- a/packaging/helm/skipper-aws/templates/skipper/hpa.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/hpa.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: skipper-ingress
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: skipper-ingress
+    chart: {{ .Chart.Version }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: skipper-ingress
+  minReplicas: 3
+  maxReplicas: 30
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 50
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: 80

--- a/packaging/helm/skipper-aws/templates/skipper/psp.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/psp.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: hostnetwork-psp
+  labels:
+    chart: {{ .Chart.Version }}
+spec:
+  hostNetwork: true
+  hostPorts:
+  - max: 9999
+    min: 9911
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - emptyDir
+  - awsElasticBlockStore
+  - secret
+  - persistentVolumeClaim
+  - downwardAPI
+  - configMap
+  - projected

--- a/packaging/helm/skipper-aws/templates/skipper/rbac.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/rbac.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skipper-ingress
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: skipper-ingress
+  labels:
+    chart: {{ .Chart.Version }}
+rules:
+- apiGroups: ["extensions"]
+  resources: ["ingresses", ]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces", "services", "endpoints", "pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: skipper-ingress
+  labels:
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: skipper-ingress
+subjects:
+- kind: ServiceAccount
+  name: skipper-ingress
+  namespace: {{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: skipper-ingress-hostnetwork-psp
+  namespace: {{ .Values.namespace }}
+  labels:
+    chart: {{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hostnetwork-psp
+subjects:
+- kind: ServiceAccount
+  name: skipper-ingress
+  namespace: {{ .Values.namespace }}

--- a/packaging/helm/skipper-aws/templates/skipper/service-internal.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/service-internal.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: skipper-internal
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: skipper-ingress
+    chart: {{ .Chart.Version }}
+spec:
+  type: ClusterIP
+  clusterIP: {{ .Values.skipper.svc_ip }}
+  ports:
+    - port: 80
+      targetPort: 9999
+      protocol: TCP
+  selector:
+    application: skipper-ingress

--- a/packaging/helm/skipper-aws/templates/skipper/service.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/service.yaml
@@ -1,0 +1,25 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: skipper-ingress
+  namespace: {{ .Values.namespace }}
+  labels:
+    application: skipper-ingress
+    chart: {{ .Chart.Version }}
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9911"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 9999
+    protocol: TCP
+  - name: support
+    port: 9911
+    targetPort: 9911
+    protocol: TCP
+  selector:
+    application: skipper-ingress

--- a/packaging/helm/skipper-aws/templates/skipper/skipper-redis-service.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/skipper-redis-service.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.skipper.cluster_ratelimit }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: skipper-ingress-redis
+    chart: {{ .Chart.Version }}
+  name: skipper-ingress-redis
+  namespace: {{ .Values.namespace }}
+spec:
+  clusterIP: None
+  ports:
+  - port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    application: skipper-ingress-redis
+  type: ClusterIP
+{{ end }}

--- a/packaging/helm/skipper-aws/templates/skipper/skipper-redis.yaml
+++ b/packaging/helm/skipper-aws/templates/skipper/skipper-redis.yaml
@@ -1,0 +1,49 @@
+{{ if .Values.skipper.cluster_ratelimit }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    application: skipper-ingress-redis
+    version: {{ .Values.skipper.redis.version }}
+    chart: {{ .Chart.Version }}
+  name: skipper-ingress-redis
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      application: skipper-ingress-redis
+  serviceName: skipper-ingress-redis
+  template:
+    metadata:
+      labels:
+        application: skipper-ingress-redis
+        version: {{ .Values.skipper.redis.version }}
+    spec:
+{{- if eq .Values.namespace "kube-system" }}
+      priorityClassName: system-cluster-critical
+{{ end }}
+      containers:
+      - image: {{ .Values.skipper.redis.image }}:{{ .Values.skipper.redis.version }}
+        name: skipper-ingress-redis
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+{{ end }}

--- a/packaging/helm/skipper-aws/values.yaml
+++ b/packaging/helm/skipper-aws/values.yaml
@@ -1,0 +1,53 @@
+clusterID: mycluster
+region: eu-central-1
+# VPA is available in your cluster
+vpa: false
+# kubernetes namespace to run all components
+namespace: kube-system
+
+# AWS IAM integration with kube2iam (optional)
+kube2iam:
+  enabled: true
+  install: true
+  aws_role: kube2iam-role
+  version: 0.10.7
+  image: registry.opensource.zalan.do/teapot/kube2iam
+
+# AWS IAM integration with kube-aws-iam-controller (optional)
+kube_aws_iam_controller:
+  enabled: false
+  install: false
+  aws_role: kube-aws-iam-controller-role
+  version: v0.1.0
+  image: registry.opensource.zalan.do/teapot/kube-aws-iam-controller
+
+# automatically create DNS records for your ingress and routegroup
+external_dns:
+  version: 0.5.18
+  image: registry.opensource.zalan.do/teapot/external-dns
+  aws_role: external-dns-role
+  ownership_prefix: skipper-test
+
+# automatically create shared ALBs and NLBs for your ingress and routegroup
+kube_ingress_aws_controller:
+  version: 0.10.1
+  image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller
+  aws_role: kube-ingress-aws-controller-role
+  ssl_policy: ELBSecurityPolicy-TLS-1-2-2017-01
+  idle_timeout: 60s
+
+# automatically create HTTP routing to endpoints for your ingress and routegroup
+skipper:
+  version: 0.11.48
+  image: registry.opensource.zalan.do/pathfinder/skipper
+  cluster_ratelimit: false
+  # redis is required for cluster ratelimit
+  redis:
+    image: registry.opensource.zalan.do/zmon/redis
+    version: 4.0.9-master-6
+  # service IP for east west feature, which should have a CoreDNS
+  # template, which points *.ingress.cluster.local to the service IP
+  # see also https://opensource.zalando.com/skipper/kubernetes/ingress-controller/#coredns
+  svc_ip: 10.3.11.28
+  east_west: false
+  east_west_domain: .ingress.cluster.local

--- a/packaging/helm/skipper-aws/values.yaml
+++ b/packaging/helm/skipper-aws/values.yaml
@@ -1,9 +1,13 @@
+awsAccountID: "AWS_ACCOUNT_ID"
 clusterID: mycluster
 region: eu-central-1
 # VPA is available in your cluster
 vpa: false
 # kubernetes namespace to run all components
 namespace: kube-system
+
+# AWS IAM integration with serviceaccounts https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html (optional)
+eks_iam: false
 
 # AWS IAM integration with kube2iam (optional)
 kube2iam:


### PR DESCRIPTION
fix https://github.com/zalando/skipper/issues/1233 and add a helm chart which can optionally enable clusterRatelimits, eastwest, and use kube2iam or kube-aws-iam-controller to get AWS credentials for external-dns and kube-ingress-aws-controller