### PR TITLE
Fix/apimonitoring

### DIFF
--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -248,7 +248,6 @@ func (s *apiUsageMonitoringSpec) buildPathInfoListFromConfiguration(apis []*apiC
 
 			pathPatternMatcher, err := loadOrCompileRegex(pathPattern)
 			if err != nil {
-				regCache.Store(pathPattern, nil)
 				log.Errorf(
 					"args[%d].path_templates[%d] ignored: error compiling regular expression %q for path %q: %v",
 					apiIndex, templateIndex, pathPattern, info.PathTemplate, err)

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -31,10 +31,10 @@ func loadOrCompileRegex(pattern string) (*regexp.Regexp, error) {
 	regI, ok := regCache.Load(pattern)
 	if !ok {
 		reg, err = regexp.Compile(pattern)
+		regCache.Store(pattern, reg)
 	} else {
 		reg = regI.(*regexp.Regexp)
 	}
-	regCache.Store(pattern, reg)
 	return reg, err
 }
 

--- a/filters/apiusagemonitoring/spec_test.go
+++ b/filters/apiusagemonitoring/spec_test.go
@@ -584,3 +584,62 @@ func Test_CreatePathPattern(t *testing.T) {
 		assert.Equalf(t, path.expectedPathPattern, actualPathPattern, message)
 	}
 }
+
+func Benchmark_CreateFilter_FullConfigSingleApiNakadi(b *testing.B) {
+	// Includes paths:
+	//   - normal (no variable part)
+	//   - with {name} variable paths
+	//   - with :name variable paths
+	//   - with/without head/trailing slash
+	spec := NewApiUsageMonitoring(
+		true,
+		"https://identity.zalando.com/realm",
+		"https://identity.zalando.com/managed-id,sub",
+		"services[.].*")
+
+	args := []interface{}{`{
+		"application_id": "my_app",
+		"tag": "staging",
+		"api_id": "my_api",
+		"path_templates": [
+			"/event-types",
+			"/event-types/{name}",
+			"/event-types/{name}/cursor-distances",
+			"/event-types/{name}/cursors-lag",
+			"/event-types/{name}/deleted-events",
+			"/event-types/{name}/events",
+			"/event-types/{name}/partition-count",
+			"/event-types/{name}/partitions",
+			"/event-types/{name}/partitions/{partition}",
+			"/event-types/{name}/schemas",
+			"/event-types/{name}/schemas/{version}",
+			"/event-types/{name}/shifted-cursors",
+			"/event-types/{name}/timelines",
+			"/metrics",
+			"/registry/enrichment-strategies",
+			"/registry/partition-strategies",
+			"/settings/admins",
+			"/settings/blacklist",
+			"/settings/blacklist/{blacklist_type}/{name}",
+			"/settings/features",
+			"/storages",
+			"/storages/default/{id}",
+			"/storages/{id}",
+			"/subscriptions",
+			"/subscriptions/{subscription_id}",
+			"/subscriptions/{subscription_id}/cursors",
+			"/subscriptions/{subscription_id}/events",
+			"/subscriptions/{subscription_id}/stats"
+		]
+	}`}
+	for n := 0; n < b.N; n++ {
+		f, err := spec.CreateFilter(args)
+		if err != nil {
+			b.Fatalf("Failed to run CreateFilter: %v", err)
+		}
+		filter, ok := f.(*apiUsageMonitoringFilter)
+		if !ok || filter == nil {
+			b.Fatal("Failed to convert filter")
+		}
+	}
+}


### PR DESCRIPTION
TL;DR: Speedup 2x and allocs 1/2

Before this PR
```
% go test -bench=Benchmark_CreateFilter_FullConfigSingleApiNakadi -benchmem ./filters/apiusagemonitoring -count 5 G -vE 'ERRO|INF
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/filters/apiusagemonitoring
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          1257           1051305 ns/op          337476 B/op       3865 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          1215            990956 ns/op          337656 B/op       3865 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          1236            926331 ns/op          337245 B/op       3865 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          1222            941034 ns/op          337497 B/op       3865 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4           789           1430919 ns/op          337588 B/op       3865 allocs/op
```

cache based on map+sync.Mutex (only one regexp.Compile possible at a time)
```
% go test -bench=Benchmark_CreateFilter_FullConfigSingleApiNakadi -benchmem ./filters/apiusagemonitoring -count 5 G -vE 'ERRO|INF
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/filters/apiusagemonitoring
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2590            527939 ns/op           55714 B/op       1379 allocs/o
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2474            447375 ns/op           55688 B/op       1379 allocs/o
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2511            525478 ns/op           55711 B/op       1379 allocs/o
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2509            449144 ns/op           55751 B/op       1379 allocs/o
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2293            451283 ns/op           55655 B/op       1379 allocs/o
PASS
ok      github.com/zalando/skipper/filters/apiusagemonitoring   8.266s
```

cache based on sync.Map (could have concurrent regexp.Compile runs)
```
% go test -bench=Benchmark_CreateFilter_FullConfigSingleApiNakadi -benchmem ./filters/apiusagemonitoring -count 5 G -vE 'ERRO|INFO|level=info|level=error'
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/filters/apiusagemonitoring
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2534            446211 ns/op           55806 B/op       1381 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2520            447876 ns/op           55691 B/op       1381 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2373            447189 ns/op           55745 B/op       1381 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2473            438565 ns/op           55700 B/op       1381 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2491            449118 ns/op           55780 B/op       1381 allocs/op
PASS
ok      github.com/zalando/skipper/filters/apiusagemonitoring   6.833s
```

More clean implementation
```
% go test -bench=Benchmark_CreateFilter_FullConfigSingleApiNakadi -benchmem ./filters/apiusagemonitoring -count 5 G -vE 'ERRO|INFO|level=info|level=error'
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/filters/apiusagemonitoring
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2576            449664 ns/op           55642 B/op       1379 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2644            578603 ns/op           55726 B/op       1379 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2010            591767 ns/op           55861 B/op       1379 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2334            476716 ns/op           55667 B/op       1379 allocs/op
Benchmark_CreateFilter_FullConfigSingleApiNakadi-4          2384            464545 ns/op           55704 B/op       1379 allocs/op
PASS
ok      github.com/zalando/skipper/filters/apiusagemonitoring   8.197s

```