### PR TITLE
flexible upstream headers

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -991,7 +991,8 @@ forwardToken("X-Tokeninfo-Forward", "access_token")
 
 ```
 oauthOidcUserInfo("https://oidc-provider.example.com", "client_id", "client_secret",
-    "http://target.example.com/subpath/callback", "email profile", "name email picture")
+    "http://target.example.com/subpath/callback", "email profile", "name email picture",
+    "parameter=value", "X-Auth-Authorization:claims.email")
 ```
 
 The filter needs the following parameters:
@@ -1003,13 +1004,17 @@ The filter needs the following parameters:
     It can be any value which is a subpath on which the filter is applied.
 * **Scopes** The OpenID scopes separated by spaces which need to be specified when requesting the token from the provider.
 * **Claims** The claims which should be present in the token returned by the provider.
+* **Auth Code Options** (optional) Passes key/value parameters to a provider's authorization endpoint.
+* **Upstream Headers** (optional) The upstream endpoint will receive these headers which values are parsed from the OIDC information. The header definition can be one or more header-query pairs, space delimited. The query syntax is [GJSON](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 ## oauthOidcAnyClaims
 
 ```
 oauthOidcAnyClaims("https://oidc-provider.example.com", "client_id", "client_secret",
-    "http://target.example.com/subpath/callback", "email profile", "name email picture")
+    "http://target.example.com/subpath/callback", "email profile", "name email picture",
+    "parameter=value", "X-Auth-Authorization:claims.email")
 ```
+
 The filter needs the following parameters:
 
 * **OpenID Connect Provider URL** For example Google OpenID Connect is available on `https://accounts.google.com`
@@ -1019,13 +1024,17 @@ The filter needs the following parameters:
     It can be any value which is a subpath on which the filter is applied.
 * **Scopes** The OpenID scopes separated by spaces which need to be specified when requesting the token from the provider.
 * **Claims** Several claims can be specified and the request is allowed as long as at least one of them is present.
+* **Auth Code Options** (optional) Passes key/value parameters to a provider's authorization endpoint.
+* **Upstream Headers** (optional) The upstream endpoint will receive these headers which values are parsed from the OIDC information. The header definition can be one or more header-query pairs, space delimited. The query syntax is [GJSON](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 ## oauthOidcAllClaims
 
 ```
 oauthOidcAllClaims("https://oidc-provider.example.com", "client_id", "client_secret",
-    "http://target.example.com/subpath/callback", "email profile", "name email picture")
+    "http://target.example.com/subpath/callback", "email profile", "name email picture",
+    "parameter=value", "X-Auth-Authorization:claims.email")
 ```
+
 The filter needs the following parameters:
 
 * **OpenID Connect Provider URL** For example Google OpenID Connect is available on `https://accounts.google.com`
@@ -1035,6 +1044,8 @@ The filter needs the following parameters:
     It can be any value which is a subpath on which the filter is applied.
 * **Scopes** The OpenID scopes separated by spaces which need to be specified when requesting the token from the provider.
 * **Claims** Several claims can be specified and the request is allowed only when all claims are present.
+* **Auth Code Options** (optional) Passes key/value parameters to a provider's authorization endpoint.
+* **Upstream Headers** (optional) The upstream endpoint will receive these headers which values are parsed from the OIDC information. The header definition can be one or more header-query pairs, space delimited. The query syntax is [GJSON](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 ## requestCookie
 


### PR DESCRIPTION
Similar to [Keycloak Gatekeeper Custom Claim Headers](https://github.com/keycloak/keycloak-documentation/blob/master/securing_apps/topics/oidc/keycloak-gatekeeper.adoc#custom-claim-headers) we need Skipper to inject headers to upstream endpoints to provide user identity.

As of now the "Skipper-Oidc-Info" header provides this information but in a custom, not ready to use format which would require to adapt each backend application.

Like Gatekeeper this information should be possible to be specified per use case on the ingress annotation level.

This implementation uses the `GJSON` syntax already used for other purposes to define and parse the information that is requested and inject as the defined header name.

For backward compatibilty, this additional field is optional, falling back to outputting the "Skipper-Oidc-Info" as before.