### PR TITLE
Support lowercase parameters in copyRequestHeader and copyResponseHeader filters

### DIFF
--- a/filters/builtin/header_test.go
+++ b/filters/builtin/header_test.go
@@ -337,6 +337,15 @@ func TestHeader(t *testing.T) {
 			expectedHeader: http.Header{
 				"X-Test-Request-Source-Host": []string{"www.example.org"},
 			},
+		}, {
+			msg:           "lowercase params",
+			args:          []interface{}{"x-test-foo", "x-test-bar"},
+			valid:         true,
+			requestHeader: http.Header{"X-Test-Foo": []string{"foo"}},
+			expectedHeader: http.Header{
+				"X-Test-Request-Foo": []string{"foo"},
+				"X-Test-Request-Bar": []string{"foo"},
+			},
 		}},
 		"copyResponseHeader": {{
 			msg:  "too few args",
@@ -371,6 +380,15 @@ func TestHeader(t *testing.T) {
 				"X-Test-Foo": []string{"foo"},
 				"X-Test-Bar": []string{"bar"},
 			},
+			expectedHeader: http.Header{
+				"X-Test-Foo": []string{"foo"},
+				"X-Test-Bar": []string{"foo"},
+			},
+		}, {
+			msg:            "lowercase params",
+			args:           []interface{}{"x-test-foo", "x-test-bar"},
+			valid:          true,
+			responseHeader: http.Header{"X-Test-Foo": []string{"foo"}},
 			expectedHeader: http.Header{
 				"X-Test-Foo": []string{"foo"},
 				"X-Test-Bar": []string{"foo"},

--- a/filters/builtin/headerfilter.go
+++ b/filters/builtin/headerfilter.go
@@ -301,8 +301,8 @@ func (f *headerFilter) Request(ctx filters.FilterContext) {
 	case appendContextRequestHeader:
 		valueFromContext(ctx, f.key, f.value, true, header.Add)
 	case copyRequestHeader, copyRequestHeaderDeprecated:
-		if _, ok := header[f.key]; ok {
-			headerValue := header.Get(f.key)
+		headerValue := header.Get(f.key)
+		if headerValue != "" {
 			header.Set(f.value, headerValue)
 			if strings.ToLower(f.value) == "host" {
 				ctx.SetOutgoingHost(headerValue)
@@ -333,8 +333,9 @@ func (f *headerFilter) Response(ctx filters.FilterContext) {
 	case appendContextResponseHeader:
 		valueFromContext(ctx, f.key, f.value, false, header.Add)
 	case copyResponseHeader, copyResponseHeaderDeprecated:
-		if _, ok := header[f.key]; ok {
-			header.Set(f.value, header.Get(f.key))
+		headerValue := header.Get(f.key)
+		if headerValue != "" {
+			header.Set(f.value, headerValue)
 		}
 	}
 }


### PR DESCRIPTION
- [ ] add lowercase name parameter tests for all header filters

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>