### PR TITLE
Release v1 move predicates

### DIFF
--- a/dataclients/kubernetes/eastwest.go
+++ b/dataclients/kubernetes/eastwest.go
@@ -44,7 +44,7 @@ func createEastWestRoutesIng(eastWestDomainRegexpPostfix, name, ns string, route
 	return ewroutes
 }
 
-func createEastWestRouteRG(name, ns, postfix string, r *eskip.Route) *eskip.Route {
+func createEastWestRouteRG(name, ns, postfix string, r *eskip.Route) (*eskip.Route, error) {
 	hostRx := createHostRx(fmt.Sprintf("%s.%s.%s", name, ns, postfix))
 
 	ewr := eskip.Copy(r)
@@ -63,6 +63,10 @@ func createEastWestRouteRG(name, ns, postfix string, r *eskip.Route) *eskip.Rout
 		Args: []interface{}{hostRx},
 	})
 
-	ewr.Predicates = p
-	return ewr
+	err := ewr.ReplacePredicates(p...)
+	if err != nil {
+		return nil, err
+	}
+
+	return ewr, nil
 }

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -323,26 +323,28 @@ func healthcheckRoute(healthy, reverseSourcePredicate bool) *eskip.Route {
 		status = http.StatusServiceUnavailable
 	}
 
-	var p []*eskip.Predicate
+	n := source.Name
 	if reverseSourcePredicate {
-		p = []*eskip.Predicate{{
-			Name: source.NameLast,
-			Args: internalIPs,
-		}}
-	} else {
-		p = []*eskip.Predicate{{
-			Name: source.Name,
-			Args: internalIPs,
-		}}
+		n = source.NameLast
 	}
 
 	return &eskip.Route{
-		Id:         healthcheckRouteID,
-		Predicates: p,
-		Path:       healthcheckPath,
-		Filters: []*eskip.Filter{{
-			Name: builtin.StatusName,
-			Args: []interface{}{status}},
+		Id: healthcheckRouteID,
+		Predicates: []*eskip.Predicate{
+			{
+				Name: "Path",
+				Args: []interface{}{healthcheckPath},
+			},
+			{
+				Name: n,
+				Args: internalIPs,
+			},
+		},
+		Filters: []*eskip.Filter{
+			{
+				Name: builtin.StatusName,
+				Args: []interface{}{status},
+			},
 		},
 		BackendType: eskip.ShuntBackend,
 	}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -340,7 +340,12 @@ func checkHealthcheck(t *testing.T, got []*eskip.Route, expected, healthy, rever
 			return
 		}
 
-		if r.Path != healthcheckPath {
+		pp, err := eskip.SinglePredicateByName(r.Predicates, "Path")
+		if err != nil {
+			t.Error("path predicate not found")
+		}
+
+		if pp == nil || pp.Args[0].(string) != healthcheckPath {
 			t.Error("invalid healthcheck path")
 			return
 		}
@@ -3284,17 +3289,17 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			"kube_foo__qux__www1_example_org_____bar":  "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www1_example_org_____": "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www1_example_org_____": "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www1_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www1_example_org_____": "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www2_example_org_____bar":  "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 			"kube___catchall__www3_example_org____":          "Host(/^www3[.]example[.]org$/) -> <shunt>",
 		},
 	}, {
@@ -3316,17 +3321,17 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			"kube_foo__qux__www1_example_org____bar":  "Host(/^www1[.]example[.]org$/) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www1_example_org____": "Host(/^www1[.]example[.]org$/) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www1_example_org____": "Host(/^www1[.]example[.]org$/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www1_example_org____": "Path(\"/a/path/somewhere\") && Host(/^www1[.]example[.]org$/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www1_example_org____": "Host(/^www1[.]example[.]org$/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www2_example_org_____bar":  "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 			"kube___catchall__www3_example_org____":          "Host(/^www3[.]example[.]org$/) -> <shunt>",
 		},
 	}, {
@@ -3485,17 +3490,17 @@ func TestSkipperCustomRoutesEastWest(t *testing.T) {
 			"kube_foo__qux__www1_example_org_____bar":  "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www1_example_org_____": "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www1_example_org_____": "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www1_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www1_example_org_____": "Host(/^www1[.]example[.]org$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www2_example_org_____bar":  "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 			"kube___catchall__www3_example_org____":          "Host(/^www3[.]example[.]org$/) -> <shunt>",
 
 			//"kubeew_foo__qux__www1_example_org_____bar":  "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
@@ -3509,9 +3514,9 @@ func TestSkipperCustomRoutesEastWest(t *testing.T) {
 			"kubeew_foo__qux_a_0__www3_example_org_a_path____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) && Method(\"OPTIONS\") -> <shunt>",
 			//"kubeew_foo__qux_b_1__www3_example_org_a_path____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
 
-			"kubeew_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) -> \"https://some.other-url.org/a/path/somewhere\"",
-			"kubeew_foo__qux_c_2__www1_example_org_____":       "Path(\"/a/path/somewhere\") && Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
-			"kubeew_foo__qux_c_2__www2_example_org_____":       "Path(\"/a/path/somewhere\") && Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kubeew_foo__qux_c_2__www3_example_org_a_path____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kubeew_foo__qux_c_2__www1_example_org_____":       "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kubeew_foo__qux_c_2__www2_example_org_____":       "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 			"kubeew___catchall__www3_example_org____":          "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) -> <shunt>"},
 	}, {
 		msg: "ingress with 3 host definitions with one without path and 3 additional custom routes",
@@ -3532,32 +3537,32 @@ func TestSkipperCustomRoutesEastWest(t *testing.T) {
 			"kube_foo__qux__www1_example_org____bar":  "Host(/^www1[.]example[.]org$/) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www1_example_org____": "Host(/^www1[.]example[.]org$/) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www1_example_org____": "Host(/^www1[.]example[.]org$/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www1_example_org____": "Path(\"/a/path/somewhere\") && Host(/^www1[.]example[.]org$/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www1_example_org____": "Host(/^www1[.]example[.]org$/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			//"kubeew_foo__qux__www1_example_org____bar":  "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) -> \"http://1.2.3.4:8181\"",
 			//"kubeew_foo__qux__www2_example_org_____bar": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
 
 			"kubeew_foo__qux_a_0__www1_example_org____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && Method(\"OPTIONS\") -> <shunt>",
 			//"kubeew_foo__qux_b_1__www1_example_org____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kubeew_foo__qux_c_2__www1_example_org____": "Path(\"/a/path/somewhere\") && Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kubeew_foo__qux_c_2__www1_example_org____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www2_example_org_____bar":  "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Host(/^www2[.]example[.]org$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kubeew_foo__qux_a_0__www2_example_org_____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 			//"kubeew_foo__qux_b_1__www2_example_org_____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kubeew_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kubeew_foo__qux_c_2__www2_example_org_____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\//) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"http://1.2.3.4:8181\"",
 			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Method(\"OPTIONS\") -> <shunt>",
 			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Host(/^www3[.]example[.]org$/) && PathRegexp(/^\\/a\\/path/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 			//"kubeew_foo__qux__www3_example_org___a_path__bar":  "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) -> \"http://1.2.3.4:8181\"",
 			"kubeew_foo__qux_a_0__www3_example_org_a_path____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) && Method(\"OPTIONS\") -> <shunt>",
 			//"kubeew_foo__qux_b_1__www3_example_org_a_path____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.2.3.6:8181\"",
-			"kubeew_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kubeew_foo__qux_c_2__www3_example_org_a_path____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) && PathRegexp(/^\\/a\\/path/) && Path(\"/a/path/somewhere\") -> \"https://some.other-url.org/a/path/somewhere\"",
 
 			"kube___catchall__www3_example_org____":   "Host(/^www3[.]example[.]org$/) -> <shunt>",
 			"kubeew___catchall__www3_example_org____": "Host(/^qux[.]foo[.]skipper[.]cluster[.]local$/) -> <shunt>",

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -60,11 +59,7 @@ func findRouteWithExactPath(r []*eskip.Route) (*eskip.Route, error) {
 			return nil, err
 		}
 
-		if p != nil && ri.Path != "" {
-			return nil, errors.New("route with duplicate path predicate found")
-		}
-
-		if p != nil || ri.Path != "" {
+		if p != nil {
 			return ri, nil
 		}
 	}

--- a/dataclients/kubernetes/redirect.go
+++ b/dataclients/kubernetes/redirect.go
@@ -166,21 +166,24 @@ func hasProtoPredicate(r *eskip.Route) bool {
 	return false
 }
 
-func createHTTPSRedirect(code int, r *eskip.Route) *eskip.Route {
+func createHTTPSRedirect(code int, r *eskip.Route) (*eskip.Route, error) {
 	// copy to avoid unexpected mutations
 	rr := eskip.Copy(r)
 	rr.Id = routeIDForRedirectRoute(rr.Id, true)
 	rr.BackendType = eskip.ShuntBackend
 
-	rr.Predicates = append(rr.Predicates, &eskip.Predicate{
+	err := rr.AppendPredicate(&eskip.Predicate{
 		Name: "Header",
 		Args: []interface{}{forwardedProtoHeader, "http"},
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	rr.Filters = append(rr.Filters, &eskip.Filter{
 		Name: "redirectTo",
 		Args: []interface{}{float64(code), "https:"},
 	})
 
-	return rr
+	return rr, nil
 }

--- a/dataclients/routestring/string_test.go
+++ b/dataclients/routestring/string_test.go
@@ -66,7 +66,12 @@ func TestRouteString(t *testing.T) {
 		}, {
 			Id:     "register",
 			Method: "POST",
-			Path:   "/register",
+			Predicates: []*eskip.Predicate{{
+				Name: "Path",
+				Args: []interface{}{
+					"/register",
+				},
+			}},
 			Filters: []*eskip.Filter{{
 				Name: "setPath",
 				Args: []interface{}{

--- a/eskip/eq.go
+++ b/eskip/eq.go
@@ -187,19 +187,6 @@ func Canonical(r *Route) *Route {
 	c.Predicates = make([]*Predicate, len(r.Predicates))
 	copy(c.Predicates, r.Predicates)
 
-	// legacy path:
-	var hasPath bool
-	for _, p := range c.Predicates {
-		if p.Name == "Path" {
-			hasPath = true
-			break
-		}
-	}
-
-	if r.Path != "" && !hasPath {
-		c.Predicates = append(c.Predicates, &Predicate{Name: "Path", Args: []interface{}{r.Path}})
-	}
-
 	// legacy host:
 	for _, h := range r.HostRegexps {
 		c.Predicates = append(c.Predicates, &Predicate{Name: "Host", Args: []interface{}{h}})

--- a/eskip/eq_test.go
+++ b/eskip/eq_test.go
@@ -194,17 +194,6 @@ func TestCanonical(t *testing.T) {
 	}{{
 		title: "nil",
 	}, {
-		title:  "path",
-		route:  &Route{Path: "/foo"},
-		expect: &Route{Predicates: []*Predicate{{Name: "Path", Args: []interface{}{"/foo"}}}},
-	}, {
-		title: "path, from predicates",
-		route: &Route{
-			Path:       "/foo",
-			Predicates: []*Predicate{{Name: "Path", Args: []interface{}{"/bar"}}},
-		},
-		expect: &Route{Predicates: []*Predicate{{Name: "Path", Args: []interface{}{"/bar"}}}},
-	}, {
 		title: "host regexps to predicates",
 		route: &Route{
 			HostRegexps: []string{"foo"},

--- a/eskip/json.go
+++ b/eskip/json.go
@@ -15,13 +15,6 @@ func marshalJsonPredicates(r *Route) []*Predicate {
 		})
 	}
 
-	if r.Path != "" {
-		rjf = append(rjf, &Predicate{
-			Name: "Path",
-			Args: []interface{}{r.Path},
-		})
-	}
-
 	for _, h := range r.HostRegexps {
 		rjf = append(rjf, &Predicate{
 			Name: "HostRegexp",

--- a/eskip/predicates.go
+++ b/eskip/predicates.go
@@ -1,0 +1,98 @@
+package eskip
+
+import (
+	"fmt"
+)
+
+// PredicatesContain checks if the route has predicate with the given name.
+func PredicatesContain(p []*Predicate, name string) bool {
+	for _, p := range p {
+		if p.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AllPredicatesByName returns all predicates that match the given name.
+func AllPredicatesByName(p []*Predicate, name string) []*Predicate {
+	pp := make([]*Predicate, 0)
+	for _, p := range p {
+		if p.Name == name {
+			pp = append(pp, p)
+		}
+	}
+
+	return pp
+}
+
+// SinglePredicateByName returns matching predicate or error when multiple predicates are given.
+func SinglePredicateByName(p []*Predicate, name string) (*Predicate, error) {
+	pp := make([]*Predicate, 0)
+	for _, p := range p {
+		if p.Name == name {
+			pp = append(pp, p)
+		}
+	}
+
+	if len(pp) == 0 {
+		return nil, nil
+	}
+
+	if len(pp) > 1 {
+		return nil, fmt.Errorf("multiple predicates of the same name: %d %s", len(pp), name)
+	}
+
+	return pp[0], nil
+}
+
+// ValidatePredicates returns an error when certain predicates are added multiple times.
+func ValidatePredicates(pp []*Predicate) error {
+	for _, p := range pp {
+		switch p.Name {
+		case "Path", "Weight":
+			if len(AllPredicatesByName(pp, p.Name)) > 1 {
+				return fmt.Errorf("predicate of type %s can only be added once", p.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// PrependPredicate prepends all predicates to the existing predicates and validates them.
+func (r *Route) PrependPredicate(pp ...*Predicate) error {
+	next := append(pp, r.Predicates...)
+	err := ValidatePredicates(next)
+	if err != nil {
+		return err
+	}
+	r.Predicates = next
+
+	return nil
+}
+
+// AppendPredicate appends all predicates to the existing predicates and validates them.
+func (r *Route) AppendPredicate(pp ...*Predicate) error {
+	next := append(r.Predicates, pp...)
+	err := ValidatePredicates(next)
+	if err != nil {
+		return err
+	}
+	r.Predicates = next
+
+	return nil
+}
+
+// ReplacePredicates replaces all predicates and validates them.
+func (r *Route) ReplacePredicates(pp ...*Predicate) error {
+	next := pp
+	err := ValidatePredicates(next)
+	if err != nil {
+		return err
+	}
+	r.Predicates = next
+
+	return nil
+}

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -69,10 +69,6 @@ func argsString(args []interface{}) string {
 func (r *Route) predicateString() string {
 	var predicates []string
 
-	if r.Path != "" {
-		predicates = appendFmtEscape(predicates, `Path("%s")`, `"`, r.Path)
-	}
-
 	for _, h := range r.HostRegexps {
 		predicates = appendFmtEscape(predicates, "Host(/%s/)", "/", h)
 	}

--- a/eskip/string_test.go
+++ b/eskip/string_test.go
@@ -54,7 +54,6 @@ func TestRouteString(t *testing.T) {
 		`Method("GET") -> "https://www.example.org"`,
 	}, {
 		&Route{
-			Path:        `/some/"/path`,
 			HostRegexps: []string{"h-expression", "slash/h-expression"},
 			PathRegexps: []string{"p-expression", "slash/p-expression"},
 			Method:      "PUT",
@@ -62,19 +61,22 @@ func TestRouteString(t *testing.T) {
 				`ap"key`: `ap"value`},
 			HeaderRegexps: map[string][]string{
 				`ap"key`: {"slash/value0", "slash/value1"}},
-			Predicates: []*Predicate{{"Test", []interface{}{3.14, "hello"}}},
+			Predicates: []*Predicate{
+				{"Path", []interface{}{`/some/"/path`}},
+				{"Test", []interface{}{3.14, "hello"}},
+			},
 			Filters: []*Filter{
 				{"filter0", []interface{}{float64(3.1415), "argvalue"}},
 				{"filter1", []interface{}{float64(-42), `ap"argvalue`}}},
 			BackendType: NetworkBackend,
 			Backend:     "https://www.example.org"},
-		`Path("/some/\"/path") && Host(/h-expression/) && ` +
+		`Host(/h-expression/) && ` +
 			`Host(/slash\/h-expression/) && ` +
 			`PathRegexp(/p-expression/) && PathRegexp(/slash\/p-expression/) && ` +
 			`Method("PUT") && ` +
 			`Header("ap\"key", "ap\"value") && ` +
 			`HeaderRegexp("ap\"key", /slash\/value0/) && HeaderRegexp("ap\"key", /slash\/value1/) && ` +
-			`Test(3.14, "hello") -> ` +
+			`Path("/some/\"/path") && Test(3.14, "hello") -> ` +
 			`filter0(3.1415, "argvalue") -> filter1(-42, "ap\"argvalue") -> ` +
 			`"https://www.example.org"`,
 	}, {

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -279,8 +279,10 @@ func TestConcurrencyMultipleRoutes(t *testing.T) {
 
 	for _, app := range apps {
 		routes = append(routes, &eskip.Route{
-			Id:          app,
-			Path:        fmt.Sprintf("/%s", app),
+			Id: app,
+			Predicates: []*eskip.Predicate{
+				{"Path", []interface{}{fmt.Sprintf("/%s", app)}},
+			},
 			BackendType: eskip.LBBackend,
 			LBEndpoints: backends[app],
 			LBAlgorithm: "roundRobin",

--- a/proxy/debug_test.go
+++ b/proxy/debug_test.go
@@ -24,13 +24,17 @@ func TestDebug(t *testing.T) {
 		"full doc",
 		debugInfo{
 			route: &eskip.Route{
-				Id:         "testRoute",
-				Path:       "/hello",
-				Backend:    "https://www.example.org",
-				Predicates: []*eskip.Predicate{{Name: "Test", Args: []interface{}{3.14, "hello"}}},
+				Id:      "testRoute",
+				Backend: "https://www.example.org",
+				Predicates: []*eskip.Predicate{
+					{Name: "Path", Args: []interface{}{"/hello"}},
+					{Name: "Test", Args: []interface{}{3.14, "hello"}},
+				},
 				Filters: []*eskip.Filter{
 					{Name: "filter0", Args: []interface{}{float64(3.1415), "argvalue"}},
-					{Name: "filter1", Args: []interface{}{float64(-42), `ap"argvalue`}}}},
+					{Name: "filter1", Args: []interface{}{float64(-42), `ap"argvalue`}},
+				},
+			},
 			incoming: &http.Request{
 				Method:     "OPTIONS",
 				RequestURI: "/testuri",
@@ -53,8 +57,11 @@ func TestDebug(t *testing.T) {
 		debugDocument{
 			RouteId: "testRoute",
 			Route: (&eskip.Route{
-				Path: "/hello", Backend: "https://www.example.org",
-				Predicates: []*eskip.Predicate{{Name: "Test", Args: []interface{}{3.14, "hello"}}},
+				Backend: "https://www.example.org",
+				Predicates: []*eskip.Predicate{
+					{Name: "Path", Args: []interface{}{"/hello"}},
+					{Name: "Test", Args: []interface{}{3.14, "hello"}},
+				},
 				Filters: []*eskip.Filter{
 					{Name: "filter0", Args: []interface{}{float64(3.1415), "argvalue"}},
 					{Name: "filter1", Args: []interface{}{float64(-42), `ap"argvalue`}}}}).String(),

--- a/proxy/idle_test.go
+++ b/proxy/idle_test.go
@@ -122,8 +122,8 @@ func TestIdleConns(t *testing.T) {
 			proxy.Params{
 				IdleConnectionsPerHost: ti.idleConns,
 				CloseIdleConnsPeriod:   ti.closeIdleConns},
-			&eskip.Route{Id: "s0", Path: "/s0", Backend: s0.URL},
-			&eskip.Route{Id: "s1", Path: "/s1", Backend: s1.URL})
+			&eskip.Route{Id: "s0", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/s0"}}}, Backend: s0.URL},
+			&eskip.Route{Id: "s1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/s1"}}}, Backend: s1.URL})
 		defer p.Close()
 
 		request := func(path string, doc []byte) {

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -426,11 +426,6 @@ func validTreePredicates(predicates []*eskip.Predicate) bool {
 
 // processes path tree relevant predicates
 func processTreePredicates(r *Route, predicates []*eskip.Predicate) error {
-	// backwards compatibility
-	if r.Path != "" {
-		predicates = append(predicates, &eskip.Predicate{Name: PathName, Args: []interface{}{r.Path}})
-	}
-
 	if !validTreePredicates(predicates) {
 		return fmt.Errorf("multiple tree predicates (Path, PathSubtree) in the route: %s", r.Id)
 	}

--- a/routing/matcher_test.go
+++ b/routing/matcher_test.go
@@ -190,7 +190,7 @@ func generateRoutes(paths []string) []*Route {
 		// the path for the backend is fine here,
 		// because it is only used for checking the
 		// found routes
-		defs[i] = &eskip.Route{Id: fmt.Sprintf("route%d", i), Path: p, Backend: p}
+		defs[i] = &eskip.Route{Id: fmt.Sprintf("route%d", i), Predicates: []*eskip.Predicate{{"Path", []interface{}{p}}}, Backend: p}
 	}
 
 	routes, _ := processRouteDefs(Options{}, nil, defs)

--- a/routing/predicates_test.go
+++ b/routing/predicates_test.go
@@ -57,7 +57,7 @@ func TestPredicateList(t *testing.T) {
 		title: "only legacy predicate, path",
 		routes: []*eskip.Route{{
 			Id:          "test",
-			Path:        "/foo",
+			Predicates:  []*eskip.Predicate{{"Path", []interface{}{"/foo"}}},
 			BackendType: eskip.ShuntBackend,
 		}, {
 			Id:          "catchAll",
@@ -336,52 +336,6 @@ func TestPredicateList(t *testing.T) {
 				Header: http.Header{
 					"X-Test": []string{"bar"},
 				},
-			},
-			allowedIDs: []string{"testLegacyAndList", "testNewOnly"},
-		}, {
-			request: &http.Request{
-				URL: &url.URL{Path: "/"},
-			},
-			expectedID: "catchAll",
-		}},
-	}, {
-
-		title: "mixed, path conflict",
-		routes: []*eskip.Route{{
-			Id:   "testLegacyAndList",
-			Path: "/foo",
-			Predicates: []*eskip.Predicate{{
-				Name: "Path",
-				Args: []interface{}{
-					"/bar",
-				},
-			}},
-			BackendType: eskip.ShuntBackend,
-		}, {
-			Id:          "testLegacyOnly",
-			Path:        "/foo",
-			BackendType: eskip.ShuntBackend,
-		}, {
-			Id: "testNewOnly",
-			Predicates: []*eskip.Predicate{{
-				Name: "Path",
-				Args: []interface{}{
-					"/bar",
-				},
-			}},
-			BackendType: eskip.ShuntBackend,
-		}, {
-			Id:          "catchAll",
-			BackendType: eskip.ShuntBackend,
-		}},
-		checks: []check{{
-			request: &http.Request{
-				URL: &url.URL{Path: "/foo"},
-			},
-			allowedIDs: []string{"testLegacyAndList", "testLegacyOnly"},
-		}, {
-			request: &http.Request{
-				URL: &url.URL{Path: "/bar"},
 			},
 			allowedIDs: []string{"testLegacyAndList", "testNewOnly"},
 		}, {

--- a/routing/routing_test.go
+++ b/routing/routing_test.go
@@ -134,7 +134,7 @@ func stringsAreSame(xs, ys []string) bool {
 }
 
 func TestKeepsReceivingInitialRouteDataUntilSucceeds(t *testing.T) {
-	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"}})
+	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"}})
 	dc.FailNext()
 	dc.FailNext()
 	dc.FailNext()
@@ -153,7 +153,7 @@ func TestKeepsReceivingInitialRouteDataUntilSucceeds(t *testing.T) {
 }
 
 func TestReceivesInitial(t *testing.T) {
-	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"}})
+	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"}})
 	tr, err := newTestRouting(dc)
 	if err != nil {
 		t.Error(err)
@@ -167,7 +167,7 @@ func TestReceivesInitial(t *testing.T) {
 }
 
 func TestReceivesFullOnFailedUpdate(t *testing.T) {
-	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"}})
+	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"}})
 	tr, err := newTestRouting(dc)
 	if err != nil {
 		t.Error(err)
@@ -178,7 +178,7 @@ func TestReceivesFullOnFailedUpdate(t *testing.T) {
 
 	tr.log.Reset()
 	dc.FailNext()
-	dc.Update([]*eskip.Route{{Id: "route2", Path: "/some-other", Backend: "https://other.example.org"}}, nil)
+	dc.Update([]*eskip.Route{{Id: "route2", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-other"}}}, Backend: "https://other.example.org"}}, nil)
 
 	if err := tr.waitForRouteSetting(); err != nil {
 		t.Error(err)
@@ -191,7 +191,7 @@ func TestReceivesFullOnFailedUpdate(t *testing.T) {
 }
 
 func TestReceivesUpdate(t *testing.T) {
-	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"}})
+	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"}})
 	tr, err := newTestRouting(dc)
 	if err != nil {
 		t.Error(err)
@@ -201,7 +201,7 @@ func TestReceivesUpdate(t *testing.T) {
 	defer tr.close()
 
 	tr.log.Reset()
-	dc.Update([]*eskip.Route{{Id: "route2", Path: "/some-other", Backend: "https://other.example.org"}}, nil)
+	dc.Update([]*eskip.Route{{Id: "route2", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-other"}}}, Backend: "https://other.example.org"}}, nil)
 
 	if err := tr.waitForRouteSetting(); err != nil {
 		t.Error(err)
@@ -215,8 +215,8 @@ func TestReceivesUpdate(t *testing.T) {
 
 func TestReceivesDelete(t *testing.T) {
 	dc := testdataclient.New([]*eskip.Route{
-		{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"},
-		{Id: "route2", Path: "/some-other", Backend: "https://other.example.org"}})
+		{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"},
+		{Id: "route2", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-other"}}}, Backend: "https://other.example.org"}})
 	tr, err := newTestRouting(dc)
 	if err != nil {
 		t.Error(err)
@@ -239,7 +239,7 @@ func TestReceivesDelete(t *testing.T) {
 }
 
 func TestUpdateDoesNotChangeRouting(t *testing.T) {
-	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"}})
+	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"}})
 	tr, err := newTestRouting(dc)
 	if err != nil {
 		t.Error(err)
@@ -262,9 +262,9 @@ func TestUpdateDoesNotChangeRouting(t *testing.T) {
 }
 
 func TestMergesMultipleSources(t *testing.T) {
-	dc1 := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"}})
-	dc2 := testdataclient.New([]*eskip.Route{{Id: "route2", Path: "/some-other", Backend: "https://other.example.org"}})
-	dc3 := testdataclient.New([]*eskip.Route{{Id: "route3", Path: "/another", Backend: "https://another.example.org"}})
+	dc1 := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"}})
+	dc2 := testdataclient.New([]*eskip.Route{{Id: "route2", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-other"}}}, Backend: "https://other.example.org"}})
+	dc3 := testdataclient.New([]*eskip.Route{{Id: "route3", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/another"}}}, Backend: "https://another.example.org"}})
 	tr, err := newTestRouting(dc1, dc2, dc3)
 	if err != nil {
 		t.Error(err)
@@ -287,9 +287,9 @@ func TestMergesMultipleSources(t *testing.T) {
 }
 
 func TestMergesUpdatesFromMultipleSources(t *testing.T) {
-	dc1 := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "https://www.example.org"}})
-	dc2 := testdataclient.New([]*eskip.Route{{Id: "route2", Path: "/some-other", Backend: "https://other.example.org"}})
-	dc3 := testdataclient.New([]*eskip.Route{{Id: "route3", Path: "/another", Backend: "https://another.example.org"}})
+	dc1 := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"}})
+	dc2 := testdataclient.New([]*eskip.Route{{Id: "route2", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-other"}}}, Backend: "https://other.example.org"}})
+	dc3 := testdataclient.New([]*eskip.Route{{Id: "route3", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/another"}}}, Backend: "https://another.example.org"}})
 	tr, err := newTestRouting(dc1, dc2, dc3)
 	if err != nil {
 		t.Error(err)
@@ -312,8 +312,8 @@ func TestMergesUpdatesFromMultipleSources(t *testing.T) {
 
 	tr.log.Reset()
 
-	dc1.Update([]*eskip.Route{{Id: "route1", Path: "/some-changed-path", Backend: "https://www.example.org"}}, nil)
-	dc2.Update([]*eskip.Route{{Id: "route2", Path: "/some-other-changed", Backend: "https://www.example.org"}}, nil)
+	dc1.Update([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-changed-path"}}}, Backend: "https://www.example.org"}}, nil)
+	dc2.Update([]*eskip.Route{{Id: "route2", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-other-changed"}}}, Backend: "https://www.example.org"}}, nil)
 	dc3.Update(nil, []string{"route3"})
 
 	if err := tr.waitForNRouteSettings(3); err != nil {
@@ -335,7 +335,7 @@ func TestMergesUpdatesFromMultipleSources(t *testing.T) {
 }
 
 func TestIgnoresInvalidBackend(t *testing.T) {
-	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Path: "/some-path", Backend: "invalid backend"}})
+	dc := testdataclient.New([]*eskip.Route{{Id: "route1", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "invalid backend"}})
 	tr, err := newTestRouting(dc)
 	if err != nil {
 		t.Error(err)
@@ -354,10 +354,10 @@ func TestProcessesFilterDefinitions(t *testing.T) {
 	fr.Register(fs)
 
 	dc := testdataclient.New([]*eskip.Route{{
-		Id:      "route1",
-		Path:    "/some-path",
-		Filters: []*eskip.Filter{{Name: "filter1", Args: []interface{}{3.14, "Hello, world!"}}},
-		Backend: "https://www.example.org"}})
+		Id:         "route1",
+		Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}},
+		Filters:    []*eskip.Filter{{Name: "filter1", Args: []interface{}{3.14, "Hello, world!"}}},
+		Backend:    "https://www.example.org"}})
 
 	tr, err := newTestRoutingWithFilters(fr, dc)
 	if err != nil {

--- a/routing/testdataclient/example_test.go
+++ b/routing/testdataclient/example_test.go
@@ -16,7 +16,8 @@ import (
 func Example() {
 	// create a data client:
 	dataClient := testdataclient.New([]*eskip.Route{
-		{Path: "/some/path", Backend: "https://www.example.org"}})
+		{Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"},
+	})
 
 	// (only in tests)
 	tl := loggingtest.New()
@@ -45,7 +46,8 @@ func Example() {
 
 func ExampleNew() {
 	testdataclient.New([]*eskip.Route{
-		{Path: "/some/path", Backend: "https://www.example.org"}})
+		{Predicates: []*eskip.Predicate{{"Path", []interface{}{"/some-path"}}}, Backend: "https://www.example.org"},
+	})
 }
 
 func ExampleNewDoc() {


### PR DESCRIPTION
This extracts the `Path` predicate to `predicates` package.

I also introduced a mechanism to guard against duplicate predicates like `Weight`, `Path` and maybe more in the future. See `AppendPredicate` and `PrependPredicate` in `eskip.go`.