### PR TITLE
Adds Content-Length header for error response

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -835,7 +835,15 @@ func (p *Proxy) lookupRoute(ctx *context) (rt *routing.Route, params map[string]
 // send a premature error response
 func (p *Proxy) sendError(c *context, id string, code int) {
 	addBranding(c.responseWriter.Header())
-	http.Error(c.responseWriter, http.StatusText(code), code)
+
+	text := http.StatusText(code) + "\n"
+
+	c.responseWriter.Header().Set("Content-Length", strconv.Itoa(len(text)))
+	c.responseWriter.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	c.responseWriter.Header().Set("X-Content-Type-Options", "nosniff")
+	c.responseWriter.WriteHeader(code)
+	c.responseWriter.Write([]byte(text))
+
 	p.metrics.MeasureServe(
 		id,
 		c.metricsHost(),

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1320,6 +1320,14 @@ func TestBackendServiceUnavailable(t *testing.T) {
 	if rsp.StatusCode != http.StatusBadGateway {
 		t.Error("failed to return 502 Bad Gateway on failing backend connection")
 	}
+
+	if rsp.Header.Get("Content-Length") != "12" { // len("Bad Gateway\n")
+		t.Errorf("expected content length of 12, got %s", rsp.Header.Get("Content-Length"))
+	}
+
+	if rsp.Header.Get("Transfer-Encoding") != "" {
+		t.Error("unexpected transfer encoding")
+	}
 }
 
 func TestRoundtripperRetry(t *testing.T) {


### PR DESCRIPTION
`Content-Length` header disables `Transfer-Encoding: chunked` and allows
client to fail earlier in case ServeHTTP hangs for some reason.

Consider malformed server that hangs:
```go
package main

import (
	"fmt"
	"log"
	"net/http"
	"time"
)

func main() {
	http.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {

		code := http.StatusBadGateway
		text := http.StatusText(code)

		if r.URL.Query().Get("cl") != "" {
			w.Header().Set("Content-Length", fmt.Sprintf("%d", 1+len(text)))
		}
		http.Error(w, text, code)

		f := w.(http.Flusher)
		f.Flush()

		time.Sleep(10 * time.Hour)
	})

	fmt.Printf("Starting server at port 8080\n")
	if err := http.ListenAndServe(":8080", nil); err != nil {
		log.Fatal(err)
	}
}
```
and
```
$ go run error.go 
Starting server at port 8080
```
so
```
$ curl -v "localhost:8080/error"
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /error HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 502 Bad Gateway
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Thu, 22 Oct 2020 14:10:17 GMT
< Transfer-Encoding: chunked
< 
Bad Gateway

```
hangs, and
```
$ curl -v "localhost:8080/error?cl=1"
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /error?cl=1 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 502 Bad Gateway
< Content-Length: 12
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Thu, 22 Oct 2020 14:10:47 GMT
< 
Bad Gateway
* Connection #0 to host localhost left intact
```
does not.
