### PR TITLE
OIDC header integrity

### DIFF
--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -670,7 +670,7 @@ func (f *tokenOidcFilter) setHeaders(ctx filters.FilterContext, container tokenC
 
 	// backwards compatible
 	if len(f.upstreamHeaders) == 0 {
-		ctx.Request().Header.Add(oidcInfoHeader, string(oidcInfoJson))
+		ctx.Request().Header.Set(oidcInfoHeader, string(oidcInfoJson))
 		return
 	}
 
@@ -683,7 +683,7 @@ func (f *tokenOidcFilter) setHeaders(ctx filters.FilterContext, container tokenC
 			log.Errorf("Lookup failed for upstream header '%s'", query)
 			continue
 		}
-		ctx.Request().Header.Add(key, match.String())
+		ctx.Request().Header.Set(key, match.String())
 	}
 	return
 }


### PR DESCRIPTION
This is a security issue mitigation, where a potential attack would be that a person is sending manipulated header that are parsed for authentication.

Currently the OIDC header are `.Add` that is an `append` operation, which keeps the user generated values as precedence.
This PR solves the issue by changing the header output to a `.Set` operation which replaces potential existing headers accordingly.
