### PR TITLE
upgrade to go1.15

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2-beta
       with:
-        go-version: '^1.14'
+        go-version: '^1.15'
     - run: go version
     - run: sudo apt-get install redis-server
     - run: make deps

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2-beta
         with:
-          go-version: '^1.14'
+          go-version: '^1.15'
       - run: go version
       - run: sudo apt-get install redis-server
       - run: make deps

--- a/filters/auth/oidc_introspection.go
+++ b/filters/auth/oidc_introspection.go
@@ -125,7 +125,7 @@ func (filter *oidcIntrospectionFilter) Request(ctx filters.FilterContext) {
 			return
 		}
 	default:
-		unauthorized(ctx, string(filter.typ), invalidClaim, r.Host, "Wrong oidcIntrospectionFilter type")
+		unauthorized(ctx, fmt.Sprint(filter.typ), invalidClaim, r.Host, "Wrong oidcIntrospectionFilter type")
 		return
 	}
 

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -817,7 +817,7 @@ func TestChunkAndMergerCookie(t *testing.T) {
 	emptyCookie.Value = ""
 	largeCookie := tinyCookie
 	for i := 0; i < 5*cookieMaxSize; i++ {
-		largeCookie.Value += string(rand.Intn('Z'-'A') + 'A' + i%2*32)
+		largeCookie.Value += string(rune(rand.Intn('Z'-'A') + 'A' + i%2*32))
 	}
 	oneCookie := largeCookie
 	oneCookie.Value = oneCookie.Value[:len(oneCookie.Value)-(len(oneCookie.String())-cookieMaxSize)-1]


### PR DESCRIPTION
- upgrade go version in github actions
- fix string conversion from rune for go1.15 compiler checks

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>