### PR TITLE
Adds consistentHashKey filter

### DIFF
--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -257,7 +257,7 @@ Current implemented algorithms:
 
 - `roundRobin`: backend is chosen by the round robin algorithm, starting with a random selected backend to spread across all backends from the beginning
 - `random`: backend is chosen at random
-- `consistentHash`: backend is chosen by a consistent hashing algorithm with the client X-Forwarded-For header with remote IP as the fallback as input to the hash function
+- `consistentHash`: backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key.
 - `powerOfRandomNChoices`: backend is chosen by powerOfRandomNChoices algorithm with selecting N random endpoints and picking the one with least outstanding requests from them. (http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf)
 - __TODO__: https://github.com/zalando/skipper/issues/557
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2296,3 +2296,27 @@ Example:
 ```
 endpointCreated("http://10.0.0.1:8080", "2020-12-18T15:30:00Z01:00")
 ```
+
+## consistentHashKey
+
+This filter sets the request key used by the [`consistentHash`](backends.md#load-balancer-backend) algorithm to select the backend endpoint.
+
+Parameters:
+
+* key (string)
+
+The key should contain [template placeholders](#template-placeholders), without placeholders the key
+is constant and therefore all requests would be made to the same endpoint.
+The algorithm will use the default key if any of the template placeholders can't be resolved.
+
+Examples:
+
+```
+pr: Path("/products/:productId")
+    -> consistentHashKey("${productId}")
+    -> <consistentHash, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+```
+```
+consistentHashKey("${request.header.Authorization}")
+consistentHashKey("${request.source}") // same as the default key
+```

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zalando/skipper/filters/accesslog"
 	"github.com/zalando/skipper/filters/auth"
 	"github.com/zalando/skipper/filters/circuit"
+	"github.com/zalando/skipper/filters/consistenthash"
 	"github.com/zalando/skipper/filters/cookie"
 	"github.com/zalando/skipper/filters/cors"
 	"github.com/zalando/skipper/filters/diag"
@@ -170,6 +171,7 @@ func MakeRegistry() filters.Registry {
 		rfc.NewPath(),
 		fadein.NewFadeIn(),
 		fadein.NewEndpointCreated(),
+		consistenthash.NewConsistentHashKey(),
 	} {
 		r.Register(s)
 	}

--- a/filters/consistenthash/key.go
+++ b/filters/consistenthash/key.go
@@ -1,0 +1,35 @@
+package consistenthash
+
+import (
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/loadbalancer"
+)
+
+type consistentHashKey struct {
+	template *eskip.Template
+}
+
+// NewConsistentHashKey creates a filter Spec, whose instances
+// set the request key used by the `consistentHash` algorithm to select backend endpoint
+func NewConsistentHashKey() filters.Spec { return &consistentHashKey{} }
+func (*consistentHashKey) Name() string  { return "consistentHashKey" }
+
+func (*consistentHashKey) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 1 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+	value, ok := args[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+	return &consistentHashKey{eskip.NewTemplate(value)}, nil
+}
+
+func (c *consistentHashKey) Request(ctx filters.FilterContext) {
+	if key, ok := c.template.ApplyContext(ctx); ok {
+		ctx.StateBag()[loadbalancer.ConsistentHashKey] = key
+	}
+}
+
+func (*consistentHashKey) Response(filters.FilterContext) {}

--- a/filters/consistenthash/key_test.go
+++ b/filters/consistenthash/key_test.go
@@ -1,0 +1,60 @@
+package consistenthash
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/loadbalancer"
+)
+
+func TestConsistentHashKey(t *testing.T) {
+	spec := NewConsistentHashKey()
+	if spec.Name() != "consistentHashKey" {
+		t.Error("wrong name")
+	}
+
+	c := &filtertest.Context{
+		FRequest: &http.Request{
+			Header: http.Header{
+				"X-Uid": []string{"user1"},
+			},
+		},
+		FStateBag: make(map[string]interface{}),
+	}
+
+	// missing placeholder does not set key
+	f, err := spec.CreateFilter([]interface{}{"missing: ${request.header.missing}"})
+	if err != nil {
+		t.Fatal("failed to create filter")
+	}
+	f.Request(c)
+
+	if _, ok := c.FStateBag[loadbalancer.ConsistentHashKey]; ok {
+		t.Error("unexpected key")
+	}
+
+	// set key with placeholder
+	f, _ = spec.CreateFilter([]interface{}{"set: ${request.header.x-uid}"})
+	f.Request(c)
+
+	if c.FStateBag[loadbalancer.ConsistentHashKey] != "set: user1" {
+		t.Error("wrong key")
+	}
+
+	// second filter overwrites
+	f, _ = spec.CreateFilter([]interface{}{"overwrite: ${request.header.x-uid}"})
+	f.Request(c)
+
+	if c.FStateBag[loadbalancer.ConsistentHashKey] != "overwrite: user1" {
+		t.Error("overwrite expected")
+	}
+
+	// missing placeholder does not overwrite
+	f, _ = spec.CreateFilter([]interface{}{"missing overwrite: ${request.header.missing}"})
+	f.Request(c)
+
+	if c.FStateBag[loadbalancer.ConsistentHashKey] != "overwrite: user1" {
+		t.Error("unexpected overwrite")
+	}
+}

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -38,6 +38,8 @@ const (
 
 const powerOfRandomNChoicesDefaultN = 2
 
+const ConsistentHashKey = "consistentHashKey"
+
 var (
 	algorithms = map[Algorithm]initializeAlgorithm{
 		RoundRobin:            newRoundRobin,
@@ -234,7 +236,10 @@ func (ch consistentHash) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 		return ctx.Route.LBEndpoints[0]
 	}
 
-	key := net.RemoteHost(ctx.Request).String()
+	key, ok := ctx.Params[ConsistentHashKey].(string)
+	if !ok {
+		key = net.RemoteHost(ctx.Request).String()
+	}
 	choice := ch.search(key)
 
 	return ctx.Route.LBEndpoints[choice]

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -481,7 +481,7 @@ func mapRequest(ctx *context, requestContext stdlibcontext.Context, removeHopHea
 		setRequestURLFromRequest(u, r)
 		setRequestURLForDynamicBackend(u, stateBag)
 	case eskip.LBBackend:
-		endpoint = setRequestURLForLoadBalancedBackend(u, rt, routing.NewLBContext(r, rt))
+		endpoint = setRequestURLForLoadBalancedBackend(u, rt, &routing.LBContext{Request: r, Route: rt, Params: stateBag})
 	default:
 		u.Scheme = rt.Scheme
 		u.Host = rt.Host

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -182,10 +182,12 @@ type LBAlgorithm interface {
 type LBContext struct {
 	Request *http.Request
 	Route   *Route
+	Params  map[string]interface{}
 }
 
 // NewLBContext is used to create a new LBContext, to pass data to the
 // load balancer algorithms.
+// Deprecated: create LBContext instead
 func NewLBContext(r *http.Request, rt *Route) *LBContext {
 	return &LBContext{
 		Request: r,


### PR DESCRIPTION
`consistentHashKey` filter configures request key used by `consistentHash` load balancing algorithm to select backend endpoint.

Fixes #1711

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>