### PR TITLE
kubernetes dataclient - mark OriginMarker as deprecated

### DIFF
--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1162,47 +1162,6 @@ func TestIngress(t *testing.T) {
 	})
 }
 
-func TestOriginMarker(t *testing.T) {
-	api := newTestAPI(t, nil, &definitions.IngressList{})
-	defer api.Close()
-
-	api.services = testServices()
-	ii := testIngresses()
-	ti := time.Now().UTC()
-	var expected []string
-	for _, i := range ii {
-		n := i.Metadata.Name
-		expected = append(expected, n)
-		i.Metadata.Uid = n
-		i.Metadata.Created = ti
-	}
-	api.ingresses.Items = ii
-
-	dc, err := New(Options{KubernetesURL: api.server.URL, OriginMarker: true})
-	if err != nil {
-		t.Error(err)
-	}
-
-	defer dc.Close()
-
-	rr, err := dc.LoadAll()
-	require.NoError(t, err)
-
-	var actual []string
-	for _, r := range rr {
-		for _, f := range r.Filters {
-			if f.Name == builtin.OriginMarkerName {
-				require.Len(t, f.Args, 3)
-				actual = append(actual, f.Args[1].(string))
-				assert.Equal(t, ingressOriginName, f.Args[0])
-				assert.Equal(t, ti, f.Args[2])
-			}
-		}
-	}
-
-	assert.ElementsMatch(t, actual, expected)
-}
-
 func TestConvertPathRule(t *testing.T) {
 	api := newTestAPI(t, nil, &definitions.IngressList{})
 	defer api.Close()

--- a/dataclients/kubernetes/update_test.go
+++ b/dataclients/kubernetes/update_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/zalando/skipper/dataclients/kubernetes/definitions"
-	"github.com/zalando/skipper/eskip"
 )
 
 func TestUpdateOnlyChangedRoutes(t *testing.T) {
@@ -40,110 +39,4 @@ func TestUpdateOnlyChangedRoutes(t *testing.T) {
 			t.Fatal("unexpected udpate received")
 		}
 	}
-}
-
-func TestOriginMarkerNotStored(t *testing.T) {
-	expectOriginMarker := func(r []*eskip.Route) {
-		for _, ri := range r {
-			for _, f := range ri.Filters {
-				if f.Name == "originMarker" {
-					return
-				}
-			}
-		}
-
-		t.Fatal("origin marker not found")
-	}
-
-	expectNoOriginMarker := func(r map[string]*eskip.Route) {
-		for _, ri := range r {
-			for _, f := range ri.Filters {
-				if f.Name == "originMarker" {
-					t.Fatal("unexpected origin marker found in stored routes")
-				}
-			}
-		}
-	}
-
-	api := newTestAPI(t,
-		&serviceList{
-			Items: []*service{
-				testService(
-					"namespace1",
-					"service1",
-					"1.2.3.4",
-					map[string]int{"port1": 8080},
-				),
-			}},
-		&definitions.IngressList{
-			Items: []*definitions.IngressItem{
-				testIngressSimple(
-					"namespace1",
-					"ingress1",
-					"service1",
-					definitions.BackendPort{Value: 8080},
-					testRule(
-						"example.org",
-						testPathRule("/", "service1", definitions.BackendPort{Value: 8080}),
-					),
-				),
-			},
-		},
-	)
-	defer api.Close()
-
-	k, err := New(Options{
-		KubernetesURL:      api.server.URL,
-		ProvideHealthcheck: true,
-		OriginMarker:       true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer k.Close()
-
-	// receive initial routes
-	r, err := k.LoadAll()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectOriginMarker(r)
-	expectNoOriginMarker(k.current)
-
-	// check for an update, expect none
-	r, d, err := k.LoadUpdate()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(r) != 0 || len(d) != 0 {
-		t.Fatal("unexpected route update received")
-	}
-
-	expectNoOriginMarker(k.current)
-
-	// make an update and receive it
-	api.ingresses.Items = append(
-		api.ingresses.Items,
-		testIngressSimple(
-			"namespace1",
-			"ingress2",
-			"service1",
-			definitions.BackendPort{Value: 8080},
-			testRule(
-				"api.example.org",
-				testPathRule("/v1", "service1", definitions.BackendPort{Value: 8080}),
-			),
-		),
-	)
-
-	r, _, err = k.LoadUpdate()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectOriginMarker(r)
-	expectNoOriginMarker(k.current)
 }


### PR DESCRIPTION
This code was for measuring a zalando internal SLO, which we do differently now. We mark the option as deprecated, log message and ignore the option

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>