### PR TITLE
fix measuring the connection count in TCP-LIFO

### DIFF
--- a/queuelistener/listener.go
+++ b/queuelistener/listener.go
@@ -101,12 +101,15 @@ func (c *connection) SetReadDeadline(t time.Time) error  { return c.net.SetReadD
 func (c *connection) SetWriteDeadline(t time.Time) error { return c.net.SetWriteDeadline(t) }
 
 func (c *connection) Close() error {
-	select {
-	case c.release <- token:
-	case <-c.quit:
-	}
+	c.once.Do(func() {
+		select {
+		case c.release <- token:
+		case <-c.quit:
+		}
 
-	c.once.Do(func() { c.closeErr = c.net.Close() })
+		c.closeErr = c.net.Close()
+	})
+
 	return c.closeErr
 }
 

--- a/queuelistener/listener_test.go
+++ b/queuelistener/listener_test.go
@@ -1275,3 +1275,41 @@ func TestQueue1(t *testing.T) {
 	}
 
 }
+
+func TestConnectionClose(t *testing.T) {
+	t.Run("server", func(t *testing.T) {
+		t.Run("measure close only once [bugfix]", func(t *testing.T) {
+			m := &metricstest.MockMetrics{}
+			l, err := listenWith(&testListener{}, Options{Metrics: m})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			defer l.Close()
+			conn, err := l.Accept()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := waitForGauge(m, acceptedConnectionsKey, 1); err != nil {
+				t.Fatalf("failed to detect active connection: %v", err)
+			}
+
+			if err := conn.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := waitForGauge(m, acceptedConnectionsKey, 0); err != nil {
+				t.Fatalf("failed to detect active connection: %v", err)
+			}
+
+			if err := conn.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := waitForGauge(m, acceptedConnectionsKey, -1); err == nil {
+				t.Fatal("the accepted connections count is below zero")
+			}
+		})
+	})
+}

--- a/queuelistener/listener_test.go
+++ b/queuelistener/listener_test.go
@@ -1300,7 +1300,7 @@ func TestConnectionClose(t *testing.T) {
 			}
 
 			if err := waitForGauge(m, acceptedConnectionsKey, 0); err != nil {
-				t.Fatalf("failed to detect active connection: %v", err)
+				t.Fatalf("failed to detect closed connection: %v", err)
 			}
 
 			if err := conn.Close(); err != nil {


### PR DESCRIPTION
fix measuring the connection count in cases when the server sides closes connections multiple times

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>