### PR TITLE
Add EastWest Range feature

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -64,6 +64,7 @@ func Test_NewConfig(t *testing.T) {
 				AppendFilters:                           &defaultFiltersFlags{},
 				PrependFilters:                          &defaultFiltersFlags{},
 				SourcePollTimeout:                       3000,
+				KubernetesEastWestRangeDomains:          commaListFlag(),
 				KubernetesHealthcheck:                   true,
 				KubernetesHTTPSRedirect:                 true,
 				KubernetesHTTPSRedirectCode:             308,

--- a/dataclients/kubernetes/eastwest.go
+++ b/dataclients/kubernetes/eastwest.go
@@ -43,3 +43,17 @@ func createEastWestRouteRG(name, ns, postfix string, r *eskip.Route) *eskip.Rout
 	ewr.Predicates = p
 	return ewr
 }
+
+func applyEastWestRange(domains []string, predicates []*eskip.Predicate, host string, routes []*eskip.Route) {
+	for _, d := range domains {
+		if strings.HasSuffix(host, d) {
+			applyEastWestRangePredicates(routes, predicates)
+		}
+	}
+}
+
+func applyEastWestRangePredicates(routes []*eskip.Route, predicates []*eskip.Predicate) {
+	for _, route := range routes {
+		route.Predicates = append(route.Predicates, predicates...)
+	}
+}

--- a/dataclients/kubernetes/hosts.go
+++ b/dataclients/kubernetes/hosts.go
@@ -62,9 +62,3 @@ func hostCatchAllRoutes(hostRoutes map[string][]*eskip.Route, createID func(stri
 
 	return catchAll
 }
-
-func mergeHostRoutes(to, from map[string][]*eskip.Route) {
-	for host, routes := range from {
-		to[host] = append(to[host], routes...)
-	}
-}

--- a/dataclients/kubernetes/ingress.go
+++ b/dataclients/kubernetes/ingress.go
@@ -47,6 +47,8 @@ type ingress struct {
 	pathMode                    PathMode
 	kubernetesEnableEastWest    bool
 	eastWestDomainRegexpPostfix string
+	eastWestRangeDomains        []string
+	eastWestRangePredicates     []*eskip.Predicate
 }
 
 var nonWord = regexp.MustCompile(`\W`)
@@ -67,6 +69,8 @@ func newIngress(o Options) *ingress {
 		pathMode:                    o.PathMode,
 		kubernetesEnableEastWest:    o.KubernetesEnableEastWest,
 		eastWestDomainRegexpPostfix: ewPostfix,
+		eastWestRangeDomains:        o.KubernetesEastWestRangeDomains,
+		eastWestRangePredicates:     o.KubernetesEastWestRangePredicates,
 	}
 }
 
@@ -753,6 +757,7 @@ func (ing *ingress) convert(state *clusterState, df defaultFilters) ([]*eskip.Ro
 			continue
 		}
 
+		applyEastWestRange(ing.eastWestRangeDomains, ing.eastWestRangePredicates, host, rs)
 		routes = append(routes, rs...)
 
 		// if routes were configured, but there is no catchall route

--- a/dataclients/kubernetes/ingress_test.go
+++ b/dataclients/kubernetes/ingress_test.go
@@ -10,5 +10,6 @@ func TestIngressFixtures(t *testing.T) {
 	kubernetestest.FixturesToTest(t, "testdata/ingress/named-ports")
 	kubernetestest.FixturesToTest(t, "testdata/ingress/ingress-data")
 	kubernetestest.FixturesToTest(t, "testdata/ingress/eastwest")
+	kubernetestest.FixturesToTest(t, "testdata/ingress/eastwestrange")
 	kubernetestest.FixturesToTest(t, "testdata/ingress/service-ports")
 }

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -152,6 +152,15 @@ type Options struct {
 	// KubernetesEastWestDomain sets the DNS domain to be used for east west traffic, defaults to "skipper.cluster.local"
 	KubernetesEastWestDomain string
 
+	// KubernetesEastWestRangeDomains set the the cluster internal domains for
+	// east west traffic. Identified routes to such domains will include
+	// the KubernetesEastWestRangePredicates.
+	KubernetesEastWestRangeDomains []string
+
+	// KubernetesEastWestRangePredicates set the Predicates that will be
+	// appended to routes identified as to KubernetesEastWestRangeDomains.
+	KubernetesEastWestRangePredicates []*eskip.Predicate
+
 	// DefaultFiltersDir enables default filters mechanism and sets the location of the default filters.
 	// The provided filters are then applied to all routes.
 	DefaultFiltersDir string

--- a/dataclients/kubernetes/kubernetestest/fixtures.go
+++ b/dataclients/kubernetes/kubernetestest/fixtures.go
@@ -32,11 +32,13 @@ type fixtureSet struct {
 }
 
 type kubeOptionsParser struct {
-	EastWest              bool   `yaml:"eastWest"`
-	EastWestDomain        string `yaml:"eastWestDomain"`
-	HTTPSRedirect         bool   `yaml:"httpsRedirect"`
-	HTTPSRedirectCode     int    `yaml:"httpsRedirectCode"`
-	BackendNameTracingTag bool   `yaml:"backendNameTracingTag"`
+	EastWest                bool               `yaml:"eastWest"`
+	EastWestDomain          string             `yaml:"eastWestDomain"`
+	EastWestRangeDomains    []string           `yaml:"eastWestRangeDomains"`
+	EastWestRangePredicates []*eskip.Predicate `yaml:"eastWestRangePredicatesAppend"`
+	HTTPSRedirect           bool               `yaml:"httpsRedirect"`
+	HTTPSRedirectCode       int                `yaml:"httpsRedirectCode"`
+	BackendNameTracingTag   bool               `yaml:"backendNameTracingTag"`
 }
 
 func baseNoExt(n string) string {
@@ -191,6 +193,8 @@ func testFixture(t *testing.T, f fixtureSet) {
 
 		o.KubernetesEnableEastWest = kop.EastWest
 		o.KubernetesEastWestDomain = kop.EastWestDomain
+		o.KubernetesEastWestRangeDomains = kop.EastWestRangeDomains
+		o.KubernetesEastWestRangePredicates = kop.EastWestRangePredicates
 		o.ProvideHTTPSRedirect = kop.HTTPSRedirect
 		o.HTTPSRedirectCode = kop.HTTPSRedirectCode
 		o.BackendNameTracingTag = kop.BackendNameTracingTag

--- a/dataclients/kubernetes/routegroups_test.go
+++ b/dataclients/kubernetes/routegroups_test.go
@@ -26,6 +26,10 @@ func TestRouteGroupEastWest(t *testing.T) {
 	kubernetestest.FixturesToTest(t, "testdata/routegroups/east-west")
 }
 
+func TestRouteGroupEastWestRange(t *testing.T) {
+	kubernetestest.FixturesToTest(t, "testdata/routegroups/east-west-range")
+}
+
 func TestRouteGroupHTTPSRedirect(t *testing.T) {
 	kubernetestest.FixturesToTest(t, "testdata/routegroups/https-redirect")
 }

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.eskip
@@ -1,0 +1,9 @@
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	-> consecutiveBreaker(15)
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	-> consecutiveBreaker(15)
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-filter: consecutiveBreaker(15)
+spec:
+  rules:
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.eskip
@@ -1,0 +1,11 @@
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	-> consecutiveBreaker(15)
+	-> preserveHost("true")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	-> consecutiveBreaker(15)
+	-> preserveHost("true")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-filter: consecutiveBreaker(15) -> preserveHost("true")
+spec:
+  rules:
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.eskip
@@ -1,0 +1,17 @@
+kube_foo__qux__0__example_ingress_cluster_local_____:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& ClientIP("10.2.0.0/16") -> <roundRobin,
+	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+
+kube_foo__qux__0__www_example_org_____:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	&& Method("OPTIONS") -> <shunt>;
+
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-routes: Method("OPTIONS") -> <shunt>
+spec:
+  rules:
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.eskip
@@ -1,0 +1,17 @@
+kube_foo__qux__0__example_ingress_cluster_local_____:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& ClientIP("10.2.0.0/16") -> <roundRobin,
+	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+
+kube_foo__qux__0__www_example_org_____:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	&& Method("OPTIONS") -> <shunt>;
+
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-routes: Method("OPTIONS") -> <shunt>
+spec:
+  rules:
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.eskip
@@ -1,0 +1,9 @@
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/") &&
+	QueryParam("version", "^alpha$") && Header("Accept", "application/json")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") &&  PathRegexp("^/")
+	&& QueryParam("version", "^alpha$") && Header("Accept", "application/json")
+	&& ClientIP("10.2.0.0/16") &&  Source("10.8.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.kube
@@ -1,0 +1,7 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]
+    - name: "Source"
+      args: ["10.8.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-predicate: QueryParam("version", "^alpha$") && Header("Accept", "application/json")
+spec:
+  rules:
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.eskip
@@ -1,0 +1,7 @@
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") &&  PathRegexp("^/") && QueryParam("version", "^alpha$") 
+	&& ClientIP("10.2.0.0/16") -> <roundRobin,
+	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-predicate: QueryParam("version", "^alpha$")
+spec:
+  rules:
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
@@ -1,0 +1,8 @@
+kube_foo__qux__0__example_ingress_cluster_local_____:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathSubtree("/")
+	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathSubtree("/")
+	&& ClientIP("10.2.0.0/16") -> <roundRobin,
+	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-routes: Method("OPTIONS") -> <shunt>
+    zalando.org/skipper-ingress-path-mode: path-prefix
+spec:
+  rules:
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.eskip
@@ -1,0 +1,8 @@
+kube_foo__qux__0__example_ingress_cluster_local_____:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& ClientIP("10.2.0.0/16") -> <roundRobin,
+	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-routes: Method("OPTIONS") -> <shunt>
+spec:
+  rules:
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.eskip
@@ -1,0 +1,6 @@
+kube_foo__qux______: *
+	-> <roundRobin, "http://10.2.9.103:2134", "http://10.2.9.104:2134">;
+
+kube_foo__qux__example_ingress_cluster_local_____bar:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.yaml
@@ -1,0 +1,56 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  namespace: foo
+  name: qux
+spec:
+  backend:
+    serviceName: bar
+    servicePort: 1234
+  rules:
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: bar
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: foo
+  name: bar
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  - name: qux
+    port: 1234
+    protocol: TCP
+    targetPort: 2134
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  namespace: foo
+  name: bar
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP
+  - name: qux
+    port: 2134
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.eskip
@@ -1,0 +1,51 @@
+kube_foo__qux_a_0__example_ingress_cluster_local_____:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+kube_foo__qux_b_1__example_ingress_cluster_local_____:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& Cookie("alpha","^enabled$") && ClientIP("10.2.0.0/16")
+	-> "http://1.1.2.0:8181";
+
+kube_foo__qux_c_2__example_ingress_cluster_local_____:
+	Host("^example[.]ingress[.]cluster[.]local$") &&
+	Path("/a/path/somewhere") && ClientIP("10.2.0.0/16") && PathRegexp("^/")
+	-> "https://some.other-url.org/a/path/somewhere";
+
+kube_foo__qux__example_ingress_cluster_local_____qux:
+	Host("^example[.]ingress[.]cluster[.]local$") && PathRegexp("^/")
+	&& ClientIP("10.2.0.0/16") -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_foo__qux_a_0__www_example_org_____:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	&& Method("OPTIONS") -> <shunt>;
+
+kube_foo__qux_b_1__www_example_org_____:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	&& Cookie("alpha","^enabled$")
+	-> "http://1.1.2.0:8181";
+
+kube_foo__qux_c_2__www_example_org_____:
+	Host("^www[.]example[.]org$") && Path("/a/path/somewhere") && PathRegexp("^/")
+	-> "https://some.other-url.org/a/path/somewhere";
+
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_foo__qux_a_0__www2_anotherexample_org_____:
+	Host("^www2[.]anotherexample[.]org$") && PathRegexp("^/")
+	&& Method("OPTIONS") -> <shunt>;
+
+kube_foo__qux_b_1__www2_anotherexample_org_____:
+	Host("^www2[.]anotherexample[.]org$") && PathRegexp("^/")
+	&& Cookie("alpha","^enabled$")
+	-> "http://1.1.2.0:8181";
+
+kube_foo__qux_c_2__www2_anotherexample_org_____:
+	Host("^www2[.]anotherexample[.]org$") && Path("/a/path/somewhere") && PathRegexp("^/")
+	-> "https://some.other-url.org/a/path/somewhere";
+
+kube_foo__qux__www2_anotherexample_org_____qux:
+	Host("^www2[.]anotherexample[.]org$") && PathRegexp("^/")
+	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.yaml
@@ -1,0 +1,65 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+  annotations:
+    zalando.org/skipper-routes: |
+        a: Method("OPTIONS") -> <shunt>;
+        b: Cookie("alpha", /^enabled$/) -> "http://1.1.2.0:8181";
+        c: Path("/a/path/somewhere") -> "https://some.other-url.org/a/path/somewhere";
+spec:
+  rules:
+  - host: example.ingress.cluster.local
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+  - host: www2.anotherexample.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.eskip
@@ -1,0 +1,3 @@
+kube_foo__qux__www_example_org_____qux:
+	Host("^www[.]example[.]org$") && PathRegexp("^/")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.kube
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.yaml
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  rules:
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: qux
+          servicePort: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.eskip
@@ -1,0 +1,14 @@
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16")
+	&& Traffic(0.3333333333333333)
+	&& True()
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+
+kube_rg__internal_default__myapp__all__0_1:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16")
+	&& Traffic(0.5)
+	-> "https://www.example.org";
+
+kube_rg__internal_default__myapp__all__0_2:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16")
+	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.yaml
@@ -1,0 +1,46 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: external
+    type: network
+    address: https://www.example.org
+  - name: test
+    type: network
+    address: https://test.example.org
+  defaultBackends:
+  - backendName: myapp
+  - backendName: external
+  - backendName: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.eskip
@@ -1,0 +1,7 @@
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+
+kube_rg__default__myapp__all__0_0:
+	Host("^(app[.]example[.]org)$")
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.yaml
@@ -1,0 +1,39 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  - app.example.org
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.eskip
@@ -1,0 +1,12 @@
+kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+kube_rg____example_org__catchall__0_0:
+	Host("^(example[.]org)$") -> <shunt>;
+
+kube_rg__default__myapp__all__0_0:
+	Host("^(example[.]org)$") && Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && Path("/app") && ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.4.16:80","http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.yaml
@@ -1,0 +1,41 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.org
+  - example.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - path: /app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.eskip
@@ -1,0 +1,1 @@
+// no routes

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
@@ -1,0 +1,3 @@
+[[]routegroup[]]
+error transforming internal hosts for default/myapp: service not found:
+default/myapp.

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.yaml
@@ -1,0 +1,16 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - path: /app

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.eskip
@@ -1,0 +1,7 @@
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") &&
+	ClientIP("10.2.0.0/16") && Header("X-Foo", "bar")
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+
+kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.yaml
@@ -1,0 +1,41 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - predicates:
+    - Header("X-Foo", "bar")
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.eskip
@@ -1,0 +1,7 @@
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16")
+	&& Path("/app")
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+
+kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.yaml
@@ -1,0 +1,40 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - path: /app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.eskip
@@ -1,0 +1,3 @@
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.yaml
@@ -1,0 +1,38 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.eskip
@@ -1,0 +1,7 @@
+kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(example[.]ingress[.]cluster[.]local)$")
+	&& Path("/app") && ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.yaml
@@ -1,0 +1,40 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - path: /app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/docs/tutorials/operations.md
+++ b/docs/tutorials/operations.md
@@ -53,7 +53,7 @@ The Kubernetes Ingress spec defines a
 as regular expression, which is not what most people would expect, nor
 want. Skipper defaults in Kubernetes to use the [PathRegexp predicate](../reference/predicates.md#pathregexp)
 for routing, because of the spec. We believe the better default is the
-path prefix mode, that uses [PathSubtree predicate](../../reference/predicates#pathsubtree),
+path prefix mode, that uses [PathSubtree predicate](../reference/predicates#pathsubtree),
 instead. Path prefix search is much more scalable and can not lead to
 unexpected results by not so experienced regular expressions users.
 
@@ -78,12 +78,16 @@ than the ALB in front.
 
 ### Opt-In more features
 
+#### Reverse Source Predicate
+
 Depending on the HTTP loadbalancer in front of your Skippers, you might
 want to set `-reverse-source-predicate`. This setting reverses the
 lookup of the client IP to find it in the `X-Forwarded-For` header
 values. If you do not care about
 [clientRatelimits](../../reference/filters#clientratelimit)
 based on X-Forwarded-For headers, you can also ignore this.
+
+#### Cluster Ratelimit
 
 Ratelimits can be calculated for the whole cluster instead of having
 only the instance based ratelimits. The common term we use in skipper
@@ -99,6 +103,8 @@ service](https://github.com/zalando-incubator/kubernetes-on-aws/blob/beta/cluste
 to have predictable names. We chose to not use a persistent volume,
 because storing the data in memory is good enough for this use case.
 
+#### East West
+
 Skipper supports cluster internal service-to-service communication as
 part of running as an [API Gateway with an East-West
 setup](../../kubernetes/ingress-controller/#run-as-api-gateway-with-east-west-setup).
@@ -106,15 +112,19 @@ You have to add `-enable-kubernetes-east-west` and optionally choose a
 domain
 `-kubernetes-east-west-domain=.ingress.cluster.local`. Be warned: There is a
 [known bug](https://github.com/zalando/skipper/issues/1024), if you
-combine it with custom routes.
+combine it with custom routes. You might want to consider [EastWest
+Range](#east-west-range).
+
+#### East West Range
 
 Alternatively, you can use Kubernetes East West Range feature. Use the
 flag `-kubernetes-east-west-range-domains` to define the cluster
 internal domains `-kubernetes-east-west-range-predicates` to define the
-[predicates](../../reference/predicates) that will be appended to every
+[predicates](../reference/predicates.md) that will be appended to every
 route identified as an internal domain. Differently from the
 `-enable-kubernetes-east-west` and the
-`-kubernetes-east-west-domain=.ingress.cluster.local` flags this feature
+`-kubernetes-east-west-domain=.ingress.cluster.local` flags (check
+[East West](#east-west)) this feature
 will not automatically create routes for you and both features shouldn't
 be used in combination. The ingress and/or route groups resources must
 opt-in for east west range routes, explicitly defining them. For example,
@@ -150,7 +160,7 @@ Skipper will secure this route adding the predicate `ClientIP("10.2.0.0/16")`.
 The same ingress might be used for internal and external hostnames. For
 example, given a slightly modified version of the ingress:
 
- ```yaml
+```yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -175,11 +185,15 @@ skippper \
   -kubernetes-east-west-range-predicates='ClientIP("10.2.0.0/16") && SourceLastFrom("10.2.0.0/16")'
 ```
 
+#### API monitoring and Auth
+
 As part of API Gateway features, skipper supports [API
 monitoring](https://opensource.zalando.com/skipper/reference/filters/#apiusagemonitoring)
 and common [authentication and
 authorization](https://opensource.zalando.com/skipper/tutorials/auth/)
 protocols in Microservices architectures.
+
+#### OpenTracing
 
 Skipper has support for different [OpenTracing API](http://opentracing.io/) vendors, including
 [jaeger](https://www.jaegertracing.io/),
@@ -190,6 +204,8 @@ searchable `component` and `cluster` `tag` you can use:
 `- "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing-collector.endpoint:8444 cmd-line=skipper-ingress max-buffered-spans=4096 tag=cluster=mycluster"`.
 The `LIGHTSTEP_TOKEN` is passed as environment variable to
 the process.
+
+#### Global default filters
 
 Skipper can also add [global default filters](../../operation/operation/#global-default-filters),
 which will be automatically added to all routes. For example you can

--- a/skipper.go
+++ b/skipper.go
@@ -195,6 +195,15 @@ type Options struct {
 	// KubernetesEastWestDomain sets the cluster internal domain used to create additional routes in skipper, defaults to skipper.cluster.local
 	KubernetesEastWestDomain string
 
+	// KubernetesEastWestRangeDomains set the the cluster internal domains for
+	// east west traffic. Identified routes to such domains will include
+	// the KubernetesEastWestRangePredicates.
+	KubernetesEastWestRangeDomains []string
+
+	// KubernetesEastWestRangePredicates set the Predicates that will be
+	// appended to routes identified as to KubernetesEastWestRangeDomains.
+	KubernetesEastWestRangePredicates []*eskip.Predicate
+
 	// *DEPRECATED* API endpoint of the Innkeeper service, storing route definitions.
 	InnkeeperUrl string
 
@@ -788,22 +797,24 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 
 	if o.Kubernetes {
 		kubernetesClient, err := kubernetes.New(kubernetes.Options{
-			KubernetesInCluster:        o.KubernetesInCluster,
-			KubernetesURL:              o.KubernetesURL,
-			ProvideHealthcheck:         o.KubernetesHealthcheck,
-			ProvideHTTPSRedirect:       o.KubernetesHTTPSRedirect,
-			HTTPSRedirectCode:          o.KubernetesHTTPSRedirectCode,
-			IngressClass:               o.KubernetesIngressClass,
-			RouteGroupClass:            o.KubernetesRouteGroupClass,
-			ReverseSourcePredicate:     o.ReverseSourcePredicate,
-			WhitelistedHealthCheckCIDR: o.WhitelistedHealthCheckCIDR,
-			PathMode:                   o.KubernetesPathMode,
-			KubernetesNamespace:        o.KubernetesNamespace,
-			KubernetesEnableEastWest:   o.KubernetesEnableEastWest,
-			KubernetesEastWestDomain:   o.KubernetesEastWestDomain,
-			DefaultFiltersDir:          o.DefaultFiltersDir,
-			OriginMarker:               o.EnableRouteCreationMetrics,
-			BackendNameTracingTag:      o.OpenTracingBackendNameTag,
+			KubernetesInCluster:               o.KubernetesInCluster,
+			KubernetesURL:                     o.KubernetesURL,
+			ProvideHealthcheck:                o.KubernetesHealthcheck,
+			ProvideHTTPSRedirect:              o.KubernetesHTTPSRedirect,
+			HTTPSRedirectCode:                 o.KubernetesHTTPSRedirectCode,
+			IngressClass:                      o.KubernetesIngressClass,
+			RouteGroupClass:                   o.KubernetesRouteGroupClass,
+			ReverseSourcePredicate:            o.ReverseSourcePredicate,
+			WhitelistedHealthCheckCIDR:        o.WhitelistedHealthCheckCIDR,
+			PathMode:                          o.KubernetesPathMode,
+			KubernetesNamespace:               o.KubernetesNamespace,
+			KubernetesEnableEastWest:          o.KubernetesEnableEastWest,
+			KubernetesEastWestDomain:          o.KubernetesEastWestDomain,
+			KubernetesEastWestRangeDomains:    o.KubernetesEastWestRangeDomains,
+			KubernetesEastWestRangePredicates: o.KubernetesEastWestRangePredicates,
+			DefaultFiltersDir:                 o.DefaultFiltersDir,
+			OriginMarker:                      o.EnableRouteCreationMetrics,
+			BackendNameTracingTag:             o.OpenTracingBackendNameTag,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The current east-west communication feature has some problems as the
lack of support for cluster-only routes and the fact that these internal
routes would still be accessible from outside if changing the Host
header. More details of #1526

This commit adds the concept of EastWest Range feature, what makes
possible to define internal domains and custom predicates to Skipper.
With this information, Skipper's Kubernetes dataclient adds the given
predicates on every route identified as part of one internal domain.
Differently from the `-enable-kubernetes-east-west` and the
`-kubernetes-east-west-domain=.ingress.cluster.local` flags this feature
will not automatically create routes and both features shouldn't be used
in combination.

It requires changing the current way we convert routegroups to eskip
routes, splitting the hostnames in internal and external hosts. All the
hosts identified as internals require a separated route once it will
have their own `ClientIP` predicate.

Also, it adds two new flags to skipper configuration,
`-kubernetes-east-west-range-domains` and
`-kubernetes-east-west-range-predicates`. It also include the basic
documentation regarding their usage.