### PR TITLE
Adds lua sleep function

### DIFF
--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -45,6 +45,10 @@ end
 
 Lua `print` builtin function writes skipper info log messages.
 
+## sleep
+
+`sleep(number)` function pauses execution for at least `number` milliseconds. A negative or zero duration causes `sleep` to return immediately.
+
 ## Available lua modules
 
 Besides the [standard modules](https://www.lua.org/manual/5.1/manual.html#5) - except

--- a/script/script.go
+++ b/script/script.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -99,6 +100,7 @@ func (s *script) newState() (*lua.LState, error) {
 	L.PreloadModule("url", gluaurl.Loader)
 	L.PreloadModule("json", gjson.Loader)
 	L.SetGlobal("print", L.NewFunction(printToLog))
+	L.SetGlobal("sleep", L.NewFunction(sleep))
 
 	L.Push(L.NewFunctionFromProto(s.proto))
 
@@ -117,6 +119,11 @@ func printToLog(L *lua.LState) int {
 		args = append(args, L.ToStringMeta(L.Get(i)).String())
 	}
 	log.Print(args...)
+	return 0
+}
+
+func sleep(L *lua.LState) int {
+	time.Sleep(time.Duration(L.CheckInt64(1)) * time.Millisecond)
 	return 0
 }
 

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
@@ -350,6 +351,22 @@ func TestScript(t *testing.T) {
 		if test.expectedStatus != 0 && test.expectedStatus != fc.Response().StatusCode {
 			t.Errorf("[%s] response status: expected %d, got: %d", test.name, test.expectedStatus, fc.Response().StatusCode)
 		}
+	}
+}
+
+func TestSleep(t *testing.T) {
+	ctx := &testContext{
+		script: `function request(ctx, params) sleep(100.1) end`,
+	}
+	t0 := time.Now()
+	_, err := runFilter(ctx)
+	if err != nil {
+		t.Fatalf("failed to run filter: %v", err)
+	}
+	t1 := time.Now()
+
+	if t1.Sub(t0) < 100*time.Millisecond {
+		t.Error("expected delay of 100 ms")
 	}
 }
 


### PR DESCRIPTION
Sleep function may be useful for prototyping but unfortunately Lua's
standard library does not provide it, see http://lua-users.org/wiki/SleepFunction

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>