### PR TITLE
drop excessive span logs

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -410,6 +410,11 @@ func cloneHeaderExcluding(h http.Header, excludeList map[string]bool) http.Heade
 func copyStream(to flushedResponseWriter, from io.Reader, tracing *proxyTracing, span ot.Span) error {
 	b := make([]byte, proxyBufferSize)
 
+	var bytesCopied int
+	defer func() {
+		tracing.logStreamEvent(span, StreamBodyEvent, fmt.Sprintf("%d", bytesCopied))
+	}()
+
 	for {
 		l, rerr := from.Read(b)
 
@@ -424,6 +429,7 @@ func copyStream(to flushedResponseWriter, from io.Reader, tracing *proxyTracing,
 			}
 
 			to.Flush()
+			bytesCopied += l
 		}
 
 		if rerr == io.EOF {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -413,8 +413,6 @@ func copyStream(to flushedResponseWriter, from io.Reader, tracing *proxyTracing,
 	for {
 		l, rerr := from.Read(b)
 
-		tracing.logStreamEvent(span, StreamBodyEvent, fmt.Sprintf("%d", l))
-
 		if rerr != nil && rerr != io.EOF {
 			return rerr
 		}


### PR DESCRIPTION
this is removing the `streamBody.byte:` logs which make up the biggest chunk of logs per proxy span.
Errors are still logged with the `streamBody.byte:` log.

