### PR TITLE
fixed: missing selector on k8s demo

### DIFF
--- a/docs/kubernetes/deploy/demo/deployment.yaml
+++ b/docs/kubernetes/deploy/demo/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: skipper-demo
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      application: skipper-demo
   template:
     metadata:
       labels:


### PR DESCRIPTION
Missing selector on k8s demo (deployment.yaml) causes following error;

`error: error validating "docs/kubernetes/deploy/demo/deployment.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false`

fixed with pull request