### PR TITLE
Reduces ratelimit key length and makes it fixed

### DIFF
--- a/ratelimit/cluster.go
+++ b/ratelimit/cluster.go
@@ -1,10 +1,5 @@
 package ratelimit
 
-const (
-	swarmPrefix    = `ratelimit.`
-	swarmKeyFormat = swarmPrefix + "%s.%s"
-)
-
 // newClusterRateLimiter will return a limiter instance, that has a
 // cluster wide knowledge of ongoing requests. Settings are the normal
 // ratelimit settings, Swarmer is an instance satisfying the Swarmer

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -335,3 +335,13 @@ func TestSettingsRatelimit(t *testing.T) {
 		}
 	})
 }
+
+func TestGetRatelimitKey(t *testing.T) {
+	// echo -n helloworld | md5sum | cut -d' ' -f1 | xxd -r -p | base64 | tr -d '=' | tr '+/' '-_'
+	const expected = "R" + "_F4DjTilcDIIVEHn_nAQsA"
+
+	key := getRatelimitKey("hello", "world")
+	if key != expected {
+		t.Errorf("expected %s, got %s", expected, key)
+	}
+}


### PR DESCRIPTION

* uses 128 bit hash function
* uses minimal prefix, hashes both group and text
* uses base64 encoding

An example key before and after:
```
ratelimit.hello.486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7
R_F4DjTilcDIIVEHn_nAQsA
```
Key size reduced by 57 bytes.

Example of redis key with one hit stored before and after:
```
127.0.0.1:6379> zcard
ratelimit.hello.41a19288ea2042e9885dda76140d225b931ec56a7fafb41d932471995d7253db
(integer) 1
127.0.0.1:6379> memory usage
ratelimit.hello.41a19288ea2042e9885dda76140d225b931ec56a7fafb41d932471995d7253db
(integer) 169
127.0.0.1:6379> zcard Rwa0Jj-UpetSydKP8JahsNA
(integer) 1
127.0.0.1:6379> memory usage Rwa0Jj-UpetSydKP8JahsNA
(integer) 110
```
Also group names could be lengthy in a setup with mutiple ratelimits configured.
