### PR TITLE
Normalizes URLs for upstream

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dimfeld/httppath"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/zalando/skipper/circuit"
@@ -37,8 +38,6 @@ import (
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/scheduler"
 	"github.com/zalando/skipper/tracing"
-
-	"github.com/dimfeld/httppath"
 )
 
 const (

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1440,12 +1440,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	// Change /foo/../bar to /bar for matching and passing upstream
+	r.URL.Path = httppath.Clean(r.URL.Path)
+
 	if p.flags.patchPath() {
 		r.URL.Path = rfc.PatchPath(r.URL.Path, r.URL.RawPath)
 	}
-
-	// Change /foo/../bar to /bar for matching and passing upstream
-	r.URL.Path = httppath.Clean(r.URL.Path)
 
 	p.tracing.setTag(span, SpanKindTag, SpanKindServer)
 	p.setCommonSpanInfo(r.URL, r, span)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -37,6 +37,8 @@ import (
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/scheduler"
 	"github.com/zalando/skipper/tracing"
+
+	"github.com/dimfeld/httppath"
 )
 
 const (
@@ -1442,6 +1444,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.flags.patchPath() {
 		r.URL.Path = rfc.PatchPath(r.URL.Path, r.URL.RawPath)
 	}
+
+	// Change /foo/../bar to /bar for matching and passing upstream
+	r.URL.Path = httppath.Clean(r.URL.Path)
 
 	p.tracing.setTag(span, SpanKindTag, SpanKindServer)
 	p.setCommonSpanInfo(r.URL, r, span)

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -487,9 +487,8 @@ func matchLeaves(leaves leafMatchers, req *http.Request, path, exactPath string)
 // returns the associated value, and the wildcard parameters from the path definition,
 // if any.
 func (m *matcher) match(r *http.Request) (*Route, map[string]string) {
-	// normalize path before matching
 	// in case ignoring trailing slashes, match without the trailing slash
-	path := httppath.Clean(r.URL.Path)
+	path := r.URL.Path
 	exact := path
 	if m.matchingOptions.ignoreTrailingSlash() {
 		path = trimTrailingSlash(path)


### PR DESCRIPTION
Currently the matching logic normalizes paths, but these transformation are not applied when proxied upstream. So /malicious/../nice will pass because the matcher sees /nice but upstream will see /malicious/../nice instead!