### PR TITLE
Improves randomContent filter performance

### DIFF
--- a/filters/diag/diag_test.go
+++ b/filters/diag/diag_test.go
@@ -194,10 +194,9 @@ func TestRandom(t *testing.T) {
 				return
 			}
 
-			randBytes := []byte(randomChars)
 			for _, bi := range b {
 				found := false
-				for _, rbi := range randBytes {
+				for _, rbi := range randomChars {
 					if rbi == bi {
 						found = true
 						break


### PR DESCRIPTION
* Uses `Context.Serve` and `io.LimitReader` to use constant memory regardless of generated length
* Uses local `rand.Rand` to avoid global rand contention and locking per character generated

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>