### PR TITLE
Fixes flaky ratelimit tests

### DIFF
--- a/proxy/ratelimit_test.go
+++ b/proxy/ratelimit_test.go
@@ -53,7 +53,7 @@ func TestCheckLocalRateLimitForShuntRoutes(t *testing.T) {
 	timeWindow := 1 * time.Second
 	ratelimitSettings := ratelimit.Settings{
 		Type:          ratelimit.LocalRatelimit,
-		MaxHits:       10,
+		MaxHits:       3,
 		TimeWindow:    timeWindow,
 		CleanInterval: 2 * timeWindow,
 	}
@@ -63,15 +63,15 @@ func TestCheckLocalRateLimitForShuntRoutes(t *testing.T) {
 	}, r...)
 	defer p.Close()
 
-	requestAndExpect(t, p.URL, 10, http.StatusNotFound, nil)
+	requestAndExpect(t, p.URL, 3, http.StatusNotFound, nil)
 
 	expectHeader := strconv.Itoa(ratelimitSettings.MaxHits * int(time.Hour/ratelimitSettings.TimeWindow))
 
-	requestAndExpect(t, p.URL, 10, http.StatusTooManyRequests, http.Header{ratelimit.Header: []string{expectHeader}})
+	requestAndExpect(t, p.URL, 1, http.StatusTooManyRequests, http.Header{ratelimit.Header: []string{expectHeader}})
 
 	time.Sleep(timeWindow)
 
-	requestAndExpect(t, p.URL, 10, http.StatusNotFound, nil)
+	requestAndExpect(t, p.URL, 3, http.StatusNotFound, nil)
 }
 
 func TestCheckLocalRateLimit(t *testing.T) {
@@ -82,7 +82,7 @@ func TestCheckLocalRateLimit(t *testing.T) {
 	timeWindow := 1 * time.Second
 	ratelimitSettings := ratelimit.Settings{
 		Type:          ratelimit.LocalRatelimit,
-		MaxHits:       10,
+		MaxHits:       3,
 		TimeWindow:    timeWindow,
 		CleanInterval: 2 * timeWindow,
 	}
@@ -92,15 +92,15 @@ func TestCheckLocalRateLimit(t *testing.T) {
 	}, r...)
 	defer p.Close()
 
-	requestAndExpect(t, p.URL, 10, http.StatusOK, nil)
+	requestAndExpect(t, p.URL, 3, http.StatusOK, nil)
 
 	expectHeader := strconv.Itoa(ratelimitSettings.MaxHits * int(time.Hour/ratelimitSettings.TimeWindow))
 
-	requestAndExpect(t, p.URL, 10, http.StatusTooManyRequests, http.Header{ratelimit.Header: []string{expectHeader}})
+	requestAndExpect(t, p.URL, 1, http.StatusTooManyRequests, http.Header{ratelimit.Header: []string{expectHeader}})
 
 	time.Sleep(timeWindow)
 
-	requestAndExpect(t, p.URL, 10, http.StatusOK, nil)
+	requestAndExpect(t, p.URL, 3, http.StatusOK, nil)
 }
 
 func TestCheckServiceRateLimit(t *testing.T) {
@@ -111,7 +111,7 @@ func TestCheckServiceRateLimit(t *testing.T) {
 	timeWindow := 1 * time.Second
 	ratelimitSettings := ratelimit.Settings{
 		Type:       ratelimit.ServiceRatelimit,
-		MaxHits:    10,
+		MaxHits:    3,
 		TimeWindow: timeWindow,
 	}
 	p := proxytest.WithParams(fr, proxy.Params{
@@ -120,15 +120,15 @@ func TestCheckServiceRateLimit(t *testing.T) {
 	}, r...)
 	defer p.Close()
 
-	requestAndExpect(t, p.URL, 10, http.StatusOK, nil)
+	requestAndExpect(t, p.URL, 3, http.StatusOK, nil)
 
 	expectHeader := strconv.Itoa(ratelimitSettings.MaxHits * int(time.Hour/ratelimitSettings.TimeWindow))
 
-	requestAndExpect(t, p.URL, 10, http.StatusTooManyRequests, http.Header{ratelimit.Header: []string{expectHeader}})
+	requestAndExpect(t, p.URL, 1, http.StatusTooManyRequests, http.Header{ratelimit.Header: []string{expectHeader}})
 
 	time.Sleep(timeWindow)
 
-	requestAndExpect(t, p.URL, 10, http.StatusOK, nil)
+	requestAndExpect(t, p.URL, 3, http.StatusOK, nil)
 }
 
 func TestRetryAfterHeader(t *testing.T) {
@@ -155,20 +155,20 @@ func TestRetryAfterHeader(t *testing.T) {
 }
 
 func requestAndExpect(t *testing.T, url string, repeat int, expectCode int, expectHeader http.Header) {
-	for i := 0; i < repeat; i++ {
+	for i := 1; i <= repeat; i++ {
 		code, header, err := doRequest(url)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("request %d/%d: %v", i, repeat, err)
 		}
 		if code != expectCode {
-			t.Fatalf("unexpected code, expected %d, got %d", expectCode, code)
+			t.Fatalf("request %d/%d: unexpected code, expected %d, got %d", i, repeat, expectCode, code)
 		}
 
 		for name := range expectHeader {
 			expected := expectHeader.Get(name)
 			got := header.Get(name)
 			if got != expected {
-				t.Fatalf("unexpected header %s, expected %s, got %s", name, expected, got)
+				t.Fatalf("request %d/%d: unexpected header %s, expected %s, got %s", i, repeat, name, expected, got)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes three tests with the following structure:
```
0. setup ratelimit: N requests/time window
1. do N requests and expect 200 OK
2. do N requests and expect 429 Too Many Requests
3. sleep for time window
4. do N requests and expect 200 OK
```

Such test passes only if steps 1 and 2 are complete within time window.
If requests are slow (e.g. CI pipeline) then time window may pass before
steps are complete, limit expires and expectaions fail on step 2
(`expected 429, got 200`).

This change reduces N thus allowing lower request rate.

Followup on #1671

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>