### PR TITLE
Implements filter resources cleanup support

### DIFF
--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -97,7 +97,7 @@ index 10d5769..da46fe0 100644
 
 Documentation for users should be done in `docs/`.
 
-```
+````
 diff --git a/docs/filters.md b/docs/filters.md
 index d3bb872..a877062 100644
 --- a/docs/filters.md
@@ -127,7 +127,7 @@ index d3bb872..a877062 100644
  ## oauthTokeninfoAnyScope
 
  If skipper is started with `-oauth2-tokeninfo-url` flag, you can use
-```
+````
 
 ### Add godoc
 
@@ -170,8 +170,8 @@ process. A spec has to satisfy the `Spec` interface `Name() string` and
 
 The actual filter implementation has to satisfy the `Filter`
 interface `Request(filters.FilterContext)` and `Response(filters.FilterContext)`.
-If you need to clean up for example a goroutine you can do it in
-`Close()`, which will be called on filter shutdown.
+If you need to clean up for example a goroutine then filter should implement
+`Close() error` method of `io.Closer` which will be called on filter shutdown.
 
 ```
 diff --git a/filters/auth/webhook.go b/filters/auth/webhook.go
@@ -256,13 +256,14 @@ index 0000000..f0632a6
 +func (*webhookFilter) Response(filters.FilterContext) {}
 +
 +// Close cleans-up the quit channel used for this filter
-+func (f *webhookFilter) Close() {
++func (f *webhookFilter) Close() error {
 +	f.authClient.mu.Lock()
 +	if f.authClient.quit != nil {
 +		close(f.authClient.quit)
 +		f.authClient.quit = nil
 +	}
 +	f.authClient.mu.Unlock()
++	return nil
 +}
 ```
 

--- a/docs/tutorials/development.md
+++ b/docs/tutorials/development.md
@@ -37,8 +37,8 @@ process. A spec has to satisfy the `filters.Spec` interface `Name() string` and
 
 The actual filter implementation has to satisfy the `filter.Filter`
 interface `Request(filters.FilterContext)` and `Response(filters.FilterContext)`.
-If you need to clean up for example a goroutine you can do it in
-`Close()`, which will be called on filter shutdown.
+If you need to clean up for example a goroutine then filter should implement
+`Close() error` method of `io.Closer` which will be called on filter shutdown.
 
 The simplest filter possible is, if `filters.Spec` and
 `filters.Filter` are the same type:

--- a/filters/auth/forwardtoken_test.go
+++ b/filters/auth/forwardtoken_test.go
@@ -132,13 +132,12 @@ func TestForwardTokenInfo(t *testing.T) {
 			if ti.oauthFilterPresent {
 				oauthTokenSpec := NewOAuthTokeninfoAnyScope(authServer.URL, oauthTimeout)
 				oauthFilterArgs := []interface{}{uidScope}
-				oauthFilter, err := oauthTokenSpec.CreateFilter(oauthFilterArgs)
+				_, err := oauthTokenSpec.CreateFilter(oauthFilterArgs)
 				if err != nil {
 					t.Errorf("error creating oauth filter.")
 					return
 				}
-				f1 := oauthFilter.(*tokeninfoFilter)
-				defer f1.Close()
+
 				routeFilters = append(routeFilters, &eskip.Filter{Name: oauthTokenSpec.Name(), Args: oauthFilterArgs})
 				fr.Register(oauthTokenSpec)
 			}
@@ -251,13 +250,12 @@ func TestForwardTokenIntrospection(t *testing.T) {
 			if ti.oauthFilterPresent {
 				oauthTokenSpec := NewOAuthTokenintrospectionAllClaims(oauthTimeout)
 				oauthFilterArgs := []interface{}{"http://" + issuerServer.Listener.Addr().String(), emailClaim}
-				oauthFilter, err := oauthTokenSpec.CreateFilter(oauthFilterArgs)
+				_, err := oauthTokenSpec.CreateFilter(oauthFilterArgs)
 				if err != nil {
 					t.Errorf("error creating oauth filter. %v", err)
 					return
 				}
-				f1 := oauthFilter.(*tokenintrospectFilter)
-				defer f1.Close()
+
 				routeFilters = append(routeFilters, &eskip.Filter{Name: oauthTokenSpec.Name(), Args: oauthFilterArgs})
 				fr.Register(oauthTokenSpec)
 			}

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -810,11 +810,6 @@ func (f *tokenOidcFilter) getTokenWithExchange(state *OauthState, ctx filters.Fi
 	return oauth2Token, err
 }
 
-func (f *tokenOidcFilter) Close() error {
-	f.encrypter.Close()
-	return nil
-}
-
 func newDeflatePoolCompressor(level int) *deflatePoolCompressor {
 	return &deflatePoolCompressor{
 		poolWriter: &sync.Pool{

--- a/filters/auth/oidc_introspection_test.go
+++ b/filters/auth/oidc_introspection_test.go
@@ -266,8 +266,6 @@ func TestOIDCQueryClaimsFilter(t *testing.T) {
 			} else if err != nil {
 				t.Fatalf("Unexpected error while creating filter: %v", err)
 			}
-			fOIDC := f.(*tokenOidcFilter)
-			defer fOIDC.Close()
 
 			// adding the OIDCQueryClaimsFilter to the route
 			querySpec := NewOIDCQueryClaimsFilter()

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -748,8 +748,6 @@ func TestOIDCSetup(t *testing.T) {
 			} else if err != nil {
 				t.Fatalf("Unexpected error while creating filter: %v", err)
 			}
-			fOIDC := f.(*tokenOidcFilter)
-			defer fOIDC.Close()
 
 			r := &eskip.Route{
 				Filters: []*eskip.Filter{{

--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -357,8 +357,3 @@ func (f *tokeninfoFilter) Request(ctx filters.FilterContext) {
 }
 
 func (f *tokeninfoFilter) Response(filters.FilterContext) {}
-
-// Close cleans-up the authClient
-func (f *tokeninfoFilter) Close() {
-	f.authClient.Close()
-}

--- a/filters/auth/tokeninfo_test.go
+++ b/filters/auth/tokeninfo_test.go
@@ -223,13 +223,11 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 			}
 
 			args = append(args, ti.args...)
-			f, err := spec.CreateFilter(args)
+			_, err := spec.CreateFilter(args)
 			if err != nil {
 				t.Logf("error in creating filter")
 				return
 			}
-			f2 := f.(*tokeninfoFilter)
-			defer f2.Close()
 
 			fr := make(filters.Registry)
 			fr.Register(spec)
@@ -324,13 +322,11 @@ func TestOAuth2TokenTimeout(t *testing.T) {
 			spec := NewOAuthTokeninfoAnyScope(u, ti.timeout)
 
 			scopes := []interface{}{"read-x"}
-			f, err := spec.CreateFilter(scopes)
+			_, err := spec.CreateFilter(scopes)
 			if err != nil {
 				t.Error(err)
 				return
 			}
-			f2 := f.(*tokeninfoFilter)
-			defer f2.Close()
 
 			fr := make(filters.Registry)
 			fr.Register(spec)
@@ -370,21 +366,14 @@ func TestOAuth2TokenTimeout(t *testing.T) {
 }
 
 func BenchmarkOAuthTokeninfoFilter(b *testing.B) {
-	allF := make([]*tokeninfoFilter, 0)
 	for i := 0; i < b.N; i++ {
 		var spec filters.Spec
 		args := []interface{}{"uid"}
 		spec = NewOAuthTokeninfoAnyScope("https://127.0.0.1:12345/token", 3*time.Second)
-		f, err := spec.CreateFilter(args)
+		_, err := spec.CreateFilter(args)
 		if err != nil {
 			b.Logf("error in creating filter")
 			break
 		}
-		f2 := f.(*tokeninfoFilter)
-		allF = append(allF, f2)
-	}
-
-	for i := range allF {
-		allF[i].Close()
 	}
 }

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -474,8 +474,3 @@ func (f *tokenintrospectFilter) Request(ctx filters.FilterContext) {
 }
 
 func (f *tokenintrospectFilter) Response(filters.FilterContext) {}
-
-// Close cleans-up the authClient
-func (f *tokenintrospectFilter) Close() {
-	f.authClient.Close()
-}

--- a/filters/auth/tokenintrospection_test.go
+++ b/filters/auth/tokenintrospection_test.go
@@ -556,7 +556,7 @@ func TestOAuth2Tokenintrospection(t *testing.T) {
 
 			args := []interface{}{testOidcConfig.Issuer}
 			args = append(args, ti.args...)
-			f, err := spec.CreateFilter(args)
+			_, err := spec.CreateFilter(args)
 			if err != nil {
 				if ti.expected == invalidFilterExpected {
 					return
@@ -564,9 +564,6 @@ func TestOAuth2Tokenintrospection(t *testing.T) {
 				t.Errorf("error in creating filter for %s: %v", ti.msg, err)
 				return
 			}
-
-			f2 := f.(*tokenintrospectFilter)
-			defer f2.Close()
 
 			fr := make(filters.Registry)
 			fr.Register(spec)

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -127,6 +127,7 @@ func (f *webhookFilter) Request(ctx filters.FilterContext) {
 func (*webhookFilter) Response(filters.FilterContext) {}
 
 // Close cleans-up the authClient
-func (f *webhookFilter) Close() {
+func (f *webhookFilter) Close() error {
 	f.authClient.Close()
+	return nil
 }

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -138,7 +138,6 @@ func newContext(
 		outgoingHost:   r.Host,
 		metrics:        &filterMetrics{impl: p.metrics},
 		proxy:          p,
-		routeLookup:    p.routing.Get(),
 	}
 
 	if p.flags.PreserveOriginal() {

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -74,6 +74,7 @@ type matcher struct {
 	paths           *pathmux.Tree
 	rootLeaves      leafMatchers
 	matchingOptions MatchingOptions
+	routes          []*Route
 }
 
 // An error created if a route definition cannot be processed.
@@ -353,7 +354,7 @@ func newMatcher(rs []*Route, o MatchingOptions) (*matcher, []*definitionError) {
 	// sort root leaves during construction time, based on their priority
 	sort.Stable(rootLeaves)
 
-	return &matcher{pathTree, rootLeaves, o}, errors
+	return &matcher{pathTree, rootLeaves, o, rs}, errors
 }
 
 // matches a path in the path trie structure.

--- a/routing/routing_internal_test.go
+++ b/routing/routing_internal_test.go
@@ -1,6 +1,10 @@
 package routing
 
 import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -72,6 +76,86 @@ func TestSlice(t *testing.T) {
 			if !cmp.Equal(res, ti.expect) {
 				t.Fatalf("Failed test case '%s', got %v and expected %v", ti.message, res, ti.expect)
 			}
+		})
+	}
+}
+
+const (
+	start = 300
+	end   = 700
+	step  = 50
+)
+
+var goprocs = runtime.GOMAXPROCS(0)
+
+type routingAV struct {
+	routeTable atomic.Value // of struct routeTable
+}
+
+// Note: load and users increment are not in the critical section
+func BenchmarkRoutingGetAtomicValue(b *testing.B) {
+	r := &routingAV{}
+	rt := &routeTable{}
+
+	r.routeTable.Store(rt)
+
+	for i := start; i < end; i += step {
+		b.Run(fmt.Sprintf("goroutines-%d", i*goprocs), func(b *testing.B) {
+			b.SetParallelism(i)
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rt := r.routeTable.Load().(*routeTable)
+					rt.users.Add(1)
+				}
+			})
+		})
+	}
+}
+
+type routingMX struct {
+	mx         sync.Mutex
+	routeTable *routeTable
+}
+
+func BenchmarkRoutingGetMutex(b *testing.B) {
+	r := &routingMX{}
+	r.routeTable = &routeTable{}
+
+	for i := start; i < end; i += step {
+		b.Run(fmt.Sprintf("goroutines-%d", i*goprocs), func(b *testing.B) {
+			b.SetParallelism(i)
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r.mx.Lock()
+					rt := r.routeTable
+					rt.users.Add(1)
+					r.mx.Unlock()
+				}
+			})
+		})
+	}
+}
+
+type routingRWMX struct {
+	mx         sync.RWMutex
+	routeTable *routeTable
+}
+
+func BenchmarkRoutingGetRWMutex(b *testing.B) {
+	r := &routingRWMX{}
+	r.routeTable = &routeTable{}
+
+	for i := start; i < end; i += step {
+		b.Run(fmt.Sprintf("goroutines-%d", i*goprocs), func(b *testing.B) {
+			b.SetParallelism(i)
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r.mx.RLock()
+					rt := r.routeTable
+					rt.users.Add(1)
+					r.mx.RUnlock()
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
Extends routing to track requests that use actual route table.
After route table update it waits for completion of requests that use old route table
and calls `Close` method for each filter from old route table that implements `io.Closer`.

Updates development documentation and removes outdated `Close` methods -
Tokeninfo, tokenOidc and tokenintrospection filters reuse shared
authclient and encrypter and thus do not need to implement cleanup.

Fixes #202