### PR TITLE
Fixes `watch_test` race conditions

### DIFF
--- a/logging/loggingtest/logger.go
+++ b/logging/loggingtest/logger.go
@@ -123,10 +123,7 @@ func New() *Logger {
 				lw.count(req)
 			case c := <-clear:
 				lw.clear()
-				select {
-				case c <- struct{}{}:
-				default:
-				}
+				c <- struct{}{}
 			case m := <-mute:
 				muted = m
 			case <-quit:


### PR DESCRIPTION
* Ensures `loggingtest.Logger` always writes to clear return channel (otherwise `Reset` will wait forever)
* Fixes race condition in `createFileWith` between `Create` (truncate) and `WriteString`
* Uses `Fatal` to fail fast

Reproduced/verified with:
```
while true; do go test -race -test.short -count=10 -timeout=10s github.com/zalando/skipper/eskipfile; done
```

Fixes #612

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>