### PR TITLE
Fully functional OAuth2 grant flow.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,8 +147,14 @@ type Config struct {
 	Oauth2SecretFile                string        `yaml:"oauth2-secret-file"`
 	Oauth2ClientID                  string        `yaml:"oauth2-client-id"`
 	Oauth2ClientSecret              string        `yaml:"oauth2-client-secret"`
+	Oauth2ClientIDFile              string        `yaml:"oauth2-client-id-file"`
+	Oauth2ClientSecretFile          string        `yaml:"oauth2-client-secret-file"`
+	Oauth2AuthURLParameters         mapFlags      `yaml:"oauth2-auth-url-parameters"`
 	Oauth2CallbackPath              string        `yaml:"oauth2-callback-path"`
 	Oauth2TokenintrospectionTimeout time.Duration `yaml:"oauth2-tokenintrospect-timeout"`
+	Oauth2AccessTokenHeaderName     string        `yaml:"oauth2-access-token-header-name"`
+	Oauth2TokeninfoSubjectKey       string        `yaml:"oauth2-tokeninfo-subject-key"`
+	Oauth2TokenCookieName           string        `yaml:"oauth2-token-cookie-name"`
 	WebhookTimeout                  time.Duration `yaml:"webhook-timeout"`
 	OidcSecretsFile                 string        `yaml:"oidc-secrets-file"`
 	CredentialPaths                 *listFlag     `yaml:"credentials-paths"`
@@ -357,8 +363,14 @@ const (
 	oauth2SecretFileUsage                = "sets the filename with the encryption key for the authentication cookie and grant flow state stored in secrets registry"
 	oauth2ClientIDUsage                  = "sets the OAuth2 client id of the current service, used to exchange the access code"
 	oauth2ClientSecretUsage              = "sets the OAuth2 client secret associated with the oauth2-client-id, used to exchange the access code"
+	oauth2ClientIDFileUsage              = "sets the path of the file containing the OAuth2 client id of the current service, used to exchange the access code"
+	oauth2ClientSecretFileUsage          = "sets the path of the file containing the OAuth2 client secret associated with the oauth2-client-id, used to exchange the access code"
 	oauth2CallbackPathUsage              = "sets the path where the OAuth2 callback requests with the authorization code should be redirected to"
 	oauth2TokenintrospectionTimeoutUsage = "sets the default tokenintrospection request timeout duration to 2000ms"
+	oauth2AuthURLParametersUsage         = "sets additional parameters to send when calling the OAuth2 authorize or token endpoints as key-value pairs"
+	oauth2AccessTokenHeaderNameUsage     = "sets the access token to a header on the request with this name"
+	oauth2TokeninfoSubjectKeyUsage       = "the key containing the subject ID in the tokeninfo map"
+	oauth2TokenCookieNameUsage           = "sets the name of the cookie where the encrypted token is stored"
 	webhookTimeoutUsage                  = "sets the webhook request timeout duration, defaults to 2s"
 	oidcSecretsFileUsage                 = "file storing the encryption key of the OID Connect token"
 	credentialPathsUsage                 = "directories or files to watch for credentials to use by bearerinjector filter"
@@ -546,9 +558,15 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.Oauth2SecretFile, "oauth2-secret-file", "", oauth2SecretFileUsage)
 	flag.StringVar(&cfg.Oauth2ClientID, "oauth2-client-id", "", oauth2ClientIDUsage)
 	flag.StringVar(&cfg.Oauth2ClientSecret, "oauth2-client-secret", "", oauth2ClientSecretUsage)
+	flag.StringVar(&cfg.Oauth2ClientIDFile, "oauth2-client-id-file", "", oauth2ClientIDFileUsage)
+	flag.StringVar(&cfg.Oauth2ClientSecretFile, "oauth2-client-secret-file", "", oauth2ClientSecretFileUsage)
 	flag.StringVar(&cfg.Oauth2CallbackPath, "oauth2-callback-path", "", oauth2CallbackPathUsage)
 	flag.DurationVar(&cfg.Oauth2TokeninfoTimeout, "oauth2-tokeninfo-timeout", defaultOAuthTokeninfoTimeout, oauth2TokeninfoTimeoutUsage)
 	flag.DurationVar(&cfg.Oauth2TokenintrospectionTimeout, "oauth2-tokenintrospect-timeout", defaultOAuthTokenintrospectionTimeout, oauth2TokenintrospectionTimeoutUsage)
+	flag.Var(&cfg.Oauth2AuthURLParameters, "oauth2-auth-url-parameters", oauth2AuthURLParametersUsage)
+	flag.StringVar(&cfg.Oauth2AccessTokenHeaderName, "oauth2-access-token-header-name", "", oauth2AccessTokenHeaderNameUsage)
+	flag.StringVar(&cfg.Oauth2TokeninfoSubjectKey, "oauth2-tokeninfo-subject-key", "uid", oauth2AccessTokenHeaderNameUsage)
+	flag.StringVar(&cfg.Oauth2TokenCookieName, "oauth2-token-cookie-name", "oauth2-grant", oauth2TokenCookieNameUsage)
 	flag.DurationVar(&cfg.WebhookTimeout, "webhook-timeout", defaultWebhookTimeout, webhookTimeoutUsage)
 	flag.StringVar(&cfg.OidcSecretsFile, "oidc-secrets-file", "", oidcSecretsFileUsage)
 	flag.Var(cfg.CredentialPaths, "credentials-paths", credentialPathsUsage)
@@ -806,8 +824,14 @@ func (c *Config) ToOptions() skipper.Options {
 		OAuth2SecretFile:               c.Oauth2SecretFile,
 		OAuth2ClientID:                 c.Oauth2ClientID,
 		OAuth2ClientSecret:             c.Oauth2ClientSecret,
+		OAuth2ClientIDFile:             c.Oauth2ClientIDFile,
+		OAuth2ClientSecretFile:         c.Oauth2ClientSecretFile,
 		OAuth2CallbackPath:             c.Oauth2CallbackPath,
 		OAuthTokenintrospectionTimeout: c.Oauth2TokenintrospectionTimeout,
+		OAuth2AuthURLParameters:        c.Oauth2AuthURLParameters.values,
+		OAuth2AccessTokenHeaderName:    c.Oauth2AccessTokenHeaderName,
+		OAuth2TokeninfoSubjectKey:      c.Oauth2TokeninfoSubjectKey,
+		OAuth2TokenCookieName:          c.Oauth2TokenCookieName,
 		WebhookTimeout:                 c.WebhookTimeout,
 		OIDCSecretsFile:                c.OidcSecretsFile,
 		CredentialsPaths:               c.CredentialPaths.values,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,6 +69,8 @@ func Test_NewConfig(t *testing.T) {
 				KubernetesPathModeString:                "kubernetes-ingress",
 				Oauth2TokeninfoTimeout:                  2 * time.Second,
 				Oauth2TokenintrospectionTimeout:         2 * time.Second,
+				Oauth2TokeninfoSubjectKey:               "uid",
+				Oauth2TokenCookieName:                   "oauth2-grant",
 				WebhookTimeout:                          2 * time.Second,
 				CredentialPaths:                         commaListFlag(),
 				CredentialsUpdateInterval:               10 * time.Minute,
@@ -117,8 +119,8 @@ func Test_NewConfig(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				if cmp.Equal(cfg, tt.want, cmp.AllowUnexported(listFlag{}, pluginFlag{}, defaultFiltersFlags{})) == false {
-					t.Errorf("config.NewConfig() got vs. want:\n%v", cmp.Diff(cfg, tt.want, cmp.AllowUnexported(listFlag{}, pluginFlag{}, defaultFiltersFlags{})))
+				if cmp.Equal(cfg, tt.want, cmp.AllowUnexported(listFlag{}, pluginFlag{}, defaultFiltersFlags{}, mapFlags{})) == false {
+					t.Errorf("config.NewConfig() got vs. want:\n%v", cmp.Diff(cfg, tt.want, cmp.AllowUnexported(listFlag{}, pluginFlag{}, defaultFiltersFlags{}, mapFlags{})))
 				}
 			}
 		})

--- a/config/mapflags.go
+++ b/config/mapflags.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// mapFlags are generic string key-value pair flags.
+// Use when option keys are not predetermined.
+type mapFlags struct {
+	values map[string]string
+}
+
+func (m mapFlags) String() string {
+	var pairs []string
+
+	for k, v := range m.values {
+		pairs = append(pairs, fmt.Sprint(k, "=", v))
+	}
+
+	return strings.Join(pairs, "'")
+}
+
+func (m *mapFlags) Set(value string) error {
+	if m == nil {
+		return nil
+	}
+
+	m.values = make(map[string]string)
+
+	vs := strings.Split(value, ",")
+	for _, vi := range vs {
+		kv := strings.Split(vi, "=")
+
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+
+		if len(kv) != 2 || k == "" || v == "" {
+			message := fmt.Sprint("invalid map key-value pair, expected format key=value but got: '", vi, "'")
+			return errors.New(message)
+		}
+
+		m.values[k] = v
+	}
+
+	return nil
+}
+
+func (m *mapFlags) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var values = make(map[string]string)
+	if err := unmarshal(&values); err != nil {
+		return err
+	}
+
+	m.values = values
+
+	return nil
+}

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -987,6 +987,98 @@ forwardToken("X-Tokeninfo-Forward")
 forwardToken("X-Tokeninfo-Forward", "access_token")
 ```
 
+## oauthGrant
+
+Enables authentication and authorization with an OAuth2 authorization code grant flow.
+Automatically redirects unauthenticated users to log in at their provider's authorization
+endpoint. Supports token refreshing and stores access and refresh tokens in an encrypted
+cookie. Supports credential rotation for the OAuth2 client ID and secret.
+
+The filter consumes and drops the grant token request cookie to prevent it from leaking
+to untrusted downstream services.
+
+The filter must be used in conjuction with the [grantCallback](#grantCallback) filter
+where the OAuth2 provider can redirect authenticated users with an authorization code.
+
+The filter may be used with the [grantClaimsQuery](#grantClaimsQuery) filter to perform
+authz and access control.
+
+See the [tutorial](../tutorials/auth.md#oauth2-authorization-grant-flow) for step-by-step 
+instructions.
+
+Examples:
+
+```
+callback:
+    Path("/oauth/callback")
+    -> grantCallback()
+    -> <shunt>;
+
+all:
+    *
+    -> oauthGrant()
+    -> "http://localhost:9090";
+```
+
+Program arguments:
+
+| Argument | Required? | Description |
+| -------- | --------- | ----------- |
+| `-enable-oauth2-grant-flow` | **yes** | toggle flag to enable the `oauthGrant()` filter. Must be set if you use the filter in routes. Example: `-enable-oauth2-grant-flow` |
+| `-oauth2-auth-url` | **yes** | URL of the OAuth2 provider's authorize endpoint. Example: `-oauth2-auth-url=https://identity.example.com/oauth2/authorize` |
+| `-oauth2-token-url` | **yes** | URL of the OAuth2 provider's token endpoint. Example: `-oauth2-token-url=https://identity.example.com/oauth2/token` |
+| `-oauth2-tokeninfo-url` | **yes** | URL of the OAuth2 provider's tokeninfo endpoint. Example: `-oauth2-tokeninfo-url=https://identity.example.com/oauth2/tokeninfo` |
+| `-oauth2-callback-path` | **yes** | path of the Skipper route containing the `grantCallback()` filter for accepting an authorization code and using it to get an access token. Example: `-oauth2-callback-path=/oauth/callback` |
+| `-oauth2-secret-file` | **yes** | path to the file containing the secret for encrypting and decrypting the grant token cookie (the secret can be anything). Example: `-oauth2-secret-file=/path/to/secret` |
+| `-oauth2-client-id-file` | conditional | path to the file containing the OAuth2 client ID. Required if you have not set `-oauth2-client-id`. Example: `-oauth2-client-id-file=/path/to/client_id` |
+| `-oauth2-client-secret-file` | conditional | path to the file containing the OAuth2 client secret. Required if you have not set `-oauth2-client-secret`. Example: `-oauth2-client-secret-file=/path/to/client_secret` |
+| `-oauth2-client-id` | conditional | OAuth2 client ID for authenticating with your OAuth2 provider. Required if you have not set `-oauth2-client-id-file`. Example: `-oauth2-client-id=myclientid` |
+| `-oauth2-client-secret` | conditional | OAuth2 client secret for authenticating with your OAuth2 provider. Required if you have not set `-oauth2-client-secret-file`. Example: `-oauth2-client-secret=myclientsecret` |
+| `-credentials-paths` | conditional | path to the directories containing the cookie encryption secret client ID, and client secret files. Required if you want Skipper to automatically update the secrets periodically. Example: `-credentials-paths=/path/to/secrets/,/path/to/othersecrets/` |
+| `-credentials-update-interval` | no | the time interval for updating credentials from files. Example: `-credentials-update-interval=30s` |
+| `-oauth2-access-token-header-name` | no | the name of the request header where the user's bearer token should be set. Default: `Authorization`. Example: `-oauth2-access-token-header-name=X-Grant-Authorization` |
+| `-oauth2-auth-url-parameters` | no | any additional URL query parameters to set for the OAuth2 provider's authorize and token endpoint calls. Example: `-oauth2-auth-url-parameters=key1=foo,key2=bar` |
+| `-oauth2-token-cookie-name` | no | the name of the cookie where the access tokens should be stored in encrypted form. Default: `oauth-grant`.  Example: `-oauth2-token-cookie-name=SESSION` |
+
+## grantCallback
+
+The filter accepts authorization codes as a result of an OAuth2 authorization code grant
+flow triggered by [oauthGrant](#oauthGrant). It uses the code to request access and
+refresh tokens from the OAuth2 provider's token endpoint.
+
+Examples:
+
+```
+grantCallback()
+```
+
+Program arguments:
+
+| Argument | Required? | Description |
+| -------- | --------- | ----------- |
+| `-oauth2-callback-path` | **yes** | path of the Skipper route containing the `grantCallback()` filter. Example: `-oauth2-callback-path=/oauth/callback` |
+
+## grantClaimsQuery
+
+The filter allows defining access control rules based on claims in a tokeninfo JSON
+payload.
+
+This filter is an alias for `oidcClaimsQuery` and functions identically to it.
+See [oidcClaimsQuery](#oidcClaimsQuery) for more information.
+
+Examples:
+
+```
+oauthGrant() -> grantClaimsQuery("/path:@_:sub%\"userid\"")
+oauthGrant() -> grantClaimsQuery("/path:scope.#[==\"email\"]")
+```
+
+Program arguments:
+
+| Argument | Required? | Description |
+| -------- | --------- | ----------- |
+| `-oauth2-tokeninfo-subject-key` | **yes** | the key of the attribute containing the OAuth2 subject ID in the OAuth2 provider's tokeninfo JSON payload. Default: `uid`. Example: `-oauth2-tokeninfo-subject-key=sub` |
+
 ## oauthOidcUserInfo
 
 ```

--- a/filters/auth/grant_test.go
+++ b/filters/auth/grant_test.go
@@ -16,20 +16,29 @@ import (
 	"github.com/zalando/skipper/proxy/proxytest"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/secrets"
+	"golang.org/x/oauth2"
 )
 
 const (
-	testToken      = "foobarbaz"
-	testAccessCode = "quxquuxquz"
-	testSecretFile = "testdata/authsecret"
+	testToken                = "foobarbaz"
+	testRefreshToken         = "refreshfoobarbaz"
+	testAccessCode           = "quxquuxquz"
+	testSecretFile           = "testdata/authsecret"
+	testAccessTokenExpiresIn = int(time.Hour / time.Second)
+	testCookieName           = "testcookie"
 )
 
-func newTestTokeninfo(validToken string) *httptest.Server {
+func newGrantTestTokeninfo(validToken string, tokenInfoJSON string) *httptest.Server {
 	const prefix = "Bearer "
+
+	if tokenInfoJSON == "" {
+		tokenInfoJSON = "{}"
+	}
+
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := func(code int) {
 			w.WriteHeader(code)
-			w.Write([]byte("{}"))
+			w.Write([]byte(tokenInfoJSON))
 		}
 
 		token := r.Header.Get("Authorization")
@@ -42,7 +51,7 @@ func newTestTokeninfo(validToken string) *httptest.Server {
 	}))
 }
 
-func newTestAuthServer(testToken, testAccessCode string) *httptest.Server {
+func newGrantTestAuthServer(testToken, testAccessCode string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := func(w http.ResponseWriter, r *http.Request) {
 			rq := r.URL.Query()
@@ -67,20 +76,35 @@ func newTestAuthServer(testToken, testAccessCode string) *httptest.Server {
 		}
 
 		token := func(w http.ResponseWriter, r *http.Request) {
-			code := r.FormValue("code")
-			if code != testAccessCode {
-				w.WriteHeader(http.StatusUnauthorized)
-				return
+			var code, refreshToken string
+
+			grantType := r.FormValue("grant_type")
+
+			switch grantType {
+			case "authorization_code":
+				code = r.FormValue("code")
+				if code != testAccessCode {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+			case "refresh_token":
+				refreshToken = r.FormValue("refresh_token")
+				if refreshToken != testRefreshToken {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
 			}
 
 			type tokenJSON struct {
-				AccessToken string `json:"access_token"`
-				ExpiresIn   int    `json:"expires_in"`
+				AccessToken  string `json:"access_token"`
+				RefreshToken string `json:"refresh_token"`
+				ExpiresIn    int    `json:"expires_in"`
 			}
 
 			token := tokenJSON{
-				AccessToken: testToken,
-				ExpiresIn:   int(time.Hour / time.Second),
+				AccessToken:  testToken,
+				RefreshToken: testRefreshToken,
+				ExpiresIn:    testAccessTokenExpiresIn,
 			}
 
 			b, err := json.Marshal(token)
@@ -104,23 +128,31 @@ func newTestAuthServer(testToken, testAccessCode string) *httptest.Server {
 	}))
 }
 
-func newAuthProxy(tokeninfoURL, providerURL string) (*proxytest.TestProxy, error) {
-	config := &auth.OAuthConfig{
-		ClientID:     "some-id",
-		ClientSecret: "some-secret",
-		Secrets:      secrets.NewRegistry(),
-		SecretFile:   testSecretFile,
-		TokeninfoURL: tokeninfoURL,
-		AuthURL:      providerURL + "/auth",
-		TokenURL:     providerURL + "/token",
+func newGrantTestConfig(tokeninfoURL, providerURL string) *auth.OAuthConfig {
+	return &auth.OAuthConfig{
+		ClientID:        "some-id",
+		ClientSecret:    "some-secret",
+		Secrets:         secrets.NewRegistry(),
+		SecretFile:      testSecretFile,
+		TokeninfoURL:    tokeninfoURL,
+		AuthURL:         providerURL + "/auth",
+		TokenURL:        providerURL + "/token",
+		TokenCookieName: testCookieName,
 	}
+}
 
+func newAuthProxy(config *auth.OAuthConfig, routes ...*eskip.Route) (*proxytest.TestProxy, error) {
 	grantSpec, err := config.NewGrant()
 	if err != nil {
 		return nil, err
 	}
 
 	grantCallbackSpec, err := config.NewGrantCallback()
+	if err != nil {
+		return nil, err
+	}
+
+	grantClaimsQuerySpec, err := config.NewGrantClaimsQuery()
 	if err != nil {
 		return nil, err
 	}
@@ -133,26 +165,52 @@ func newAuthProxy(tokeninfoURL, providerURL string) (*proxytest.TestProxy, error
 	fr := builtin.MakeRegistry()
 	fr.Register(grantSpec)
 	fr.Register(grantCallbackSpec)
+	fr.Register(grantClaimsQuerySpec)
 
 	ro := routing.Options{
 		PreProcessors: []routing.PreProcessor{grantPrep},
 	}
 
-	return proxytest.WithRoutingOptions(fr, ro, &eskip.Route{
+	return proxytest.WithRoutingOptions(fr, ro, routes...), nil
+}
+
+func newSimpleGrantAuthProxy(t *testing.T, config *auth.OAuthConfig) *proxytest.TestProxy {
+	proxy, err := newAuthProxy(config, &eskip.Route{
 		Filters: []*eskip.Filter{
 			{Name: auth.OAuthGrantName},
 			{Name: "status", Args: []interface{}{http.StatusNoContent}},
 		},
 		BackendType: eskip.ShuntBackend,
-	}), nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return proxy
 }
 
-func newHTTPClient() *http.Client {
+func newGrantHTTPClient() *http.Client {
 	return &http.Client{
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
+}
+
+func newGrantCookie(config auth.OAuthConfig) (*http.Cookie, error) {
+	return newGrantCookieWithExpiration(config, time.Now().Add(time.Second*time.Duration(testAccessTokenExpiresIn)))
+}
+
+func newGrantCookieWithExpiration(config auth.OAuthConfig, expiry time.Time) (*http.Cookie, error) {
+	token := &oauth2.Token{
+		AccessToken:  testToken,
+		RefreshToken: testRefreshToken,
+		Expiry:       expiry,
+	}
+
+	cookie, err := auth.CreateCookie(config, "", token)
+	return cookie, err
 }
 
 func checkStatus(t *testing.T, rsp *http.Response, expectedStatus int) {
@@ -179,7 +237,7 @@ func checkRedirect(t *testing.T, rsp *http.Response, expectedURL string) {
 
 func findAuthCookie(rsp *http.Response) (*http.Cookie, bool) {
 	for _, c := range rsp.Cookies() {
-		if c.Name == auth.OAuthGrantCookieName {
+		if c.Name == testCookieName {
 			return c, true
 		}
 	}
@@ -196,78 +254,213 @@ func checkCookie(t *testing.T, rsp *http.Response) {
 	if c.Value == "" {
 		t.Fatalf("Cookie deleted.")
 	}
+
+	if !c.Secure {
+		t.Fatalf("Cookie not secure")
+	}
+
+	if !c.HttpOnly {
+		t.Fatalf("Cookie not HTTP only")
+	}
+
+	accessTokenExpiryTime := time.Now().Add(time.Second * time.Duration(testAccessTokenExpiresIn))
+	if c.Expires.Before(accessTokenExpiryTime) || c.Expires == accessTokenExpiryTime {
+		t.Fatalf("Cookie expires with or before access token.")
+	}
+}
+
+func grantQueryWithCookie(t *testing.T, client *http.Client, url string, cookies ...*http.Cookie) *http.Response {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer rsp.Body.Close()
+
+	return rsp
 }
 
 func TestGrantFlow(t *testing.T) {
 	t.Log("create a test provider")
-	provider := newTestAuthServer(testToken, testAccessCode)
+	provider := newGrantTestAuthServer(testToken, testAccessCode)
 	defer provider.Close()
 
 	t.Log("create a test tokeninfo")
-	tokeninfo := newTestTokeninfo(testToken)
+	tokeninfo := newGrantTestTokeninfo(testToken, "")
 	defer tokeninfo.Close()
 
+	t.Log("create a test config")
+	config := newGrantTestConfig(tokeninfo.URL, provider.URL)
+
 	t.Log("create a proxy, returning 204, oauthGrant filter, initially without parameters")
-	proxy, err := newAuthProxy(tokeninfo.URL, provider.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	proxy := newSimpleGrantAuthProxy(t, config)
+	defer proxy.Close()
 
 	t.Log("create a client without redirects, to check it manually")
-	client := newHTTPClient()
+	client := newGrantHTTPClient()
 
-	t.Log("make a request to the proxy without a cookie")
-	rsp, err := client.Get(proxy.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("check full grant flow", func(t *testing.T) {
+		t.Log("make a request to the proxy without a cookie")
+		rsp, err := client.Get(proxy.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	defer rsp.Body.Close()
+		defer rsp.Body.Close()
 
-	t.Log("get redirected to the auth endpoint")
-	checkRedirect(t, rsp, provider.URL+"/auth")
+		t.Log("get redirected to the auth endpoint")
+		checkRedirect(t, rsp, provider.URL+"/auth")
 
-	t.Log("follow the redirect")
-	rsp, err = client.Get(rsp.Header.Get("Location"))
-	if err != nil {
-		t.Fatalf("Failed to make request to provider: %v.", err)
-	}
+		t.Log("follow the redirect")
+		rsp, err = client.Get(rsp.Header.Get("Location"))
+		if err != nil {
+			t.Fatalf("Failed to make request to provider: %v.", err)
+		}
 
-	defer rsp.Body.Close()
+		defer rsp.Body.Close()
 
-	t.Log("get redirected back to the proxy callback URL")
-	checkRedirect(t, rsp, proxy.URL+"/.well-known/oauth2-callback")
+		t.Log("get redirected back to the proxy callback URL")
+		checkRedirect(t, rsp, proxy.URL+"/.well-known/oauth2-callback")
 
-	t.Log("follow the redirect")
-	rsp, err = client.Get(rsp.Header.Get("Location"))
-	if err != nil {
-		t.Fatalf("Failed to make request to proxy: %v.", err)
-	}
+		t.Log("follow the redirect")
+		rsp, err = client.Get(rsp.Header.Get("Location"))
+		if err != nil {
+			t.Fatalf("Failed to make request to proxy: %v.", err)
+		}
 
-	defer rsp.Body.Close()
+		defer rsp.Body.Close()
 
-	t.Log("get redirected back to the proxy")
-	checkRedirect(t, rsp, proxy.URL)
+		t.Log("get redirected back to the proxy")
+		checkRedirect(t, rsp, proxy.URL)
 
-	t.Log("check auth cookie was set")
-	checkCookie(t, rsp)
+		t.Log("check auth cookie was set")
+		checkCookie(t, rsp)
 
-	t.Log("follow the redirect, with the cookie")
-	req, err := http.NewRequest("GET", rsp.Header.Get("Location"), nil)
-	if err != nil {
-		t.Fatalf("Failed to create request: %v.", err)
-	}
+		t.Log("follow the redirect, with the cookie")
+		req, err := http.NewRequest("GET", rsp.Header.Get("Location"), nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v.", err)
+		}
 
-	c, _ := findAuthCookie(rsp)
-	req.Header.Set("Cookie", fmt.Sprintf("%s=%s", c.Name, c.Value))
-	rsp, err = client.Do(req)
-	if err != nil {
-		t.Fatalf("Failed to make request to proxy: %v.", err)
-	}
+		c, _ := findAuthCookie(rsp)
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", c.Name, c.Value))
+		rsp, err = client.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to make request to proxy: %v.", err)
+		}
 
-	t.Log("check for successful request")
-	checkStatus(t, rsp, http.StatusNoContent)
+		t.Log("check for successful request")
+		checkStatus(t, rsp, http.StatusNoContent)
+	})
+
+	t.Run("check login is triggered access token is invalid", func(t *testing.T) {
+		t.Log("create expired cookie with invalid refresh token")
+		token := &oauth2.Token{
+			AccessToken:  "invalid",
+			RefreshToken: testRefreshToken,
+			Expiry:       time.Now().Add(time.Duration(1) * time.Hour),
+		}
+
+		cookie, err := auth.CreateCookie(*config, "", token)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rsp := grantQueryWithCookie(t, client, proxy.URL, cookie)
+
+		t.Log("get redirected to the auth endpoint")
+		checkRedirect(t, rsp, provider.URL+"/auth")
+	})
+
+	t.Run("check login is triggered when cookie is corrupted", func(t *testing.T) {
+		t.Log("create expired cookie with invalid refresh token")
+		url, _ := url.Parse(proxy.URL)
+		cookie := &http.Cookie{
+			Name:     config.TokenCookieName,
+			Value:    "corruptedcookievalue",
+			Path:     "/",
+			Domain:   url.Hostname(),
+			Expires:  time.Now().Add(time.Duration(1) * time.Hour),
+			Secure:   true,
+			HttpOnly: true,
+		}
+
+		rsp := grantQueryWithCookie(t, client, proxy.URL, cookie)
+
+		t.Log("get redirected to the auth endpoint")
+		checkRedirect(t, rsp, provider.URL+"/auth")
+	})
+
+	t.Run("check handles multiple cookies with same name and uses the first decodable one", func(t *testing.T) {
+		t.Log("send a request with a bad and good cookie")
+		badCookie, _ := newGrantCookie(*config)
+		badCookie.Value = "invalid"
+		goodCookie, _ := newGrantCookie(*config)
+
+		rsp := grantQueryWithCookie(t, client, proxy.URL, badCookie, goodCookie)
+
+		t.Log("check for successful request")
+		checkStatus(t, rsp, http.StatusNoContent)
+	})
 }
 
 func TestGrantRefresh(t *testing.T) {
+	t.Log("create a test provider")
+	provider := newGrantTestAuthServer(testToken, testAccessCode)
+	defer provider.Close()
+
+	t.Log("create a test tokeninfo")
+	tokeninfo := newGrantTestTokeninfo(testToken, "")
+	defer tokeninfo.Close()
+
+	t.Log("create a test config")
+	config := newGrantTestConfig(tokeninfo.URL, provider.URL)
+
+	t.Log("create a client without redirects, to check it manually")
+	client := newGrantHTTPClient()
+
+	t.Log("create a proxy, returning 204, oauthGrant filter")
+	proxy := newSimpleGrantAuthProxy(t, config)
+	defer proxy.Close()
+
+	t.Run("check token is refreshed if it expired", func(t *testing.T) {
+		t.Log("create a valid cookie")
+		cookie, err := newGrantCookieWithExpiration(*config, time.Now().Add(time.Duration(-1)*time.Minute))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rsp := grantQueryWithCookie(t, client, proxy.URL, cookie)
+
+		t.Log("check for successful request")
+		checkStatus(t, rsp, http.StatusNoContent)
+	})
+
+	t.Run("check login is triggered if refresh token is invalid", func(t *testing.T) {
+		t.Log("create expired cookie with invalid refresh token")
+		token := &oauth2.Token{
+			AccessToken:  testToken,
+			RefreshToken: "invalid",
+			Expiry:       time.Now().Add(time.Duration(-1) * time.Minute),
+		}
+
+		cookie, err := auth.CreateCookie(*config, "", token)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rsp := grantQueryWithCookie(t, client, proxy.URL, cookie)
+
+		t.Log("get redirected to the auth endpoint")
+		checkRedirect(t, rsp, provider.URL+"/auth")
+	})
 }

--- a/filters/auth/grantclaimsquery.go
+++ b/filters/auth/grantclaimsquery.go
@@ -1,0 +1,24 @@
+//
+// grantClaimsQuery filter
+//
+// An alias for oidcClaimsQuery filter allowing a clearer
+// API when used in conjunction with the oauthGrant filter.
+//
+
+package auth
+
+import "github.com/zalando/skipper/filters"
+
+const GrantClaimsQueryName = "grantClaimsQuery"
+
+type grantClaimsQuerySpec struct {
+	oidcSpec oidcIntrospectionSpec
+}
+
+func (s grantClaimsQuerySpec) Name() string {
+	return GrantClaimsQueryName
+}
+
+func (s grantClaimsQuerySpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	return s.oidcSpec.CreateFilter(args)
+}

--- a/filters/auth/grantclaimsquery_test.go
+++ b/filters/auth/grantclaimsquery_test.go
@@ -1,0 +1,88 @@
+package auth_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters/auth"
+	"github.com/zalando/skipper/proxy/proxytest"
+)
+
+func TestGrantClaimsQuery(t *testing.T) {
+	t.Log("create a test provider")
+	provider := newGrantTestAuthServer(testToken, testAccessCode)
+	defer provider.Close()
+
+	t.Log("create a test tokeninfo")
+	tokeninfo := newGrantTestTokeninfo(testToken, "{\"scope\":[\"match\"], \"uid\":\"foo\"}")
+	defer tokeninfo.Close()
+
+	t.Log("create a test config")
+	config := newGrantTestConfig(tokeninfo.URL, provider.URL)
+
+	t.Log("create a client without redirects, to check it manually")
+	client := newGrantHTTPClient()
+
+	t.Log("create a valid cookie")
+	cookie, err := newGrantCookie(*config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createProxyForQuery := func(config *auth.OAuthConfig, query string) *proxytest.TestProxy {
+		t.Log("create a proxy")
+		proxy, err := newAuthProxy(config, &eskip.Route{
+			Filters: []*eskip.Filter{
+				{Name: auth.OAuthGrantName},
+				{Name: auth.GrantClaimsQueryName, Args: []interface{}{query}},
+				{Name: "status", Args: []interface{}{http.StatusNoContent}},
+			},
+			BackendType: eskip.ShuntBackend,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return proxy
+	}
+
+	t.Run("check that matching tokeninfo properties allows the request", func(t *testing.T) {
+		proxy := createProxyForQuery(config, "/allowed:scope.#[==\"match\"]")
+		defer proxy.Close()
+
+		t.Log("make a request to an allowed endpoint")
+		url := fmt.Sprint(proxy.URL, "/allowed")
+		rsp := grantQueryWithCookie(t, client, url, cookie)
+
+		t.Log("check for successful request")
+		checkStatus(t, rsp, http.StatusNoContent)
+	})
+
+	t.Run("check that non-matching tokeninfo properties block the request", func(t *testing.T) {
+		proxy := createProxyForQuery(config, "/forbidden:scope.#[==\"noMatch\"]")
+		defer proxy.Close()
+
+		t.Log("make a request to a forbidden endpoint")
+		url := fmt.Sprint(proxy.URL, "/forbidden")
+		rsp := grantQueryWithCookie(t, client, url, cookie)
+
+		t.Log("check for unauthorized")
+		checkStatus(t, rsp, http.StatusUnauthorized)
+	})
+
+	t.Run("check that the subject claim gets initialized from a configurable tokeninfo property and is queriable", func(t *testing.T) {
+		newConfig := *config
+		newConfig.TokeninfoSubjectKey = "uid"
+
+		proxy := createProxyForQuery(&newConfig, "/allowed:@_:sub%\"foo\"")
+		defer proxy.Close()
+
+		t.Log("make a request to the endpoint")
+		url := fmt.Sprint(proxy.URL, "/allowed")
+		rsp := grantQueryWithCookie(t, client, url, cookie)
+
+		t.Log("check for successful request")
+		checkStatus(t, rsp, http.StatusNoContent)
+	})
+}

--- a/filters/auth/grantcookie.go
+++ b/filters/auth/grantcookie.go
@@ -6,10 +6,16 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/zalando/skipper/secrets"
 	"golang.org/x/oauth2"
 )
 
-const OAuthGrantCookieName = "oauth-token"
+type cookie struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	Expiry       time.Time `json:"expiry,omitempty"`
+	RefreshAfter time.Time `json:"refresh_after,omitempty"`
+}
 
 func refreshAfter(expiry time.Time) time.Time {
 	now := time.Now()
@@ -26,7 +32,56 @@ func refreshAfter(expiry time.Time) time.Time {
 	return now.Add(d)
 }
 
-func createCookie(config OAuthConfig, host string, t *oauth2.Token) (*http.Cookie, error) {
+func decodeCookie(cookieHeader string, config OAuthConfig) (c *cookie, err error) {
+	var eb []byte
+	if eb, err = base64.StdEncoding.DecodeString(cookieHeader); err != nil {
+		return
+	}
+
+	var encryption secrets.Encryption
+	if encryption, err = config.Secrets.GetEncrypter(secretsRefreshInternal, config.SecretFile); err != nil {
+		return
+	}
+
+	var b []byte
+	if b, err = encryption.Decrypt(eb); err != nil {
+		return
+	}
+
+	err = json.Unmarshal(b, &c)
+	return
+}
+
+func (c cookie) isAccessTokenExpired() bool {
+	now := time.Now()
+	return now.After(c.Expiry)
+}
+
+// GetCookie extracts the OAuth Grant token cookie from a HTTP request.
+// The function supports multiple cookies with the same name and returns
+// the best match (the one that decodes properly).
+// The client may send multiple cookies if a parent domain has set a
+// cookie of the same name.
+func getCookie(request *http.Request, config OAuthConfig) (c *cookie, err error) {
+	for _, c := range request.Cookies() {
+		if c.Name == config.TokenCookieName {
+			cookie, _ := decodeCookie(c.Value, config)
+			if cookie != nil {
+				return cookie, nil
+			}
+		}
+	}
+	return nil, http.ErrNoCookie
+}
+
+// Drops the grant token cookie from the request
+func dropCookie(request *http.Request, config OAuthConfig) {
+	cookies := request.Header.Get("Cookie")
+	cookies = config.TokenCookieRegexp.ReplaceAllString(cookies, "")
+	request.Header.Set("Cookie", cookies)
+}
+
+func CreateCookie(config OAuthConfig, host string, t *oauth2.Token) (*http.Cookie, error) {
 	c := cookie{
 		AccessToken:  t.AccessToken,
 		RefreshToken: t.RefreshToken,
@@ -53,12 +108,18 @@ func createCookie(config OAuthConfig, host string, t *oauth2.Token) (*http.Cooki
 	}
 
 	b64 := base64.StdEncoding.EncodeToString(eb)
+
+	// The cookie expiry date must not be the same as the access token
+	// expiry. Otherwise the browser deletes the cookie as soon as the
+	// access token expires, but _before_ the refresh token has expired.
+	// Since we don't know the actual refresh token expiry, set it to
+	// 30 days as a good compromise.
 	return &http.Cookie{
-		Name:     OAuthGrantCookieName,
+		Name:     config.TokenCookieName,
 		Value:    b64,
 		Path:     "/",
 		Domain:   extractDomainFromHost(host),
-		Expires:  t.Expiry,
+		Expires:  t.Expiry.Add(time.Hour * 24 * 30),
 		Secure:   true,
 		HttpOnly: true,
 	}, nil

--- a/filters/auth/grantflowstate.go
+++ b/filters/auth/grantflowstate.go
@@ -33,7 +33,7 @@ func newFlowState(secrets *secrets.Registry, secretsFile string) *flowState {
 }
 
 func stateValidityTime() int64 {
-	return time.Now().Add(time.Minute).Unix()
+	return time.Now().Add(time.Hour).Unix()
 }
 
 func (s *flowState) createState(redirectURL string) (string, error) {

--- a/filters/auth/grantprep.go
+++ b/filters/auth/grantprep.go
@@ -5,6 +5,7 @@ import "github.com/zalando/skipper/eskip"
 const (
 	defaultCallbackRouteID = "__oauth2_grant_callback"
 	defaultCallbackPath    = "/.well-known/oauth2-callback"
+	defaultTokenCookieName = "oauth-grant"
 )
 
 type grantPrep struct {

--- a/filters/auth/oidc_introspection.go
+++ b/filters/auth/oidc_introspection.go
@@ -110,7 +110,7 @@ func (filter *oidcIntrospectionFilter) Request(ctx filters.FilterContext) {
 			return
 		}
 	default:
-		unauthorized(ctx, string(filter.typ), invalidClaim, r.Host, "Wrong oidcIntrospectionFilter type")
+		unauthorized(ctx, fmt.Sprint(filter.typ), invalidClaim, r.Host, "Wrong oidcIntrospectionFilter type")
 		return
 	}
 

--- a/filters/auth/oidc_introspection.go
+++ b/filters/auth/oidc_introspection.go
@@ -110,7 +110,7 @@ func (filter *oidcIntrospectionFilter) Request(ctx filters.FilterContext) {
 			return
 		}
 	default:
-		unauthorized(ctx, fmt.Sprint(filter.typ), invalidClaim, r.Host, "Wrong oidcIntrospectionFilter type")
+		unauthorized(ctx, string(rune(filter.typ)), invalidClaim, r.Host, "Wrong oidcIntrospectionFilter type")
 		return
 	}
 

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -795,7 +795,7 @@ func TestChunkAndMergerCookie(t *testing.T) {
 	emptyCookie.Value = ""
 	largeCookie := tinyCookie
 	for i := 0; i < 5*cookieMaxSize; i++ {
-		largeCookie.Value += string(rand.Intn('Z'-'A') + 'A' + i%2*32)
+		largeCookie.Value += fmt.Sprint(rand.Intn('Z'-'A') + 'A' + i%2*32)
 	}
 	oneCookie := largeCookie
 	oneCookie.Value = oneCookie.Value[:len(oneCookie.Value)-(len(oneCookie.String())-cookieMaxSize)-1]

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -795,7 +795,7 @@ func TestChunkAndMergerCookie(t *testing.T) {
 	emptyCookie.Value = ""
 	largeCookie := tinyCookie
 	for i := 0; i < 5*cookieMaxSize; i++ {
-		largeCookie.Value += fmt.Sprint(rand.Intn('Z'-'A') + 'A' + i%2*32)
+		largeCookie.Value += string(rune(rand.Intn('Z'-'A') + 'A' + i%2*32))
 	}
 	oneCookie := largeCookie
 	oneCookie.Value = oneCookie.Value[:len(oneCookie.Value)-(len(oneCookie.String())-cookieMaxSize)-1]

--- a/skipper.go
+++ b/skipper.go
@@ -588,12 +588,35 @@ type Options struct {
 	// the access code.
 	OAuth2ClientSecret string
 
+	// OAuth2ClientIDFile, the path of the file containing the OAuth2 client id of
+	// the current service, used to exchange the access code.
+	OAuth2ClientIDFile string
+
+	// OAuth2ClientSecretFile, the path of the file containing the secret associated
+	// with the ClientID, used to exchange the access code.
+	OAuth2ClientSecretFile string
+
 	// OAuth2CallbackPath contains the path where the OAuth2 callback requests with the
 	// authorization code should be redirected to.
 	OAuth2CallbackPath string
 
 	// OAuthTokenintrospectionTimeout sets timeout duration while calling oauth tokenintrospection service
 	OAuthTokenintrospectionTimeout time.Duration
+
+	// OAuth2AuthURLParameters the additional parameters to send to OAuth2 authorize and token endpoints.
+	OAuth2AuthURLParameters map[string]string
+
+	// OAuth2AccessTokenHeaderName the name of the header to which the access token
+	// should be assigned after the oauthGrant filter.
+	OAuth2AccessTokenHeaderName string
+
+	// OAuth2TokeninfoSubjectKey the key of the subject ID attribute in the
+	// tokeninfo map. Used for downstream oidcClaimsQuery compatibility.
+	OAuth2TokeninfoSubjectKey string
+
+	// OAuth2TokenCookieName the name of the cookie that Skipper sets after a
+	// successful OAuth2 token exchange. Stores the encrypted access token.
+	OAuth2TokenCookieName string
 
 	// OIDCSecretsFile path to the file containing key to encrypt OpenID token
 	OIDCSecretsFile string
@@ -946,7 +969,12 @@ func initGrant(c *auth.OAuthConfig, o *Options) error {
 		return err
 	}
 
-	o.CustomFilters = append(o.CustomFilters, grant, grantCallback)
+	grantClaimsQuery, err := c.NewGrantClaimsQuery()
+	if err != nil {
+		return err
+	}
+
+	o.CustomFilters = append(o.CustomFilters, grant, grantCallback, grantClaimsQuery)
 	return nil
 }
 
@@ -1124,9 +1152,18 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		oauthConfig.SecretFile = o.OAuth2SecretFile
 		oauthConfig.ClientID = o.OAuth2ClientID
 		oauthConfig.ClientSecret = o.OAuth2ClientSecret
+		oauthConfig.ClientIDFile = o.OAuth2ClientIDFile
+		oauthConfig.ClientSecretFile = o.OAuth2ClientSecretFile
 		oauthConfig.CallbackPath = o.OAuth2CallbackPath
-
+		oauthConfig.AuthURLParameters = o.OAuth2AuthURLParameters
+		oauthConfig.SecretsProvider = sp
 		oauthConfig.Secrets = secrets.NewRegistry()
+		oauthConfig.AccessTokenHeaderName = o.OAuth2AccessTokenHeaderName
+		oauthConfig.TokeninfoSubjectKey = o.OAuth2TokeninfoSubjectKey
+		oauthConfig.TokenCookieName = o.OAuth2TokenCookieName
+		oauthConfig.ConnectionTimeout = o.OAuthTokeninfoTimeout
+		oauthConfig.MaxIdleConnectionsPerHost = o.IdleConnectionsPerHost
+		oauthConfig.Tracer = tracer
 
 		if err := initGrant(oauthConfig, &o); err != nil {
 			log.Errorf("Error while initializing oauth grant filter: %v.", err)


### PR DESCRIPTION
Fixes and extends the original grant PR for a fully functional OAuth2
authorization code grant flow.

Add support for loading and automatic reloading of client credentials
from the filesystem. This is accomplished by using the preexisting
`SecretsProvider`.

Make the feature more configurable. For example:
* provide arbitrary key-value pairs which should be set for all calls
to authorize and token endpoints. Accomplished with the help of a new
`mapFlags` option type.
* name of the header where to place the user's access token.
* name of the cookie where to store encrypted tokens.

Create a new `grantClaimsQuery()` filter. This is an alias for
`oidcClaimsQuery()` and enables the combination of access control rules
with the `oauthGrant()` filter.

Increase OAuth grant flow state validity time from 1 minute -> 1 hour.
One minute is a short time. The user's login is disrupted and must be
restarted if it takes them longer than a minute to actually log in.
By increasing this to 1 hour the user experience improves without
undermining security much.

Fix invalid redirect URI given to the token callback.

Fix broken token refresh. When token is valid, but token refreshing
fails, the code crashes with a segfault. The fix involves not setting
the state bag oauth2 token to a nil value.

Fix cookie expiration. Expiration relies on access token expiry,
meaning cookie is deleted by the browser before refresh token expires.
This is fixed by adding an extra 30 days to the cookie expiration time.

Reuse the `TokeninfoClient` for fetching token claims and remove the
duplicated code.

Refactor token validity checking and token refreshing code for improved
readability.

Add the tokeninfo payload to the state bag under the `tokeninfoCacheKey`
so the `oauthGrant()` filter can be used with the `forwardToken()`
filter.

Add support for handling multiple cookies with the same name. It's
possible that the browser calls `oauthGrant()` with multiple cookies
under the same name as the grant token cookie. The code handles it by
attempting to decode each cookie with the correct name, until it finds
one that decodes properly.

Make sure the grant token cookie is dropped from all requests that it
forwards downstream to prevent the cookie from leaking.

Add tutorial documentation for using the OAuth2 auth code grant flow.

Add reference documentation for all grant-related filters.

Add unit tests for new code and unit test the existing token
refresh functionality.