### PR TITLE
InlineContent > Replace \n with newline

### DIFF
--- a/filters/builtin/inlinecontent.go
+++ b/filters/builtin/inlinecontent.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/zalando/skipper/filters"
 )
@@ -60,6 +61,9 @@ func (c *inlineContent) CreateFilter(args []interface{}) (filters.Filter, error)
 	if err != nil {
 		return nil, err
 	}
+
+	f.text = strings.ReplaceAll(f.text, `\r`, "\r")
+	f.text = strings.ReplaceAll(f.text, `\n`, "\n")
 
 	if len(args) == 2 {
 		f.mime, err = stringArg(args[1])

--- a/filters/builtin/inlinecontent_test.go
+++ b/filters/builtin/inlinecontent_test.go
@@ -39,6 +39,11 @@ func TestInlineContentArgs(t *testing.T) {
 		expectedText: "foo",
 		expectedMime: "text/plain",
 	}, {
+		title:        "newlines",
+		args:         []interface{}{`foo\nbar\r\n`},
+		expectedText: "foo\nbar\r\n",
+		expectedMime: "text/plain",
+	}, {
 		title:        "html, detected",
 		args:         []interface{}{`<!doctype html><html>foo</html>`},
 		expectedText: `<!doctype html><html>foo</html>`,


### PR DESCRIPTION
```eskip
test_robots:
        Path("/robots.txt")
        -> setResponseHeader("Content-Type", "text/plain")
        -> inlineContent("User-agent: *\nDisallow: /")
        -> <shunt>;
```

```bash
$ http get localhost:9090/robots.txt
HTTP/1.1 200 OK
Content-Length: 25
Content-Type: text/plain
Date: Thu, 05 Mar 2020 19:04:35 GMT
Server: Skipper

User-agent: *
Disallow: /
```

I think we only need this in `inlineContent` filter. If you think it's better, we can also try to get this support in [eskip lexer](https://github.com/zalando/skipper/blob/master/eskip/lexer.go#L127) so that it works everywhere.