### PR TITLE
Filter RouteGroups via an annotation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,6 +125,7 @@ type Config struct {
 	KubernetesHTTPSRedirect     bool                `yaml:"kubernetes-https-redirect"`
 	KubernetesHTTPSRedirectCode int                 `yaml:"kubernetes-https-redirect-code"`
 	KubernetesIngressClass      string              `yaml:"kubernetes-ingress-class"`
+	KubernetesRouteGroupClass   string              `yaml:"kubernetes-routegroup-class"`
 	WhitelistedHealthCheckCIDR  string              `yaml:"whitelisted-healthcheck-cidr"`
 	KubernetesPathModeString    string              `yaml:"kubernetes-path-mode"`
 	KubernetesPathMode          kubernetes.PathMode `yaml:"-"`
@@ -332,6 +333,7 @@ const (
 	kubernetesHTTPSRedirectUsage     = "automatic HTTP->HTTPS redirect route; valid only with kubernetes"
 	kubernetesHTTPSRedirectCodeUsage = "overrides the default redirect code (308) when used together with -kubernetes-https-redirect"
 	kubernetesIngressClassUsage      = "ingress class regular expression used to filter ingress resources for kubernetes"
+	kubernetesRouteGroupClassUsage   = "route group class regular expression used to filter route group resources for kubernetes"
 	whitelistedHealthCheckCIDRUsage  = "sets the iprange/CIDRS to be whitelisted during healthcheck"
 	kubernetesPathModeUsage          = "controls the default interpretation of Kubernetes ingress paths: <kubernetes-ingress|path-regexp|path-prefix>"
 	kubernetesNamespaceUsage         = "watch only this namespace for ingresses"
@@ -515,6 +517,7 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.KubernetesHTTPSRedirect, "kubernetes-https-redirect", true, kubernetesHTTPSRedirectUsage)
 	flag.IntVar(&cfg.KubernetesHTTPSRedirectCode, "kubernetes-https-redirect-code", 308, kubernetesHTTPSRedirectCodeUsage)
 	flag.StringVar(&cfg.KubernetesIngressClass, "kubernetes-ingress-class", "", kubernetesIngressClassUsage)
+	flag.StringVar(&cfg.KubernetesRouteGroupClass, "kubernetes-routegroup-class", "", kubernetesRouteGroupClassUsage)
 	flag.StringVar(&cfg.WhitelistedHealthCheckCIDR, "whitelisted-healthcheck-cidr", "", whitelistedHealthCheckCIDRUsage)
 	flag.StringVar(&cfg.KubernetesPathModeString, "kubernetes-path-mode", "kubernetes-ingress", kubernetesPathModeUsage)
 	flag.StringVar(&cfg.KubernetesNamespace, "kubernetes-namespace", "", kubernetesNamespaceUsage)
@@ -758,6 +761,7 @@ func (c *Config) ToOptions() skipper.Options {
 		KubernetesHTTPSRedirect:     c.KubernetesHTTPSRedirect,
 		KubernetesHTTPSRedirectCode: c.KubernetesHTTPSRedirectCode,
 		KubernetesIngressClass:      c.KubernetesIngressClass,
+		KubernetesRouteGroupClass:   c.KubernetesRouteGroupClass,
 		WhitelistedHealthCheckCIDR:  whitelistCIDRS,
 		KubernetesPathMode:          c.KubernetesPathMode,
 		KubernetesNamespace:         c.KubernetesNamespace,

--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -25,6 +25,7 @@ const (
 	clusterZalandoResourcesURI = "/apis/zalando.org/v1"
 	routeGroupsName            = "routegroups"
 	routeGroupsClusterURI      = "/apis/zalando.org/v1/routegroups"
+	routeGroupClassKey         = "zalando.org/routegroup-class"
 	servicesClusterURI         = "/api/v1/services"
 	endpointsClusterURI        = "/api/v1/endpoints"
 	defaultKubernetesURL       = "http://localhost:8001"
@@ -41,14 +42,15 @@ const routeGroupsNotInstalledMessage = `RouteGroups CRD is not installed in the 
 See: https://opensource.zalando.com/skipper/kubernetes/routegroups/#installation`
 
 type clusterClient struct {
-	ingressesURI   string
-	routeGroupsURI string
-	servicesURI    string
-	endpointsURI   string
-	ingressClass   *regexp.Regexp
-	tokenProvider  secrets.SecretsProvider
-	httpClient     *http.Client
-	apiURL         string
+	ingressesURI    string
+	routeGroupsURI  string
+	servicesURI     string
+	endpointsURI    string
+	ingressClass    *regexp.Regexp
+	routeGroupClass *regexp.Regexp
+	tokenProvider   secrets.SecretsProvider
+	httpClient      *http.Client
+	apiURL          string
 
 	loggedMissingRouteGroups bool
 }
@@ -109,7 +111,7 @@ func buildHTTPClient(certFilePath string, inCluster bool, quit <-chan struct{}) 
 	}, nil
 }
 
-func newClusterClient(o Options, apiURL, ingCls string, quit <-chan struct{}) (*clusterClient, error) {
+func newClusterClient(o Options, apiURL, ingCls, rgCls string, quit <-chan struct{}) (*clusterClient, error) {
 	httpClient, err := buildHTTPClient(serviceAccountDir+serviceAccountRootCAKey, o.KubernetesInCluster, quit)
 	if err != nil {
 		return nil, err
@@ -120,14 +122,20 @@ func newClusterClient(o Options, apiURL, ingCls string, quit <-chan struct{}) (*
 		return nil, err
 	}
 
+	rgClsRx, err := regexp.Compile(rgCls)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &clusterClient{
-		ingressesURI:   ingressesClusterURI,
-		routeGroupsURI: routeGroupsClusterURI,
-		servicesURI:    servicesClusterURI,
-		endpointsURI:   endpointsClusterURI,
-		ingressClass:   ingClsRx,
-		httpClient:     httpClient,
-		apiURL:         apiURL,
+		ingressesURI:    ingressesClusterURI,
+		routeGroupsURI:  routeGroupsClusterURI,
+		servicesURI:     servicesClusterURI,
+		endpointsURI:    endpointsClusterURI,
+		ingressClass:    ingClsRx,
+		routeGroupClass: rgClsRx,
+		httpClient:      httpClient,
+		apiURL:          apiURL,
 	}
 
 	if o.KubernetesInCluster {
@@ -283,6 +291,25 @@ func (c *clusterClient) loadIngresses() ([]*ingressItem, error) {
 	return fItems, nil
 }
 
+func (c *clusterClient) filterRouteGroup(i *routeGroupItem) bool {
+
+	// Validate RouteGroup item
+	if err := i.validate(); err != nil {
+		log.Errorf("[routegroup] %v", err)
+		return true
+	}
+
+	// Filter on RouteGroup class annotation
+	if i.Metadata != nil {
+		cls, ok := i.Metadata.Annotations[routeGroupClassKey]
+		if ok && cls != "" && !c.routeGroupClass.MatchString(cls) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (c *clusterClient) loadRouteGroups() ([]*routeGroupItem, error) {
 	var rgl routeGroupList
 	if err := c.getJSON(c.routeGroupsURI, &rgl); err != nil {
@@ -291,8 +318,7 @@ func (c *clusterClient) loadRouteGroups() ([]*routeGroupItem, error) {
 
 	rgs := make([]*routeGroupItem, 0, len(rgl.Items))
 	for _, i := range rgl.Items {
-		if err := i.validate(); err != nil {
-			log.Errorf("[routegroup] %v", err)
+		if c.filterRouteGroup(i) {
 			continue
 		}
 

--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -25,7 +25,7 @@ const (
 	clusterZalandoResourcesURI = "/apis/zalando.org/v1"
 	routeGroupsName            = "routegroups"
 	routeGroupsClusterURI      = "/apis/zalando.org/v1/routegroups"
-	routeGroupClassKey         = "zalando.org/routegroup-class"
+	routeGroupClassKey         = "zalando.org/routegroup.class"
 	servicesClusterURI         = "/api/v1/services"
 	endpointsClusterURI        = "/api/v1/endpoints"
 	defaultKubernetesURL       = "http://localhost:8001"
@@ -291,7 +291,8 @@ func (c *clusterClient) loadIngresses() ([]*ingressItem, error) {
 	return fItems, nil
 }
 
-func (c *clusterClient) filterRouteGroup(i *routeGroupItem) bool {
+// skipRouteGroup decides whether a found RouteGroup should be skipped or not.
+func (c *clusterClient) skipRouteGroup(i *routeGroupItem) bool {
 
 	// Validate RouteGroup item
 	if err := i.validate(); err != nil {
@@ -316,9 +317,9 @@ func (c *clusterClient) loadRouteGroups() ([]*routeGroupItem, error) {
 		return nil, err
 	}
 
-	rgs := make([]*routeGroupItem, 0, len(rgl.Items))
+	rgs := []*routeGroupItem{}
 	for _, i := range rgl.Items {
-		if c.filterRouteGroup(i) {
+		if c.skipRouteGroup(i) {
 			continue
 		}
 

--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -297,7 +297,7 @@ func (c *clusterClient) loadRouteGroups() ([]*routeGroupItem, error) {
 		return nil, err
 	}
 
-	rgs := []*routeGroupItem{}
+	rgs := make([]*routeGroupItem, 0, len(rgl.Items))
 	for _, i := range rgl.Items {
 
 		// Validate RouteGroup item.

--- a/dataclients/kubernetes/clusterclient_test.go
+++ b/dataclients/kubernetes/clusterclient_test.go
@@ -107,6 +107,14 @@ func TestSkipRouteGroups(t *testing.T) {
 			Skipped:         false,
 		},
 		{
+			Name:            "empty-class-matches",
+			RouteGroupClass: "test",
+			Annotations: map[string]string{
+				"zalando.org/routegroup.class": "",
+			},
+			Skipped: false,
+		},
+		{
 			Name:            "class-regexp-matches",
 			RouteGroupClass: "^test.*",
 			Annotations: map[string]string{

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -127,6 +127,11 @@ type Options struct {
 	//		https://github.com/nginxinc/kubernetes-ingress/tree/master/examples/multiple-ingress-controllers
 	IngressClass string
 
+	// RouteGroupClass is a regular expression to filter only those RouteGroups that match. If a RouteGroup
+	// does not have the required annotation (zalando.org/routegroup.class) or the annotation is an empty string,
+	// skipper will load it. The default value for the RouteGroup class is 'skipper'.
+	RouteGroupClass string
+
 	// ReverseSourcePredicate set to true will do the Source IP
 	// whitelisting for the heartbeat endpoint correctly in AWS.
 	// Amazon's ALB writes the client IP to the last item of the
@@ -188,10 +193,12 @@ func New(o Options) (*Client, error) {
 	}
 
 	rgCls := defaultRoutegroupClass
-	// TODO
+	if o.RouteGroupClass != "" {
+		rgCls = o.RouteGroupClass
+	}
 
 	log.Debugf(
-		"running in-cluster: %t. api server url: %s. provide health check: %t. ingress.class filter: %s. routegroup-class filter: %s. namespace: %s",
+		"running in-cluster: %t. api server url: %s. provide health check: %t. ingress.class filter: %s. routegroup.class filter: %s. namespace: %s",
 		o.KubernetesInCluster, apiURL, o.ProvideHealthcheck, ingCls, rgCls, o.KubernetesNamespace,
 	)
 

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	defaultIngressClass          = "skipper"
-	defaultRoutegroupClass       = "skipper"
+	defaultRouteGroupClass       = "skipper"
 	serviceHostEnvVar            = "KUBERNETES_SERVICE_HOST"
 	servicePortEnvVar            = "KUBERNETES_SERVICE_PORT"
 	healthcheckRouteID           = "kube__healthz"
@@ -192,7 +192,7 @@ func New(o Options) (*Client, error) {
 		ingCls = o.IngressClass
 	}
 
-	rgCls := defaultRoutegroupClass
+	rgCls := defaultRouteGroupClass
 	if o.RouteGroupClass != "" {
 		rgCls = o.RouteGroupClass
 	}

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	defaultIngressClass          = "skipper"
+	defaultRoutegroupClass       = "skipper"
 	serviceHostEnvVar            = "KUBERNETES_SERVICE_HOST"
 	servicePortEnvVar            = "KUBERNETES_SERVICE_PORT"
 	healthcheckRouteID           = "kube__healthz"
@@ -186,9 +187,12 @@ func New(o Options) (*Client, error) {
 		ingCls = o.IngressClass
 	}
 
+	rgCls := defaultRoutegroupClass
+	// TODO
+
 	log.Debugf(
-		"running in-cluster: %t. api server url: %s. provide health check: %t. ingress.class filter: %s. namespace: %s",
-		o.KubernetesInCluster, apiURL, o.ProvideHealthcheck, ingCls, o.KubernetesNamespace,
+		"running in-cluster: %t. api server url: %s. provide health check: %t. ingress.class filter: %s. routegroup-class filter: %s. namespace: %s",
+		o.KubernetesInCluster, apiURL, o.ProvideHealthcheck, ingCls, rgCls, o.KubernetesNamespace,
 	)
 
 	var sigs chan os.Signal
@@ -219,7 +223,7 @@ func New(o Options) (*Client, error) {
 		}
 	}
 
-	clusterClient, err := newClusterClient(o, apiURL, ingCls, quit)
+	clusterClient, err := newClusterClient(o, apiURL, ingCls, rgCls, quit)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/kubernetes/routegroups.md
+++ b/docs/kubernetes/routegroups.md
@@ -620,3 +620,32 @@ Ingress: | RouteGroup:
 `path-regexp` and `/foo` | pathRegexp: `/foo`
 `path-prefix` and `/foo` | pathSubtree: `/foo`
 `kubernetes-ingress` and /foo$ | path: `/foo`
+
+## Multiple skipper deployments
+
+If you want to split for example `internal` and `public` traffic, it
+might be a good choice to split your RouteGroups. Skipper has
+the flag `--kubernetes-routegroup-class=<string>` to only select RouteGroup
+objects that have the annotation `zalando.org/routegroup.class` set to
+`<string>`. Skipper will only create routes for RouteGroup objects with
+it's annotation or RouteGroup objects that do not have this annotation. The
+default class is `skipper`, if not set. 
+
+Example RouteGroup:
+
+```yaml
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: my-route-group
+  annotations:
+    zalando.org/routegroup.class: internal
+spec:
+  backends:
+  - name: my-backend
+    type: service
+    serviceName: my-service
+    servicePort: 80
+  defaultBackends:
+  - backendName: my-service
+```

--- a/skipper.go
+++ b/skipper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/zalando/skipper/predicates/tee"
 	"io"
 	"io/ioutil"
 	"net"
@@ -16,9 +15,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/zalando/skipper/predicates/cron"
-	"github.com/zalando/skipper/predicates/primitive"
 
 	ot "github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
@@ -40,10 +36,13 @@ import (
 	"github.com/zalando/skipper/metrics"
 	pauth "github.com/zalando/skipper/predicates/auth"
 	"github.com/zalando/skipper/predicates/cookie"
+	"github.com/zalando/skipper/predicates/cron"
 	"github.com/zalando/skipper/predicates/interval"
 	"github.com/zalando/skipper/predicates/methods"
+	"github.com/zalando/skipper/predicates/primitive"
 	"github.com/zalando/skipper/predicates/query"
 	"github.com/zalando/skipper/predicates/source"
+	"github.com/zalando/skipper/predicates/tee"
 	"github.com/zalando/skipper/predicates/traffic"
 	"github.com/zalando/skipper/proxy"
 	"github.com/zalando/skipper/queuelistener"
@@ -166,11 +165,17 @@ type Options struct {
 	KubernetesHTTPSRedirectCode int
 
 	// KubernetesIngressClass is a regular expression, that will make
-	// skipper load only the ingress resources that that have a matching
+	// skipper load only the ingress resources that have a matching
 	// kubernetes.io/ingress.class annotation. For backwards compatibility,
 	// the ingresses without an annotation, or an empty annotation, will
 	// be loaded, too.
 	KubernetesIngressClass string
+
+	// KubernetesRouteGroupClass is a regular expression, that will make skipper
+	// load only the RouteGroup resources that have a matching
+	// zalando.org/routegroup.class annotation. Any RouteGroups without the
+	// annotation, or which an empty annotation, will be loaded too.
+	KubernetesRouteGroupClass string
 
 	// PathMode controls the default interpretation of ingress paths in cases
 	// when the ingress doesn't specify it with an annotation.
@@ -694,6 +699,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 			ProvideHTTPSRedirect:       o.KubernetesHTTPSRedirect,
 			HTTPSRedirectCode:          o.KubernetesHTTPSRedirectCode,
 			IngressClass:               o.KubernetesIngressClass,
+			RouteGroupClass:            o.KubernetesRouteGroupClass,
 			ReverseSourcePredicate:     o.ReverseSourcePredicate,
 			WhitelistedHealthCheckCIDR: o.WhitelistedHealthCheckCIDR,
 			PathMode:                   o.KubernetesPathMode,


### PR DESCRIPTION
Closes #1452.

Few todos that I'd love some pointers on, if possible.

todo:
- [x] Confirm annotation: `zalando.org/routegroup.class`
- [x] Add documentation
- [x] Add more tests?
