### PR TITLE
Pass custom support handlers

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -329,6 +329,10 @@ type Options struct {
 	// which accepts original skipper http.RoundTripper as an argument and returns a wrapped roundtripper
 	CustomHttpRoundTripperWrap func(http.RoundTripper) http.RoundTripper
 
+	// CustomSupportHttpHandlers allows adding custom HTTP handlers to listen on SupportListener address.
+	// It is ignored if SupportListener == false.
+	CustomSupportHttpHandlers map[string]http.Handler
+
 	// WaitFirstRouteLoad prevents starting the listener before the first batch
 	// of routes were applied.
 	WaitFirstRouteLoad bool
@@ -1329,6 +1333,10 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		mux.Handle("/metrics/", metricsHandler)
 		mux.Handle("/debug/pprof", metricsHandler)
 		mux.Handle("/debug/pprof/", metricsHandler)
+
+		for pattern, handler := range o.CustomSupportHttpHandlers {
+			mux.Handle(pattern, handler)
+		}
 
 		log.Infof("support listener on %s", supportListener)
 		go func() {

--- a/skipper.go
+++ b/skipper.go
@@ -1337,7 +1337,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			}
 		}()
 	} else {
-		log.Infoln("Metrics are disabled")
+		log.Infoln("Support listener is disabled")
 	}
 
 	proxyParams.OpenTracing = &proxy.OpenTracingParams{


### PR DESCRIPTION
Enables passing a map of HTTP handlers to be added to a support listener.

_Disclaimer: this is a draft PR to show the idea, it's not yet complete in any sense_
[Related issue](https://github.com/zalando/skipper/issues/1573)