### PR TITLE
Fixes gosec errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,9 @@ staticcheck: $(SOURCES)
 # G101 find by variable name match "oauth" are not hardcoded credentials
 # G104 ignoring errors are in few cases fine
 # G304 reading kubernetes secret filepaths are not a file inclusions
+# G402 See https://github.com/securego/gosec/issues/551 and https://github.com/securego/gosec/issues/528
 gosec: $(SOURCES)
-	GO111MODULE=$(GO111) .bin/gosec -quiet -exclude="G101,G104,G304" ./...
+	GO111MODULE=$(GO111) .bin/gosec -quiet -exclude="G101,G104,G304,G402" ./...
 
 fmt: $(SOURCES)
 	@gofmt -w -s $(SOURCES)

--- a/_test_plugins/multitype_noop.go
+++ b/_test_plugins/multitype_noop.go
@@ -7,23 +7,23 @@ import (
 	"github.com/zalando/skipper/routing"
 )
 
-type noopSpec struct {
+type multiSpec struct {
 	Type string
 }
 
 func InitPlugin(opts []string) ([]filters.Spec, []routing.PredicateSpec, []routing.DataClient, error) {
-	return []filters.Spec{noopSpec{"noop"}}, []routing.PredicateSpec{noopSpec{"None"}}, nil, nil
+	return []filters.Spec{multiSpec{"noop"}}, []routing.PredicateSpec{multiSpec{"None"}}, nil, nil
 }
 
-func (s noopSpec) Name() string {
+func (s multiSpec) Name() string {
 	return s.Type
 }
 
-func (s noopSpec) CreateFilter(config []interface{}) (filters.Filter, error) {
+func (s multiSpec) CreateFilter(config []interface{}) (filters.Filter, error) {
 	return noop{}, nil
 }
 
-func (s noopSpec) Create(config []interface{}) (routing.Predicate, error) {
+func (s multiSpec) Create(config []interface{}) (routing.Predicate, error) {
 	return noop{}, nil
 }
 


### PR DESCRIPTION
* Fixes `_test_plugins` type redeclation (`gosec` treats `_test_plugins` as a package)
* Excludes `G402` `gosec` check due to https://github.com/securego/gosec/issues/551 and https://github.com/securego/gosec/issues/528

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>