### PR TITLE
Fix: Align CRD backend algorithms to those allowed by skipper

### DIFF
--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -65,9 +65,9 @@ spec:
                   algorithm:
                     type: string
                     enum:
-                    - roundrobin
+                    - roundRobin
                     - random
-                    - consistent-hash
+                    - consistentHash
                   endpoints:
                     type: array
                     minLength: 1

--- a/packaging/helm/skipper-aws/crds/routegroups.yaml
+++ b/packaging/helm/skipper-aws/crds/routegroups.yaml
@@ -65,9 +65,9 @@ spec:
                   algorithm:
                     type: string
                     enum:
-                    - roundrobin
+                    - roundRobin
                     - random
-                    - consistent-hash
+                    - consistentHash
                   endpoints:
                     type: array
                     minLength: 1


### PR DESCRIPTION
The backend algorithms should be specified like so, `roundRobin`/`random`/`consistentHash`: https://github.com/zalando/skipper/blob/master/loadbalancer/algorithm.go#L113-L129.

This PR aligns the CRD definitions to this.

When applying a route group with, say, `roundRobin`, I get
```
routegroups.zalando.org "test" was not valid:
<...>
spec.backends.algorithm in body should be one of [roundrobin random consistent-hash]
```

but if i apply `roundrobin`, I get an error in skipper saying `unsupported algorithm`.


Signed-off-by: Daniel Middlecote <dlmiddlecote@gmail.com>