### PR TITLE
Pass the logrus JSONFormatter along so options can be changed

### DIFF
--- a/logging/access_test.go
+++ b/logging/access_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	logFilter "github.com/zalando/skipper/filters/log"
 )
 
@@ -195,6 +197,23 @@ func TestPresentAuditJSON(t *testing.T) {
 		entry,
 		`{"audit":"c4ddfe9d-a0d3-4afb-bf26-24b9588731a0","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`,
 		Options{AccessLogJSONEnabled: true},
+	)
+}
+
+func TestPresentAuditJSONWithCustomFormatter(t *testing.T) {
+	entry := testAccessEntry()
+	entry.Request.Header.Set(logFilter.UnverifiedAuditHeader, "c4ddfe9d-a0d3-4afb-bf26-24b9588731a0")
+	jsonFormatter := &logrus.JSONFormatter{
+		DisableTimestamp: true,
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyLevel: "my_level",
+			logrus.FieldKeyMsg:   "my_message",
+		}}
+	testAccessLog(
+		t,
+		entry,
+		`{"audit":"c4ddfe9d-a0d3-4afb-bf26-24b9588731a0","duration":42,"flow-id":"","host":"127.0.0.1","method":"GET","my_level":"info","my_message":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`,
+		Options{AccessLogJSONEnabled: true, AccessLogJsonFormatter: jsonFormatter},
 	)
 }
 

--- a/skipper.go
+++ b/skipper.go
@@ -463,6 +463,11 @@ type Options struct {
 	// from the request URI in the access logs.
 	AccessLogStripQuery bool
 
+	// LogrusJsonFormatter is passed along to to the underlying Logrus logging if JSON logging is enabled.
+	// To enable structured logging, use the ApplicationLogJSONEnabled and AccessLogJSONEnabled settings.
+	// In the case of access logs, the timestamp format will be overwritten and timestamps will be disabled.
+	LogrusJsonFormatter log.JSONFormatter
+
 	DebugListener string
 
 	// Path of certificate(s) when using TLS, mutiple may be given comma separated
@@ -787,6 +792,7 @@ func initLog(o Options) error {
 		AccessLogOutput:           accessLogOutput,
 		AccessLogJSONEnabled:      o.AccessLogJSONEnabled,
 		AccessLogStripQuery:       o.AccessLogStripQuery,
+		LogrusJsonFormatter:       o.LogrusJsonFormatter,
 	})
 
 	return nil

--- a/skipper.go
+++ b/skipper.go
@@ -442,6 +442,10 @@ type Options struct {
 	// Enables logs in JSON format
 	ApplicationLogJSONEnabled bool
 
+	// ApplicationLogJsonFormatter, when set and JSON logging is enabled, is passed along to to the underlying
+	// Logrus logger for application logs. To enable structured logging, use ApplicationLogJSONEnabled.
+	ApplicationLogJsonFormatter *log.JSONFormatter
+
 	// Output file for the access log. Default value: /dev/stderr.
 	//
 	// When /dev/stderr or /dev/stdout is passed in, it will be resolved
@@ -463,10 +467,9 @@ type Options struct {
 	// from the request URI in the access logs.
 	AccessLogStripQuery bool
 
-	// LogrusJsonFormatter is passed along to to the underlying Logrus logging if JSON logging is enabled.
-	// To enable structured logging, use the ApplicationLogJSONEnabled and AccessLogJSONEnabled settings.
-	// In the case of access logs, the timestamp format will be overwritten and timestamps will be disabled.
-	LogrusJsonFormatter log.JSONFormatter
+	// AccessLogJsonFormatter, when set and JSON logging is enabled, is passed along to to the underlying
+	// Logrus logger for access logs. To enable structured logging, use AccessLogJSONEnabled.
+	AccessLogJsonFormatter *log.JSONFormatter
 
 	DebugListener string
 
@@ -786,13 +789,14 @@ func initLog(o Options) error {
 	}
 
 	logging.Init(logging.Options{
-		ApplicationLogPrefix:      o.ApplicationLogPrefix,
-		ApplicationLogOutput:      logOutput,
-		ApplicationLogJSONEnabled: o.ApplicationLogJSONEnabled,
-		AccessLogOutput:           accessLogOutput,
-		AccessLogJSONEnabled:      o.AccessLogJSONEnabled,
-		AccessLogStripQuery:       o.AccessLogStripQuery,
-		LogrusJsonFormatter:       o.LogrusJsonFormatter,
+		ApplicationLogPrefix:        o.ApplicationLogPrefix,
+		ApplicationLogOutput:        logOutput,
+		ApplicationLogJSONEnabled:   o.ApplicationLogJSONEnabled,
+		ApplicationLogJsonFormatter: o.ApplicationLogJsonFormatter,
+		AccessLogOutput:             accessLogOutput,
+		AccessLogJSONEnabled:        o.AccessLogJSONEnabled,
+		AccessLogStripQuery:         o.AccessLogStripQuery,
+		AccessLogJsonFormatter:      o.AccessLogJsonFormatter,
 	})
 
 	return nil


### PR DESCRIPTION
Expose Logrus JSON formatter in `skipper.Options` so the defaults can be overwritten.

Issue: [feature request 1535](https://github.com/zalando/skipper/issues/1535)