### PR TITLE
Use file path on url to forward fastcgi requests

### DIFF
--- a/proxy/fastcgi/fastcgi.go
+++ b/proxy/fastcgi/fastcgi.go
@@ -75,7 +75,7 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		if strings.Contains(errBuffer.String(), "Primary script unknown") {
 			body := http.StatusText(http.StatusNotFound)
 			return &http.Response{
-				Status:        "404 Not Found",
+				Status:        body,
 				StatusCode:    http.StatusNotFound,
 				Body:          ioutil.NopCloser(bytes.NewBufferString(body)),
 				ContentLength: int64(len(body)),

--- a/proxy/fastcgi/fastcgi.go
+++ b/proxy/fastcgi/fastcgi.go
@@ -73,7 +73,7 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if errBuffer.Len() > 0 {
 		if strings.Contains(errBuffer.String(), "Primary script unknown") {
-			body := "Not Found"
+			body := http.StatusText(http.StatusNotFound)
 			return &http.Response{
 				Status:        "404 Not Found",
 				StatusCode:    http.StatusNotFound,

--- a/proxy/fastcgi/fastcgi.go
+++ b/proxy/fastcgi/fastcgi.go
@@ -76,7 +76,7 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			body := "Not Found"
 			return &http.Response{
 				Status:        "404 Not Found",
-				StatusCode:    404,
+				StatusCode:    http.StatusNotFound,
 				Body:          ioutil.NopCloser(bytes.NewBufferString(body)),
 				ContentLength: int64(len(body)),
 				Request:       req,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -973,6 +973,9 @@ func (p *Proxy) getRoundTripper(ctx *context, req *http.Request) (http.RoundTrip
 		if sf, ok := ctx.StateBag()["fastCgiFilename"]; ok {
 			f = sf.(string)
 		}
+		if req.URL.Path[1:] != "" {
+			f = req.URL.Path[1:]
+		}
 		rt, err := fastcgi.NewRoundTripper(p.log, req.URL.Host, f)
 		if err != nil {
 			return nil, err

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -972,7 +972,7 @@ func (p *Proxy) getRoundTripper(ctx *context, req *http.Request) (http.RoundTrip
 		f := "index.php"
 		if sf, ok := ctx.StateBag()["fastCgiFilename"]; ok {
 			f = sf.(string)
-		} else if req.URL.Path != "/" {
+		} else if len(req.URL.Path) > 1 && req.URL.Path != "/" {
 			f = req.URL.Path[1:]
 		}
 		rt, err := fastcgi.NewRoundTripper(p.log, req.URL.Host, f)


### PR DESCRIPTION
The issue this PR tries to fix is the case where we want to forward the lookup path the the fastcgi backend to serve different files and not only index.php.

Last commit adds the return code 404 when file is not existing on backend :

```
::1 - - [03/Feb/2021:12:19:35 +0100] "HEAD /test5.php?name=foo HTTP/1.1" 404 10 "-" "curl/7.63.0" 8 localhost - -
::1 - - [03/Feb/2021:12:19:50 +0100] "GET /test2.php?name=foo HTTP/1.1" 200 28 "-" "curl/7.63.0" 7 localhost - -
```

Tested locally with docker-compose