### PR TITLE
Allow Traffic to receive values >= 1

### DIFF
--- a/predicates/traffic/traffic.go
+++ b/predicates/traffic/traffic.go
@@ -102,7 +102,7 @@ func (s *spec) Create(args []interface{}) (routing.Predicate, error) {
 
 	p := &predicate{}
 
-	if c, ok := args[0].(float64); ok && 0.0 <= c && c < 1.0 {
+	if c, ok := args[0].(float64); ok && 0.0 <= c {
 		p.chance = c
 	} else {
 		return nil, predicates.ErrInvalidPredicateParameters

--- a/predicates/traffic/traffic_test.go
+++ b/predicates/traffic/traffic_test.go
@@ -52,10 +52,10 @@ func TestCreate(t *testing.T) {
 		predicate{chance: .3},
 		false,
 	}, {
-		"wrong chance, bigger than 1",
+		"bigger than 1 is acceptable",
 		[]interface{}{1.3},
 		predicate{chance: 1.3},
-		true,
+		false,
 	}, {
 		"wrong chance, less than 0",
 		[]interface{}{-0.3},


### PR DESCRIPTION
If a user adds a filter with Traffic >= 1 it will drop the route due to invalid parameters. Specially when setting it to 1, the current implementation seems to have a consequence too severe.