### PR TITLE
Logs X-Forwarded-For header without modification in access log

### DIFF
--- a/logging/access.go
+++ b/logging/access.go
@@ -63,20 +63,14 @@ func stripPort(address string) string {
 	return address
 }
 
-// The remote address of the client. When the 'X-Forwarded-For'
-// header is set, then it is used instead.
-func remoteAddr(r *http.Request) string {
+// The remote host of the client. When the 'X-Forwarded-For'
+// header is set, then its value is used as is.
+func remoteHost(r *http.Request) string {
 	ff := r.Header.Get("X-Forwarded-For")
 	if ff != "" {
 		return ff
 	}
-
-	return r.RemoteAddr
-}
-
-func remoteHost(r *http.Request) string {
-	a := remoteAddr(r)
-	return stripPort(a)
+	return stripPort(r.RemoteAddr)
 }
 
 func omitWhitespace(h string) string {

--- a/logging/access_test.go
+++ b/logging/access_test.go
@@ -97,6 +97,26 @@ func TestUseXForwarded(t *testing.T) {
 	)
 }
 
+func TestUseXForwardedList(t *testing.T) {
+	entry := testAccessEntry()
+	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3, 192.168.4.4")
+	testAccessLogDefault(
+		t,
+		entry,
+		`192.168.3.3, 192.168.4.4 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`,
+	)
+}
+
+func TestUseXForwardedListLiteral(t *testing.T) {
+	entry := testAccessEntry()
+	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:80, 192.168.4.4")
+	testAccessLogDefault(
+		t,
+		entry,
+		`192.168.3.3:80, 192.168.4.4 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`,
+	)
+}
+
 func TestUseXForwardedJSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3")
@@ -108,22 +128,22 @@ func TestUseXForwardedJSON(t *testing.T) {
 	)
 }
 
-func TestStripPortFwd4(t *testing.T) {
+func TestPortFwd4(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:6969")
 	testAccessLogDefault(
 		t,
 		entry,
-		`192.168.3.3 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`,
+		`192.168.3.3:6969 - - [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`,
 	)
 }
 
-func TestStripPortFwd4JSON(t *testing.T) {
+func TestPortFwd4JSON(t *testing.T) {
 	entry := testAccessEntry()
 	entry.Request.Header.Set("X-Forwarded-For", "192.168.3.3:6969")
 	testAccessLog(
 		t, entry,
-		`{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`,
+		`{"audit":"","duration":42,"flow-id":"","host":"192.168.3.3:6969","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`,
 		Options{AccessLogJSONEnabled: true},
 	)
 }


### PR DESCRIPTION
`X-Forwarded-For` may contain a comma-separated list of IP addresses
without ports. Stripping port will truncate list if one address contains port, e.g.:
```
X-Forwarded-For: 8.8.8.8:80, 4.4.4.4
```
will be logged as
```
8.8.8.8 - - [19/Oct/2020:21:27:02 +0200] "GET / HTTP/1.1" 404 10 "-" "curl/7.58.0" 0 localhost:9090 - -
```

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>