### PR TITLE
Always add http status code to initial span

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -42,6 +42,7 @@ type context struct {
 	startServe           time.Time
 	metrics              *filterMetrics
 	tracer               opentracing.Tracer
+	initialSpan          opentracing.Span
 	proxySpan            opentracing.Span
 	parentSpan           opentracing.Span
 	proxy                *Proxy

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1175,6 +1175,8 @@ func (p *Proxy) serveResponse(ctx *context) {
 		p.tracing.setTag(ctx.proxySpan, ClientRequestStateTag, ClientRequestCanceled)
 	}
 
+	p.tracing.setTag(ctx.initialSpan, HTTPStatusCodeTag, uint16(ctx.response.StatusCode))
+
 	ctx.responseWriter.WriteHeader(ctx.response.StatusCode)
 	ctx.responseWriter.Flush()
 	n, err := copyStream(ctx.responseWriter, ctx.response.Body)
@@ -1413,6 +1415,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = newContext(lw, r, p)
 	ctx.startServe = time.Now()
 	ctx.tracer = p.tracing.tracer
+	ctx.initialSpan = span
 
 	defer func() {
 		if ctx.response != nil && ctx.response.Body != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1224,13 +1224,10 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		code = perr.code
 	}
 
-	if span := ot.SpanFromContext(ctx.Request().Context()); span != nil {
-		p.tracing.setTag(span, ErrorTag, true)
-		p.tracing.setTag(span, HTTPStatusCodeTag, uint16(code))
-		if err == errRouteLookupFailed {
-			span.LogKV("event", "error", "message", errRouteLookup.Error())
-		}
-
+	p.tracing.setTag(ctx.initialSpan, ErrorTag, true)
+	p.tracing.setTag(ctx.initialSpan, HTTPStatusCodeTag, uint16(code))
+	if err == errRouteLookupFailed {
+		ctx.initialSpan.LogKV("event", "error", "message", errRouteLookup.Error())
 	}
 
 	if p.flags.Debug() {

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -134,7 +134,7 @@ func TestTracingIngressSpan(t *testing.T) {
 	verifyTag(t, span, HTTPPathTag, "/hello")
 	verifyTag(t, span, HTTPHostTag, ps.Listener.Addr().String())
 	verifyTag(t, span, FlowIDTag, "test-flow-id")
-	verifyTag(t, span, HTTPStatusCodeTag, nil) // status tag is not set on ingress span
+	verifyTag(t, span, HTTPStatusCodeTag, uint16(200))
 }
 
 func TestTracingSpanName(t *testing.T) {


### PR DESCRIPTION
Try to always set `http.status_code` on the initial span too and not just on the `proxy` span to allow querying the main span by `http.status_code` regardless if the status code is coming from the downstream or by skipper itself (eg. not found route, filters serving the response).

~Should fix also #1145~ 