### PR TITLE
Unify detection of upgrade requests.

### DIFF
--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -67,7 +67,7 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	// https://tools.ietf.org/html/rfc7230#section-6.7
 	// and https://tools.ietf.org/html/rfc6455 (websocket)
 	if (req.ProtoMajor <= 1 && req.ProtoMinor < 1) ||
-		strings.ToLower(req.Header.Get("Connection")) != "upgrade" ||
+		!isUpgradeRequest(req) ||
 		req.Header.Get("Upgrade") == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(http.StatusText(http.StatusBadRequest)))


### PR DESCRIPTION
When firefox sends a websocket request, it sends it with a connection header of

Connection: keep-alive, Upgrade

Due to skipper having multiple definitions of an upgrade request, these requests are rejected with 400 bad request. This patch unifies skippers idea of what an upgrade request is.