### PR TITLE
Docs > Fix wrong redirectTo

### DIFF
--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -203,7 +203,7 @@ end
 ## redirectTo vs lua redirect
 See skptesting/benchmark-lua.sh
 
-Route for "skipper" is `* -> redirectTo("http://localhost:9980") -> <shunt>`,
+Route for "skipper" is `* -> redirectTo(302, "http://localhost:9980") -> <shunt>`,
 route for "lua" is `* -> lua("function request(c,p); c.serve({status_code=302, header={location='http://localhost:9980'}});end") -> <shunt>`
 
 ```

--- a/script/README.md
+++ b/script/README.md
@@ -156,7 +156,7 @@ end
 ## redirectTo vs lua redirect
 See skptesting/benchmark-lua.sh
 
-Route for "skipper" is `* -> redirectTo("http://localhost:9980") -> <shunt>`,
+Route for "skipper" is `* -> redirectTo(302, "http://localhost:9980") -> <shunt>`,
 route for "lua" is `* -> lua("function request(c,p); c.serve({status_code=302, header={location='http://localhost:9980'}});end") -> <shunt>`
 
 ```


### PR DESCRIPTION
I checked the code and `redirectTo("http://localhost:9980")` seems invalid? This fixes it.