### PR TITLE
feat: Add power-of-N-choices load balancing algorithm

### DIFF
--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -65,7 +65,7 @@ func (r *roundRobin) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 }
 
 type random struct {
-	rand *rand.Rand
+	rand  *rand.Rand
 	mutex sync.Mutex
 }
 
@@ -105,10 +105,10 @@ func (*consistentHash) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 	return ctx.Route.LBEndpoints.At(choice)
 }
 
-type powerOfChoices struct{
-	rand *rand.Rand
+type powerOfChoices struct {
+	rand            *rand.Rand
 	numberOfChoices int
-	mutex sync.Mutex
+	mutex           sync.Mutex
 }
 
 func (a *powerOfChoices) GetScore(e routing.LBEndpoint) int {
@@ -121,7 +121,7 @@ func (a *powerOfChoices) GetScore(e routing.LBEndpoint) int {
 func newPowerOfChoices(endpoints []string) routing.LBAlgorithm {
 	t := time.Now().UnixNano()
 	return &powerOfChoices{
-		rand: rand.New(rand.NewSource(t)),
+		rand:            rand.New(rand.NewSource(t)),
 		numberOfChoices: 2, // TODO: make this the value part of skipper configuration.
 	}
 }
@@ -147,7 +147,7 @@ func (a *powerOfChoices) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 		return bestEndpoint
 	}
 	var currEndpoint routing.LBEndpoint
-	for i := 1 ; i < a.numberOfChoices ; i++  {
+	for i := 1; i < a.numberOfChoices; i++ {
 		candidateIdx = a.GetRandomIndex(numEndpoints)
 		currEndpoint = ctx.Route.LBEndpoints.At(candidateIdx)
 		if a.GetScore(currEndpoint) > a.GetScore(bestEndpoint) {
@@ -167,7 +167,6 @@ type (
 func NewAlgorithmProvider() routing.PostProcessor {
 	return &algorithmProvider{}
 }
-
 
 // AlgorithmFromString parses the string representation of the algorithm definition.
 func AlgorithmFromString(a string) (Algorithm, error) {

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -205,7 +205,7 @@ func (a Algorithm) String() string {
 }
 
 func parseEndpoints(r *routing.Route) error {
-	err, endpoints := routing.NewEndpointCollection(r)
+	endpoints, err := routing.NewEndpointCollection(r)
 	if err != nil {
 		return err
 	}

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -105,6 +105,7 @@ func (*consistentHash) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 	return ctx.Route.LBEndpoints.At(choice)
 }
 
+// Paper http://www.eecs.harvard.edu/~michaelm/NEWWORK/postscripts/twosurvey.pdf
 type powerOfRandomNChoices struct {
 	rand            *rand.Rand
 	numberOfChoices int

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -126,7 +126,7 @@ func newPowerOfChoices(endpoints []string) routing.LBAlgorithm {
 	}
 }
 
-func (a *powerOfChoices) GetRandomIndex(length int) int {
+func (a *powerOfChoices) getRandomIndex(length int) int {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	return a.rand.Intn(length)
@@ -134,22 +134,11 @@ func (a *powerOfChoices) GetRandomIndex(length int) int {
 
 func (a *powerOfChoices) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 	numEndpoints := ctx.Route.LBEndpoints.Length()
-
-	// no need to compute a random endpoint if only one is given
-	if numEndpoints == 1 && a.numberOfChoices == 1 {
-		return ctx.Route.LBEndpoints.At(0)
-	}
-	candidateIdx := a.GetRandomIndex(numEndpoints)
+	candidateIdx := a.getRandomIndex(numEndpoints)
 	bestEndpoint := ctx.Route.LBEndpoints.At(candidateIdx)
-
-	// no need to compute the scores when only one endpoint can be chosen
-	if a.numberOfChoices == 1 {
-		return bestEndpoint
-	}
-	var currEndpoint routing.LBEndpoint
 	for i := 1; i < a.numberOfChoices; i++ {
-		candidateIdx = a.GetRandomIndex(numEndpoints)
-		currEndpoint = ctx.Route.LBEndpoints.At(candidateIdx)
+		candidateIdx = a.getRandomIndex(numEndpoints)
+		currEndpoint := ctx.Route.LBEndpoints.At(candidateIdx)
 		if a.GetScore(currEndpoint) > a.GetScore(bestEndpoint) {
 			bestEndpoint = currEndpoint
 		}

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -243,7 +243,7 @@ func TestApply(t *testing.T) {
 			name:          "powerOfChoices algorithm",
 			iterations:    100,
 			jitter:        0,
-			expected:      1,
+			expected:      N,
 			algorithm:     newPowerOfChoices(eps),
 			algorithmName: "powerOfChoices",
 		}} {

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -128,12 +128,12 @@ func TestSelectAlgorithm(t *testing.T) {
 		}
 	})
 
-	t.Run("LB route with explicit powerOfChoices algorithm", func(t *testing.T) {
+	t.Run("LB route with explicit randomNChoices algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
-				LBAlgorithm: "powerOfChoices",
+				LBAlgorithm: "randomNChoices",
 				LBEndpoints: []string{"https://www.example.org"},
 			},
 		}
@@ -149,7 +149,7 @@ func TestSelectAlgorithm(t *testing.T) {
 			t.Fatal("failed to set the endpoints")
 		}
 
-		if _, ok := rr[0].LBAlgorithm.(*powerOfChoices); !ok {
+		if _, ok := rr[0].LBAlgorithm.(*randomNChoices); !ok {
 			t.Fatal("failed to set the right algorithm")
 		}
 	})
@@ -240,12 +240,12 @@ func TestApply(t *testing.T) {
 			algorithm:     newConsistentHash(eps),
 			algorithmName: "consistentHash",
 		}, {
-			name:          "powerOfChoices algorithm",
+			name:          "randomNChoices algorithm",
 			iterations:    100,
 			jitter:        0,
 			expected:      N,
-			algorithm:     newPowerOfChoices(eps),
-			algorithmName: "powerOfChoices",
+			algorithm:     newRandomNChoices(eps),
+			algorithmName: "randomNChoices",
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -128,12 +128,12 @@ func TestSelectAlgorithm(t *testing.T) {
 		}
 	})
 
-	t.Run("LB route with explicit randomNChoices algorithm", func(t *testing.T) {
+	t.Run("LB route with explicit powerOfRandomNChoices algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
-				LBAlgorithm: "randomNChoices",
+				LBAlgorithm: "powerOfRandomNChoices",
 				LBEndpoints: []string{"https://www.example.org"},
 			},
 		}
@@ -149,7 +149,7 @@ func TestSelectAlgorithm(t *testing.T) {
 			t.Fatal("failed to set the endpoints")
 		}
 
-		if _, ok := rr[0].LBAlgorithm.(*randomNChoices); !ok {
+		if _, ok := rr[0].LBAlgorithm.(*powerOfRandomNChoices); !ok {
 			t.Fatal("failed to set the right algorithm")
 		}
 	})
@@ -240,12 +240,12 @@ func TestApply(t *testing.T) {
 			algorithm:     newConsistentHash(eps),
 			algorithmName: "consistentHash",
 		}, {
-			name:          "randomNChoices algorithm",
+			name:          "powerOfRandomNChoices algorithm",
 			iterations:    100,
 			jitter:        0,
 			expected:      N,
-			algorithm:     newRandomNChoices(eps),
-			algorithmName: "randomNChoices",
+			algorithm:     newPowerOfRandomNChoices(eps),
+			algorithmName: "powerOfRandomNChoices",
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -45,7 +45,7 @@ func TestConcurrencySingleRouteRoundRobin(t *testing.T) {
 }
 
 func TestConcurrencySingleRoutePowerOfChoices(t *testing.T) {
-	executeSingleRouteTest(t, "powerOfChoices",5)
+	executeSingleRouteTest(t, "powerOfChoices", 5)
 }
 
 func TestConcurrencySingleRouteRandom(t *testing.T) {
@@ -170,7 +170,7 @@ func executeSingleRouteTest(t *testing.T, algorithmName string, distributionTole
 	checkDistribution(t, memberCounters, distributionTolerance)
 }
 
-func executeConstantlyUpdatingRoutes(t *testing.T, algorithmName string, distributionToleranceRatio int){
+func executeConstantlyUpdatingRoutes(t *testing.T, algorithmName string, distributionToleranceRatio int) {
 	const (
 		backendCount     = 7
 		concurrency      = 32

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -44,19 +44,19 @@ func TestConcurrencySingleRouteRoundRobin(t *testing.T) {
 	executeSingleRouteTest(t, "roundRobin", 5)
 }
 
-func TestConcurrencySingleRouteRandomNChoices(t *testing.T) {
-	executeSingleRouteTest(t, "randomNChoices", 10)
+func TestConcurrencySingleRoutePowerOfRandomNChoices(t *testing.T) {
+	executeSingleRouteTest(t, "powerOfRandomNChoices", 10)
 }
 
-func TestConcurrencySingleRouteRandom(t *testing.T) {
+func TestConcurrencySingleRoutePowerOfRandom(t *testing.T) {
 	executeSingleRouteTest(t, "random", 10)
 }
 
 func TestConstantlyUpdatingRoutesRoundRobin(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "roundRobin", 5)
 }
-func TestConstantlyUpdatingRoutesRandomNChoices(t *testing.T) {
-	executeConstantlyUpdatingRoutes(t, "randomNChoices", 10)
+func TestConstantlyUpdatingRoutesPowerOfRandomNChoices(t *testing.T) {
+	executeConstantlyUpdatingRoutes(t, "powerOfRandomNChoices", 10)
 }
 func TestConstantlyUpdatingRoutesRandom(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "random", 10)
@@ -66,8 +66,8 @@ func TestConcurrencyMultipleRoutesRoundRobin(t *testing.T) {
 	executeConcurrencyMultipleRoutes(t, "roundRobin", 5)
 }
 
-func TestConcurrencyMultipleRoutesRandomNChoices(t *testing.T) {
-	executeConcurrencyMultipleRoutes(t, "randomNChoices", 10)
+func TestConcurrencyMultipleRoutesPowerOfRandomNChoices(t *testing.T) {
+	executeConcurrencyMultipleRoutes(t, "powerOfRandomNChoices", 10)
 }
 
 func TestConcurrencyMultipleRoutesRandom(t *testing.T) {

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -45,21 +45,21 @@ func TestConcurrencySingleRouteRoundRobin(t *testing.T) {
 }
 
 func TestConcurrencySingleRoutePowerOfChoices(t *testing.T) {
-	executeSingleRouteTest(t, "powerOfChoices", 9)
+	executeSingleRouteTest(t, "powerOfChoices", 10)
 }
 
 func TestConcurrencySingleRouteRandom(t *testing.T) {
-	executeSingleRouteTest(t, "random", 9)
+	executeSingleRouteTest(t, "random", 10)
 }
 
 func TestConstantlyUpdatingRoutesRoundRobin(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "roundRobin", 5)
 }
 func TestConstantlyUpdatingRoutesPowerOfChoices(t *testing.T) {
-	executeConstantlyUpdatingRoutes(t, "powerOfChoices", 9)
+	executeConstantlyUpdatingRoutes(t, "powerOfChoices", 10)
 }
 func TestConstantlyUpdatingRoutesRandom(t *testing.T) {
-	executeConstantlyUpdatingRoutes(t, "random", 9)
+	executeConstantlyUpdatingRoutes(t, "random", 10)
 }
 
 func TestConcurrencyMultipleRoutesRoundRobin(t *testing.T) {
@@ -67,11 +67,11 @@ func TestConcurrencyMultipleRoutesRoundRobin(t *testing.T) {
 }
 
 func TestConcurrencyMultipleRoutesPowerOfChoices(t *testing.T) {
-	executeConcurrencyMultipleRoutes(t, "powerOfChoices", 9)
+	executeConcurrencyMultipleRoutes(t, "powerOfChoices", 10)
 }
 
 func TestConcurrencyMultipleRoutesRandom(t *testing.T) {
-	executeConcurrencyMultipleRoutes(t, "random", 9)
+	executeConcurrencyMultipleRoutes(t, "random", 10)
 }
 
 func executeSingleRouteTest(t *testing.T, algorithmName string, distributionToleranceRatio int) {

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -45,11 +45,11 @@ func TestConcurrencySingleRouteRoundRobin(t *testing.T) {
 }
 
 func TestConcurrencySingleRoutePowerOfChoices(t *testing.T) {
-	executeSingleRouteTest(t, "powerOfChoices", 7)
+	executeSingleRouteTest(t, "powerOfChoices", 9)
 }
 
 func TestConcurrencySingleRouteRandom(t *testing.T) {
-	executeSingleRouteTest(t, "random", 7)
+	executeSingleRouteTest(t, "random", 9)
 }
 
 func TestConstantlyUpdatingRoutesRoundRobin(t *testing.T) {
@@ -59,7 +59,7 @@ func TestConstantlyUpdatingRoutesPowerOfChoices(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "powerOfChoices", 9)
 }
 func TestConstantlyUpdatingRoutesRandom(t *testing.T) {
-	executeConstantlyUpdatingRoutes(t, "random", 10)
+	executeConstantlyUpdatingRoutes(t, "random", 9)
 }
 
 func TestConcurrencyMultipleRoutesRoundRobin(t *testing.T) {
@@ -71,7 +71,7 @@ func TestConcurrencyMultipleRoutesPowerOfChoices(t *testing.T) {
 }
 
 func TestConcurrencyMultipleRoutesRandom(t *testing.T) {
-	executeConcurrencyMultipleRoutes(t, "random", 10)
+	executeConcurrencyMultipleRoutes(t, "random", 9)
 }
 
 func executeSingleRouteTest(t *testing.T, algorithmName string, distributionToleranceRatio int) {

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -59,7 +59,7 @@ func TestConstantlyUpdatingRoutesPowerOfChoices(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "powerOfChoices", 9)
 }
 func TestConstantlyUpdatingRoutesRandom(t *testing.T) {
-	executeConstantlyUpdatingRoutes(t, "random", 9)
+	executeConstantlyUpdatingRoutes(t, "random", 10)
 }
 
 func TestConcurrencyMultipleRoutesRoundRobin(t *testing.T) {
@@ -71,7 +71,7 @@ func TestConcurrencyMultipleRoutesPowerOfChoices(t *testing.T) {
 }
 
 func TestConcurrencyMultipleRoutesRandom(t *testing.T) {
-	executeConcurrencyMultipleRoutes(t, "random", 9)
+	executeConcurrencyMultipleRoutes(t, "random", 10)
 }
 
 func executeSingleRouteTest(t *testing.T, algorithmName string, distributionToleranceRatio int) {

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -44,8 +44,8 @@ func TestConcurrencySingleRouteRoundRobin(t *testing.T) {
 	executeSingleRouteTest(t, "roundRobin", 5)
 }
 
-func TestConcurrencySingleRoutePowerOfChoices(t *testing.T) {
-	executeSingleRouteTest(t, "powerOfChoices", 10)
+func TestConcurrencySingleRouteRandomNChoices(t *testing.T) {
+	executeSingleRouteTest(t, "randomNChoices", 10)
 }
 
 func TestConcurrencySingleRouteRandom(t *testing.T) {
@@ -55,8 +55,8 @@ func TestConcurrencySingleRouteRandom(t *testing.T) {
 func TestConstantlyUpdatingRoutesRoundRobin(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "roundRobin", 5)
 }
-func TestConstantlyUpdatingRoutesPowerOfChoices(t *testing.T) {
-	executeConstantlyUpdatingRoutes(t, "powerOfChoices", 10)
+func TestConstantlyUpdatingRoutesRandomNChoices(t *testing.T) {
+	executeConstantlyUpdatingRoutes(t, "randomNChoices", 10)
 }
 func TestConstantlyUpdatingRoutesRandom(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "random", 10)
@@ -66,8 +66,8 @@ func TestConcurrencyMultipleRoutesRoundRobin(t *testing.T) {
 	executeConcurrencyMultipleRoutes(t, "roundRobin", 5)
 }
 
-func TestConcurrencyMultipleRoutesPowerOfChoices(t *testing.T) {
-	executeConcurrencyMultipleRoutes(t, "powerOfChoices", 10)
+func TestConcurrencyMultipleRoutesRandomNChoices(t *testing.T) {
+	executeConcurrencyMultipleRoutes(t, "randomNChoices", 10)
 }
 
 func TestConcurrencyMultipleRoutesRandom(t *testing.T) {

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -78,7 +78,7 @@ func executeSingleRouteTest(t *testing.T, algorithmName string, distributionTole
 	const (
 		backendCount     = 7
 		concurrency      = 32
-		repeatedRequests = 300
+		repeatedRequests = 400
 
 		// 5% tolerated
 	)
@@ -174,7 +174,7 @@ func executeConstantlyUpdatingRoutes(t *testing.T, algorithmName string, distrib
 	const (
 		backendCount     = 7
 		concurrency      = 32
-		repeatedRequests = 300
+		repeatedRequests = 400
 
 		routeUpdateTimeout   = 5 * time.Millisecond
 		routePollTimeout     = 10 * time.Millisecond
@@ -284,7 +284,7 @@ func executeConcurrencyMultipleRoutes(t *testing.T, algorithmName string, distri
 	const (
 		backendCount     = 7
 		concurrency      = 32
-		repeatedRequests = 300
+		repeatedRequests = 400
 
 		// 5% tolerated
 

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -45,7 +45,7 @@ func TestConcurrencySingleRouteRoundRobin(t *testing.T) {
 }
 
 func TestConcurrencySingleRoutePowerOfChoices(t *testing.T) {
-	executeSingleRouteTest(t, "powerOfChoices", 5)
+	executeSingleRouteTest(t, "powerOfChoices", 7)
 }
 
 func TestConcurrencySingleRouteRandom(t *testing.T) {
@@ -56,7 +56,7 @@ func TestConstantlyUpdatingRoutesRoundRobin(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "roundRobin", 5)
 }
 func TestConstantlyUpdatingRoutesPowerOfChoices(t *testing.T) {
-	executeConstantlyUpdatingRoutes(t, "powerOfChoices", 7)
+	executeConstantlyUpdatingRoutes(t, "powerOfChoices", 9)
 }
 func TestConstantlyUpdatingRoutesRandom(t *testing.T) {
 	executeConstantlyUpdatingRoutes(t, "random", 9)
@@ -67,7 +67,7 @@ func TestConcurrencyMultipleRoutesRoundRobin(t *testing.T) {
 }
 
 func TestConcurrencyMultipleRoutesPowerOfChoices(t *testing.T) {
-	executeConcurrencyMultipleRoutes(t, "powerOfChoices", 7)
+	executeConcurrencyMultipleRoutes(t, "powerOfChoices", 9)
 }
 
 func TestConcurrencyMultipleRoutesRandom(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -872,12 +872,9 @@ func (p *Proxy) makeBackendRequest(ctx *context) (*http.Response, *proxyError) {
 		return nil, &proxyError{err: err}
 	}
 	if ctx.route.BackendType == eskip.LBBackend && ctx.route.LBEndpoints != nil {
-		// TODO: check req.URL vs req.Host
 		endpoint := ctx.route.LBEndpoints.Get(req.URL.Host)
 		endpoint.Metrics.IncInflightRequest()
-		defer func() {
-			endpoint.Metrics.DecInflightRequest()
-		}()
+		defer endpoint.Metrics.DecInflightRequest()
 	}
 	if p.experimentalUpgrade && isUpgradeRequest(req) {
 		if err = p.makeUpgradeRequest(ctx, req); err != nil {

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -185,7 +185,7 @@ type LBEndpointCollection struct {
 // The underlying endpoints can be accessed using public getters and setters.
 // Internally endpoints are stored in two synchronized data structures, so
 // it is possible to reference them by index or key.
-func NewEndpointCollection(r *Route) (error, *LBEndpointCollection) {
+func NewEndpointCollection(r *Route) (*LBEndpointCollection, error) {
 	collection := &LBEndpointCollection{
 		endpoints:    make([]LBEndpoint, 0, len(r.Route.LBEndpoints)),
 		endpointsMap: map[string]LBEndpoint{},
@@ -193,11 +193,11 @@ func NewEndpointCollection(r *Route) (error, *LBEndpointCollection) {
 	for _, e := range r.Route.LBEndpoints {
 		eu, err := url.ParseRequestURI(e)
 		if err != nil {
-			return err, nil
+			return nil, err
 		}
 		collection.Set(eu.Host, LBEndpoint{Scheme: eu.Scheme, Host: eu.Host, Metrics: &LBMetrics{}})
 	}
-	return nil, collection
+	return collection, nil
 }
 
 // Stores an endpoint indexed by key

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -145,7 +145,7 @@ type RouteFilter struct {
 // LBMetrics contains metrics used by LB algorithms
 type LBMetrics struct {
 	inflightRequests int
-	mutex sync.RWMutex
+	mutex            sync.RWMutex
 }
 
 // IncInflightRequest increments the number of outstanding requests from the proxy to a given backend.
@@ -163,7 +163,7 @@ func (m *LBMetrics) DecInflightRequest() {
 }
 
 // GetInflightRequests decrements the number of outstanding requests from the proxy to a given backend.
-func (m *LBMetrics) GetInflightRequests() int{
+func (m *LBMetrics) GetInflightRequests() int {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	return m.inflightRequests
@@ -173,11 +173,11 @@ func (m *LBMetrics) GetInflightRequests() int{
 // backends.
 type LBEndpoint struct {
 	Scheme, Host string
-	Metrics *LBMetrics
+	Metrics      *LBMetrics
 }
 
 type LBEndpointCollection struct {
-	endpoints []LBEndpoint
+	endpoints    []LBEndpoint
 	endpointsMap map[string]LBEndpoint
 }
 
@@ -187,7 +187,7 @@ type LBEndpointCollection struct {
 // it is possible to reference them by index or key.
 func NewEndpointCollection(r *Route) (error, *LBEndpointCollection) {
 	collection := &LBEndpointCollection{
-		endpoints: make([]LBEndpoint, 0, len(r.Route.LBEndpoints)),
+		endpoints:    make([]LBEndpoint, 0, len(r.Route.LBEndpoints)),
 		endpointsMap: map[string]LBEndpoint{},
 	}
 	for _, e := range r.Route.LBEndpoints {
@@ -197,7 +197,7 @@ func NewEndpointCollection(r *Route) (error, *LBEndpointCollection) {
 		}
 		collection.Set(eu.Host, LBEndpoint{Scheme: eu.Scheme, Host: eu.Host, Metrics: &LBMetrics{}})
 	}
-	return  nil, collection
+	return nil, collection
 }
 
 // Stores an endpoint indexed by key
@@ -220,7 +220,6 @@ func (e *LBEndpointCollection) At(index int) LBEndpoint {
 func (e *LBEndpointCollection) Length() int {
 	return len(e.endpoints)
 }
-
 
 // LBAlgorithm implementations apply a load balancing algorithm
 // over the possible endpoints of a load balanced route.
@@ -275,7 +274,6 @@ type Route struct {
 	// LBAlgorithm is the selected load balancing algorithm
 	// of a load balanced route.
 	LBAlgorithm LBAlgorithm
-
 }
 
 // PostProcessor is an interface for custom post-processors applying changes

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -144,29 +144,23 @@ type RouteFilter struct {
 
 // LBMetrics contains metrics used by LB algorithms
 type LBMetrics struct {
-	inflightRequests int
+	inflightRequests int32
 	mutex            sync.RWMutex
 }
 
 // IncInflightRequest increments the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) IncInflightRequest() {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.inflightRequests++
+	atomic.AddInt32(&m.inflightRequests, 1)
 }
 
 // DecInflightRequest decrements the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) DecInflightRequest() {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.inflightRequests--
+	atomic.AddInt32(&m.inflightRequests, -1)
 }
 
 // GetInflightRequests decrements the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) GetInflightRequests() int {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	return m.inflightRequests
+	return int(atomic.LoadInt32(&m.inflightRequests))
 }
 
 // LBEndpoint represents the scheme and the host of load balanced

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -142,27 +142,27 @@ type RouteFilter struct {
 	Index int
 }
 
-// Contains metrics used by LB algorithms
+// LBMetrics contains metrics used by LB algorithms
 type LBMetrics struct {
 	inflightRequests int
 	mutex sync.RWMutex
 }
 
-// Increment the number of outstanding requests from the proxy to a given backend.
+// IncInflightRequest increments the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) IncInflightRequest() {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.inflightRequests++
 }
 
-// Decrement the number of outstanding requests from the proxy to a given backend.
+// DecInflightRequest decrements the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) DecInflightRequest() {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.inflightRequests--
 }
 
-// Decrement the number of outstanding requests from the proxy to a given backend.
+// GetInflightRequests decrements the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) GetInflightRequests() int{
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()


### PR DESCRIPTION
## Description
The PR introduces the power of N choices algorithm for load balancing.

The algorithm works like this: first selects N elements from the list of endpoints attached to the route and then, from those N elements picks the one with least outstanding requests.

The algorithm work improves the load distribution compare to random and round robin when there are multiple load balancer instance that not share state. This is, however, the most common setup for Skipper.

## References 
- https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf
- https://www.haproxy.com/blog/power-of-two-load-balancing/
- https://blog.envoyproxy.io/examining-load-balancing-algorithms-with-envoy-1be643ea121c
- https://netflixtechblog.com/netflix-edge-load-balancing-695308b5548c?gi=eb9e22cdebc4

## Tests 
I think we should refactor them as they are very unstable. Random and P2C algorithms distributes better with a big number of request which we can't reach due to max open files restrictions.

I will leave them broken until we come to a conclusion.