### PR TITLE
add plaintext=bool parameter to lightstep tracer

### DIFF
--- a/tracing/tracers/lightstep/lightstep.go
+++ b/tracing/tracers/lightstep/lightstep.go
@@ -24,6 +24,7 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 		port             int
 		host, token      string
 		cmdLine          string
+		plaintext        bool
 		logCmdLine       bool
 		logEvents        bool
 		maxBufferedSpans int
@@ -84,6 +85,12 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 			if err != nil {
 				return lightstep.Options{}, fmt.Errorf("failed to parse %s as int: %v", sport, err)
 			}
+		case "plaintext":
+			var err error
+			plaintext, err = strconv.ParseBool(parts[1])
+			if err != nil {
+				return lightstep.Options{}, fmt.Errorf("failed to parse %s as bool: %v", parts[1], err)
+			}
 		case "cmd-line":
 			cmdLine = parts[1]
 			logCmdLine = true
@@ -130,8 +137,9 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 	return lightstep.Options{
 		AccessToken: token,
 		Collector: lightstep.Endpoint{
-			Host: host,
-			Port: port,
+			Host:      host,
+			Port:      port,
+			Plaintext: plaintext,
 		},
 		UseGRPC:                     true,
 		Tags:                        tags,

--- a/tracing/tracers/lightstep/lightstep_test.go
+++ b/tracing/tracers/lightstep/lightstep_test.go
@@ -190,6 +190,30 @@ func TestParseOptions(t *testing.T) {
 			want:    lightstep.Options{},
 			wantErr: true,
 		},
+		{
+			name: "test with plaintext set",
+			opts: []string{
+				"token=" + token,
+				"collector=collector.example.com:8888",
+				"plaintext=true",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host:      "collector.example.com",
+					Port:      8888,
+					Plaintext: true,
+				},
+				UseGRPC: true,
+				Tags: map[string]interface{}{
+					lightstep.ComponentNameKey: defComponentName,
+				},
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
this can be used to talk to lightstep satellites without TLS (e.g. an in-cluster
service).

Signed-off-by: Hanno Hecker <hanno@zalando.de>