### PR TITLE
condition already checked before

### DIFF
--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -91,11 +91,6 @@ func newRedirectTest(t *testing.T, redirectEnabled bool) (*redirectTest, error) 
 		t.Fatal("waiting for route settings", err)
 	}
 
-	if err != nil {
-		t.Error(err)
-		return nil, err
-	}
-
 	ingress := i.Items[0]
 	rule := ingress.Spec.Rules[0]
 	service := s.Items[0].Spec


### PR DESCRIPTION
```
% nilness ./...
/home/sszuecs/go/src/github.com/zalando/skipper/dataclients/kubernetes/httpsredirect_test.go:94:9: impossible condition: nil != nil
zsh: exit 3     nilness ./...

```

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>