### PR TITLE
Introduce powerofnchoices algorithm in Load Balancer

### DIFF
--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -74,6 +74,7 @@ spec:
                     - roundRobin
                     - random
                     - consistentHash
+                    - powerOfRandomNChoices
                   endpoints:
                     type: array
                     minItems: 1

--- a/dataclients/kubernetes/routegroup-proposal.md
+++ b/dataclients/kubernetes/routegroup-proposal.md
@@ -171,7 +171,7 @@ information required to create the skipper
   name: <string>
   type: <string>            one of "service|shunt|loopback|dynamic|lb|network"
   address: <string>         optional, required for type=network
-  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash
+  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash|powerOfRandomNChoices
   endpoints: <stringarray>  optional, required for type=lb
   serviceName: <string>     optional, required for type=service
   servicePort: <number>     optional, required for type=service

--- a/docs/kubernetes/routegroup-crd.md
+++ b/docs/kubernetes/routegroup-crd.md
@@ -73,7 +73,7 @@ fields are the name and the type, while the rest of the fields may be required b
   name: <string>
   type: <string>            one of "service|shunt|loopback|dynamic|lb|network"
   address: <string>         optional, required for type=network
-  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash
+  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash|powerOfRandomNChoices
   endpoints: <stringarray>  optional, required for type=lb
   serviceName: <string>     optional, required for type=service
   servicePort: <number>     optional, required for type=service

--- a/docs/kubernetes/routegroups.md
+++ b/docs/kubernetes/routegroups.md
@@ -548,7 +548,7 @@ spec:
     filters:
     - status(200)
     backends:
-    - options200
+    - backendName: options200
 ```
 
 ### zalando.org/ratelimit
@@ -559,7 +559,7 @@ The ratelimiting can be defined on the route level among the filters, in the sam
 
 Skipper ingress provides global HTTPS redirect, but it allows individual ingresses to override the global
 settings: enabling/disabling it and changing the default redirect code. With route groups, this override can be
-achieved by simply defining an addtional route, with the same matching rules, and therefore the override can be
+achieved by simply defining an additional route, with the same matching rules, and therefore the override can be
 controlled eventually on a route basis. E.g:
 
 ```yaml
@@ -585,7 +585,7 @@ spec:
     filters:
     - redirectTo(302, "https:")
     backends:
-    - redirectShunt
+    - backendName: redirectShunt
 ```
 
 ### zalando.org/skipper-loadbalancer

--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -258,6 +258,7 @@ Current implemented algorithms:
 - `roundRobin`: backend is chosen by the round robin algorithm, starting with a random selected backend to spread across all backends from the beginning
 - `random`: backend is chosen at random
 - `consistentHash`: backend is chosen by a consistent hashing algorithm with the client X-Forwarded-For header with remote IP as the fallback as input to the hash function
+- `powerOfRandomNChoices`: backend is chosen by powerIfRandomNChoices algorithm with randomly select N backends and choose less active one.
 - __TODO__: https://github.com/zalando/skipper/issues/557
 
 Route example with 2 backends and the `roundRobin` algorithm:
@@ -273,6 +274,11 @@ r0: * -> <random, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 Route example with 2 backends and the `consistentHash` algorithm:
 ```
 r0: * -> <consistentHash, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+```
+
+Route example with 2 backends and the `powerOfRandomNChoices` algorithm:
+```
+r0: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 ```
 
 Proxy with `roundRobin` loadbalancer and two backends:

--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -258,7 +258,7 @@ Current implemented algorithms:
 - `roundRobin`: backend is chosen by the round robin algorithm, starting with a random selected backend to spread across all backends from the beginning
 - `random`: backend is chosen at random
 - `consistentHash`: backend is chosen by a consistent hashing algorithm with the client X-Forwarded-For header with remote IP as the fallback as input to the hash function
-- `powerOfRandomNChoices`: backend is chosen by powerIfRandomNChoices algorithm with randomly select N backends and choose less active one.
+- `powerOfRandomNChoices`: backend is chosen by powerOfRandomNChoices algorithm with randomly select N backends and choose less active one.
 - __TODO__: https://github.com/zalando/skipper/issues/557
 
 Route example with 2 backends and the `roundRobin` algorithm:

--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -258,7 +258,7 @@ Current implemented algorithms:
 - `roundRobin`: backend is chosen by the round robin algorithm, starting with a random selected backend to spread across all backends from the beginning
 - `random`: backend is chosen at random
 - `consistentHash`: backend is chosen by a consistent hashing algorithm with the client X-Forwarded-For header with remote IP as the fallback as input to the hash function
-- `powerOfRandomNChoices`: backend is chosen by powerOfRandomNChoices algorithm with randomly select N backends and choose less active one.
+- `powerOfRandomNChoices`: backend is chosen by powerOfRandomNChoices algorithm with selecting N random endpoints and picking the one with least outstanding requests from them. (http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf)
 - __TODO__: https://github.com/zalando/skipper/issues/557
 
 Route example with 2 backends and the `roundRobin` algorithm:

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -1,4 +1,4 @@
-package algorithm
+package loadbalancer
 
 import (
 	"errors"

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -1,4 +1,4 @@
-package loadbalancer
+package algorithm
 
 import (
 	"errors"

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -35,6 +35,8 @@ const (
 	PowerOfRandomNChoices
 )
 
+const powerOfRandomNChoicesDefaultN = 2
+
 var (
 	algorithms = map[Algorithm]initializeAlgorithm{
 		RoundRobin:            newRoundRobin,
@@ -212,7 +214,7 @@ func newPowerOfRandomNChoices(endpoints []string) routing.LBAlgorithm {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return &powerOfRandomNChoices{
 		rand:            rnd,
-		numberOfChoices: 2,
+		numberOfChoices: powerOfRandomNChoicesDefaultN,
 	}
 }
 

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -244,8 +244,7 @@ func TestApply(t *testing.T) {
 			expected:      1,
 			algorithm:     newConsistentHash(eps),
 			algorithmName: "consistentHash",
-		},
-		{
+		}, {
 			name:          "powerOfRandomNChoices algorithm",
 			iterations:    100,
 			jitter:        0,

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -41,7 +41,8 @@ func TestSelectAlgorithm(t *testing.T) {
 
 		if len(rr[0].LBEndpoints) != 1 ||
 			rr[0].LBEndpoints[0].Scheme != "https" ||
-			rr[0].LBEndpoints[0].Host != "www.example.org" {
+			rr[0].LBEndpoints[0].Host != "www.example.org" ||
+			rr[0].LBEndpoints[0].Metrics == nil {
 			t.Fatal("failed to set the endpoints")
 		}
 
@@ -67,7 +68,8 @@ func TestSelectAlgorithm(t *testing.T) {
 
 		if len(rr[0].LBEndpoints) != 1 ||
 			rr[0].LBEndpoints[0].Scheme != "https" ||
-			rr[0].LBEndpoints[0].Host != "www.example.org" {
+			rr[0].LBEndpoints[0].Host != "www.example.org" ||
+			rr[0].LBEndpoints[0].Metrics == nil {
 			t.Fatal("failed to set the endpoints")
 		}
 
@@ -93,7 +95,8 @@ func TestSelectAlgorithm(t *testing.T) {
 
 		if len(rr[0].LBEndpoints) != 1 ||
 			rr[0].LBEndpoints[0].Scheme != "https" ||
-			rr[0].LBEndpoints[0].Host != "www.example.org" {
+			rr[0].LBEndpoints[0].Host != "www.example.org" ||
+			rr[0].LBEndpoints[0].Metrics == nil {
 			t.Fatal("failed to set the endpoints")
 		}
 
@@ -119,11 +122,39 @@ func TestSelectAlgorithm(t *testing.T) {
 
 		if len(rr[0].LBEndpoints) != 1 ||
 			rr[0].LBEndpoints[0].Scheme != "https" ||
-			rr[0].LBEndpoints[0].Host != "www.example.org" {
+			rr[0].LBEndpoints[0].Host != "www.example.org" ||
+			rr[0].LBEndpoints[0].Metrics == nil {
 			t.Fatal("failed to set the endpoints")
 		}
 
 		if _, ok := rr[0].LBAlgorithm.(*random); !ok {
+			t.Fatal("failed to set the right algorithm")
+		}
+	})
+
+	t.Run("LB route with explicit powerOfRandomNChoices algorithm", func(t *testing.T) {
+		p := NewAlgorithmProvider()
+		r := &routing.Route{
+			Route: eskip.Route{
+				BackendType: eskip.LBBackend,
+				LBAlgorithm: "powerOfRandomNChoices",
+				LBEndpoints: []string{"https://www.example.org"},
+			},
+		}
+
+		rr := p.Do([]*routing.Route{r})
+		if len(rr) != 1 {
+			t.Fatal("failed to process LB route")
+		}
+
+		if len(rr[0].LBEndpoints) != 1 ||
+			rr[0].LBEndpoints[0].Scheme != "https" ||
+			rr[0].LBEndpoints[0].Host != "www.example.org" ||
+			rr[0].LBEndpoints[0].Metrics == nil {
+			t.Fatal("failed to set the endpoints")
+		}
+
+		if _, ok := rr[0].LBAlgorithm.(*powerOfRandomNChoices); !ok {
 			t.Fatal("failed to set the right algorithm")
 		}
 	})
@@ -213,6 +244,14 @@ func TestApply(t *testing.T) {
 			expected:      1,
 			algorithm:     newConsistentHash(eps),
 			algorithmName: "consistentHash",
+		},
+		{
+			name:          "powerOfRandomNChoices algorithm",
+			iterations:    100,
+			jitter:        0,
+			expected:      N,
+			algorithm:     newPowerOfRandomNChoices(eps),
+			algorithmName: "powerOfRandomNChoices",
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -1,4 +1,4 @@
-package loadbalancer_test
+package algorithm_test
 
 import (
 	"fmt"

--- a/loadbalancer/concurrency_test.go
+++ b/loadbalancer/concurrency_test.go
@@ -1,4 +1,4 @@
-package algorithm_test
+package loadbalancer_test
 
 import (
 	"fmt"

--- a/loadbalancer/doc.go
+++ b/loadbalancer/doc.go
@@ -35,6 +35,7 @@ Eskip example:
         r1: * -> <roundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
         r2: * -> <consistentHash, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
         r3: * -> <random, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+		r4: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 
 
 Package loadbalancer also implements health checking of pool members for

--- a/loadbalancer/doc.go
+++ b/loadbalancer/doc.go
@@ -35,7 +35,7 @@ Eskip example:
         r1: * -> <roundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
         r2: * -> <consistentHash, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
         r3: * -> <random, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
-		r4: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+        r4: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 
 
 Package loadbalancer also implements health checking of pool members for

--- a/loadbalancer/doc.go
+++ b/loadbalancer/doc.go
@@ -19,6 +19,12 @@ consistentHash Algorithm
     client IP, which will be looked up from X-Forwarded-For header
     with remote IP as the fallback.
 
+powerOfRandomNChoices Algorithm
+
+	The powerOfRandomNChoices algorithm selects N random endpoints
+	and picks the one with least outstanding requests from them.
+	Currently, N is 2.
+
 The roundRobin and the random algorithms also provide fade-in behavior for LB endpoints of routes where the
 fade-in duration was configured. This feature can be used to gradually add traffic to new instances of
 applications that require a certain amount of warm-up time.

--- a/packaging/helm/skipper-aws/crds/routegroups.yaml
+++ b/packaging/helm/skipper-aws/crds/routegroups.yaml
@@ -68,6 +68,7 @@ spec:
                     - roundRobin
                     - random
                     - consistentHash
+                    - powerOfRandomNChoices
                   endpoints:
                     type: array
                     minLength: 1

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -470,22 +470,24 @@ func setRequestURLForDynamicBackend(u *url.URL, stateBag map[string]interface{})
 	}
 }
 
-func setRequestURLForLoadBalancedBackend(u *url.URL, rt *routing.Route, lbctx *routing.LBContext) {
+func setRequestURLForLoadBalancedBackend(u *url.URL, rt *routing.Route, lbctx *routing.LBContext) *routing.LBEndpoint {
 	e := rt.LBAlgorithm.Apply(lbctx)
 	u.Scheme = e.Scheme
 	u.Host = e.Host
+	return &e
 }
 
 // creates an outgoing http request to be forwarded to the route endpoint
 // based on the augmented incoming request
-func mapRequest(r *http.Request, rt *routing.Route, host string, removeHopHeaders bool, stateBag map[string]interface{}) (*http.Request, error) {
+func mapRequest(r *http.Request, rt *routing.Route, host string, removeHopHeaders bool, stateBag map[string]interface{}) (*http.Request, *routing.LBEndpoint, error) {
+	var endpoint *routing.LBEndpoint
 	u := r.URL
 	switch rt.BackendType {
 	case eskip.DynamicBackend:
 		setRequestURLFromRequest(u, r)
 		setRequestURLForDynamicBackend(u, stateBag)
 	case eskip.LBBackend:
-		setRequestURLForLoadBalancedBackend(u, rt, routing.NewLBContext(r, rt))
+		endpoint = setRequestURLForLoadBalancedBackend(u, rt, routing.NewLBContext(r, rt))
 	default:
 		u.Scheme = rt.Scheme
 		u.Host = rt.Host
@@ -498,7 +500,7 @@ func mapRequest(r *http.Request, rt *routing.Route, host string, removeHopHeader
 
 	rr, err := http.NewRequest(r.Method, u.String(), body)
 	if err != nil {
-		return nil, err
+		return nil, endpoint, err
 	}
 
 	rr = rr.WithContext(r.Context())
@@ -527,7 +529,7 @@ func mapRequest(r *http.Request, rt *routing.Route, host string, removeHopHeader
 		rr = rr.WithContext(ot.ContextWithSpan(rr.Context(), ctxspan))
 	}
 
-	return rr, nil
+	return rr, endpoint, nil
 }
 
 func forwardToProxy(incoming, outgoing *http.Request) {
@@ -866,10 +868,15 @@ func (p *Proxy) makeUpgradeRequest(ctx *context, req *http.Request) error {
 
 func (p *Proxy) makeBackendRequest(ctx *context) (*http.Response, *proxyError) {
 	var err error
-	req, err := mapRequest(ctx.request, ctx.route, ctx.outgoingHost, p.flags.HopHeadersRemoval(), ctx.StateBag())
+	req, endpoint, err := mapRequest(ctx.request, ctx.route, ctx.outgoingHost, p.flags.HopHeadersRemoval(), ctx.StateBag())
 	if err != nil {
 		p.log.Errorf("could not map backend request, caused by: %v", err)
 		return nil, &proxyError{err: err}
+	}
+
+	if endpoint != nil {
+		endpoint.Metrics.IncInflightRequest()
+		defer endpoint.Metrics.DecInflightRequest()
 	}
 
 	if p.experimentalUpgrade && isUpgradeRequest(req) {
@@ -1125,7 +1132,7 @@ func (p *Proxy) do(ctx *context) error {
 		ctx.setResponse(loopCTX.response, p.flags.PreserveOriginal())
 		ctx.proxySpan = loopCTX.proxySpan
 	} else if p.flags.Debug() {
-		debugReq, err := mapRequest(ctx.request, ctx.route, ctx.outgoingHost, p.flags.HopHeadersRemoval(), ctx.StateBag())
+		debugReq, _, err := mapRequest(ctx.request, ctx.route, ctx.outgoingHost, p.flags.HopHeadersRemoval(), ctx.StateBag())
 		if err != nil {
 			return &proxyError{err: err}
 		}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -140,10 +140,31 @@ type RouteFilter struct {
 	Index int
 }
 
+// LBMetrics contains metrics used by LB algorithms
+type LBMetrics struct {
+	inflightRequests int64
+}
+
+// IncInflightRequest increments the number of outstanding requests from the proxy to a given backend.
+func (m *LBMetrics) IncInflightRequest() {
+	atomic.AddInt64(&m.inflightRequests, 1)
+}
+
+// DecInflightRequest decrements the number of outstanding requests from the proxy to a given backend.
+func (m *LBMetrics) DecInflightRequest() {
+	atomic.AddInt64(&m.inflightRequests, -1)
+}
+
+// GetInflightRequests decrements the number of outstanding requests from the proxy to a given backend.
+func (m *LBMetrics) GetInflightRequests() int {
+	return int(atomic.LoadInt64(&m.inflightRequests))
+}
+
 // LBEndpoint represents the scheme and the host of load balanced
 // backends.
 type LBEndpoint struct {
 	Scheme, Host string
+	Metrics      *LBMetrics
 
 	// Detected represents the time when skipper instances first detected a new LB endpoint. This detection
 	// time is used for the fade-in feature of the round-robin and random LB algorithms.


### PR DESCRIPTION
This pull request is rewritten version of https://github.com/zalando/skipper/pull/1507. 

I tested in locally;

- Run 5 simple Go HTTP Servers(same code, different ports and random sleeps 0-2000 milliseconds)
- Skipper eskip configuration, `hello: * -> <powerOfRandomNChoices, "http://localhost:8001", "http://localhost:8002", "http://localhost:8003", "http://localhost:8004", "http://localhost:8005">;`
- Python script sending 2000 request with asyncio.

it distributes traffic better than round robin. However, this is just a first phase trial, it is better to test algorithm in real time traffic or suggested any other method does not come to my mind.