### PR TITLE
Log proxy errors in access log

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -41,6 +41,7 @@ type context struct {
 	tracer               opentracing.Tracer
 	proxySpan            opentracing.Span
 	parentSpan           opentracing.Span
+	proxyErr             error
 
 	routeLookup *routing.RouteLookup
 }


### PR DESCRIPTION
Logging the proxy errors without the request context is pretty useless. The only way to find out which request failed is to enable flowId's and try to map them together. On a production server with lots of requests this is almost impossible.

To make it easier to find out which request failed, the proxy errros are now stored in the Context.

When the access log is enabled, the proxy error is appended to the end of the access log.

Normal access log looks like this (watch the `"-"` at the end):
```
::1 - - [02/Apr/2020:09:34:38 +0200] "GET /robots.txt HTTP/1.1" 200 11 "-" "HTTPie/2.0.0" 0 localhost:9090 - - "-"
```

When an error occurred while proxying, it looks like this:
```
::1 - - [02/Apr/2020:09:37:11 +0200] "GET / HTTP/1.1" 500 22 "-" "HTTPie/2.0.0" 0 localhost:9090 - - "error while proxying after 118.044µs, route php with backend network fastcgi://0.0.0.0:9123: dialing failed false: gofast: failed creating client: dial tcp 0.0.0.0:9123: connect: connection refused"
```

Much better, isn't it? 