### PR TITLE
Adds repeatContent filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -485,6 +485,21 @@ Example:
 * -> randomContent(42) -> <shunt>;
 ```
 
+## repeatContent
+
+Generate response of specified size from repeated text.
+
+Parameters:
+
+* text to repeat (string)
+* size of response in bytes (int)
+
+Example:
+
+```
+* -> repeatContent("I will not waste chalk. ", 1000) -> <shunt>;
+```
+
 ## latency
 
 Enable adding artificial latency

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -127,6 +127,7 @@ func MakeRegistry() filters.Registry {
 		NewSetDynamicBackendUrl(),
 		NewOriginMarkerSpec(),
 		diag.NewRandom(),
+		diag.NewRepeat(),
 		diag.NewLatency(),
 		diag.NewBandwidth(),
 		diag.NewChunks(),


### PR DESCRIPTION
`repeatContent` filter generates response of specified size from repeated text

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>