### PR TITLE
fix upgrade connections create panic logs on connection tear down

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -29,6 +29,7 @@ type context struct {
 	route                *routing.Route
 	deprecatedServed     bool
 	servedWithResponse   bool // to support the deprecated way independently
+	successfulUpgrade   bool
 	pathParams           map[string]string
 	stateBag             map[string]interface{}
 	originalRequest      *http.Request

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -29,7 +29,7 @@ type context struct {
 	route                *routing.Route
 	deprecatedServed     bool
 	servedWithResponse   bool // to support the deprecated way independently
-	successfulUpgrade   bool
+	successfulUpgrade    bool
 	pathParams           map[string]string
 	stateBag             map[string]interface{}
 	originalRequest      *http.Request

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -870,6 +870,7 @@ func (p *Proxy) makeUpgradeRequest(ctx *context, req *http.Request) error {
 	}
 
 	upgradeProxy.serveHTTP(ctx.responseWriter, req)
+	ctx.stateBag["upgraded-connection"] = true
 	p.log.Debugf("finished upgraded protocol %s session", getUpgradeRequest(ctx.request))
 	return nil
 }
@@ -1448,7 +1449,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			logging.LogAccess(entry, additionalData)
 		}
 		// This flush is required in I/O error
-		lw.Flush()
+		if _, ok := ctx.stateBag["upgraded-connection"]; !ok {
+			lw.Flush()
+		}
 	}()
 
 	// Change /foo/../bar to /bar for matching and passing upstream

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -870,7 +870,7 @@ func (p *Proxy) makeUpgradeRequest(ctx *context, req *http.Request) error {
 	}
 
 	upgradeProxy.serveHTTP(ctx.responseWriter, req)
-	ctx.stateBag["upgraded-connection"] = true
+	ctx.successfulUpgrade = true
 	p.log.Debugf("finished upgraded protocol %s session", getUpgradeRequest(ctx.request))
 	return nil
 }
@@ -1449,7 +1449,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			logging.LogAccess(entry, additionalData)
 		}
 		// This flush is required in I/O error
-		if _, ok := ctx.stateBag["upgraded-connection"]; !ok {
+		if ctx.successfulUpgrade {
 			lw.Flush()
 		}
 	}()


### PR DESCRIPTION
fix https://github.com/zalando/skipper/issues/1564
hijacked connections panic if we flush on so mark via statebag that we are upgraded and if not we flush

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>