### PR TITLE
Improve RouteGroup CRD schema

### DIFF
--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -41,6 +41,7 @@ spec:
               type: array
               items:
                 type: string
+                pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
             backends:
               type: array
               minLength: 1

--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -35,6 +35,7 @@ spec:
           required:
           - backends
           - routes
+          - hosts
           type: object
           properties:
             hosts:
@@ -42,6 +43,7 @@ spec:
               items:
                 type: string
                 pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+              minItems: 1
             backends:
               type: array
               minItems: 1

--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -44,7 +44,7 @@ spec:
                 pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
             backends:
               type: array
-              minLength: 1
+              minItems: 1
               items:
                 type: object
                 required:
@@ -74,7 +74,7 @@ spec:
                     - consistentHash
                   endpoints:
                     type: array
-                    minLength: 1
+                    minItems: 1
                     items:
                       type: string
                   address:
@@ -91,7 +91,7 @@ spec:
                     minimum: 0
             routes:
               type: array
-              minLength: 1
+              minItems: 1
               items:
                 type: object
                 properties:


### PR DESCRIPTION
 * Add a regex for hostnames (matching one used for Ingress validation).
 * Fix array validation to use `minItems` (`minLength` doesn't do anything).
 * Make `hosts` required; having a RouteGroup that matches everything is an extremely unlikely case, so I'd rather optimise for the users not being able to break anything in a cluster by deploying a match-all RG.