### PR TITLE
Logging requests to webhook during debug logging

### DIFF
--- a/cmd/webhook/admission/admission.go
+++ b/cmd/webhook/admission/admission.go
@@ -110,6 +110,7 @@ func Handler(admitter Admitter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		admitterName := admitter.Name()
 		totalRequests.WithLabelValues(admitterName).Inc()
+		log.Debug("received req:\n %v", r)
 
 		if r.Method != "POST" || r.Header.Get("Content-Type") != "application/json" {
 			invalidRequests.WithLabelValues(admitterName).Inc()

--- a/cmd/webhook/admission/admission.go
+++ b/cmd/webhook/admission/admission.go
@@ -110,7 +110,7 @@ func Handler(admitter Admitter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		admitterName := admitter.Name()
 		totalRequests.WithLabelValues(admitterName).Inc()
-		log.Debug("received req:\n %v", r)
+		log.Debugf("received req:\n %v", r)
 
 		if r.Method != "POST" || r.Header.Get("Content-Type") != "application/json" {
 			invalidRequests.WithLabelValues(admitterName).Inc()

--- a/cmd/webhook/admission/admission.go
+++ b/cmd/webhook/admission/admission.go
@@ -111,21 +111,20 @@ func Handler(admitter Admitter) http.HandlerFunc {
 		admitterName := admitter.Name()
 		totalRequests.WithLabelValues(admitterName).Inc()
 
-		body, err := ioutil.ReadAll(r.Body)
-		log.Debugln("request received", r.Method, r.URL.Path, r.Header, string(body))
-
 		if r.Method != "POST" || r.Header.Get("Content-Type") != "application/json" {
 			invalidRequests.WithLabelValues(admitterName).Inc()
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
+		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			log.Errorf("Failed to read request: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			invalidRequests.WithLabelValues(admitterName).Inc()
 			return
 		}
+		log.Debugln("request received", r.Method, r.URL.Path, r.Header, string(body))
 
 		review := admissionsv1.AdmissionReview{}
 		err = json.Unmarshal(body, &review)

--- a/cmd/webhook/admission/admission.go
+++ b/cmd/webhook/admission/admission.go
@@ -110,7 +110,9 @@ func Handler(admitter Admitter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		admitterName := admitter.Name()
 		totalRequests.WithLabelValues(admitterName).Inc()
-		log.Debugf("received req:\n %v", r)
+
+		body, err := ioutil.ReadAll(r.Body)
+		log.Debugln("request received", r.Method, r.URL.Path, r.Header, string(body))
 
 		if r.Method != "POST" || r.Header.Get("Content-Type") != "application/json" {
 			invalidRequests.WithLabelValues(admitterName).Inc()
@@ -118,7 +120,6 @@ func Handler(admitter Admitter) http.HandlerFunc {
 			return
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			log.Errorf("Failed to read request: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/cmd/webhook/admission/admission.go
+++ b/cmd/webhook/admission/admission.go
@@ -179,6 +179,10 @@ func Handler(admitter Admitter) http.HandlerFunc {
 
 func writeResponse(writer http.ResponseWriter, response *admissionsv1.AdmissionResponse) {
 	resp, err := json.Marshal(admissionsv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
 		Response: response,
 	})
 	if err != nil {


### PR DESCRIPTION
To help debug ValidatingWebhookConfiguration, logging requests to the
webhook. Note that this will only be requests from the API server since
the webhook is not accessible otherwise.

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>