### PR TITLE
Log request info on proxy error

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -40,7 +40,6 @@ import (
 
 const (
 	proxyBufferSize         = 8192
-	unknownFlowId           = "not set"
 	unknownRouteID          = "_unknownroute_"
 	unknownRouteBackendType = "<unknown>"
 	unknownRouteBackend     = "<unknown>"
@@ -1208,9 +1207,10 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		return
 	}
 
+	flowIdLog := ""
 	flowId := ctx.Request().Header.Get(flowidFilter.HeaderName)
-	if flowId == "" {
-		flowId = unknownFlowId
+	if flowId != "" {
+		flowIdLog = fmt.Sprintf(", flow id %s", flowId)
 	}
 	id := unknownRouteID
 	backendType := unknownRouteBackendType
@@ -1269,12 +1269,12 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		}
 
 		p.log.Errorf(
-			`client canceled after %v, route %s with backend %s %s, flow id %s, status code %d: %v, remote host: %s, request: "%s %s %s", user agent: "%s"`,
+			`client canceled after %v, route %s with backend %s %s%s, status code %d: %v, remote host: %s, request: "%s %s %s", user agent: "%s"`,
 			time.Since(ctx.startServe),
 			id,
 			backendType,
 			backend,
-			flowId,
+			flowIdLog,
 			code,
 			err,
 			remoteAddr,
@@ -1292,12 +1292,12 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		}
 
 		p.log.Errorf(
-			`error while proxying after %v, route %s with backend %s %s, flow id %s, status code %d: %v, remote host: %s, request: "%s %s %s", user agent: "%s"`,
+			`error while proxying after %v, route %s with backend %s %s%s, status code %d: %v, remote host: %s, request: "%s %s %s", user agent: "%s"`,
 			time.Since(ctx.startServe),
 			id,
 			backendType,
 			backend,
-			flowId,
+			flowIdLog,
 			code,
 			err,
 			remoteAddr,


### PR DESCRIPTION
This makes it easier to debug why a proxy request failed.

## How does it look?
```
[APP]ERRO[0040] error while proxying after 225.477µs, route php with backend network fastcgi://0.0.0.0:55212, flow id not set, status code 500: dialing failed false: gofast: failed creating client: dial tcp 0.0.0.0:55212: connect: connection refused, remote host: 1.2.3.4, request: "GET /hello HTTP/1.1", user agent: "HTTPie/2.0.0" 
```