### PR TITLE
tracingTag with a backend name for RouteGroup-generated routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*.sw?
 bin
+.bin
 pkg
 src/github.com/mailgun
 default.etcd

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	OpenTracingExcludedProxyTags        string    `yaml:"opentracing-excluded-proxy-tags"`
 	OpentracingLogFilterLifecycleEvents bool      `yaml:"opentracing-log-filter-lifecycle-events"`
 	OpentracingLogStreamEvents          bool      `yaml:"opentracing-log-stream-events"`
+	OpentracingBackendNameTag           bool      `yaml:"opentracing-backend-name-tag"`
 	MetricsListener                     string    `yaml:"metrics-listener"`
 	MetricsPrefix                       string    `yaml:"metrics-prefix"`
 	EnableProfile                       bool      `yaml:"enable-profile"`
@@ -280,6 +281,7 @@ const (
 	openTracingExcludedProxyTagsUsage        = "set tags that should be excluded from spans created for proxy operation. must be a comma-separated list of strings."
 	opentracingLogFilterLifecycleEventsUsage = "enables the logs for request & response filters' lifecycle events that are marking start & end times."
 	opentracingLogStreamEventsUsage          = "enables the logs for events marking the times response headers & payload are streamed to the client"
+	opentracingBackendNameTag                = "enables an additional tracing tag that contains a backend name for a route when it's available  (e.g. for RouteGroups) (default false)"
 	metricsListenerUsage                     = "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty."
 	metricsPrefixUsage                       = "allows setting a custom path prefix for metrics export"
 	enableProfileUsage                       = "enable profile information on the metrics endpoint with path /pprof"
@@ -463,6 +465,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.OpenTracingExcludedProxyTags, "opentracing-excluded-proxy-tags", "", openTracingExcludedProxyTagsUsage)
 	flag.BoolVar(&cfg.OpentracingLogFilterLifecycleEvents, "opentracing-log-filter-lifecycle-events", true, opentracingLogFilterLifecycleEventsUsage)
 	flag.BoolVar(&cfg.OpentracingLogStreamEvents, "opentracing-log-stream-events", true, opentracingLogStreamEventsUsage)
+	flag.BoolVar(&cfg.OpentracingBackendNameTag, "opentracing-backend-name-tag", false, opentracingBackendNameTag)
 	flag.StringVar(&cfg.MetricsListener, "metrics-listener", defaultMetricsListener, metricsListenerUsage)
 	flag.StringVar(&cfg.MetricsPrefix, "metrics-prefix", defaultMetricsPrefix, metricsPrefixUsage)
 	flag.BoolVar(&cfg.EnableProfile, "enable-profile", false, enableProfileUsage)

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -158,6 +158,10 @@ type Options struct {
 
 	// If the OriginMarker should be added as a filter
 	OriginMarker bool
+
+	// If the OpenTracing tag containing RouteGroup backend name
+	// (using tracingTag filter) should be added to all routes
+	BackendNameTracingTag bool
 }
 
 // Client is a Skipper DataClient implementation used to create routes based on Kubernetes Ingress settings.
@@ -176,6 +180,7 @@ type Client struct {
 	quit                   chan struct{}
 	defaultFiltersDir      string
 	originMarker           bool
+	BackendNameTracingTag  bool
 }
 
 // New creates and initializes a Kubernetes DataClient.
@@ -251,6 +256,7 @@ func New(o Options) (*Client, error) {
 		quit:                   quit,
 		defaultFiltersDir:      o.DefaultFiltersDir,
 		originMarker:           o.OriginMarker,
+		BackendNameTracingTag:  o.BackendNameTracingTag,
 	}, nil
 }
 

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -180,7 +180,6 @@ type Client struct {
 	quit                   chan struct{}
 	defaultFiltersDir      string
 	originMarker           bool
-	BackendNameTracingTag  bool
 }
 
 // New creates and initializes a Kubernetes DataClient.
@@ -256,7 +255,6 @@ func New(o Options) (*Client, error) {
 		quit:                   quit,
 		defaultFiltersDir:      o.DefaultFiltersDir,
 		originMarker:           o.OriginMarker,
-		BackendNameTracingTag:  o.BackendNameTracingTag,
 	}, nil
 }
 

--- a/dataclients/kubernetes/kubernetestest/fixtures.go
+++ b/dataclients/kubernetes/kubernetestest/fixtures.go
@@ -32,10 +32,11 @@ type fixtureSet struct {
 }
 
 type kubeOptionsParser struct {
-	EastWest          bool   `yaml:"eastWest"`
-	EastWestDomain    string `yaml:"eastWestDomain"`
-	HTTPSRedirect     bool   `yaml:"httpsRedirect"`
-	HTTPSRedirectCode int    `yaml:"httpsRedirectCode"`
+	EastWest              bool   `yaml:"eastWest"`
+	EastWestDomain        string `yaml:"eastWestDomain"`
+	HTTPSRedirect         bool   `yaml:"httpsRedirect"`
+	HTTPSRedirectCode     int    `yaml:"httpsRedirectCode"`
+	BackendNameTracingTag bool   `yaml:"backendNameTracingTag"`
 }
 
 func baseNoExt(n string) string {
@@ -186,6 +187,7 @@ func testFixture(t *testing.T, f fixtureSet) {
 		o.KubernetesEastWestDomain = kop.EastWestDomain
 		o.ProvideHTTPSRedirect = kop.HTTPSRedirect
 		o.HTTPSRedirectCode = kop.HTTPSRedirectCode
+		o.BackendNameTracingTag = kop.BackendNameTracingTag
 	}
 
 	o.KubernetesURL = s.URL

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -312,7 +312,7 @@ func appendFilter(f []*eskip.Filter, name string, args ...interface{}) []*eskip.
 }
 
 func applyBackendFilters(backend *definitions.SkipperBackend, r *eskip.Route) {
-	appendFilter(r.Filters, "tracingTag", tracingSkipperBackendNameTag, backend.Name)
+	r.Filters = appendFilter(r.Filters, "tracingTag", tracingSkipperBackendNameTag, backend.Name)
 }
 
 func applyBackend(ctx *routeGroupContext, backend *definitions.SkipperBackend, r *eskip.Route) error {

--- a/dataclients/kubernetes/routegroups_test.go
+++ b/dataclients/kubernetes/routegroups_test.go
@@ -37,3 +37,7 @@ func TestRouteGroupDefaultFilters(t *testing.T) {
 func TestRouteGroupWithIngress(t *testing.T) {
 	kubernetestest.FixturesToTest(t, "testdata/routegroups/with-ingress")
 }
+
+func TestRouteGroupTracingTag(t *testing.T) {
+	kubernetestest.FixturesToTest(t, "testdata/routegroups/tracing-tag")
+}

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.eskip
@@ -1,0 +1,6 @@
+kube_rg__default__myapp__all__0_0:
+	Host("^(example[.]org)$") && PathSubtree("/")
+    -> tracingTag("skipper.backend_name", "myapp")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.kube
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.kube
@@ -1,0 +1,1 @@
+backendNameTracingTag: true

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.yaml
@@ -1,0 +1,49 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.org
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - pathSubtree: /
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 7272
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+  namespace: default
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: main
+    port: 7272
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.eskip
@@ -1,0 +1,7 @@
+kube_rg__default__myapp__all__0_0:
+	Host("^(example[.]org)$")
+	&& PathSubtree("/")
+	-> tracingTag("skipper.backend_name", "myapp")
+    -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.kube
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.kube
@@ -1,0 +1,1 @@
+backendNameTracingTag: true

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.yaml
@@ -1,0 +1,49 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.org
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 7272
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+  namespace: default
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: main
+    port: 7272
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.eskip
@@ -1,0 +1,4 @@
+kube_rg__default__myapp__all__0_0:
+	Host("^(example[.]org)$")
+    -> tracingTag("skipper.backend_name", "myapp")
+	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.kube
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.kube
@@ -1,0 +1,1 @@
+backendNameTracingTag: true

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.yaml
@@ -1,0 +1,38 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.org
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/skipper.go
+++ b/skipper.go
@@ -527,6 +527,10 @@ type Options struct {
 	// times when response headers & payload are streamed to the client
 	OpenTracingLogStreamEvents bool
 
+	// OpenTracingBackendNameTag enables an additional tracing tag containing a backend name
+	// for a route when it's available (e.g. for RouteGroups)
+	OpenTracingBackendNameTag bool
+
 	// PluginDir defines the directory to load plugins from, DEPRECATED, use PluginDirs
 	PluginDir string
 	// PluginDirs defines the directories to load plugins from
@@ -720,6 +724,7 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 			KubernetesEastWestDomain:   o.KubernetesEastWestDomain,
 			DefaultFiltersDir:          o.DefaultFiltersDir,
 			OriginMarker:               o.EnableRouteCreationMetrics,
+			BackendNameTracingTag:      o.OpenTracingBackendNameTag,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This is a simple change that adds an idiomatic OpenTracing tag (`skipper.backend_name`) for all routes originating from RouteGroups containing a backend reference name. That can be very helpful in debugging (clearly visible which logical backend was serving instead of seeing just actual service IPs) and metrics gathering/comparison (imagine comparing metrics between a primary and canary or AB test).

It's implemented adding an implicit `tracingTag` filter to all generated routes. (implemented this way for RouteGroups only as by default Skipper backends do not have names so it is not universal to all sources of routes).