### PR TITLE
Document default filters with regards to grantCallback route

### DIFF
--- a/docs/tutorials/auth.md
+++ b/docs/tutorials/auth.md
@@ -261,7 +261,10 @@ It works as follows:
 1. The provider redirects the user back to Skipper with an authorization code, using the 
    callback URL parameter which was part of the previous redirect. The callback route must
    have a `grantCallback()` filter defined. Skipper automatically adds this callback route for you
-   when the OAuth2 authorization grant flow feature is enabled.
+   when the OAuth2 authorization grant flow feature is enabled. Note that the automatically added
+	 callback route does not apply [default filters](../../operation/operation/#default-filters).
+	 If you need default filters to be applied to the callback route as well, please register
+	 the route manually in your routes files.
 1. Skipper calls the provider's token URL with the authorization code, and receives a response 
    with the access and refresh tokens.
 1. Skipper stores the tokens in an `oauth-grant`<sup>1</sup> cookie which is stored in the user's browser.


### PR DESCRIPTION
After the oauth grant flow related filters where merged I realised that I could clean up our routes file and remove a manually added `grantCallback` route since it gets automatically added by Skipper. I then realised that this automatically added route does not apply the default filters. I think that is it relatively rare that users would want to apply default filters here but it should still be pointed out in the documentation.