### PR TITLE
Checks request context error before roundtrip error

### DIFF
--- a/proxy/clienttimeout_test.go
+++ b/proxy/clienttimeout_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -56,4 +57,59 @@ func TestClientTimeout(t *testing.T) {
 	if err = tp.log.WaitFor(msgErrClientCanceledAfter, 3*d); err != nil {
 		t.Errorf("log should contain '%s'", msgErrClientCanceledAfter)
 	}
+}
+
+func TestClientCancellation(t *testing.T) {
+	service := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer service.Close()
+
+	doc := fmt.Sprintf(`* -> "%s"`, service.URL)
+	tp, err := newTestProxy(doc, FlagsNone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tp.close()
+	if testing.Verbose() {
+		tp.log.Unmute()
+	}
+
+	ps := httptest.NewServer(tp.proxy)
+	defer ps.Close()
+
+	addr := ps.Listener.Addr().String()
+
+	const N = 100
+	for i := 0; i < N; i++ {
+		if err := postTruncated(addr); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const msg = "POST / HTTP/1.1"
+	if err = tp.log.WaitForN(msg, N, 500*time.Millisecond); err != nil {
+		t.Fatalf("expected %d requests, got %d", N, tp.log.Count(msg))
+	}
+
+	// Look for N messages like
+	// 2020/12/05 17:24:00 client canceled after 1.090638ms, route  with backend network http://127.0.0.1:39687, status code 499: dialing failed false: context canceled, remote host: 127.0.0.1, request: "POST / HTTP/1.1", user agent: ""
+	for _, m := range []string{"client canceled after", "status code 499", "context canceled"} {
+		count := tp.log.Count(m)
+		if count != N {
+			t.Errorf("expected '%s' %d times, got %d", m, N, tp.log.Count(m))
+		}
+	}
+}
+
+func postTruncated(addr string) (err error) {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return
+	}
+	_, err = conn.Write([]byte("POST / HTTP/1.1\nHost: " + addr + "\nContent-Length: 100\n\ntruncated"))
+	if err != nil {
+		return
+	}
+	return conn.Close()
 }


### PR DESCRIPTION
When client abruptly closes request the context gets `context canceled` error but the roundtrip
may end up with either `unexpected EOF` or the same `context canceled` error nondeterministically.

This change checks request context error before checking roundtrip error.

See https://github.com/zalando/skipper/issues/1631#issuecomment-739110280

Fixes #1631

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>