### PR TITLE
Set status and headers in rate limit filter, instead of short circuiting

### DIFF
--- a/filters/builtin/inlinecontentifstatus.go
+++ b/filters/builtin/inlinecontentifstatus.go
@@ -2,10 +2,11 @@ package builtin
 
 import (
 	"bytes"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"strconv"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/zalando/skipper/filters"
 )

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -399,10 +399,9 @@ func (f *filter) Request(ctx filters.FilterContext) {
 	}
 
 	if !rateLimiter.AllowContext(ctx.Request().Context(), s) {
-		ctx.Serve(&http.Response{
-			StatusCode: http.StatusTooManyRequests,
-			Header:     ratelimit.Headers(&f.settings, rateLimiter.RetryAfter(s)),
-		})
+		ctx.Response().StatusCode = http.StatusTooManyRequests
+		ctx.Response().Header = ratelimit.Headers(&f.settings, rateLimiter.RetryAfter(s))
+		return
 	}
 }
 


### PR DESCRIPTION
Alternate fix for https://github.com/zalando/skipper/issues/1628.

Changes the rate limit filter so that it sets the status and headers instead of returning its own response immediately. This allows the inlineContentIfStatus filter to work with rate limits