### PR TITLE
feat: Add IncGauge and DecGauge for metrics

### DIFF
--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -39,6 +39,14 @@ func (a *All) UpdateGauge(key string, v float64) {
 	a.prometheus.UpdateGauge(key, v)
 	a.codaHale.UpdateGauge(key, v)
 }
+func (a *All) IncGauge(key string) {
+	a.prometheus.IncGauge(key)
+	a.codaHale.IncGauge(key)
+}
+func (a *All) DecGauge(key string) {
+	a.prometheus.DecGauge(key)
+	a.codaHale.DecGauge(key)
+}
 func (a *All) MeasureRouteLookup(start time.Time) {
 	a.prometheus.MeasureRouteLookup(start)
 	a.codaHale.MeasureRouteLookup(start)

--- a/metrics/codahale.go
+++ b/metrics/codahale.go
@@ -114,6 +114,16 @@ func (c *CodaHale) UpdateGauge(key string, v float64) {
 	}
 }
 
+// Codahale supports decrements in counters but not on Gauges
+func (c *CodaHale) IncGauge(key string) {
+	c.incCounter(key, 1)
+}
+
+// Codahale supports decrements in counters but not on Gauges
+func (c *CodaHale) DecGauge(key string) {
+	c.decCounter(key, 1)
+}
+
 func (c *CodaHale) IncCounter(key string) {
 	c.incCounter(key, 1)
 }
@@ -198,11 +208,15 @@ func (c *CodaHale) getCounter(key string) metrics.Counter {
 }
 
 func (c *CodaHale) incCounter(key string, value int64) {
-	go func() {
-		if c := c.getCounter(key); c != nil {
-			c.Inc(value)
-		}
-	}()
+	if c := c.getCounter(key); c != nil {
+		c.Inc(value)
+	}
+}
+
+func (c *CodaHale) decCounter(key string, value int64) {
+	if c := c.getCounter(key); c != nil {
+		c.Dec(value)
+	}
 }
 
 func (c *CodaHale) IncRoutingFailures() {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -76,6 +76,8 @@ type Metrics interface {
 	IncErrorsStreaming(routeId string)
 	RegisterHandler(path string, handler *http.ServeMux)
 	UpdateGauge(key string, value float64)
+	IncGauge(key string)
+	DecGauge(key string)
 }
 
 // Options for initializing metrics collection.

--- a/metrics/metricstest/metricsmock.go
+++ b/metrics/metricstest/metricsmock.go
@@ -170,6 +170,14 @@ func (m *MockMetrics) UpdateGauge(key string, value float64) {
 	})
 }
 
+func (*MockMetrics) IncGauge(key string) {
+	panic("implement me")
+}
+
+func (*MockMetrics) DecGauge(key string) {
+	panic("implement me")
+}
+
 func (m *MockMetrics) Gauge(key string) (v float64, ok bool) {
 	m.WithGauges(func(g map[string]float64) {
 		v, ok = g[key]

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -314,6 +314,16 @@ func (p *Prometheus) UpdateGauge(key string, v float64) {
 	p.customGaugeM.WithLabelValues(key).Set(v)
 }
 
+// IncGauge satisfies Metrics interface.
+func (p *Prometheus) IncGauge(key string) {
+	p.customGaugeM.WithLabelValues(key).Inc()
+}
+
+// DecGauge satisfies Metrics interface.
+func (p *Prometheus) DecGauge(key string) {
+	p.customGaugeM.WithLabelValues(key).Dec()
+}
+
 // MeasureRouteLookup satisfies Metrics interface.
 func (p *Prometheus) MeasureRouteLookup(start time.Time) {
 	t := p.sinceS(start)


### PR DESCRIPTION
## Context
This change is a step toward the least-request algorithm implementation. 

## Description
Gauges and Counter are implemented differently on the metrics providers we support. Codahale allows to decrement counters but only allows to set values on gauges. Conversely, prometheus supports increment and decrement values on gauges but it doesn't allow decrement counters.

## Solution
After some research seems like the Prometheus semantic is more accurate than Codahale. As a consequence, Codahale implementation uses counters under-the-hood. 

I added the IncGauge and DecGauge methods to the metrics interface to hide these inconsistencies.

## Additional changes
For some reason, the incCounter implementation wraps the increment in a goroutine while this does not happen in the prometheus version. I tried to find documentation in the PR that introduced the change but I could not find it. IMHO spawning a new goroutine on every increment seems overkill.

Moreover, the internal implementation of then codahale library and it only use atomic operations which most likely are cheaper than creating a new gorotine although I am not completely sure about this. I decided to remove the goroutine wrapper in this PR. Let me know if there is a reason to keep it. If so, I can exclude it.

Signed-off-by: Mariano Carballal <marianocarballal@gmail.com>

