### PR TITLE
Validate compression level in compress filter by comparing integers

### DIFF
--- a/filters/builtin/compress.go
+++ b/filters/builtin/compress.go
@@ -140,13 +140,11 @@ func (c *compress) CreateFilter(args []interface{}) (filters.Filter, error) {
 
 	if lf, ok := args[0].(float64); ok && math.Trunc(lf) == lf {
 		f.level = int(lf)
-		_, err := gzip.NewWriterLevel(nil, f.level)
-		if err != nil {
+		if f.level < gzip.HuffmanOnly || f.level > gzip.BestCompression {
 			return nil, filters.ErrInvalidFilterParameters
 		}
 
-		_, err = flate.NewWriter(nil, f.level)
-		if err != nil {
+		if f.level < flate.HuffmanOnly || f.level > flate.BestCompression {
 			return nil, filters.ErrInvalidFilterParameters
 		}
 


### PR DESCRIPTION
On a cluster with a lot of routes where many of those routes activate the `compress()` filter, skipper uses significantly more CPU on route updates.

We saw an increase of 100% - 400% of CPU usage during route updates, e.g. a Kubernetes worker joining or leaving or a new Deployment resource being created. Sometimes skipper pods also started to OOM.
This issue can be traced down to the check for validity of the compression level in the spec of the `compress()` filter.

This change replaces the creation of writers to check for validity of the compression level with comparing the levels directly without creating a writer for each type of compression.