### PR TITLE
Support hash comments

### DIFF
--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -99,6 +99,11 @@ func TestParseRouteExpression(t *testing.T) {
 		&Route{Id: "route", BackendType: ShuntBackend, Shunt: true},
 		false,
 	}, {
+		"hash comment as last token",
+		"route: Any() -> <shunt>; # some comment",
+		&Route{Id: "route", BackendType: ShuntBackend, Shunt: true},
+		false,
+	}, {
 		"catch all",
 		`* -> "https://www.example.org"`,
 		&Route{Backend: "https://www.example.org"},

--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -215,6 +215,12 @@ func scanRegexpOrComment(code string) (t token, rest string, err error) {
 		return
 	}
 
+	if code[0] == '#' {
+		rest = scanComment(code)
+		err = void
+		return
+	}
+
 	if code[1] == '/' {
 		rest = scanComment(code)
 		err = void
@@ -291,6 +297,7 @@ func selectVaryingScanner(code string) scanner {
 	var sf scannerFunc
 	switch code[0] {
 	case '/':
+	case '#':
 		sf = scanRegexpOrComment
 	case '"':
 		sf = scanDoubleQuote

--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -306,11 +306,11 @@ func selectVaryingScanner(code string) scanner {
 		sf = scanSymbol
 	}
 
-	if sf != nil {
-		return scanner(sf)
+	if sf == nil {
+		return nil
 	}
 
-	return nil
+	return scanner(sf)
 }
 
 func selectScanner(code string) scanner {


### PR DESCRIPTION
In Go it's only possible to comment with `//` but in the context of Kubernetes (YAML) it's pretty common to use hashes `#`. So let's support both.