### PR TITLE
Remove escaping backslashes

### DIFF
--- a/eskip/string.go
+++ b/eskip/string.go
@@ -14,8 +14,6 @@ type PrettyPrintInfo struct {
 }
 
 func escape(s string, chars string) string {
-
-	s = strings.Replace(s, "\\", "\\\\", -1)
 	for i := 0; i < len(chars); i++ {
 		c := chars[i : i+1]
 		s = strings.Replace(s, c, "\\"+c, -1)


### PR DESCRIPTION
I was looking at this code and it doesn't make sense to me what the purpose is. There is also no comment on why this is needed.

To me, the only thing that needs escaping are the `chars` that are provided as input. That is done in the `for` loop. Let's see if the tests fail on this. 