### PR TITLE
Docs > Lowercase filter

### DIFF
--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -337,6 +337,6 @@ Current implemented protocols:
 
 Route example that uses FastCGI (*experimental*):
 ```
-php: * -> SetFastCgiFilename("index.php") -> "fastcgi://127.0.0.1:9000";
-php_lb: * -> SetFastCgiFilename("index.php") -> <roundRobin, "fastcgi://127.0.0.1:9000", "fastcgi://127.0.0.1:9001">;
+php: * -> setFastCgiFilename("index.php") -> "fastcgi://127.0.0.1:9000";
+php_lb: * -> setFastCgiFilename("index.php") -> <roundRobin, "fastcgi://127.0.0.1:9000", "fastcgi://127.0.0.1:9001">;
 ```


### PR DESCRIPTION
Filters always need to be lowercase first.