### PR TITLE
Allow setting a custom Prometheus registry

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -6,6 +6,8 @@ import (
 	"net/http/pprof"
 	"strings"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -152,6 +154,11 @@ type Options struct {
 	// EnableProfile exposes profiling information on /pprof of the
 	// metrics listener.
 	EnableProfile bool
+
+	// An instance of a Prometheus registry. It allows registering and serving custom metrics when skipper is used as a
+	// library.
+	// A new registry is created if this option is nil.
+	PrometheusRegistry *prometheus.Registry
 }
 
 var (

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -222,8 +222,12 @@ func NewPrometheus(opts Options) *Prometheus {
 		customGaugeM:               customGauge,
 		customHistogramM:           customHistogram,
 
+		registry: opts.PrometheusRegistry,
 		opts:     opts,
-		registry: prometheus.NewRegistry(),
+	}
+
+	if p.registry == nil {
+		p.registry = prometheus.NewRegistry()
 	}
 
 	// Register all metrics.

--- a/skipper.go
+++ b/skipper.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	ot "github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/zalando/skipper/circuit"
@@ -560,6 +561,11 @@ type Options struct {
 	// use the MetricsFlavours option.
 	EnablePrometheusMetrics bool
 
+	// An instance of a Prometheus registry. It allows registering and serving custom metrics when skipper is used as a
+	// library.
+	// A new registry is created if this option is nil.
+	PrometheusRegistry *prometheus.Registry
+
 	// MetricsFlavours sets the metrics storage and exposed format
 	// of metrics endpoints.
 	MetricsFlavours []string
@@ -973,6 +979,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		UseExpDecaySample:                  o.MetricsUseExpDecaySample,
 		HistogramBuckets:                   o.HistogramMetricBuckets,
 		DisableCompatibilityDefaults:       o.DisableMetricsCompatibilityDefaults,
+		PrometheusRegistry:                 o.PrometheusRegistry,
 	}
 
 	mtr := o.MetricsBackend


### PR DESCRIPTION
We are maintaining several custom filters and thus use skipper as a library. Prometheus is our monitoring system of choice.
The default API methods of the `metrics` package like `IncCounter()` or `UpdateGauge()` sometimes do not cut it for us.
In some cases we would like to be able to change the name of the metric instead of the label `key` to aid in discovery. Or it would be useful to add more than one label to a metric.

This change allows passing a registry down to the Prometheus implementation of the `metrics` package. This makes it possible to create custom metrics for filters, register them with the custom registry and instruct skipper to use that custom registry.
The code falls back to the current behavior of creating a new registry if no custom registry is passed from the outside.