### PR TITLE
Fix -ratelimit flag to accept cluster based options

### DIFF
--- a/config/ratelimiterflags.go
+++ b/config/ratelimiterflags.go
@@ -11,11 +11,12 @@ import (
 	"github.com/zalando/skipper/ratelimit"
 )
 
-const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=local,max-hits=20,time-window=60s
+const ratelimitUsage = `set global rate limit settings, e.g. -ratelimit type=client,max-hits=20,time-window=60s
 	possible ratelimit properties:
-	type: local/service/disabled (defaults to disabled)
+	type: client/service/clusterClient/clusterService/disabled (defaults to disabled)
 	max-hits: the number of hits a ratelimiter can get
 	time-window: the duration of the sliding window for the rate limiter
+	group: defines the ratelimit group, which can be the same for different routes.
 	(see also: https://godoc.org/github.com/zalando/skipper/ratelimit)`
 
 const enableRatelimitUsage = `enable ratelimit`
@@ -53,6 +54,10 @@ func (r *ratelimitFlags) Set(value string) error {
 				s.Type = ratelimit.ClientRatelimit
 			case "service":
 				s.Type = ratelimit.ServiceRatelimit
+			case "clusterClient":
+				s.Type = ratelimit.ClusterClientRatelimit
+			case "clusterService":
+				s.Type = ratelimit.ClusterServiceRatelimit
 			case "disabled":
 				s.Type = ratelimit.DisableRatelimit
 			default:

--- a/config/ratelimiterflags_test.go
+++ b/config/ratelimiterflags_test.go
@@ -81,6 +81,30 @@ func Test_ratelimitFlags_Set(t *testing.T) {
 			},
 		},
 		{
+			name:    "test clusterClient ratelimit",
+			args:    "type=clusterClient,max-hits=50,time-window=2m",
+			wantErr: false,
+			want: ratelimit.Settings{
+				Type:          ratelimit.ClusterClientRatelimit,
+				MaxHits:       50,
+				TimeWindow:    2 * time.Minute,
+				Group:         "",
+				CleanInterval: 2 * time.Minute * 10,
+			},
+		},
+		{
+			name:    "test clusterService ratelimit",
+			args:    "type=clusterService,max-hits=50,time-window=2m",
+			wantErr: false,
+			want: ratelimit.Settings{
+				Type:          ratelimit.ClusterServiceRatelimit,
+				MaxHits:       50,
+				TimeWindow:    2 * time.Minute,
+				Group:         "",
+				CleanInterval: 2 * time.Minute * 10,
+			},
+		},
+		{
 			name:    "test invalid type",
 			args:    "type=invalid,max-hits=50,time-window=2m",
 			wantErr: true,

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -58,6 +58,10 @@ func (rt *RatelimitType) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		*rt = ClientRatelimit
 	case "service":
 		*rt = ServiceRatelimit
+	case "clusterClient":
+		*rt = ClusterClientRatelimit
+	case "clusterService":
+		*rt = ClusterServiceRatelimit
 	case "disabled":
 		*rt = DisableRatelimit
 	default:


### PR DESCRIPTION
Relates to #1428 

The cluster-based rate-limiting implementations are available but couldn't be passed in via command-line flags.

This PR enables `clusterClient` and `clusterService` as valid types for rate-limiting as well as the `group` flag.