### PR TITLE
Revert "we moved the responsibility of the project "

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -6,4 +6,4 @@ approvals:
       from:
         orgs:
           - "zalando"
-X-Zalando-Team: "teapot"
+X-Zalando-Team: "pathfinder"


### PR DESCRIPTION
Reverts zalando/skipper#1638, because it breaks the pipeline