### PR TITLE
Introduce Weight predicate

### DIFF
--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -325,8 +325,7 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			PathRegexp("^/foo") &&
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*")
+			Weight(1000)
 
 			-> redirectTo(308, "https:")
 			-> <shunt>;
@@ -336,8 +335,7 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 		kube___catchall__www_example_org_____https_redirect:
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*") &&
+			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$")
@@ -440,8 +438,7 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 			PathRegexp("^/bar") &&
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*") &&
+			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http")
 			-> "http://5.6.7.8:8181";
@@ -452,16 +449,14 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 			Host("^api[.]example[.]org$") &&
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*") &&
+			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http")
 			-> <shunt>;
 		kube__redirect:
 
 			// increase priority of the redirect routes.
-			PathRegexp(/.*/) &&
-			PathRegexp(/.*/) &&
+			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http")
 			-> redirectTo(308, "https:")
@@ -540,8 +535,7 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			PathRegexp("^/foo") &&
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*")
+			Weight(1000)
 
 			-> redirectTo(301, "https:")
 			-> <shunt>;
@@ -551,8 +545,7 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 		kube___catchall__www_example_org_____https_redirect:
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*") &&
+			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$")
@@ -568,8 +561,7 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 		kube__redirect:
 
 			// increase priority of the redirect routes.
-			PathRegexp(/.*/) &&
-			PathRegexp(/.*/) &&
+			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http")
 			-> redirectTo(308, "https:")
@@ -648,8 +640,7 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			PathRegexp("^/foo") &&
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*")
+			Weight(1000)
 
 			-> redirectTo(301, "https:")
 			-> <shunt>;
@@ -659,8 +650,7 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 		kube___catchall__www_example_org_____https_redirect:
 
 			// increase priority of the redirect routes.
-			PathRegexp(".*") &&
-			PathRegexp(".*") &&
+			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
 			Host("^www[.]example[.]org$")

--- a/dataclients/kubernetes/redirect.go
+++ b/dataclients/kubernetes/redirect.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/routing"
 )
 
 const (
@@ -87,16 +88,11 @@ func initRedirectRoute(r *eskip.Route, code int) {
 	}
 	r.Headers[forwardedProtoHeader] = "http"
 
-	// the below duplicate any-path (.*) is set to make sure that
-	// the redirect route has a higher priority during matching than
-	// the normal routes that may have max 2 predicates: path regexp
-	// and host.
-	//
-	// A better solution might be to implement a Weight() predicate
-	// and apply it here.
-	//
-	r.PathRegexps = append(r.PathRegexps, ".*")
-	r.PathRegexps = append(r.PathRegexps, ".*")
+	// Give this route a higher weight so that it will get precedence over existing routes
+	r.Predicates = append([]*eskip.Predicate{{
+		Name: routing.WeightPredicateName,
+		Args: []interface{}{float64(1000)},
+	}}, r.Predicates...)
 
 	r.Filters = append(r.Filters, &eskip.Filter{
 		Name: "redirectTo",
@@ -113,16 +109,11 @@ func initDisableRedirectRoute(r *eskip.Route) {
 	}
 	r.Headers[forwardedProtoHeader] = "http"
 
-	// the below duplicate any-path (.*) is set to make sure that
-	// the redirect route has a higher priority during matching than
-	// the normal routes that may have max 2 predicates: path regexp
-	// and host.
-	//
-	// A better solution might be to implement a Weight() predicate
-	// and apply it here.
-	//
-	r.PathRegexps = append(r.PathRegexps, ".*")
-	r.PathRegexps = append(r.PathRegexps, ".*")
+	// Give this route a higher weight so that it will get precedence over existing routes
+	r.Predicates = append([]*eskip.Predicate{{
+		Name: routing.WeightPredicateName,
+		Args: []interface{}{float64(1000)},
+	}}, r.Predicates...)
 }
 
 func globalRedirectRoute(code int) *eskip.Route {

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/custom-code.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/custom-code.eskip
@@ -15,7 +15,6 @@ kube_rg____example_org__catchall__0_0: Host("^(example[.]org)$") -> <shunt>;
 // global, legacy:
 kube__redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& PathRegexp(".*")
-	&& PathRegexp(".*")
+	&& Weight(1000)
 	-> redirectTo(302, "https:")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-for-east-west.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-for-east-west.eskip
@@ -20,7 +20,6 @@ kube_rg____example_org__catchall__0_0: Host("^(example[.]org)$") -> <shunt>;
 // global, legacy redirect:
 kube__redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& PathRegexp(".*")
-	&& PathRegexp(".*")
+	&& Weight(1000)
 	-> redirectTo(308, "https:")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-if-proto-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-if-proto-predicate.eskip
@@ -8,7 +8,6 @@ kube_rg____example_org__catchall__0_0: Host("^(example[.]org)$") -> <shunt>;
 // global, legacy:
 kube__redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& PathRegexp(".*")
-	&& PathRegexp(".*")
+	&& Weight(1000)
 	-> redirectTo(308, "https:")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-implicit-route.eskip
@@ -11,6 +11,5 @@ kube_rg__default__myapp__all__0_0_https_redirect:
 // global, legacy:
 kube__redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& PathRegexp(".*")
-	&& PathRegexp(".*")
+	&& Weight(1000)
 	-> redirectTo(308, "https:") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-simple.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-simple.eskip
@@ -15,7 +15,6 @@ kube_rg____example_org__catchall__0_0: Host("^(example[.]org)$") -> <shunt>;
 // global, legacy:
 kube__redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& PathRegexp(".*")
-	&& PathRegexp(".*")
+	&& Weight(1000)
 	-> redirectTo(308, "https:")
 	-> <shunt>;

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -105,8 +105,8 @@ The route matching logic can be summed up as follows:
 
 2. _If_ step #1 matches multiple routes, which means there are multiple
    routes in the same position of the path tree, and all other predicates
-   match the request, too, then the route with the most defined predicates
-   is matched.
+   match the request, too, then the route with the highest 
+   [weight](predicates.md#weight) is matched.
 
     * this is an O(n) lookup, but only on the same leaf
 

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -128,6 +128,30 @@ Host(/^my-host-header\.example\.org$/)
 Host(/header\.example\.org$/)
 ```
 
+## Weight (priority)
+
+By default, the weight (priority) of a route is determined by the number of defined predicates.
+
+If you want to give a route more priority, you can give it more weight.
+
+Parameters:
+
+* Weight (int)
+
+Example where `route2` has more priority because it has more predicates:
+
+```
+route1: Path("/test") -> "http://www.zalando.de";
+route2: Path("/test") && True() -> "http://www.zalando.de";
+```
+
+Example where `route1` has more priority because it has more weight:
+
+```
+route1: Path("/test") && Weight(100) -> "http://www.zalando.de";
+route2: Path("/test") && True() && True() -> "http://www.zalando.de";
+```
+
 ## Method
 
 The HTTP method that the request must match. HTTP methods are one of

--- a/docs/tutorials/basics.md
+++ b/docs/tutorials/basics.md
@@ -221,8 +221,8 @@ The route matching logic can be summed up as follows:
 
 2. _If_ step #1 matches multiple routes, which means there are multiple
    routes in the same position of the path tree, and all other predicates
-   match the request, too, then the route with the most defined predicates
-   is matched.
+   match the request, too, then the route with the highest 
+   [weight](../reference/predicates.md#weight) is matched.
 
     * this is an O(n) lookup, but only on the same leaf
 

--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -57,6 +57,16 @@ func TestParseRouteExpression(t *testing.T) {
 			Backend:     "https://www.example.org"},
 		false,
 	}, {
+		"weight predicate",
+		`Weight(50) -> "https://www.example.org"`,
+		&Route{
+			Predicates: []*Predicate{
+				{"Weight", []interface{}{float64(50)}},
+			},
+			Backend: "https://www.example.org",
+		},
+		false,
+	}, {
 		"method predicate",
 		`Method("HEAD") -> "https://www.example.org"`,
 		&Route{Method: "HEAD", Backend: "https://www.example.org"},

--- a/predicates/cookie/cookie.go
+++ b/predicates/cookie/cookie.go
@@ -1,5 +1,5 @@
 /*
-Package cookie implements prediate to check parsed cookie headers by name and value.
+Package cookie implements predicate to check parsed cookie headers by name and value.
 */
 package cookie
 

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -33,6 +33,7 @@ type leafMatcher struct {
 	hasFreeWildcardParam bool
 	exactPath            string
 	method               string
+	weight               int
 	hostRxs              []*regexp.Regexp
 	pathRxs              []*regexp.Regexp
 	headersExact         map[string]string
@@ -44,7 +45,7 @@ type leafMatcher struct {
 type leafMatchers []*leafMatcher
 
 func leafWeight(l *leafMatcher) int {
-	w := 0
+	w := l.weight
 
 	if l.method != "" {
 		w++
@@ -237,6 +238,7 @@ func newLeaf(r *Route, rxs map[string]*regexp.Regexp) (*leafMatcher, error) {
 		wildcardParamNames:   extractWildcardParamNames(r),
 		hasFreeWildcardParam: hasFreeWildcardParam(r),
 
+		weight:        r.weight,
 		method:        r.Method,
 		hostRxs:       hostRxs,
 		pathRxs:       pathRxs,

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -25,6 +25,8 @@ const (
 	// at https://godoc.org/github.com/zalando/skipper/eskip)
 	PathSubtreeName = "PathSubtree"
 
+	WeightPredicateName = "Weight"
+
 	routesTimestampName      = "X-Timestamp"
 	routesCountName          = "X-Count"
 	defaultRouteListingLimit = 1024
@@ -171,6 +173,9 @@ type Route struct {
 
 	// Fields from the static route definition.
 	eskip.Route
+
+	// weight used internally, received from the Weight() predicates.
+	weight int
 
 	// path predicate matching a subtree
 	path string

--- a/routing/weight_test.go
+++ b/routing/weight_test.go
@@ -1,0 +1,52 @@
+package routing
+
+import (
+	"testing"
+)
+
+func TestWeightArgs(t *testing.T) {
+	for _, ti := range []struct {
+		msg    string
+		args   []interface{}
+		weight int
+		err    bool
+	}{{
+		"no args",
+		nil,
+		0,
+		true,
+	}, {
+		"too many args",
+		[]interface{}{"name", "value"},
+		0,
+		true,
+	}, {
+		"invalid value",
+		[]interface{}{"string"},
+		0,
+		true,
+	}, {
+		"ok float to int",
+		[]interface{}{500.99},
+		500,
+		false,
+	}, {
+		"ok",
+		[]interface{}{500},
+		500,
+		false,
+	}} {
+		func() {
+			p, err := parseWeightPredicateArgs(ti.args)
+			if ti.err && err == nil {
+				t.Error(ti.msg, "failed to fail")
+			} else if !ti.err && err != nil {
+				t.Error(ti.msg, err)
+			}
+
+			if p != ti.weight {
+				t.Error(ti.msg, "wrong weight")
+			}
+		}()
+	}
+}


### PR DESCRIPTION
I noticed this odd looking double Regexp in my Kubernetes Skipper instance:
```eskip
route: 
    Host(/^www[.]xxx[.]no$/) && 
    PathRegexp(/.*/) && 
    PathRegexp(/.*/) && 
    Header("X-Forwarded-Proto", "http")
    -> <roundRobin, "http://xxx:80">;
```

Turns out it's by design:
https://github.com/zalando/skipper/blob/ae2a3bfe499c888154a630bbab008de4a84b11c3/dataclients/kubernetes/redirect.go#L90-L99

Let's fix this.

## Todo

- [x] Add more tests
- [x] Add documentation