### PR TITLE
Refactors per-route ratelimit handling

### DIFF
--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -14,7 +14,6 @@ import (
 	"github.com/zalando/skipper/filters/fadein"
 	"github.com/zalando/skipper/filters/flowid"
 	logfilter "github.com/zalando/skipper/filters/log"
-	"github.com/zalando/skipper/filters/ratelimit"
 	"github.com/zalando/skipper/filters/rfc"
 	"github.com/zalando/skipper/filters/scheduler"
 	"github.com/zalando/skipper/filters/sed"
@@ -151,12 +150,6 @@ func MakeRegistry() filters.Registry {
 		circuit.NewConsecutiveBreaker(),
 		circuit.NewRateBreaker(),
 		circuit.NewDisableBreaker(),
-		ratelimit.NewClientRatelimit(),
-		ratelimit.NewLocalRatelimit(),
-		ratelimit.NewRatelimit(),
-		ratelimit.NewClusterRateLimit(),
-		ratelimit.NewClusterClientRateLimit(),
-		ratelimit.NewDisableRatelimit(),
 		script.NewLuaScript(),
 		cors.NewOrigin(),
 		logfilter.NewUnverifiedAuditLog(),

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -420,5 +421,13 @@ func newRatelimit(s Settings, sw Swarmer, redisRing *ring) *Ratelimit {
 	return &Ratelimit{
 		settings: s,
 		impl:     impl,
+	}
+}
+
+func Headers(s *Settings, retryAfter int) http.Header {
+	limitPerHour := int64(s.MaxHits) * int64(time.Hour) / int64(s.TimeWindow)
+	return http.Header{
+		Header:           []string{strconv.FormatInt(limitPerHour, 10)},
+		RetryAfterHeader: []string{strconv.Itoa(retryAfter)},
 	}
 }


### PR DESCRIPTION
At present per-route ratelimit filters do not perform actual ratelimiting but rather
store a configuration marker in request context. Ratelimits are
considered by proxy after request path of filter chain is executed but
before backend request.

For example in `clientRatelimit(3, "1m") -> oauthTokeninfoAnyScope("s1")` route
`oauthTokeninfoAnyScope` filter will request tokeninfo even if ratelimit is reached.

This change:

* refactors ratelimit filters to actually consult ratelimits and
shunt request path of filter chain with `429 Too Many Requests` if limit
is reached
* removes per-route ratelimit handling from proxy

Part of #1238

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>