### PR TITLE
Implements cluster leaky bucket rate limit filter

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -268,6 +268,7 @@ const (
 	RatelimitName                              = "ratelimit"
 	ClusterClientRatelimitName                 = "clusterClientRatelimit"
 	ClusterRatelimitName                       = "clusterRatelimit"
+	ClusterLeakyBucketRatelimitName            = "clusterLeakyBucketRatelimit"
 	BackendRateLimitName                       = "backendRatelimit"
 	LuaName                                    = "lua"
 	CorsOriginName                             = "corsOrigin"

--- a/filters/ratelimit/leakybucket.go
+++ b/filters/ratelimit/leakybucket.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -48,7 +49,7 @@ func (s *leakyBucketSpec) CreateFilter(args []interface{}) (filters.Filter, erro
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
-	leakVolume, err := getIntArg(args[1])
+	leakVolume, err := natural(args[1])
 	if err != nil {
 		return nil, err
 	}
@@ -57,13 +58,16 @@ func (s *leakyBucketSpec) CreateFilter(args []interface{}) (filters.Filter, erro
 	if err != nil {
 		return nil, err
 	}
+	if leakPeriod <= 0 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
 
-	capacity, err := getIntArg(args[3])
+	capacity, err := natural(args[3])
 	if err != nil {
 		return nil, err
 	}
 
-	increment, err := getIntArg(args[4])
+	increment, err := natural(args[4])
 	if err != nil {
 		return nil, err
 	}
@@ -95,3 +99,11 @@ func (f *leakyBucketFilter) Request(ctx filters.FilterContext) {
 }
 
 func (*leakyBucketFilter) Response(filters.FilterContext) {}
+
+func natural(arg interface{}) (n int, err error) {
+	n, err = getIntArg(arg)
+	if err == nil && n <= 0 {
+		err = fmt.Errorf(`number %d must be positive`, n)
+	}
+	return
+}

--- a/filters/ratelimit/leakybucket.go
+++ b/filters/ratelimit/leakybucket.go
@@ -1,0 +1,113 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/ratelimit"
+)
+
+type leakyBucket interface {
+	Add(ctx context.Context, label string, increment int) (added bool, retry time.Duration, err error)
+}
+
+type leakyBucketSpec struct {
+	create func(capacity int, emission time.Duration) leakyBucket
+}
+
+type leakyBucketFilter struct {
+	label     *eskip.Template
+	bucket    leakyBucket
+	increment int
+}
+
+func NewLeakyBucket(registry *ratelimit.Registry) filters.Spec {
+	return &leakyBucketSpec{
+		create: func(capacity int, emission time.Duration) leakyBucket {
+			return ratelimit.NewClusterLeakyBucket(registry, capacity, emission)
+		},
+	}
+}
+
+func (s *leakyBucketSpec) Name() string {
+	return filters.ClusterLeakyBucketRatelimitName
+}
+
+// clusterLeakyBucketRatelimit("a-label-${template}", leakVolume, "leak period", capacity, increment)
+func (s *leakyBucketSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 5 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	label, ok := args[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	leakVolume, err := natural(args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	leakPeriod, err := getDurationArg(args[2])
+	if err != nil {
+		return nil, err
+	}
+
+	capacity, err := natural(args[3])
+	if err != nil {
+		return nil, err
+	}
+
+	increment, err := natural(args[4])
+	if err != nil {
+		return nil, err
+	}
+
+	// emission is the reciprocal of the leak rate
+	emission := leakPeriod / time.Duration(leakVolume)
+
+	return &leakyBucketFilter{eskip.NewTemplate(label), s.create(capacity, emission), increment}, nil
+}
+
+func (f *leakyBucketFilter) Request(ctx filters.FilterContext) {
+	label, ok := f.label.ApplyContext(ctx)
+	if !ok {
+		return // allow on missing placeholders
+	}
+	added, retry, err := f.bucket.Add(ctx.Request().Context(), label, f.increment)
+	if err != nil {
+		return // allow on error
+	}
+	if added {
+		return // allow if successfully added
+	}
+
+	header := http.Header{}
+	if retry > 0 {
+		header.Set("Retry-After", strconv.Itoa(int(retry/time.Second)))
+	}
+	ctx.Serve(&http.Response{StatusCode: http.StatusTooManyRequests, Header: header})
+}
+
+func (*leakyBucketFilter) Response(filters.FilterContext) {}
+
+func natural(arg interface{}) (n int, err error) {
+	switch v := arg.(type) {
+	case int:
+		n = v
+	case float64:
+		n = int(v)
+	default:
+		return 0, fmt.Errorf(`failed to convert "%v" to integer`, arg)
+	}
+	if n < 1 {
+		err = fmt.Errorf(`number %d must be positive`, n)
+	}
+	return
+}

--- a/filters/ratelimit/leakybucket.go
+++ b/filters/ratelimit/leakybucket.go
@@ -26,6 +26,17 @@ type leakyBucketFilter struct {
 	increment int
 }
 
+// NewClusterLeakyBucket creates a filter Spec, whose instances implement rate limiting using leaky bucket algorithm.
+//
+// The leaky bucket is an algorithm based on an analogy of how a bucket with a constant leak will overflow if either
+// the average rate at which water is poured in exceeds the rate at which the bucket leaks or if more water than
+// the capacity of the bucket is poured in all at once.
+// See https://en.wikipedia.org/wiki/Leaky_bucket
+//
+// Example to allow each unique Authorization header once in five seconds:
+//
+//    clusterLeakyBucketRatelimit("auth-${request.header.Authorization}", 1, "5s", 2, 1)
+//
 func NewClusterLeakyBucket(registry *ratelimit.Registry) filters.Spec {
 	return &leakyBucketSpec{
 		create: func(capacity int, emission time.Duration) leakyBucket {
@@ -38,7 +49,6 @@ func (s *leakyBucketSpec) Name() string {
 	return filters.ClusterLeakyBucketRatelimitName
 }
 
-// clusterLeakyBucketRatelimit("a-label-${template}", leakVolume, "leak period", capacity, increment)
 func (s *leakyBucketSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 	if len(args) != 5 {
 		return nil, filters.ErrInvalidFilterParameters

--- a/filters/ratelimit/leakybucket.go
+++ b/filters/ratelimit/leakybucket.go
@@ -26,7 +26,7 @@ type leakyBucketFilter struct {
 	increment int
 }
 
-func NewLeakyBucket(registry *ratelimit.Registry) filters.Spec {
+func NewClusterLeakyBucket(registry *ratelimit.Registry) filters.Spec {
 	return &leakyBucketSpec{
 		create: func(capacity int, emission time.Duration) leakyBucket {
 			return ratelimit.NewClusterLeakyBucket(registry, capacity, emission)

--- a/filters/ratelimit/leakybucket.go
+++ b/filters/ratelimit/leakybucket.go
@@ -2,7 +2,6 @@ package ratelimit
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -49,7 +48,7 @@ func (s *leakyBucketSpec) CreateFilter(args []interface{}) (filters.Filter, erro
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
-	leakVolume, err := natural(args[1])
+	leakVolume, err := getIntArg(args[1])
 	if err != nil {
 		return nil, err
 	}
@@ -59,12 +58,12 @@ func (s *leakyBucketSpec) CreateFilter(args []interface{}) (filters.Filter, erro
 		return nil, err
 	}
 
-	capacity, err := natural(args[3])
+	capacity, err := getIntArg(args[3])
 	if err != nil {
 		return nil, err
 	}
 
-	increment, err := natural(args[4])
+	increment, err := getIntArg(args[4])
 	if err != nil {
 		return nil, err
 	}
@@ -96,18 +95,3 @@ func (f *leakyBucketFilter) Request(ctx filters.FilterContext) {
 }
 
 func (*leakyBucketFilter) Response(filters.FilterContext) {}
-
-func natural(arg interface{}) (n int, err error) {
-	switch v := arg.(type) {
-	case int:
-		n = v
-	case float64:
-		n = int(v)
-	default:
-		return 0, fmt.Errorf(`failed to convert "%v" to integer`, arg)
-	}
-	if n < 1 {
-		err = fmt.Errorf(`number %d must be positive`, n)
-	}
-	return
-}

--- a/filters/ratelimit/leakybucket.go
+++ b/filters/ratelimit/leakybucket.go
@@ -26,7 +26,7 @@ type leakyBucketFilter struct {
 	increment int
 }
 
-// NewClusterLeakyBucket creates a filter Spec, whose instances implement rate limiting using leaky bucket algorithm.
+// NewClusterLeakyBucketRatelimit creates a filter Spec, whose instances implement rate limiting using leaky bucket algorithm.
 //
 // The leaky bucket is an algorithm based on an analogy of how a bucket with a constant leak will overflow if either
 // the average rate at which water is poured in exceeds the rate at which the bucket leaks or if more water than
@@ -37,7 +37,7 @@ type leakyBucketFilter struct {
 //
 //    clusterLeakyBucketRatelimit("auth-${request.header.Authorization}", 1, "5s", 2, 1)
 //
-func NewClusterLeakyBucket(registry *ratelimit.Registry) filters.Spec {
+func NewClusterLeakyBucketRatelimit(registry *ratelimit.Registry) filters.Spec {
 	return &leakyBucketSpec{
 		create: func(capacity int, emission time.Duration) leakyBucket {
 			return ratelimit.NewClusterLeakyBucket(registry, capacity, emission)

--- a/filters/ratelimit/leakybucket_test.go
+++ b/filters/ratelimit/leakybucket_test.go
@@ -1,0 +1,182 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeakyBucketFilterInvalidArgs(t *testing.T) {
+	spec := &leakyBucketSpec{
+		create: func(_ int, _ time.Duration) leakyBucket {
+			t.Fatal("unexpected call to create a bucket")
+			return nil
+		},
+	}
+	assert.Equal(t, filters.ClusterLeakyBucketRatelimitName, spec.Name())
+
+	for i, test := range []struct {
+		args []interface{}
+	}{
+		{[]interface{}{"missing args"}},
+		{[]interface{}{123, 1, "1s", 1, 1}},
+		{[]interface{}{"alabel", "invalid volume", "1s", 1, 1}},
+		{[]interface{}{"alabel", 1, "invalid period", 1, 1}},
+		{[]interface{}{"alabel", 1, "1s", "invalid capacity", 1}},
+		{[]interface{}{"alabel", 1, "1s", 1, "invalid increment"}},
+		{[]interface{}{"negative increment", 1, "1s", 1, -1}},
+	} {
+		t.Run(fmt.Sprintf("test#%d", i), func(t *testing.T) {
+			_, err := spec.CreateFilter(test.args)
+
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestLeakyBucketFilterValidArgs(t *testing.T) {
+	for i, test := range []struct {
+		args            []interface{}
+		expectCapacity  int
+		expectEmission  time.Duration
+		expectIncrement int
+	}{
+		{
+			args:            []interface{}{"alabel", 4, "1s", 2, 1},
+			expectCapacity:  2,
+			expectEmission:  250 * time.Millisecond,
+			expectIncrement: 1,
+		},
+		{
+			args:            []interface{}{"floatargs", 4.0, "1s", 2.0, 1.0},
+			expectCapacity:  2,
+			expectEmission:  250 * time.Millisecond,
+			expectIncrement: 1,
+		},
+	} {
+		t.Run(fmt.Sprintf("test#%d", i), func(t *testing.T) {
+			spec := &leakyBucketSpec{
+				create: func(capacity int, emission time.Duration) leakyBucket {
+					assert.Equal(t, test.expectCapacity, capacity)
+					assert.Equal(t, test.expectEmission, emission)
+					return nil
+				},
+			}
+
+			f, err := spec.CreateFilter(test.args)
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectIncrement, f.(*leakyBucketFilter).increment)
+		})
+	}
+}
+
+type leakyBucketFunc func(context.Context, string, int) (bool, time.Duration, error)
+
+func (b leakyBucketFunc) Add(ctx context.Context, label string, increment int) (added bool, retry time.Duration, err error) {
+	return b(ctx, label, increment)
+}
+
+func TestLeakyBucketFilterRequest(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		args       []interface{}
+		add        func(*testing.T, string, int) (bool, time.Duration, error)
+		served     bool
+		status     int
+		retryAfter string
+	}{
+		{
+			name: "allow on missing placeholder",
+			args: []interface{}{"alabel-${missing}", 3, "1s", 2, 1},
+			add: func(t *testing.T, _ string, _ int) (bool, time.Duration, error) {
+				t.Error("unexpected call on missing placeholder")
+				return false, 0, nil
+			},
+		},
+		{
+			name: "allow on error",
+			args: []interface{}{"alabel", 3, "1s", 2, 1},
+			add: func(*testing.T, string, int) (bool, time.Duration, error) {
+				return false, 0, fmt.Errorf("oops")
+			},
+		},
+		{
+			name: "allow on added",
+			args: []interface{}{"alabel", 3, "1s", 2, 1},
+			add: func(t *testing.T, label string, increment int) (bool, time.Duration, error) {
+				assert.Equal(t, "alabel", label)
+				assert.Equal(t, 1, increment)
+				return true, 0, nil
+			},
+		},
+		{
+			name: "allow with a placeholder",
+			args: []interface{}{"alabel-${request.header.X-Foo}", 3, "1s", 2, 1},
+			add: func(t *testing.T, label string, increment int) (bool, time.Duration, error) {
+				assert.Equal(t, "alabel-bar", label)
+				assert.Equal(t, 1, increment)
+				return true, 0, nil
+			},
+		},
+		{
+			name: "deny",
+			args: []interface{}{"alabel", 3, "1s", 2, 1},
+			add: func(t *testing.T, label string, increment int) (bool, time.Duration, error) {
+				assert.Equal(t, "alabel", label)
+				assert.Equal(t, 1, increment)
+				return false, 3 * time.Second, nil
+			},
+			served:     true,
+			status:     429,
+			retryAfter: "3",
+		},
+		{
+			name: "deny with a placeholder",
+			args: []interface{}{"alabel-${request.header.X-Foo}", 3, "1s", 2, 1},
+			add: func(t *testing.T, label string, increment int) (bool, time.Duration, error) {
+				assert.Equal(t, "alabel-bar", label)
+				assert.Equal(t, 1, increment)
+				return false, 3 * time.Second, nil
+			},
+			served:     true,
+			status:     429,
+			retryAfter: "3",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			spec := &leakyBucketSpec{
+				create: func(capacity int, emission time.Duration) leakyBucket {
+					return leakyBucketFunc(func(_ context.Context, label string, increment int) (bool, time.Duration, error) {
+						return test.add(t, label, increment)
+					})
+				},
+			}
+
+			f, err := spec.CreateFilter(test.args)
+			require.NoError(t, err)
+
+			ctx := &filtertest.Context{
+				FRequest: &http.Request{Header: http.Header{"X-Foo": []string{"bar"}}},
+			}
+
+			f.Request(ctx)
+
+			if test.served {
+				assert.True(t, ctx.FServed)
+				assert.Equal(t, test.status, ctx.FResponse.StatusCode)
+				assert.Equal(t, test.retryAfter, ctx.FResponse.Header.Get("Retry-After"))
+			} else {
+				assert.False(t, ctx.FServed)
+			}
+		})
+	}
+}

--- a/filters/ratelimit/leakybucket_test.go
+++ b/filters/ratelimit/leakybucket_test.go
@@ -32,6 +32,10 @@ func TestLeakyBucketFilterInvalidArgs(t *testing.T) {
 		{[]interface{}{"alabel", 1, "invalid period", 1, 1}},
 		{[]interface{}{"alabel", 1, "1s", "invalid capacity", 1}},
 		{[]interface{}{"alabel", 1, "1s", 1, "invalid increment"}},
+		{[]interface{}{"zero volume", 0, "1s", 1, 1}},
+		{[]interface{}{"zero period", 1, "0s", 1, 1}},
+		{[]interface{}{"zero capacity", 1, "1s", 0, 1}},
+		{[]interface{}{"zero increment", 1, "1s", 1, 0}},
 	} {
 		t.Run(fmt.Sprintf("test#%d", i), func(t *testing.T) {
 			_, err := spec.CreateFilter(test.args)

--- a/filters/ratelimit/leakybucket_test.go
+++ b/filters/ratelimit/leakybucket_test.go
@@ -32,7 +32,6 @@ func TestLeakyBucketFilterInvalidArgs(t *testing.T) {
 		{[]interface{}{"alabel", 1, "invalid period", 1, 1}},
 		{[]interface{}{"alabel", 1, "1s", "invalid capacity", 1}},
 		{[]interface{}{"alabel", 1, "1s", 1, "invalid increment"}},
-		{[]interface{}{"negative increment", 1, "1s", 1, -1}},
 	} {
 		t.Run(fmt.Sprintf("test#%d", i), func(t *testing.T) {
 			_, err := spec.CreateFilter(test.args)

--- a/net/redisclient.go
+++ b/net/redisclient.go
@@ -82,6 +82,10 @@ type RedisRingClient struct {
 	quit          chan struct{}
 }
 
+type RedisScript struct {
+	script *redis.Script
+}
+
 const (
 	// DefaultReadTimeout is the default socket read timeout
 	DefaultReadTimeout = 25 * time.Millisecond
@@ -324,4 +328,12 @@ func (r *RedisRingClient) ZRangeByScoreWithScoresFirst(ctx context.Context, key 
 	}
 
 	return zs[0].Member, nil
+}
+
+func (r *RedisRingClient) NewScript(source string) *RedisScript {
+	return &RedisScript{redis.NewScript(source)}
+}
+
+func (r *RedisRingClient) RunScript(ctx context.Context, s *RedisScript, keys []string, args ...interface{}) (interface{}, error) {
+	return s.script.Run(ctx, r.ring, keys, args...).Result()
 }

--- a/net/redisclient.go
+++ b/net/redisclient.go
@@ -281,6 +281,7 @@ func (r *RedisRingClient) Get(ctx context.Context, key string) (string, error) {
 	res := r.ring.Get(ctx, key)
 	return res.Val(), res.Err()
 }
+
 func (r *RedisRingClient) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) (string, error) {
 	res := r.ring.Set(ctx, key, value, expiration)
 	return res.Result()

--- a/ratelimit/leakybucket.go
+++ b/ratelimit/leakybucket.go
@@ -28,9 +28,10 @@ type ClusterLeakyBucket struct {
 }
 
 const (
-	leakyBucketMetricPrefix  = "leakybucket.redis."
-	leakyBucketMetricLatency = leakyBucketMetricPrefix + "latency"
-	leakyBucketSpanName      = "redis_leakybucket"
+	leakyBucketRedisKeyPrefix = "lkb."
+	leakyBucketMetricPrefix   = "leakybucket.redis."
+	leakyBucketMetricLatency  = leakyBucketMetricPrefix + "latency"
+	leakyBucketSpanName       = "redis_leakybucket"
 )
 
 // Implements leaky bucket algorithm as a Redis lua script.
@@ -102,7 +103,7 @@ func (b *ClusterLeakyBucket) add(ctx context.Context, label string, increment in
 }
 
 func (b *ClusterLeakyBucket) getBucketId(label string) string {
-	return "lkb." + getHashedKey(b.labelPrefix+label)
+	return leakyBucketRedisKeyPrefix + getHashedKey(b.labelPrefix+label)
 }
 
 func (b *ClusterLeakyBucket) startSpan(ctx context.Context) (span opentracing.Span) {

--- a/ratelimit/leakybucket.go
+++ b/ratelimit/leakybucket.go
@@ -85,9 +85,9 @@ func (b *ClusterLeakyBucket) add(ctx context.Context, label string, increment in
 	r, err := b.ringClient.RunScript(ctx, b.script,
 		[]string{b.getBucketId(label)},
 		b.capacity,
-		b.emission.Nanoseconds(),
+		b.emission.Microseconds(),
 		increment,
-		now.UnixNano(),
+		now.UnixMicro(),
 	)
 
 	if err == nil {
@@ -95,7 +95,7 @@ func (b *ClusterLeakyBucket) add(ctx context.Context, label string, increment in
 		if x >= 0 {
 			added, retry = true, 0
 		} else {
-			added, retry = false, time.Duration(-x)
+			added, retry = false, time.Duration(-x*1000)
 		}
 	}
 	return

--- a/ratelimit/leakybucket.go
+++ b/ratelimit/leakybucket.go
@@ -95,7 +95,7 @@ func (b *ClusterLeakyBucket) add(ctx context.Context, label string, increment in
 		if x >= 0 {
 			added, retry = true, 0
 		} else {
-			added, retry = false, time.Duration(-x*1000)
+			added, retry = false, -time.Duration(x)*time.Microsecond
 		}
 	}
 	return

--- a/ratelimit/leakybucket.go
+++ b/ratelimit/leakybucket.go
@@ -13,10 +13,6 @@ import (
 	"github.com/zalando/skipper/net"
 )
 
-// The leaky bucket is an algorithm based on an analogy of how a bucket with a constant leak will overflow if either
-// the average rate at which water is poured in exceeds the rate at which the bucket leaks or if more water than
-// the capacity of the bucket is poured in all at once.
-// See https://en.wikipedia.org/wiki/Leaky_bucket
 type ClusterLeakyBucket struct {
 	capacity    int
 	emission    time.Duration
@@ -49,6 +45,11 @@ var leakyBucketScript string
 
 // NewClusterLeakyBucket creates a class of leaky buckets of a given capacity and emission.
 // Emission is the reciprocal of the leak rate and equals the time to leak one unit.
+//
+// The leaky bucket is an algorithm based on an analogy of how a bucket with a constant leak will overflow if either
+// the average rate at which water is poured in exceeds the rate at which the bucket leaks or if more water than
+// the capacity of the bucket is poured in all at once.
+// See https://en.wikipedia.org/wiki/Leaky_bucket
 func NewClusterLeakyBucket(r *Registry, capacity int, emission time.Duration) *ClusterLeakyBucket {
 	return newClusterLeakyBucket(r.redisRing, capacity, emission, time.Now)
 }

--- a/ratelimit/leakybucket.go
+++ b/ratelimit/leakybucket.go
@@ -55,10 +55,14 @@ func NewClusterLeakyBucket(r *Registry, capacity int, emission time.Duration) *C
 }
 
 func newClusterLeakyBucket(ringClient *net.RedisRingClient, capacity int, emission time.Duration, now func() time.Time) *ClusterLeakyBucket {
-	labelPrefix := fmt.Sprintf("%d-%v-", capacity, emission)
 	return &ClusterLeakyBucket{
-		capacity, emission, labelPrefix,
-		ringClient.NewScript(leakyBucketScript), ringClient, metrics.Default, now,
+		capacity:    capacity,
+		emission:    emission,
+		labelPrefix: fmt.Sprintf("%d-%v-", capacity, emission),
+		script:      ringClient.NewScript(leakyBucketScript),
+		ringClient:  ringClient,
+		metrics:     metrics.Default,
+		now:         now,
 	}
 }
 

--- a/ratelimit/leakybucket.go
+++ b/ratelimit/leakybucket.go
@@ -1,0 +1,118 @@
+package ratelimit
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+
+	"github.com/zalando/skipper/metrics"
+	"github.com/zalando/skipper/net"
+)
+
+// The leaky bucket is an algorithm based on an analogy of how a bucket with a constant leak will overflow if either
+// the average rate at which water is poured in exceeds the rate at which the bucket leaks or if more water than
+// the capacity of the bucket is poured in all at once.
+// See https://en.wikipedia.org/wiki/Leaky_bucket
+type ClusterLeakyBucket struct {
+	capacity    int
+	emission    time.Duration
+	labelPrefix string
+	script      *net.RedisScript
+	ringClient  *net.RedisRingClient
+	metrics     metrics.Metrics
+	now         func() time.Time
+}
+
+const (
+	leakyBucketMetricPrefix  = "leakybucket.redis."
+	leakyBucketMetricLatency = leakyBucketMetricPrefix + "latency"
+	leakyBucketSpanName      = "redis_leakybucket"
+)
+
+// Implements leaky bucket algorithm as a Redis lua script.
+// Redis guarantees that a script is executed in an atomic way:
+// no other script or Redis command will be executed while a script is being executed.
+//
+// Possible optimization: substitute capacity and emission in script source code
+// on script creation in order not to send them over the wire on each call.
+// This way every distinct bucket configuration will get its own script.
+//
+// See https://redis.io/commands/eval
+//
+//go:embed leakybucket.lua
+var leakyBucketScript string
+
+// NewClusterLeakyBucket creates a class of leaky buckets of a given capacity and emission.
+// Emission is the reciprocal of the leak rate and equals the time to leak one unit.
+func NewClusterLeakyBucket(r *Registry, capacity int, emission time.Duration) *ClusterLeakyBucket {
+	return newClusterLeakyBucket(r.redisRing, capacity, emission, time.Now)
+}
+
+func newClusterLeakyBucket(ringClient *net.RedisRingClient, capacity int, emission time.Duration, now func() time.Time) *ClusterLeakyBucket {
+	labelPrefix := fmt.Sprintf("%d-%v-", capacity, emission)
+	return &ClusterLeakyBucket{
+		capacity, emission, labelPrefix,
+		ringClient.NewScript(leakyBucketScript), ringClient, metrics.Default, now,
+	}
+}
+
+// Add adds an increment amount to the bucket identified by the label.
+// It returns true if the amount was successfully added to the bucket or a time to wait for the next attempt.
+// It also returns any error occurred during the attempt.
+func (b *ClusterLeakyBucket) Add(ctx context.Context, label string, increment int) (added bool, retry time.Duration, err error) {
+	if increment > b.capacity {
+		// not allowed to add more than capacity and retry is not possible
+		return false, 0, nil
+	}
+
+	now := b.now()
+	span := b.startSpan(ctx)
+	defer span.Finish()
+	defer b.metrics.MeasureSince(leakyBucketMetricLatency, now)
+
+	added, retry, err = b.add(ctx, label, increment, now)
+	if err != nil {
+		ext.Error.Set(span, true)
+	}
+	return
+}
+
+func (b *ClusterLeakyBucket) add(ctx context.Context, label string, increment int, now time.Time) (added bool, retry time.Duration, err error) {
+	r, err := b.ringClient.RunScript(ctx, b.script,
+		[]string{b.getBucketId(label)},
+		b.capacity,
+		b.emission.Nanoseconds(),
+		increment,
+		now.UnixNano(),
+	)
+
+	if err == nil {
+		x := r.(int64)
+		if x >= 0 {
+			added, retry = true, 0
+		} else {
+			added, retry = false, time.Duration(-x)
+		}
+	}
+	return
+}
+
+func (b *ClusterLeakyBucket) getBucketId(label string) string {
+	return "lkb." + getHashedKey(b.labelPrefix+label)
+}
+
+func (b *ClusterLeakyBucket) startSpan(ctx context.Context) (span opentracing.Span) {
+	parent := opentracing.SpanFromContext(ctx)
+	if parent != nil {
+		span = b.ringClient.StartSpan(leakyBucketSpanName, opentracing.ChildOf(parent.Context()))
+	} else {
+		span = opentracing.NoopTracer{}.StartSpan("")
+	}
+	ext.Component.Set(span, "skipper")
+	ext.SpanKind.Set(span, "client")
+	return
+}

--- a/ratelimit/leakybucket.lua
+++ b/ratelimit/leakybucket.lua
@@ -1,10 +1,12 @@
 local bucket_id = KEYS[1]           -- bucket id
 local capacity = tonumber(ARGV[1])  -- bucket capacity in units (increment <= capacity)
-local emission = tonumber(ARGV[2])  -- time to leak one unit in ns (emission > 0)
+local emission = tonumber(ARGV[2])  -- time to leak one unit in microseconds (emission > 0)
 local increment = tonumber(ARGV[3]) -- increment in units (increment <= capacity)
-local now = tonumber(ARGV[4])       -- current time in ns (now >= 0)
+local now = tonumber(ARGV[4])       -- current time in microseconds (now >= 0)
 
 -- Redis stores the timestamp when bucket drains out.
+-- Lua uses double floating-point as a number type which can precisely represent integers only up to 2^53.
+-- The timestamp is stored in microseconds (and not nanoseconds) to keep values below 2^53.
 -- If bucket does not exist or is drained out, consider it empty now.
 local empty_at = redis.call("GET", bucket_id)
 if not empty_at then
@@ -24,7 +26,7 @@ local x = (capacity - increment) * emission - (empty_at - now)
 if x >= 0 then
     empty_at = empty_at + increment * emission
 
-    redis.call("SET", bucket_id, empty_at, "PX", math.ceil((empty_at - now) / 1e6))
+    redis.call("SET", bucket_id, empty_at, "PX", math.ceil((empty_at - now) / 1000))
 end
 
 return x

--- a/ratelimit/leakybucket.lua
+++ b/ratelimit/leakybucket.lua
@@ -1,0 +1,30 @@
+local bucket_id = KEYS[1]           -- bucket id
+local capacity = tonumber(ARGV[1])  -- bucket capacity in units (increment <= capacity)
+local emission = tonumber(ARGV[2])  -- time to leak one unit in ns (emission > 0)
+local increment = tonumber(ARGV[3]) -- increment in units (increment <= capacity)
+local now = tonumber(ARGV[4])       -- current time in ns (now >= 0)
+
+-- Redis stores the timestamp when bucket drains out.
+-- If bucket does not exist or is drained out, consider it empty now.
+local empty_at = redis.call("GET", bucket_id)
+if not empty_at then
+    empty_at = now
+else
+    empty_at = tonumber(empty_at)
+    if empty_at < now then
+        empty_at = now
+    end
+end
+
+-- bucket level == time to drain / emission == (empty_at - now) / emission
+-- free capacity left after increment == capacity - bucket level - increment
+-- If free capacity is negative then retry is possible after -(free capacity * emission)
+-- Calculate and check the value of x == free capacity * emission
+local x = (capacity - increment) * emission - (empty_at - now)
+if x >= 0 then
+    empty_at = empty_at + increment * emission
+
+    redis.call("SET", bucket_id, empty_at, "PX", math.ceil((empty_at - now) / 1e6))
+end
+
+return x

--- a/ratelimit/leakybucket_test.go
+++ b/ratelimit/leakybucket_test.go
@@ -1,0 +1,115 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/net"
+	"github.com/zalando/skipper/net/redistest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type attempt struct {
+	tplus int
+	added bool
+	retry int
+}
+
+func TestLeakyBucketAdd(t *testing.T) {
+	verifyAttempts(t, 3, time.Minute, 1, []attempt{
+		// initial burst of three units fills up capacity
+		{+0, true, 0}, // just added unit leaks after 60s
+		{+1, true, 0}, // after 59
+		{+2, true, 0}, // after 58
+		// the bucket is full
+		{+3, false, 57},
+		{+4, false, 56},
+		// ...
+		{+58, false, 2},
+		{+59, false, 1},
+		// by this point one unit has leaked
+		{+60, true, 0},
+		// the bucket is full again
+		{+61, false, 59},
+		{+62, false, 58},
+		{+63, false, 57},
+		// ... wait two minutes to add two units
+		{+180, true, 0},
+		{+181, true, 0},
+		// the bucket is full again
+		{+182, false, 58},
+		{+183, false, 57},
+		// ...
+	})
+}
+
+func TestLeakyBucketAddMoreThanCapacity(t *testing.T) {
+	verifyAttempts(t, 1, time.Minute, 2, []attempt{
+		{+0, false, 0},  // not allowed and no retry possible
+		{+61, false, 0}, // even after a minute
+	})
+}
+
+func TestLeakyBucketAddAtSlowRate(t *testing.T) {
+	verifyAttempts(t, 1, time.Second/2, 1, []attempt{
+		{+0, true, 0},
+		{+1, true, 0},
+		{+2, true, 0},
+	})
+}
+
+func verifyAttempts(t *testing.T, capacity int, emission time.Duration, increment int, attempts []attempt) {
+	redisAddr, done := redistest.NewTestRedis(t)
+	defer done()
+
+	ringClient := net.NewRedisRingClient(
+		&net.RedisOptions{
+			Addrs: []string{redisAddr},
+		},
+	)
+	defer ringClient.Close()
+
+	now := time.Now()
+	bucket := newClusterLeakyBucket(ringClient, capacity, emission, func() time.Time { return now })
+
+	t0 := now
+	for _, a := range attempts {
+		now = t0.Add(time.Duration(a.tplus) * time.Second)
+		added, retry, err := bucket.Add(context.Background(), "alabel", increment)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a.added != added {
+			t.Errorf("error at %+d: added mismatch, expected %v, got %v", a.tplus, a.added, added)
+		}
+		expectedRetry := time.Duration(a.retry) * time.Second
+		if expectedRetry != retry {
+			t.Errorf("error at %+d: retry mismatch, expected %v, got %v", a.tplus, expectedRetry, retry)
+		}
+	}
+}
+
+func TestLeakyBucketRedisError(t *testing.T) {
+	ringClient := net.NewRedisRingClient(
+		&net.RedisOptions{
+			Addrs: []string{"no-such-host.test:123"},
+		},
+	)
+	defer ringClient.Close()
+
+	bucket := newClusterLeakyBucket(ringClient, 1, time.Minute, time.Now)
+	_, _, err := bucket.Add(context.Background(), "alabel", 1)
+
+	assert.Error(t, err)
+}
+
+func TestLeakyBucketId(t *testing.T) {
+	const label = "alabel"
+
+	b1 := newClusterLeakyBucket(nil, 1, time.Minute, time.Now)
+	b2 := newClusterLeakyBucket(nil, 2, time.Minute, time.Now)
+
+	assert.NotEqual(t, b1.getBucketId(label), b2.getBucketId(label))
+}

--- a/skipper.go
+++ b/skipper.go
@@ -1454,7 +1454,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		)
 
 		if redisOptions != nil {
-			o.CustomFilters = append(o.CustomFilters, ratelimitfilters.NewClusterLeakyBucket(ratelimitRegistry))
+			o.CustomFilters = append(o.CustomFilters, ratelimitfilters.NewClusterLeakyBucketRatelimit(ratelimitRegistry))
 		}
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -1505,6 +1505,10 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		o.CustomFilters = append(o.CustomFilters, compress)
 	}
 
+	if ratelimitRegistry != nil && redisOptions != nil {
+		o.CustomFilters = append(o.CustomFilters, ratelimitfilters.NewLeakyBucket(ratelimitRegistry))
+	}
+
 	// create a filter registry with the available filter specs registered,
 	// and register the custom filters
 	registry := builtin.MakeRegistry()

--- a/skipper.go
+++ b/skipper.go
@@ -1452,6 +1452,10 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			ratelimitfilters.NewDisableRatelimit(provider),
 			ratelimitfilters.NewBackendRatelimit(),
 		)
+
+		if redisOptions != nil {
+			o.CustomFilters = append(o.CustomFilters, ratelimitfilters.NewClusterLeakyBucket(ratelimitRegistry))
+		}
 	}
 
 	if o.TLSMinVersion == 0 {
@@ -1503,10 +1507,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			return err
 		}
 		o.CustomFilters = append(o.CustomFilters, compress)
-	}
-
-	if ratelimitRegistry != nil && redisOptions != nil {
-		o.CustomFilters = append(o.CustomFilters, ratelimitfilters.NewLeakyBucket(ratelimitRegistry))
 	}
 
 	// create a filter registry with the available filter specs registered,


### PR DESCRIPTION
The `clusterLeakyBucketRatelimit` filter implements ratelimiting _meter_ variant of [Leaky Bucket algorithm](https://en.wikipedia.org/wiki/Leaky_bucket)
and uses Redis as a storage. Leaky Bucket algorithm is also known as [Generic cell rate algorithm](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm).

Prior art
---

* https://github.com/throttled/throttled - implements CGRA algorithm,
uses optimistic locking i.e. two queries (get and set) to the storage per request
* https://github.com/brandur/redis-cell - implements GCRA as a Redis module
* https://github.com/rwz/redis-gcra - implements GCRA as Redis lua
script, uses Redis time, microsecond-only precision, floating point, divisions and rounding.
* https://github.com/go-redis/redis_rate - for go-redis v7 currently used by skipper implements
[basic rate limiter](https://redis.io/commands/incr#pattern-rate-limiter) as a counter, since v8 uses lua script implementation from `rwz`.

This implementation uses Redis lua script and makes single Redis query per request.
