### PR TITLE
Traffic(): allow weight of 1.0

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -459,7 +459,7 @@ a given route by setting its weight.
 
 The probability for matching a route is defined by the mandatory first
 parameter, that must be a decimal number between 0.0 and 1.0 (both
-exclusive).
+inclusive).
 
 The optional second argument is used to specify the cookie name for
 the traffic group, in case you want to use stickiness. Stickiness

--- a/predicates/traffic/traffic.go
+++ b/predicates/traffic/traffic.go
@@ -4,7 +4,7 @@ probability for a given route by setting its weight.
 
 The probability for matching a route is defined by the mandatory first
 parameter, that must be a decimal number between 0.0 and 1.0 (both
-exclusive).
+inclusive).
 
 The optional second argument is used to specify the cookie name for
 the traffic group, in case you want to use stickiness. Stickiness
@@ -102,7 +102,7 @@ func (s *spec) Create(args []interface{}) (routing.Predicate, error) {
 
 	p := &predicate{}
 
-	if c, ok := args[0].(float64); ok && 0.0 <= c && c < 1.0 {
+	if c, ok := args[0].(float64); ok && 0.0 <= c && c <= 1.0 {
 		p.chance = c
 	} else {
 		return nil, predicates.ErrInvalidPredicateParameters

--- a/predicates/traffic/traffic_test.go
+++ b/predicates/traffic/traffic_test.go
@@ -52,6 +52,16 @@ func TestCreate(t *testing.T) {
 		predicate{chance: .3},
 		false,
 	}, {
+		"0.0 is allowed",
+		[]interface{}{0.0},
+		predicate{chance: 0},
+		false,
+	}, {
+		"1.0 is allowed",
+		[]interface{}{1.0},
+		predicate{chance: 1},
+		false,
+	}, {
 		"wrong chance, bigger than 1",
 		[]interface{}{1.3},
 		predicate{chance: 1.3},


### PR DESCRIPTION
This is not optimal (because the user should just delete the other routes), but in some cases it makes it a lot easier to define the routes. An example is defining a route where the weight passed to the `Traffic()` predicate is parameterised and then changing it between `0.0` and `1.0`. The users would expect `1.0` to work, but currently it doesn't.

Update the documentation and the comments to mention that both values are now allowed (`0.0` used to work but was documented as not working).