### PR TITLE
log: degrade level to debug in case no lookuper

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1022,7 +1022,7 @@ func (p *Proxy) checkRatelimit(ctx *context) (ratelimit.Settings, int) {
 
 		s := setting.Lookuper.Lookup(ctx.Request())
 		if s == "" {
-			p.log.Errorf("Lookuper found no data in request for setting: %s and request: %v", setting, ctx.Request())
+			p.log.Debugf("Lookuper found no data in request for setting: %s and request: %v", setting, ctx.Request())
 			continue
 		}
 


### PR DESCRIPTION
degrade log level to debug because lookuper is called in the hot path and provide not much value at runtime, because it is likely dependent on user configuration

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>