### PR TITLE
Support newlines in lexer

### DIFF
--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -133,7 +133,24 @@ func scanEscaped(delimiter byte, code string) ([]byte, string) {
 		isEscapeChar := c == escapeChar
 
 		if escaped {
-			if !isDelimiter && !isEscapeChar {
+			switch c {
+			case 'a':
+				c = '\a'
+			case 'b':
+				c = '\b'
+			case 'f':
+				c = '\f'
+			case 'n':
+				c = '\n'
+			case 'r':
+				c = '\r'
+			case 't':
+				c = '\t'
+			case 'v':
+				c = '\v'
+			case delimiter:
+			case escapeChar:
+			default:
 				b = append(b, escapeChar)
 			}
 

--- a/eskip/parser_test.go
+++ b/eskip/parser_test.go
@@ -102,6 +102,25 @@ func TestParseSingleRoute(t *testing.T) {
 	checkSingleRouteExample(r[0], t)
 }
 
+func TestParsingSpecialChars(t *testing.T) {
+	r, err := parse(`Path("newlines") -> inlineContent("Line \ \1\nLine 2\r\nLine 3\a\b\f\n\r\t\v") -> <shunt>`)
+
+	if err != nil {
+		t.Error("failed to parse", err)
+	}
+
+	if len(r) != 1 {
+		t.Error("failed to parse, no route returned")
+	}
+
+	expected := "Line \\ \\1\nLine 2\r\nLine 3\a\b\f\n\r\t\v"
+	actual := r[0].filters[0].Args[0]
+
+	if actual != expected {
+		t.Error("wrong arguments")
+	}
+}
+
 func TestParseSingleRouteDef(t *testing.T) {
 	r, err := parse(singleRouteDefExample)
 

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -16,7 +16,7 @@ type PrettyPrintInfo struct {
 func escape(s string, chars string) string {
 	for i := 0; i < len(chars); i++ {
 		c := chars[i : i+1]
-		s = strings.Replace(s, c, "\\"+c, -1)
+		s = strings.Replace(s, c, `\`+c, -1)
 	}
 
 	return s

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -14,6 +14,13 @@ type PrettyPrintInfo struct {
 }
 
 func escape(s string, chars string) string {
+	s = strings.Replace(s, "\a", `\a`, -1)
+	s = strings.Replace(s, "\b", `\b`, -1)
+	s = strings.Replace(s, "\f", `\f`, -1)
+	s = strings.Replace(s, "\n", `\n`, -1)
+	s = strings.Replace(s, "\r", `\r`, -1)
+	s = strings.Replace(s, "\t", `\t`, -1)
+	s = strings.Replace(s, "\v", `\v`, -1)
 	for i := 0; i < len(chars); i++ {
 		c := chars[i : i+1]
 		s = strings.Replace(s, c, `\`+c, -1)

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -14,8 +14,6 @@ type PrettyPrintInfo struct {
 }
 
 func escape(s string, chars string) string {
-
-	s = strings.Replace(s, "\\", "\\\\", -1)
 	for i := 0; i < len(chars); i++ {
 		c := chars[i : i+1]
 		s = strings.Replace(s, c, "\\"+c, -1)

--- a/eskip/string_test.go
+++ b/eskip/string_test.go
@@ -100,6 +100,16 @@ func TestRouteString(t *testing.T) {
 			Filters:     []*Filter{{"filter0", []interface{}{"arg"}}},
 			BackendType: DynamicBackend},
 		`* -> filter0("arg") -> <dynamic>`,
+	}, {
+		&Route{
+			Filters:     []*Filter{{"filter0", []interface{}{`Line 1\r\nLine 2`}}},
+			BackendType: DynamicBackend},
+		`* -> filter0("Line 1\r\nLine 2") -> <dynamic>`,
+	}, {
+		&Route{
+			Filters:     []*Filter{{"filter0", []interface{}{"Line 1\r\nLine 2"}}},
+			BackendType: DynamicBackend},
+		`* -> filter0("Line 1\r\nLine 2") -> <dynamic>`,
 	}} {
 		rstring := item.route.String()
 		if rstring != item.string {


### PR DESCRIPTION
This is a different approach to solve #1339.

## Problem

I have the following route:
```eskip
test:
    Path("/test")
    -> inlineContent("Line 1\nLine 2")
    -> <shunt>;
```

When I run this, Skipper will return my content wrong:
```
$ http get localhost:9090/test
HTTP/1.1 200 OK
Content-Length: 14
Content-Type: text/plain; charset=utf-8
Date: Fri, 06 Mar 2020 14:52:13 GMT
Server: Skipper

Line 1\nLine 2

$ http get localhost:9090/test | hexdump
0000000 4c 69 6e 65 20 31 5c 6e 4c 69 6e 65 20 32
000000e

// 5c = \
// 6e = n
```

As you can see, the `\n` is not a real newline char (10). 

In the log of Skipper I see this:
```
[APP]INFO[0156] route settings, update, route: test: Path("/test") -> inlineContent("Line 1\\nLine 2") -> <shunt> 
```

It escaped the escape char.

The only way to get this working is by creating a route like this and insert a newline:

```eskip
test:
    Path("/test")
    -> inlineContent("Line 1
Line 2")
    -> <shunt>;

$ http get localhost:9090/test
HTTP/1.1 200 OK
Content-Length: 13
Content-Type: text/plain; charset=utf-8
Date: Fri, 06 Mar 2020 14:53:49 GMT
Server: Skipper

Line 1
Line 2

$ http get localhost:9090/test | hexdump
0000000 4c 69 6e 65 20 31 0a 4c 69 6e 65 20 32
000000d

// 0a = \n
```

In the log I now see an actual newline:
```
[APP]INFO[0210] route settings, update, route: test: Path("/test") -> inlineContent("Line 1
Line 2") -> <shunt> 
```

## Solution

Correctly convert `\` + `n` to `char(10)` and `\` + `r` to `char(13)`.

Now, the log will always show it like this:
```
[APP]INFO[0000] route settings, reset, route: test: Path("/test") -> inlineContent("Line 1\nLine 2") -> <shunt> 
```

No more real newlines in the log! 

