### PR TITLE
Change default value for no flow id

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	proxyBufferSize         = 8192
-	unknownFlowId           = "-"
+	unknownFlowId           = "not set"
 	unknownRouteID          = "_unknownroute_"
 	unknownRouteBackendType = "<unknown>"
 	unknownRouteBackend     = "<unknown>"


### PR DESCRIPTION
Looks better in the logs.

```
level=error msg="client canceled after 48.961234ms, route x with backend lb http://100.109.163.119:80, flow id -, status code 499: dialing failed false: context canceled"
```

Kinda weird, that single dash.

Much better:
```
level=error msg="client canceled after 48.961234ms, route x with backend lb http://100.109.163.119:80, flow id not set, status code 499: dialing failed false: context canceled"
```
