### PR TITLE
Log call duration, backendType + backend on proxy error

### DIFF
--- a/proxy/clienttimeout_test.go
+++ b/proxy/clienttimeout_test.go
@@ -52,4 +52,8 @@ func TestClientTimeout(t *testing.T) {
 	if err = tp.log.WaitFor(msgErrClientTimeout, 3*d); err != nil {
 		t.Errorf("log should contain '%s'", msgErrClientTimeout)
 	}
+	const msgErrClientCanceledAfter = "client canceled after"
+	if err = tp.log.WaitFor(msgErrClientCanceledAfter, 3*d); err != nil {
+		t.Errorf("log should contain '%s'", msgErrClientCanceledAfter)
+	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1241,8 +1241,10 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		code = p.defaultHTTPStatus
 	case ok && perr.err == errRatelimit:
 		code = perr.code
+	case code == 499:
+		p.log.Errorf("client canceled after %v, route %s with backend %s, status code %d: %v", time.Since(ctx.startServe), id, backend, code, err)
 	default:
-		p.log.Errorf("error while proxying, route %s with backend %s, status code %d: %v", id, backend, code, err)
+		p.log.Errorf("error while proxying after %v, route %s with backend %s, status code %d: %v", time.Since(ctx.startServe), id, backend, code, err)
 	}
 
 	p.sendError(ctx, id, code)


### PR DESCRIPTION
Instead of logging:
```
time="2020-03-31T14:44:16Z" level=error msg="error while proxying, route kube_frontend__frontend__www_ticketswap_nl with backend , status code 499: dialing failed false: context canceled"
```

it will now log:
```
time="2020-03-31T14:44:16Z" level=error msg="error while proxying after 5m41s, route kube_frontend__frontend__www_ticketswap_nl with backend , status code 499: dialing failed false: context canceled"
```

Also, discovered that when you use loadbalanced backends, the error log will be an empty string:
```
time="2020-03-31T14:44:16Z" level=error msg="error while proxying, route kube_frontend__frontend__www_ticketswap_nl with backend , status code 499: dialing failed false: context canceled"
```

Look at `with backend , `. 

This is because the single `Backend` is selected there. If you have a route `* -> "https://zalando.de"` it would show it, but if you have `* -> <roundRobin, "ip:port">` it won't.