### PR TITLE
fixed: missing selector on k8s demo

### DIFF
--- a/docs/kubernetes/deploy/daemonset/daemonset.yaml
+++ b/docs/kubernetes/deploy/daemonset/daemonset.yaml
@@ -22,6 +22,7 @@ spec:
         component: ingress
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: skipper-ingress
       tolerations:
       - key: dedicated
         operator: Exists

--- a/docs/kubernetes/deploy/daemonset/rbac.yaml
+++ b/docs/kubernetes/deploy/daemonset/rbac.yaml
@@ -1,0 +1,94 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: hostnetwork
+spec:
+  hostNetwork: true
+  hostPorts:
+  - max: 10000
+    min: 50
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: RunAsAny
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hostnetwork-psp
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - hostnetwork
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skipper-ingress
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: skipper-ingress
+rules:
+- apiGroups:
+    - extensions
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - list
+- apiGroups: [""]
+  resources:
+    - namespaces
+    - services
+    - endpoints
+    - pods
+  verbs:
+    - get
+    - list
+- apiGroups:
+  - zalando.org
+  resources:
+  - routegroups
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: skipper-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: skipper-ingress
+subjects:
+- kind: ServiceAccount
+  name: skipper-ingress
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: skipper-ingress-hostnetwork-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hostnetwork-psp
+subjects:
+- kind: ServiceAccount
+  name: skipper-ingress
+  namespace: kube-system

--- a/docs/kubernetes/deploy/demo/deployment.yaml
+++ b/docs/kubernetes/deploy/demo/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: skipper-demo
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      application: skipper-demo
   template:
     metadata:
       labels:


### PR DESCRIPTION
Missing selector on k8s demo (deployment.yaml) causes following error;

`error: error validating "docs/kubernetes/deploy/demo/deployment.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false`

fixed.

Signed-off-by: Fatih Boy <fatih@enterprisecoding.com>