### PR TITLE
Adds request IP address template placeholders

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -26,6 +26,10 @@ Template placeholder is replaced by the value that is looked up in the following
 * request url query (if starts with `request.query.` prefix, e.g `${request.query.q}` is replaced by `q` query parameter value)
 * request headers (if starts with `request.header.` prefix, e.g `${request.header.Content-Type}` is replaced by `Content-Type` request header value)
 * request cookies (if starts with `request.cookie.` prefix, e.g `${request.cookie.PHPSESSID}` is replaced by `PHPSESSID` request cookie value)
+* request IP address 
+    - `${request.source}` - first IP address from `X-Forwarded-For` header or request remote IP address if header is absent, similar to [Source](predicates.md#source) predicate
+    - `${request.sourceFromLast}` - last IP address from `X-Forwarded-For` header or request remote IP address if header is absent, similar to [SourceFromLast](predicates.md#sourcefromlast) predicate
+    - `${request.clientIP}` - request remote IP address similar to [ClientIP](predicates.md#clientip) predicate
 * response headers (if starts with `response.header.` prefix, e.g `${response.header.Location}` is replaced by `Location` response header value)
 * filter context path parameters (e.g. `${id}` is replaced by `id` path parameter value)
 

--- a/eskip/template_test.go
+++ b/eskip/template_test.go
@@ -268,6 +268,65 @@ func TestTemplateApplyContext(t *testing.T) {
 		},
 		"Hello one two three four five",
 		true,
+	}, {
+		"request source and X-Forwarded-For present",
+		"${request.source}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				RemoteAddr: "192.168.0.1:9876",
+				Header: http.Header{
+					"X-Forwarded-For": []string{"203.0.113.195, 70.41.3.18, 150.172.238.178"},
+				},
+			},
+		},
+		"203.0.113.195",
+		true,
+	}, {
+		"request source and X-Forwarded-For absent",
+		"${request.source}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				RemoteAddr: "192.168.0.1:9876",
+			},
+		},
+		"192.168.0.1",
+		true,
+	}, {
+		"request sourceFromLast and X-Forwarded-For present",
+		"${request.sourceFromLast}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				RemoteAddr: "192.168.0.1:9876",
+				Header: http.Header{
+					"X-Forwarded-For": []string{"203.0.113.195, 70.41.3.18, 150.172.238.178"},
+				},
+			},
+		},
+		"150.172.238.178",
+		true,
+	}, {
+		"request sourceFromLast and X-Forwarded-For absent",
+		"${request.sourceFromLast}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				RemoteAddr: "192.168.0.1:9876",
+			},
+		},
+		"192.168.0.1",
+		true,
+	}, {
+		"request clientIP (ignores X-Forwarded-For)",
+		"${request.clientIP}",
+		&filtertest.Context{
+			FRequest: &http.Request{
+				RemoteAddr: "192.168.0.1:9876",
+				Header: http.Header{
+					"X-Forwarded-For": []string{"203.0.113.195, 70.41.3.18, 150.172.238.178"},
+				},
+			},
+		},
+		"192.168.0.1",
+		true,
 	},
 	} {
 		t.Run(ti.name, func(t *testing.T) {


### PR DESCRIPTION
Adds three new template placeholders that resolve into request IP address similar to existing `Source`, `SourceFromLast` and `ClientIP` predicates.

* could be handy to support default key in "Configurable consistent hash request key" (#1711)
* allows client rate limit based on last value of `X-Forwarded-For` (`XForwardedForLookuper` supports only first value)
* named after existing predicates to avoid confusion (could be extended if/when "Configurable ClientIP utility function" (#1620) is implemented)

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>