### PR TITLE
Extends templating with request/response placeholders

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -19,13 +19,27 @@ all: * -> filter1 -> filter2 -> "http://127.0.0.1:1234/";
 ## Template placeholders
 
 Several filters support template placeholders (`${var}`) in string parameters.
-Template placeholder is replaced by the value that is looked up in filter context path parameters.
-Missing template placeholder value interpretation depends on the filter.
+
+Template placeholder is replaced by the value that is looked up in the following sources:
+
+* request url path (`${request.path}`)
+* request url query (if starts with `request.query.` prefix, e.g `${request.query.q}` is replaced by `q` query parameter value)
+* request headers (if starts with `request.header.` prefix, e.g `${request.header.Content-Type}` is replaced by `Content-Type` request header value)
+* request cookies (if starts with `request.cookie.` prefix, e.g `${request.cookie.PHPSESSID}` is replaced by `PHPSESSID` request cookie value)
+* response headers (if starts with `response.header.` prefix, e.g `${response.header.Location}` is replaced by `Location` response header value)
+* filter context path parameters (e.g. `${id}` is replaced by `id` path parameter value)
+
+Missing value interpretation depends on the filter.
 
 Example route that rewrites path using template placeholder:
 
 ```
 u1: Path("/user/:id") -> setPath("/v2/user/${id}") -> <loopback>;
+```
+
+Example route that creates header from query parameter:
+```
+r: Path("/redirect") && QueryParam("to") -> status(303) -> setResponseHeader("Location", "${request.query.to}") -> <shunt>;
 ```
 
 ## backendIsProxy

--- a/eskip/template_test.go
+++ b/eskip/template_test.go
@@ -1,6 +1,8 @@
 package eskip
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/zalando/skipper/filters/filtertest"
@@ -63,6 +65,14 @@ func TestTemplateGetter(t *testing.T) {
 }
 
 func TestTemplateApplyRequestResponseContext(t *testing.T) {
+	parseUrl := func(s string) *url.URL {
+		u, err := url.Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
+
 	for _, ti := range []struct {
 		name           string
 		template       string
@@ -104,18 +114,185 @@ func TestTemplateApplyRequestResponseContext(t *testing.T) {
 		false,
 		"hello X ",
 		false,
+	}, {
+		"request header",
+		"hello ${request.header.X-Foo}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				Header: http.Header{
+					"X-Foo": []string{"foo"},
+				},
+			},
+		},
+		"hello foo",
+		true,
+		"hello foo",
+		true,
+	}, {
+		"missing request header",
+		"hello ${request.header.X-Foo}",
+		&filtertest.Context{
+			FRequest: &http.Request{},
+		},
+		"hello ",
+		false,
+		"hello ",
+		false,
+	}, {
+		"response header",
+		"hello ${response.header.X-Foo}",
+		&filtertest.Context{
+			FResponse: &http.Response{
+				Header: http.Header{
+					"X-Foo": []string{"foo"},
+				},
+			},
+		},
+		"hello ",
+		false, // response headers are not available in request context
+		"hello foo",
+		true,
+	}, {
+		"missing response header",
+		"hello ${response.header.X-Foo}",
+		&filtertest.Context{
+			FResponse: &http.Response{},
+		},
+		"hello ",
+		false,
+		"hello ",
+		false,
+	}, {
+		"request and response headers (lowercase)",
+		"hello ${request.header.x-foo} ${response.header.x-foo}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				Header: http.Header{
+					"X-Foo": []string{"bar"},
+				},
+			},
+			FResponse: &http.Response{
+				Header: http.Header{
+					"X-Foo": []string{"baz"},
+				},
+			},
+		},
+		"hello bar ",
+		false, // response headers are not available in request context
+		"hello bar baz",
+		true,
+	}, {
+		"request query",
+		"hello ${request.query.q-Q} ${request.query.P_p}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				URL: parseUrl("http://example.com/path?q-Q=foo&P_p=bar"),
+			},
+		},
+		"hello foo bar",
+		true,
+		"hello foo bar",
+		true,
+	}, {
+		"missing request query",
+		"hello ${request.query.missing}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				URL: parseUrl("http://example.com/path?p=foo"),
+			},
+		},
+		"hello ",
+		false,
+		"hello ",
+		false,
+	}, {
+		"request cookie",
+		"hello ${request.cookie.foo} ${request.cookie.x}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				Header: http.Header{
+					"Cookie": []string{"foo=bar; x=y"},
+				},
+			},
+		},
+		"hello bar y",
+		true,
+		"hello bar y",
+		true,
+	}, {
+		"missing request cookie",
+		"hello ${request.cookie.missing}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				Header: http.Header{
+					"Cookie": []string{"foo=bar; x=y"},
+				},
+			},
+		},
+		"hello ",
+		false,
+		"hello ",
+		false,
+	}, {
+		"request path",
+		"hello ${request.path}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				URL: parseUrl("http://example.com/foo/bar"),
+			},
+		},
+		"hello /foo/bar",
+		true,
+		"hello /foo/bar",
+		true,
+	}, {
+		"request path is empty",
+		"hello ${request.path}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				URL: parseUrl("http://example.com"),
+			},
+		},
+		"hello ",
+		false, // path is empty
+		"hello ",
+		false,
+	}, {
+		"all in one",
+		"Hello ${name} ${request.header.name} ${request.query.name} ${request.cookie.name} ${response.header.name}",
+		&filtertest.Context{
+			FParams: map[string]string{
+				"name": "one",
+			},
+			FRequest: &http.Request{
+				URL: parseUrl("http://example.com/path?name=three"),
+				Header: http.Header{
+					"Name":   []string{"two"},
+					"Cookie": []string{"name=four"},
+				},
+			},
+			FResponse: &http.Response{
+				Header: http.Header{
+					"Name": []string{"five"},
+				},
+			},
+		},
+		"Hello one two three four ",
+		false, // response headers are not available in request context
+		"Hello one two three four five",
+		true,
 	},
 	} {
 		t.Run(ti.name, func(t *testing.T) {
 			template := NewTemplate(ti.template)
 			result, ok := template.ApplyRequestContext(ti.context)
 			if result != ti.requestExpect || ok != ti.requestOk {
-				t.Errorf("Apply request context result mismatch: '%s' != '%s'", result, ti.requestExpect)
+				t.Errorf("Apply request context result mismatch: '%s' (%v) != '%s' (%v)", result, ok, ti.requestExpect, ti.requestOk)
 			}
 
 			result, ok = template.ApplyResponseContext(ti.context)
 			if result != ti.responseExpect || ok != ti.responseOk {
-				t.Errorf("Apply response context result mismatch: '%s' != '%s'", result, ti.responseExpect)
+				t.Errorf("Apply response context result mismatch: '%s' (%v) != '%s' (%v)", result, ok, ti.responseExpect, ti.responseOk)
 			}
 		})
 	}


### PR DESCRIPTION
Adds support for the following placeholders:
* request header
* request url query
* request cookie
* response header

See #1444

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>