### PR TITLE
logHeader filter to have options "request" and "response"

### DIFF
--- a/filters/diag/logheader.go
+++ b/filters/diag/logheader.go
@@ -66,10 +66,16 @@ func (lh logHeader) Response(ctx filters.FilterContext) {
 	buf.WriteString(resp.Status)
 	buf.WriteString("\r\n")
 	for k, v := range resp.Header {
-		buf.WriteString(k)
-		buf.WriteString(": ")
-		buf.WriteString(strings.Join(v, " "))
-		buf.WriteString("\r\n")
+		if strings.ToLower(k) == "authorization" {
+			buf.WriteString(k)
+			buf.WriteString(": ")
+			buf.WriteString("TRUNCATED\r\n")
+		} else {
+			buf.WriteString(k)
+			buf.WriteString(": ")
+			buf.WriteString(strings.Join(v, " "))
+			buf.WriteString("\r\n")
+		}
 	}
 	buf.WriteString("\r\n")
 
@@ -93,10 +99,16 @@ func (lh logHeader) Request(ctx filters.FilterContext) {
 	buf.WriteString(req.Host)
 	buf.WriteString("\r\n")
 	for k, v := range req.Header {
-		buf.WriteString(k)
-		buf.WriteString(": ")
-		buf.WriteString(strings.Join(v, " "))
-		buf.WriteString("\r\n")
+		if strings.ToLower(k) == "authorization" {
+			buf.WriteString(k)
+			buf.WriteString(": ")
+			buf.WriteString("TRUNCATED\r\n")
+		} else {
+			buf.WriteString(k)
+			buf.WriteString(": ")
+			buf.WriteString(strings.Join(v, " "))
+			buf.WriteString("\r\n")
+		}
 	}
 	buf.WriteString("\r\n")
 

--- a/filters/diag/logheader.go
+++ b/filters/diag/logheader.go
@@ -2,33 +2,103 @@ package diag
 
 import (
 	"bytes"
-	"io/ioutil"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/filters"
 )
 
-type logHeader struct{}
+type logHeader struct {
+	request  bool
+	response bool
+}
 
 // NewLogHeader creates a filter specification for the 'logHeader()' filter.
-func NewLogHeader() filters.Spec                                     { return logHeader{} }
-func (logHeader) Name() string                                       { return "logHeader" }
-func (logHeader) CreateFilter([]interface{}) (filters.Filter, error) { return logHeader{}, nil }
-func (logHeader) Response(filters.FilterContext)                     {}
+func NewLogHeader() filters.Spec { return logHeader{} }
+func (logHeader) Name() string   { return "logHeader" }
 
-func (logHeader) Request(ctx filters.FilterContext) {
-	req := ctx.Request()
-	body := req.Body
-	defer func() {
-		req.Body = body
-	}()
+func (logHeader) CreateFilter(args []interface{}) (filters.Filter, error) {
+	var (
+		request  = false
+		response = false
+	)
 
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(nil))
-	buf := bytes.NewBuffer(nil)
-	if err := req.Write(buf); err != nil {
-		log.Println(err)
+	// default behavior
+	if len(args) == 0 {
+		request = true
+	}
+
+	for i := range args {
+		opt, ok := args[i].(string)
+		if !ok {
+			return nil, filters.ErrInvalidFilterParameters
+		}
+		switch strings.ToLower(opt) {
+		case "response":
+			response = true
+		case "request":
+			request = true
+		}
+
+	}
+
+	return logHeader{
+		request:  request,
+		response: response,
+	}, nil
+}
+
+func (lh logHeader) Response(ctx filters.FilterContext) {
+	if !lh.response {
 		return
 	}
+
+	req := ctx.Request()
+	resp := ctx.Response()
+
+	buf := bytes.NewBuffer(nil)
+	buf.WriteString(req.Method)
+	buf.WriteString(" ")
+	buf.WriteString(req.URL.Path)
+	buf.WriteString(" ")
+	buf.WriteString(req.Proto)
+	buf.WriteString("\r\n")
+	buf.WriteString(resp.Status)
+	buf.WriteString("\r\n")
+	for k, v := range resp.Header {
+		buf.WriteString(k)
+		buf.WriteString(": ")
+		buf.WriteString(strings.Join(v, " "))
+		buf.WriteString("\r\n")
+	}
+	buf.WriteString("\r\n")
+
+	log.Println("Response for", buf.String())
+}
+
+func (lh logHeader) Request(ctx filters.FilterContext) {
+	if !lh.request {
+		return
+	}
+
+	req := ctx.Request()
+
+	buf := bytes.NewBuffer(nil)
+	buf.WriteString(req.Method)
+	buf.WriteString(" ")
+	buf.WriteString(req.URL.Path)
+	buf.WriteString(" ")
+	buf.WriteString(req.Proto)
+	buf.WriteString("\r\nHost: ")
+	buf.WriteString(req.Host)
+	buf.WriteString("\r\n")
+	for k, v := range req.Header {
+		buf.WriteString(k)
+		buf.WriteString(": ")
+		buf.WriteString(strings.Join(v, " "))
+		buf.WriteString("\r\n")
+	}
+	buf.WriteString("\r\n")
 
 	log.Println(buf.String())
 }

--- a/filters/diag/logheader_test.go
+++ b/filters/diag/logheader_test.go
@@ -17,10 +17,11 @@ func TestLogHeader(t *testing.T) {
 		log.SetOutput(os.Stderr)
 	}()
 
-	req, err := http.NewRequest("GET", "https://example.org", nil)
+	req, err := http.NewRequest("GET", "https://example.org/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Set("User-Agent", "Go-http-client/1.1")
 
 	ctx := &filtertest.Context{
 		FRequest: req,
@@ -40,7 +41,13 @@ func TestLogHeader(t *testing.T) {
 	log.SetOutput(loggerTest)
 
 	req.Body = ioutil.NopCloser(bytes.NewBufferString("foo bar baz"))
-	(logHeader{}).Request(ctx)
+
+	lh, err := (logHeader{}).CreateFilter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lh.Request(ctx)
 	if loggerTest.Len() == 0 || !bytes.Equal(loggerTest.Bytes(), loggerVerify.Bytes()) {
 		t.Error("failed to log the request header")
 		t.Log("expected:")

--- a/filters/diag/logheader_test.go
+++ b/filters/diag/logheader_test.go
@@ -57,56 +57,6 @@ func TestLogHeader(t *testing.T) {
 	}
 }
 
-// TODO: test better with proxy, because we want to check if we log
-// Headers and in REsponse we can check these. If we chec raw string
-// we dependend on internal ordering of hashmap which shows in local
-// tests to be flaky.
-func TestLogHeaderPost(t *testing.T) {
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
-
-	body := ioutil.NopCloser(bytes.NewBufferString("my body"))
-	req, err := http.NewRequest("POST", "https://example.org/", body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("User-Agent", "Go-http-client/1.1")
-	req.Header.Set("Transfer-Encoding", "chunked")
-
-	ctx := &filtertest.Context{
-		FRequest: req,
-	}
-
-	outputVerify := bytes.NewBuffer(nil)
-	if err := req.Write(outputVerify); err != nil {
-		t.Fatal(err)
-	}
-
-	loggerVerify := bytes.NewBuffer(nil)
-	log.SetOutput(loggerVerify)
-	log.Println(outputVerify.String())
-
-	loggerTest := bytes.NewBuffer(nil)
-	log.SetOutput(loggerTest)
-
-	lh, err := (logHeader{
-		request: true,
-	}).CreateFilter(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lh.Request(ctx)
-	if loggerTest.Len() == 0 || !bytes.Equal(loggerTest.Bytes(), loggerVerify.Bytes()) {
-		t.Error("failed to log the request header")
-		t.Log("expected:")
-		t.Log(loggerVerify.String())
-		t.Log("got:")
-		t.Log(loggerTest.String())
-	}
-}
-
 func TestLogHeaderRequestResponse(t *testing.T) {
 	defer func() {
 		log.SetOutput(os.Stderr)

--- a/filters/diag/logheader_test.go
+++ b/filters/diag/logheader_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -47,4 +48,100 @@ func TestLogHeader(t *testing.T) {
 		t.Log("got:")
 		t.Log(loggerTest.String())
 	}
+}
+
+func TestLogHeaderRequestResponse(t *testing.T) {
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	req, err := http.NewRequest("GET", "https://example.org/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("User-Agent", "Go-http-client/1.1")
+
+	resp := &http.Response{
+		Header: http.Header{
+			"Foo": []string{"Bar"},
+		},
+		StatusCode:    http.StatusOK,
+		Status:        http.StatusText(200),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          nil,
+		ContentLength: 0,
+	}
+
+	ctx := &filtertest.Context{
+		FRequest:  req,
+		FResponse: resp,
+	}
+
+	outputVerify := bytes.NewBuffer(nil)
+	req.Body = nil
+	if err := req.Write(outputVerify); err != nil {
+		t.Fatal(err)
+	}
+
+	loggerVerify := bytes.NewBuffer(nil)
+	log.SetOutput(loggerVerify)
+	log.Println(outputVerify.String())
+
+	loggerTest := bytes.NewBuffer(nil)
+	log.SetOutput(loggerTest)
+
+	req.Body = ioutil.NopCloser(bytes.NewBufferString("foo bar baz"))
+
+	lh := logHeader{
+		request:  true,
+		response: true,
+	}
+
+	lh.Request(ctx)
+	if loggerTest.Len() == 0 || !bytes.Equal(loggerTest.Bytes(), loggerVerify.Bytes()) {
+		t.Error("failed to log the request header")
+		t.Log("expected:")
+		t.Log(loggerVerify.String())
+		t.Log("got:")
+		t.Log(loggerTest.String())
+	}
+
+	// response
+	outputVerify = bytes.NewBuffer(nil)
+	resp.Body = nil
+	outputVerify.WriteString("Response for ")
+	outputVerify.WriteString(req.Method)
+	outputVerify.WriteString(" ")
+	outputVerify.WriteString(req.URL.Path)
+	outputVerify.WriteString(" ")
+	outputVerify.WriteString(req.Proto)
+	outputVerify.WriteString("\r\n")
+	outputVerify.WriteString(resp.Status)
+	outputVerify.WriteString("\r\n")
+	for k, v := range resp.Header {
+		outputVerify.WriteString(k)
+		outputVerify.WriteString(": ")
+		outputVerify.WriteString(strings.Join(v, " "))
+		outputVerify.WriteString("\r\n")
+	}
+	outputVerify.WriteString("\r\n")
+
+	loggerVerify = bytes.NewBuffer(nil)
+	log.SetOutput(loggerVerify)
+	log.Println(outputVerify.String())
+
+	loggerTest = bytes.NewBuffer(nil)
+	log.SetOutput(loggerTest)
+
+	lh.Response(ctx)
+	if loggerTest.Len() == 0 || !bytes.Equal(loggerTest.Bytes(), loggerVerify.Bytes()) {
+		t.Error("failed to log the response header")
+		t.Log("expected:")
+		t.Log(loggerVerify.String())
+		t.Log("got:")
+		t.Log(loggerTest.String())
+	}
+
 }


### PR DESCRIPTION
compatible version of logHeader() filter which logs the request headers.
logHeader support 2 args: "request" and "response"
The new version also logs if we have a non nil body

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>