### PR TITLE
Allow specifying a custom content type and response body for rate limiting

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1354,11 +1354,17 @@ Parameters:
 * number of allowed requests per time period (int)
 * time period for requests being counted (time.Duration)
 * optional parameter to set the same client by header, in case the provided string contains `,`, it will combine all these headers (string)
+* optional parameter to set the "Content-Type" header in responses to the client when the rate limit is exceeded (string)
+* optional parameter to set the response body in responses to the client when the rate limit is exceeded (string)
+
+Note: To set Content-Type and Response body, you will also need to define the preceeding optional parameter, which specifies the header to use for identifying a client.
+The default value for this header is "X-Forwarded-For", so specify this value in order to add custom rate limit response and retain your previous behaviour.
 
 ```
 clusterClientRatelimit("groupA", 10, "1h")
 clusterClientRatelimit("groupA", 10, "1h", "Authorization")
 clusterClientRatelimit("groupA", 10, "1h", "X-Forwarded-For,Authorization,User-Agent")
+clusterClientRatelimit("groupA", 10, "1h", "X-Forwarded-For", "application/problem+json", "{\"title\":\"Rate limit exceeded\",\"detail\":\"You have exceeded your ratelimit. See the retry-after and x-rate-limit headers for details.\",\"status\":429}")
 ```
 
 See also the [ratelimit docs](https://godoc.org/github.com/zalando/skipper/ratelimit).

--- a/ratelimit/doc.go
+++ b/ratelimit/doc.go
@@ -106,6 +106,14 @@ route. Make sure your settings are the same for the whole group. In
 case of different settings for the same group the behavior is
 undefined and could toggle between different configurations.
 
+Settings - ResponseContentType
+
+Defines the "Content-Type" header in responses to the client when the rate limit is exceeded.
+
+Settings - ResponseBody
+
+Defines the response body in responses to the client when the rate limit is exceeded.
+
 HTTP Response
 
 In case of rate limiting, the HTTP response status will be 429 Too

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -277,6 +277,14 @@ type Settings struct {
 	// A ratelimit group considers all hits to the same group as
 	// one target.
 	Group string `yaml:"group"`
+
+	// The Content-Type header to be used in http responses to clients
+	// when the rate limit is exceeded.
+	ResponseContentType string `yaml:"response-content-type-header"`
+
+	// The response body to be used in http responses to clients
+	// when the rate limit is exceeded.
+	ResponseBody string `yaml:"response-body"`
 }
 
 func (s Settings) Empty() bool {
@@ -296,7 +304,7 @@ func (s Settings) String() string {
 	case ClusterServiceRatelimit:
 		return fmt.Sprintf("ratelimit(type=clusterService,max-hits=%d,time-window=%s,group=%s)", s.MaxHits, s.TimeWindow, s.Group)
 	case ClusterClientRatelimit:
-		return fmt.Sprintf("ratelimit(type=clusterClient,max-hits=%d,time-window=%s,group=%s)", s.MaxHits, s.TimeWindow, s.Group)
+		return fmt.Sprintf("ratelimit(type=clusterClient,max-hits=%d,time-window=%s,group=%s,responseContentType=%s,responseBody=%s)", s.MaxHits, s.TimeWindow, s.Group, s.ResponseContentType, s.ResponseBody)
 	default:
 		return "non"
 	}


### PR DESCRIPTION
Initial attempt at closing https://github.com/zalando/skipper/issues/1628, not sure if it needs more testing and documentation