### PR TITLE
Uses debug log level for lifo error logs

### DIFF
--- a/filters/scheduler/lifo.go
+++ b/filters/scheduler/lifo.go
@@ -297,13 +297,13 @@ func request(q *scheduler.Queue, key string, ctx filters.FilterContext) {
 		// TODO: replace the log with metrics
 		switch err {
 		case jobqueue.ErrStackFull:
-			log.Errorf("Failed to get an entry on to the queue to process QueueFull: %v for host %s", err, ctx.Request().Host)
+			log.Debugf("Failed to get an entry on to the queue to process QueueFull: %v for host %s", err, ctx.Request().Host)
 			ctx.Serve(&http.Response{
 				StatusCode: http.StatusServiceUnavailable,
 				Status:     "Queue Full - https://opensource.zalando.com/skipper/operation/operation/#scheduler",
 			})
 		case jobqueue.ErrTimeout:
-			log.Errorf("Failed to get an entry on to the queue to process Timeout: %v for host %s", err, ctx.Request().Host)
+			log.Debugf("Failed to get an entry on to the queue to process Timeout: %v for host %s", err, ctx.Request().Host)
 			ctx.Serve(&http.Response{
 				StatusCode: http.StatusBadGateway,
 				Status:     "Queue timeout - https://opensource.zalando.com/skipper/operation/operation/#scheduler",


### PR DESCRIPTION
to avoid flooding the logs when lifo filter overruns

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>