### PR TITLE
Enhances `tracingTag` filter to support template placeholders

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2179,9 +2179,17 @@ Syntax:
 tracingTag("<tag_name>", "<tag_value>")
 ```
 
+Tag value may contain [template placeholders](#template-placeholders).
+If a template placeholder can't be resolved then filter does not set the tag.
+
 Example: Adding the below filter will add a tag named `foo` with the value `bar`.
 ```
 tracingTag("foo", "bar")
+```
+
+Example: Set tag from request header
+```
+tracingTag("http.flow_id", "${request.header.X-Flow-Id}")
 ```
 
 ## originMarker


### PR DESCRIPTION
Fixes #704
See also https://github.com/zalando/skipper/issues/1516#issuecomment-748941875

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>