### PR TITLE
Refactor/origin marker

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -360,10 +360,6 @@ func (c *Client) hasReceivedTerm() bool {
 }
 
 func setOriginMarker(s *clusterState, r []*eskip.Route) []*eskip.Route {
-	if len(r) == 0 {
-		return nil
-	}
-
 	or := &eskip.Route{
 		Id: "kube__originMarkers",
 		Predicates: []*eskip.Predicate{{
@@ -463,7 +459,7 @@ func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
 		}
 	}
 
-	if c.originMarker {
+	if c.originMarker && (len(updatedRoutes) > 0 || len(deletedIDs) > 0) {
 		updatedRoutes = setOriginMarker(clusterState, updatedRoutes)
 	}
 


### PR DESCRIPTION
the origin markers are now set on an arbitrary route that doesn't necessarily gets updated/deleted when a partial update happens. Here using a dedicated route, that has always the same ID, and is only set when there is a change or a full reset.

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>