### PR TITLE
remove early close of the response body

### DIFF
--- a/filters/builtin/compress_test.go
+++ b/filters/builtin/compress_test.go
@@ -561,8 +561,7 @@ func TestStreaming(t *testing.T) {
 			return
 		}
 
-		defer rsp.Body.Close()
-
+		// this body is closed in the enclosing function
 		body = rsp.Body
 
 		if rsp.StatusCode != http.StatusOK {


### PR DESCRIPTION
removing early close of the response body as it is closed by the enclosing function

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>