### PR TITLE
feature: limit logs per span, log key size, log value size

### DIFF
--- a/tracing/tracers/lightstep/lightstep.go
+++ b/tracing/tracers/lightstep/lightstep.go
@@ -28,6 +28,9 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 		logCmdLine       bool
 		logEvents        bool
 		maxBufferedSpans int
+		maxLogKeyLen     int
+		maxLogValueLen   int
+		maxLogsPerSpan   int
 
 		grpcMaxMsgSize     = defaultGRPMaxMsgSize
 		minReportingPeriod = lightstep.DefaultMinReportingPeriod
@@ -116,6 +119,21 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 			if maxBufferedSpans, err = strconv.Atoi(parts[1]); err != nil {
 				return lightstep.Options{}, fmt.Errorf("failed to parse max buffered spans: %v", err)
 			}
+		case "max-log-key-len":
+			var err error
+			if maxLogKeyLen, err = strconv.Atoi(parts[1]); err != nil {
+				return lightstep.Options{}, fmt.Errorf("failed to parse max log key length: %v", err)
+			}
+		case "max-log-value-len":
+			var err error
+			if maxLogValueLen, err = strconv.Atoi(parts[1]); err != nil {
+				return lightstep.Options{}, fmt.Errorf("failed to parse max log value length: %v", err)
+			}
+		case "max-logs-per-span":
+			var err error
+			if maxLogsPerSpan, err = strconv.Atoi(parts[1]); err != nil {
+				return lightstep.Options{}, fmt.Errorf("failed to parse max logs per span: %v", err)
+			}
 		case "propagators":
 			if len(parts) > 1 {
 				prStack := lightstep.PropagatorStack{}
@@ -175,6 +193,9 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 		UseGRPC:                     useGRPC,
 		Tags:                        tags,
 		MaxBufferedSpans:            maxBufferedSpans,
+		MaxLogKeyLen:                maxLogKeyLen,
+		MaxLogValueLen:              maxLogValueLen,
+		MaxLogsPerSpan:              maxLogsPerSpan,
 		GRPCMaxCallSendMsgSizeBytes: grpcMaxMsgSize,
 		ReportingPeriod:             maxReportingPeriod,
 		MinReportingPeriod:          minReportingPeriod,

--- a/tracing/tracers/lightstep/lightstep_test.go
+++ b/tracing/tracers/lightstep/lightstep_test.go
@@ -199,6 +199,117 @@ func TestParseOptions(t *testing.T) {
 			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
 		},
 		{
+			name: "test with token set wrong max buffered spans",
+			opts: []string{
+				"token=" + token,
+				"max-buffered-spans=foo",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with token set max log key length",
+			opts: []string{
+				"token=" + token,
+				"max-log-key-len=20",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: lightstep.DefaultGRPCCollectorHost,
+					Port: lightstep.DefaultSecurePort,
+				},
+				Tags:                        opentracing.Tags{"lightstep.component_name": string("skipper")},
+				UseGRPC:                     true,
+				MaxLogKeyLen:                20,
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
+			name: "test with token set no max log key length",
+			opts: []string{
+				"token=" + token,
+				"max-log-key-len=",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with token set wrong max log key length",
+			opts: []string{
+				"token=" + token,
+				"max-log-key-len=foo",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with token set max log value length",
+			opts: []string{
+				"token=" + token,
+				"max-log-value-len=100",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: lightstep.DefaultGRPCCollectorHost,
+					Port: lightstep.DefaultSecurePort,
+				},
+				Tags:                        opentracing.Tags{"lightstep.component_name": string("skipper")},
+				UseGRPC:                     true,
+				MaxLogValueLen:              100,
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
+			name: "test with token set no max log value length",
+			opts: []string{
+				"token=" + token,
+				"max-log-value-len=",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with token set max logs per span",
+			opts: []string{
+				"token=" + token,
+				"max-logs-per-span=25",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: lightstep.DefaultGRPCCollectorHost,
+					Port: lightstep.DefaultSecurePort,
+				},
+				Tags:                        opentracing.Tags{"lightstep.component_name": string("skipper")},
+				UseGRPC:                     true,
+				MaxLogsPerSpan:              25,
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
+			name: "test with token set wrong max logs per span",
+			opts: []string{
+				"token=" + token,
+				"max-logs-per-span=2a5",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
 			name: "test with token set max call message size",
 			opts: []string{
 				"token=" + token,
@@ -220,6 +331,15 @@ func TestParseOptions(t *testing.T) {
 			},
 			wantErr:     false,
 			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
+			name: "test with token max call message size no number",
+			opts: []string{
+				"token=" + token,
+				"grpc-max-msg-size=foo",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
 		},
 		{
 			name: "test with token set reporting periods",
@@ -256,6 +376,85 @@ func TestParseOptions(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "test with token and not parseable min period values should fail",
+			opts: []string{
+				"token=" + token,
+				"min-period=foo",
+				"max-period=100ms",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with token and not parseable max period values should fail",
+			opts: []string{
+				"token=" + token,
+				"min-period=100ms",
+				"max-period=foo",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with token and set tags",
+			opts: []string{
+				"token=" + token,
+				"tag=foo=bar",
+				"tag=teapot=418",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: lightstep.DefaultGRPCCollectorHost,
+					Port: lightstep.DefaultSecurePort,
+				},
+				UseGRPC: true,
+				Tags: map[string]interface{}{
+					lightstep.ComponentNameKey: defComponentName,
+					"foo":                      "bar",
+					"teapot":                   "418",
+				},
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
+			name: "test with token and set wrong tag",
+			opts: []string{
+				"token=" + token,
+				"tag=foo",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with token and set empty tag",
+			opts: []string{
+				"token=" + token,
+				"tag=foo=",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: lightstep.DefaultGRPCCollectorHost,
+					Port: lightstep.DefaultSecurePort,
+				},
+				UseGRPC: true,
+				Tags: map[string]interface{}{
+					lightstep.ComponentNameKey: defComponentName,
+					"foo":                      "",
+				},
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
 			name: "test with plaintext set",
 			opts: []string{
 				"token=" + token,
@@ -281,6 +480,15 @@ func TestParseOptions(t *testing.T) {
 			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
 		},
 		{
+			name: "test with wrong plaintext set",
+			opts: []string{
+				"token=" + token,
+				"plaintext=foo",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
 			name: "test with b3 propagator",
 			opts: []string{
 				"token=" + token,
@@ -303,6 +511,105 @@ func TestParseOptions(t *testing.T) {
 			},
 			wantErr:     false,
 			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: b3Propagator},
+		},
+		{
+			name: "test with ls propagator",
+			opts: []string{
+				"token=" + token,
+				"collector=collector.example.com:8888",
+				"propagators=ls",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: "collector.example.com",
+					Port: 8888,
+				},
+				UseGRPC: true,
+				Tags: map[string]interface{}{
+					lightstep.ComponentNameKey: defComponentName,
+				},
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
+			name: "test with wrong propagator",
+			opts: []string{
+				"token=" + token,
+				"collector=collector.example.com:8888",
+				"propagators=foo",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with wrong collector",
+			opts: []string{
+				"token=" + token,
+				"collector=collector.example.com:http",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with wrong collector hostport",
+			opts: []string{
+				"token=" + token,
+				"collector=collector.example.com",
+			},
+			want:    lightstep.Options{},
+			wantErr: true,
+		},
+		{
+			name: "test with cmdline",
+			opts: []string{
+				"token=" + token,
+				"cmd-line=hello world",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: lightstep.DefaultGRPCCollectorHost,
+					Port: lightstep.DefaultSecurePort,
+				},
+				UseGRPC: true,
+				Tags: map[string]interface{}{
+					lightstep.ComponentNameKey: defComponentName,
+					lightstep.CommandLineKey:   "hello world",
+				},
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
+		},
+		{
+			name: "test with logevents",
+			opts: []string{
+				"token=" + token,
+				"log-events",
+			},
+			want: lightstep.Options{
+				AccessToken: token,
+				Collector: lightstep.Endpoint{
+					Host: lightstep.DefaultGRPCCollectorHost,
+					Port: lightstep.DefaultSecurePort,
+				},
+				UseGRPC: true,
+				Tags: map[string]interface{}{
+					lightstep.ComponentNameKey: defComponentName,
+				},
+				GRPCMaxCallSendMsgSizeBytes: defaultGRPMaxMsgSize,
+				ReportingPeriod:             lightstep.DefaultMaxReportingPeriod,
+				MinReportingPeriod:          lightstep.DefaultMinReportingPeriod,
+			},
+			wantErr:     false,
+			propagators: map[opentracing.BuiltinFormat]lightstep.Propagator{opentracing.HTTPHeaders: defPropagator},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
feature: limit logs per span, log key size, log value size
test: 100% parse coverage, 2 funcs left

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>