### PR TITLE
V1 > Remove deprecated Proxy.New

### DIFF
--- a/eskipfile/example_test.go
+++ b/eskipfile/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 	defer rt.Close()
 
 	// create an http.Handler:
-	p := proxy.WithParams(proxy.Params{
+	p := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/eskipfile/example_test.go
+++ b/eskipfile/example_test.go
@@ -18,6 +18,8 @@ func Example() {
 	defer rt.Close()
 
 	// create an http.Handler:
-	p := proxy.New(rt, proxy.OptionsNone)
+	p := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer p.Close()
 }

--- a/eskipfile/example_test.go
+++ b/eskipfile/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 	defer rt.Close()
 
 	// create an http.Handler:
-	p := proxy.New(proxy.Params{
+	p := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/etcd/example_test.go
+++ b/etcd/example_test.go
@@ -42,7 +42,7 @@ func Example() {
 	defer rt.Close()
 
 	// create http.Handler:
-	p := proxy.WithParams(proxy.Params{
+	p := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/etcd/example_test.go
+++ b/etcd/example_test.go
@@ -42,7 +42,7 @@ func Example() {
 	defer rt.Close()
 
 	// create http.Handler:
-	p := proxy.New(proxy.Params{
+	p := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/etcd/example_test.go
+++ b/etcd/example_test.go
@@ -42,6 +42,8 @@ func Example() {
 	defer rt.Close()
 
 	// create http.Handler:
-	p := proxy.New(rt, proxy.OptionsNone)
+	p := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer p.Close()
 }

--- a/filters/builtin/redirect_test.go
+++ b/filters/builtin/redirect_test.go
@@ -58,7 +58,7 @@ func TestRedirectLower(t *testing.T) {
 				FilterRegistry: MakeRegistry(),
 				DataClients:    []routing.DataClient{dc},
 				Log:            tl})
-			p := proxy.New(proxy.Params{
+			p := proxy.New(proxy.Options{
 				Routing: rt,
 			})
 

--- a/filters/builtin/redirect_test.go
+++ b/filters/builtin/redirect_test.go
@@ -58,7 +58,7 @@ func TestRedirectLower(t *testing.T) {
 				FilterRegistry: MakeRegistry(),
 				DataClients:    []routing.DataClient{dc},
 				Log:            tl})
-			p := proxy.WithParams(proxy.Params{
+			p := proxy.New(proxy.Params{
 				Routing: rt,
 			})
 

--- a/filters/example_test.go
+++ b/filters/example_test.go
@@ -84,6 +84,8 @@ func Example() {
 	defer rt.Close()
 
 	// create http.Handler:
-	p := proxy.New(rt, proxy.OptionsNone)
+	p := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer p.Close()
 }

--- a/filters/example_test.go
+++ b/filters/example_test.go
@@ -84,7 +84,7 @@ func Example() {
 	defer rt.Close()
 
 	// create http.Handler:
-	p := proxy.WithParams(proxy.Params{
+	p := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/filters/example_test.go
+++ b/filters/example_test.go
@@ -84,7 +84,7 @@ func Example() {
 	defer rt.Close()
 
 	// create http.Handler:
-	p := proxy.New(proxy.Params{
+	p := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/filters/filtertest/example_test.go
+++ b/filters/filtertest/example_test.go
@@ -51,7 +51,7 @@ func ExampleFilter() {
 	defer rt.Close()
 
 	// create an http.Handler:
-	p := proxy.WithParams(proxy.Params{
+	p := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/filters/filtertest/example_test.go
+++ b/filters/filtertest/example_test.go
@@ -51,7 +51,7 @@ func ExampleFilter() {
 	defer rt.Close()
 
 	// create an http.Handler:
-	p := proxy.New(proxy.Params{
+	p := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer p.Close()

--- a/filters/filtertest/example_test.go
+++ b/filters/filtertest/example_test.go
@@ -51,7 +51,9 @@ func ExampleFilter() {
 	defer rt.Close()
 
 	// create an http.Handler:
-	p := proxy.New(rt, proxy.OptionsNone)
+	p := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer p.Close()
 }
 

--- a/proxy/breaker_test.go
+++ b/proxy/breaker_test.go
@@ -50,7 +50,7 @@ func newBreakerProxy(
 	settings []circuit.BreakerSettings,
 	filters map[string][]*eskip.Filter,
 ) *proxytest.TestProxy {
-	params := proxy.Params{
+	options := proxy.Options{
 		CloseIdleConnsPeriod: -1,
 	}
 
@@ -77,7 +77,7 @@ func newBreakerProxy(
 			}
 		}
 
-		params.CircuitBreakers = circuit.NewRegistry(settings...)
+		options.CircuitBreakers = circuit.NewRegistry(settings...)
 	} else {
 		r = append(r, &eskip.Route{
 			Backend: backends[defaultHost].url,
@@ -85,7 +85,7 @@ func newBreakerProxy(
 	}
 
 	fr := builtin.MakeRegistry()
-	return proxytest.WithParams(fr, params, r...)
+	return proxytest.WithOptions(fr, options, r...)
 }
 
 func testBreaker(t *testing.T, s breakerScenario) {

--- a/proxy/example_test.go
+++ b/proxy/example_test.go
@@ -34,7 +34,7 @@ func ExamplePriorityRoute() {
 	pr := &priorityRoute{}
 
 	// create an http.Handler:
-	proxy.WithParams(proxy.Params{
+	proxy.New(proxy.Params{
 		Routing: routing.New(routing.Options{
 			FilterRegistry: builtin.MakeRegistry(),
 			DataClients:    []routing.DataClient{dataClient}},

--- a/proxy/example_test.go
+++ b/proxy/example_test.go
@@ -34,10 +34,11 @@ func ExamplePriorityRoute() {
 	pr := &priorityRoute{}
 
 	// create an http.Handler:
-	proxy.New(
-		routing.New(routing.Options{
+	proxy.WithParams(proxy.Params{
+		Routing: routing.New(routing.Options{
 			FilterRegistry: builtin.MakeRegistry(),
-			DataClients:    []routing.DataClient{dataClient}}),
-		proxy.OptionsNone,
-		pr)
+			DataClients:    []routing.DataClient{dataClient}},
+		),
+		PriorityRoutes: []proxy.PriorityRoute{pr},
+	})
 }

--- a/proxy/example_test.go
+++ b/proxy/example_test.go
@@ -34,7 +34,7 @@ func ExamplePriorityRoute() {
 	pr := &priorityRoute{}
 
 	// create an http.Handler:
-	proxy.New(proxy.Params{
+	proxy.New(proxy.Options{
 		Routing: routing.New(routing.Options{
 			FilterRegistry: builtin.MakeRegistry(),
 			DataClients:    []routing.DataClient{dataClient}},

--- a/proxy/idle_test.go
+++ b/proxy/idle_test.go
@@ -118,8 +118,8 @@ func TestIdleConns(t *testing.T) {
 		256,
 		closePeriod,
 	}} {
-		p := proxytest.WithParams(nil,
-			proxy.Params{
+		p := proxytest.WithOptions(nil,
+			proxy.Options{
 				IdleConnectionsPerHost: ti.idleConns,
 				CloseIdleConnsPeriod:   ti.closeIdleConns},
 			&eskip.Route{Id: "s0", Predicates: []*eskip.Predicate{{"Path", []interface{}{"/s0"}}}, Backend: s0.URL},

--- a/proxy/pathpatch_test.go
+++ b/proxy/pathpatch_test.go
@@ -24,7 +24,7 @@ func testPatch(t *testing.T, title string, f Flags, expectedStatus int) {
 		})
 		defer rt.Close()
 
-		p := New(Params{Routing: rt, Flags: f})
+		p := New(Options{Routing: rt, Flags: f})
 		defer p.Close()
 
 		s := httptest.NewServer(p)

--- a/proxy/pathpatch_test.go
+++ b/proxy/pathpatch_test.go
@@ -24,7 +24,7 @@ func testPatch(t *testing.T, title string, f Flags, expectedStatus int) {
 		})
 		defer rt.Close()
 
-		p := WithParams(Params{Routing: rt, Flags: f})
+		p := New(Params{Routing: rt, Flags: f})
 		defer p.Close()
 
 		s := httptest.NewServer(p)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -101,18 +101,6 @@ const (
 	PatchPath
 )
 
-// Options are deprecated alias for Flags.
-type Options Flags
-
-const (
-	OptionsNone              = Options(FlagsNone)
-	OptionsInsecure          = Options(Insecure)
-	OptionsPreserveOriginal  = Options(PreserveOriginal)
-	OptionsPreserveHost      = Options(PreserveHost)
-	OptionsDebug             = Options(Debug)
-	OptionsHopHeadersRemoval = Options(HopHeadersRemoval)
-)
-
 type OpenTracingParams struct {
 	// Tracer holds the tracer enabled for this proxy instance
 	Tracer ot.Tracer

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -300,7 +300,7 @@ type PriorityRoute interface {
 }
 
 // Proxy instances implement Skipper proxying functionality. For
-// initializing, see the WithParams the constructor and Params.
+// initializing, see the New the constructor and Params.
 type Proxy struct {
 	experimentalUpgrade      bool
 	experimentalUpgradeAudit bool
@@ -575,8 +575,8 @@ func (dc *skipperDialer) DialContext(ctx stdlibcontext.Context, network, addr st
 	return con, nil
 }
 
-// WithParams returns an initialized Proxy.
-func WithParams(p Params) *Proxy {
+// New returns an initialized Proxy.
+func New(p Params) *Proxy {
 	if p.IdleConnectionsPerHost <= 0 {
 		p.IdleConnectionsPerHost = DefaultIdleConnsPerHost
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -575,17 +575,6 @@ func (dc *skipperDialer) DialContext(ctx stdlibcontext.Context, network, addr st
 	return con, nil
 }
 
-// New returns an initialized Proxy.
-// Deprecated, see WithParams and Params instead.
-func New(r *routing.Routing, options Options, pr ...PriorityRoute) *Proxy {
-	return WithParams(Params{
-		Routing:              r,
-		Flags:                Flags(options),
-		PriorityRoutes:       pr,
-		CloseIdleConnsPeriod: -time.Second,
-	})
-}
-
 // WithParams returns an initialized Proxy.
 func WithParams(p Params) *Proxy {
 	if p.IdleConnectionsPerHost <= 0 {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -124,7 +124,7 @@ type OpenTracingParams struct {
 }
 
 // Proxy initialization options.
-type Params struct {
+type Options struct {
 	// The proxy expects a routing instance that is used to match
 	// the incoming requests to routes.
 	Routing *routing.Routing
@@ -288,7 +288,7 @@ type PriorityRoute interface {
 }
 
 // Proxy instances implement Skipper proxying functionality. For
-// initializing, see the New the constructor and Params.
+// initializing, see the New the constructor and Options.
 type Proxy struct {
 	experimentalUpgrade      bool
 	experimentalUpgradeAudit bool
@@ -564,7 +564,7 @@ func (dc *skipperDialer) DialContext(ctx stdlibcontext.Context, network, addr st
 }
 
 // New returns an initialized Proxy.
-func New(p Params) *Proxy {
+func New(p Options) *Proxy {
 	if p.IdleConnectionsPerHost <= 0 {
 		p.IdleConnectionsPerHost = DefaultIdleConnsPerHost
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -157,7 +157,7 @@ func newTestProxyWithFiltersAndParams(fr filters.Registry, doc string, params Pa
 	rt := routing.New(opts)
 
 	params.Routing = rt
-	p := WithParams(params)
+	p := New(params)
 	p.log = tl
 
 	if err := tl.WaitFor("route settings applied", time.Second); err != nil {
@@ -1630,13 +1630,13 @@ func TestSettingDefaultHTTPStatus(t *testing.T) {
 	params := Params{
 		DefaultHTTPStatus: http.StatusBadGateway,
 	}
-	p := WithParams(params)
+	p := New(params)
 	if p.defaultHTTPStatus != http.StatusBadGateway {
 		t.Errorf("expected default HTTP status %d, got %d", http.StatusBadGateway, p.defaultHTTPStatus)
 	}
 
 	params.DefaultHTTPStatus = http.StatusNetworkAuthenticationRequired + 1
-	p = WithParams(params)
+	p = New(params)
 	if p.defaultHTTPStatus != http.StatusNotFound {
 		t.Errorf("expected default HTTP status %d, got %d", http.StatusNotFound, p.defaultHTTPStatus)
 	}

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -22,14 +22,14 @@ type TestProxy struct {
 }
 
 func WithRoutingOptions(fr filters.Registry, o routing.Options, routes ...*eskip.Route) *TestProxy {
-	return newTestProxy(fr, o, proxy.Params{CloseIdleConnsPeriod: -time.Second}, routes...)
+	return newTestProxy(fr, o, proxy.Options{CloseIdleConnsPeriod: -time.Second}, routes...)
 }
 
-func WithParams(fr filters.Registry, proxyParams proxy.Params, routes ...*eskip.Route) *TestProxy {
-	return newTestProxy(fr, routing.Options{}, proxyParams, routes...)
+func WithOptions(fr filters.Registry, proxyOptions proxy.Options, routes ...*eskip.Route) *TestProxy {
+	return newTestProxy(fr, routing.Options{}, proxyOptions, routes...)
 }
 
-func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyParams proxy.Params, routes ...*eskip.Route) *TestProxy {
+func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyOptions proxy.Options, routes ...*eskip.Route) *TestProxy {
 	tl := loggingtest.New()
 
 	if len(routingOptions.DataClients) == 0 {
@@ -42,9 +42,9 @@ func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyPara
 	routingOptions.PostProcessors = []routing.PostProcessor{loadbalancer.NewAlgorithmProvider()}
 
 	rt := routing.New(routingOptions)
-	proxyParams.Routing = rt
+	proxyOptions.Routing = rt
 
-	pr := proxy.New(proxyParams)
+	pr := proxy.New(proxyOptions)
 	tsp := httptest.NewServer(pr)
 
 	if err := tl.WaitFor("route settings applied", 3*time.Second); err != nil {
@@ -61,7 +61,7 @@ func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyPara
 }
 
 func New(fr filters.Registry, routes ...*eskip.Route) *TestProxy {
-	return WithParams(fr, proxy.Params{CloseIdleConnsPeriod: -time.Second}, routes...)
+	return WithOptions(fr, proxy.Options{CloseIdleConnsPeriod: -time.Second}, routes...)
 }
 
 func (p *TestProxy) Close() error {

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -44,7 +44,7 @@ func newTestProxy(fr filters.Registry, routingOptions routing.Options, proxyPara
 	rt := routing.New(routingOptions)
 	proxyParams.Routing = rt
 
-	pr := proxy.WithParams(proxyParams)
+	pr := proxy.New(proxyParams)
 	tsp := httptest.NewServer(pr)
 
 	if err := tl.WaitFor("route settings applied", 3*time.Second); err != nil {

--- a/proxy/ratelimit_test.go
+++ b/proxy/ratelimit_test.go
@@ -72,7 +72,7 @@ func TestCheckDisableRateLimit(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	defer backend.Close()
 	r := []*eskip.Route{{Backend: backend.URL}}
-	p := proxytest.WithParams(fr, proxy.Params{
+	p := proxytest.WithOptions(fr, proxy.Options{
 		CloseIdleConnsPeriod: -time.Second,
 		RateLimiters: ratelimit.NewRegistry(ratelimit.Settings{
 			Type:          ratelimit.DisableRatelimit,
@@ -137,7 +137,7 @@ func TestCheckServiceRateLimit(t *testing.T) {
 		MaxHits:    10,
 		TimeWindow: timeWindow,
 	}
-	p := proxytest.WithParams(fr, proxy.Params{
+	p := proxytest.WithOptions(fr, proxy.Options{
 		CloseIdleConnsPeriod: -time.Second,
 		RateLimiters:         ratelimit.NewRegistry(ratelimitSettings),
 	}, r...)
@@ -225,7 +225,7 @@ func TestRetryAfterHeader(t *testing.T) {
 		MaxHits:    1,
 		TimeWindow: timeWindow,
 	}
-	p := proxytest.WithParams(fr, proxy.Params{
+	p := proxytest.WithOptions(fr, proxy.Options{
 		CloseIdleConnsPeriod: -time.Second,
 		RateLimiters:         ratelimit.NewRegistry(ratelimitSettings),
 	}, r...)

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -43,14 +43,14 @@ func TestTracingFromWire(t *testing.T) {
 
 	doc := fmt.Sprintf(`hello: Path("/hello") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{}
-	params := Params{
+	options := Options{
 		OpenTracing: &OpenTracingParams{
 			Tracer: tracer,
 		},
 		Flags: FlagsNone,
 	}
 
-	tp, err := newTestProxyWithParams(doc, params)
+	tp, err := newTestProxyWithOptions(doc, options)
 	if err != nil {
 		t.Error(err)
 		return
@@ -94,14 +94,14 @@ func TestTracingRoot(t *testing.T) {
 
 	doc := fmt.Sprintf(`hello: Path("/hello") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{TraceContent: traceContent}
-	params := Params{
+	params := Options{
 		OpenTracing: &OpenTracingParams{
 			Tracer: tracer,
 		},
 		Flags: FlagsNone,
 	}
 
-	tp, err := newTestProxyWithParams(doc, params)
+	tp, err := newTestProxyWithOptions(doc, params)
 	if err != nil {
 		t.Error(err)
 		return
@@ -151,14 +151,14 @@ func TestTracingSpanName(t *testing.T) {
 
 	doc := fmt.Sprintf(`hello: Path("/hello") -> tracingSpanName("test-span") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{TraceContent: traceContent}
-	params := Params{
+	params := Options{
 		OpenTracing: &OpenTracingParams{
 			Tracer: tracer,
 		},
 		Flags: FlagsNone,
 	}
 
-	tp, err := newTestProxyWithParams(doc, params)
+	tp, err := newTestProxyWithOptions(doc, params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestTracingInitialSpanName(t *testing.T) {
 
 	doc := fmt.Sprintf(`hello: Path("/hello") -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{TraceContent: traceContent}
-	params := Params{
+	params := Options{
 		OpenTracing: &OpenTracingParams{
 			Tracer:      tracer,
 			InitialSpan: "test-initial-span",
@@ -204,7 +204,7 @@ func TestTracingInitialSpanName(t *testing.T) {
 		Flags: FlagsNone,
 	}
 
-	tp, err := newTestProxyWithParams(doc, params)
+	tp, err := newTestProxyWithOptions(doc, params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestTracingProxySpan(t *testing.T) {
 
 	doc := fmt.Sprintf(`* -> "%s"`, s.URL)
 	tracer := &tracingtest.Tracer{}
-	tp, err := newTestProxyWithParams(doc, Params{OpenTracing: &OpenTracingParams{Tracer: tracer}})
+	tp, err := newTestProxyWithOptions(doc, Options{OpenTracing: &OpenTracingParams{Tracer: tracer}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func TestTracingProxySpanWithRetry(t *testing.T) {
 	const docFmt = `r: * -> <roundRobin, "%s", "%s">;`
 	doc := fmt.Sprintf(docFmt, s0.URL, s1.URL)
 	tracer := &tracingtest.Tracer{}
-	tp, err := newTestProxyWithParams(doc, Params{OpenTracing: &OpenTracingParams{Tracer: tracer}})
+	tp, err := newTestProxyWithOptions(doc, Options{OpenTracing: &OpenTracingParams{Tracer: tracer}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/proxy/upgrade_test.go
+++ b/proxy/upgrade_test.go
@@ -187,7 +187,7 @@ func TestServeHTTP(t *testing.T) {
 			if ti.noBackend {
 				backend.Close()
 			}
-			tp, err := newTestProxyWithParams(routes, Params{ExperimentalUpgrade: true})
+			tp, err := newTestProxyWithOptions(routes, Options{ExperimentalUpgrade: true})
 			if err != nil {
 				t.Error(err)
 				return
@@ -366,7 +366,7 @@ func TestAuditLogging(t *testing.T) {
 			}
 
 			auditHook := make(chan struct{}, 1)
-			p := New(Params{
+			p := New(Options{
 				Routing:                  rt,
 				ExperimentalUpgrade:      true,
 				ExperimentalUpgradeAudit: enabled,

--- a/proxy/upgrade_test.go
+++ b/proxy/upgrade_test.go
@@ -366,7 +366,7 @@ func TestAuditLogging(t *testing.T) {
 			}
 
 			auditHook := make(chan struct{}, 1)
-			p := WithParams(Params{
+			p := New(Params{
 				Routing:                  rt,
 				ExperimentalUpgrade:      true,
 				ExperimentalUpgradeAudit: enabled,

--- a/skipper.go
+++ b/skipper.go
@@ -1200,7 +1200,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	if o.DebugListener != "" {
 		do := proxyParams
 		do.Flags |= proxy.Debug
-		dbg := proxy.WithParams(do)
+		dbg := proxy.New(do)
 		log.Infof("debug listener on %v", o.DebugListener)
 		go func() { http.ListenAndServe(o.DebugListener, dbg) }()
 	}
@@ -1243,7 +1243,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	}
 
 	// create the proxy
-	proxy := proxy.WithParams(proxyParams)
+	proxy := proxy.New(proxyParams)
 	defer proxy.Close()
 
 	for _, startupCheckURL := range o.StatusChecks {

--- a/skipper.go
+++ b/skipper.go
@@ -202,10 +202,6 @@ type Options struct {
 	// DefaultFilters will be applied to all routes automatically.
 	DefaultFilters *eskip.DefaultFilters
 
-	// Deprecated. See ProxyFlags. When used together with ProxyFlags,
-	// the values will be combined with |.
-	ProxyOptions proxy.Options
-
 	// Flags controlling the proxy behavior.
 	ProxyFlags proxy.Flags
 
@@ -1100,10 +1096,9 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	routing := routing.New(ro)
 	defer routing.Close()
 
-	proxyFlags := proxy.Flags(o.ProxyOptions) | o.ProxyFlags
 	proxyOptions := proxy.Options{
 		Routing:                  routing,
-		Flags:                    proxyFlags,
+		Flags:                    o.ProxyFlags,
 		PriorityRoutes:           o.PriorityRoutes,
 		IdleConnectionsPerHost:   o.IdleConnectionsPerHost,
 		CloseIdleConnsPeriod:     o.CloseIdleConnsPeriod,

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -99,7 +99,7 @@ func TestWithWrongCertPathFails(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(proxy.Params{
+	proxy := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -126,7 +126,7 @@ func TestWithWrongKeyPathFails(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(proxy.Params{
+	proxy := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -159,7 +159,7 @@ func TestHTTPSServer(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(proxy.Params{
+	proxy := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -200,7 +200,7 @@ func TestHTTPServer(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(proxy.Params{
+	proxy := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -243,7 +243,7 @@ func TestHTTPServerShutdown(t *testing.T) {
 	})
 	defer rt.Close()
 
-	proxy := proxy.New(proxy.Params{
+	proxy := proxy.New(proxy.Options{
 		Routing: rt,
 	})
 	defer proxy.Close()

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -99,7 +99,9 @@ func TestWithWrongCertPathFails(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(rt, proxy.OptionsNone)
+	proxy := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer proxy.Close()
 
 	err = listenAndServe(proxy, &o)
@@ -124,7 +126,9 @@ func TestWithWrongKeyPathFails(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(rt, proxy.OptionsNone)
+	proxy := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer proxy.Close()
 	err = listenAndServe(proxy, &o)
 	if err == nil {
@@ -155,7 +159,9 @@ func TestHTTPSServer(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(rt, proxy.OptionsNone)
+	proxy := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer proxy.Close()
 	go listenAndServe(proxy, &o)
 
@@ -194,7 +200,9 @@ func TestHTTPServer(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.New(rt, proxy.OptionsNone)
+	proxy := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer proxy.Close()
 	go listenAndServe(proxy, &o)
 	r, err := waitConnGet("http://" + o.Address)
@@ -235,7 +243,9 @@ func TestHTTPServerShutdown(t *testing.T) {
 	})
 	defer rt.Close()
 
-	proxy := proxy.New(rt, proxy.OptionsNone)
+	proxy := proxy.WithParams(proxy.Params{
+		Routing: rt,
+	})
 	defer proxy.Close()
 	go func() {
 		if errLas := listenAndServe(proxy, &o); errLas != nil {

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -99,7 +99,7 @@ func TestWithWrongCertPathFails(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.WithParams(proxy.Params{
+	proxy := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -126,7 +126,7 @@ func TestWithWrongKeyPathFails(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.WithParams(proxy.Params{
+	proxy := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -159,7 +159,7 @@ func TestHTTPSServer(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.WithParams(proxy.Params{
+	proxy := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -200,7 +200,7 @@ func TestHTTPServer(t *testing.T) {
 		DataClients:    []routing.DataClient{}})
 	defer rt.Close()
 
-	proxy := proxy.WithParams(proxy.Params{
+	proxy := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer proxy.Close()
@@ -243,7 +243,7 @@ func TestHTTPServerShutdown(t *testing.T) {
 	})
 	defer rt.Close()
 
-	proxy := proxy.WithParams(proxy.Params{
+	proxy := proxy.New(proxy.Params{
 		Routing: rt,
 	})
 	defer proxy.Close()


### PR DESCRIPTION
Now that `Proxy.New` is removed, can we rename `Proxy.WithParams` to `Proxy.New`? I changed this in 3e353e1. We can remove the commit if this is not what you want.