### PR TITLE
feat: add status code as arg to ratelimit and clusterRatelimit filters

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1529,10 +1529,12 @@ Parameters:
 
 * number of allowed requests per time period (int)
 * time period for requests being counted (time.Duration)
+* response status code to use for a rate limited request - optional, default: 429
 
 ```
 ratelimit(20, "1m")
 ratelimit(300, "1h")
+ratelimit(4000, "1m", 503)
 ```
 
 See also the [ratelimit docs](https://godoc.org/github.com/zalando/skipper/ratelimit).
@@ -1580,10 +1582,12 @@ Parameters:
 * rate limit group (string)
 * number of allowed requests per time period (int)
 * time period for requests being counted (time.Duration)
+* response status code to use for a rate limited request - optional, default: 429
 
 ```
 clusterRatelimit("groupB", 20, "1m")
 clusterRatelimit("groupB", 300, "1h")
+clusterRatelimit("groupB", 4000, "1m", 503)
 ```
 
 See also the [ratelimit docs](https://godoc.org/github.com/zalando/skipper/ratelimit).

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -97,6 +97,15 @@ func NewClientRatelimit(provider RatelimitProvider) filters.Spec {
 //    backendHealthcheck: Path("/healthcheck")
 //    -> ratelimit(20, "1s")
 //    -> "https://foo.backend.net";
+//
+//
+// Optionally a custom response status code can be provided as an argument (default is 429).
+//
+// Example:
+//
+//    backendHealthcheck: Path("/healthcheck")
+//    -> ratelimit(20, "1s", 503)
+//    -> "https://foo.backend.net";
 func NewRatelimit(provider RatelimitProvider) filters.Spec {
 	return &spec{typ: ratelimit.ServiceRatelimit, provider: provider, filterName: ratelimit.ServiceRatelimitName}
 }
@@ -112,6 +121,14 @@ func NewRatelimit(provider RatelimitProvider) filters.Spec {
 //    -> clusterRatelimit("groupA", 200, "1m")
 //    -> "https://foo.backend.net";
 //
+//
+// Optionally a custom response status code can be provided as an argument (default is 429).
+//
+// Example:
+//
+//    backendHealthcheck: Path("/healthcheck")
+//    -> clusterRatelimit("groupA", 200, "1m", 503)
+//    -> "https://foo.backend.net";
 func NewClusterRateLimit(provider RatelimitProvider) filters.Spec {
 	return &spec{typ: ratelimit.ClusterServiceRatelimit, provider: provider, filterName: ratelimit.ClusterServiceRatelimitName}
 }
@@ -402,12 +419,7 @@ func getStatusCodeArg(args []interface{}, index int) (int, error) {
 		return defaultStatusCode, nil
 	}
 
-	statusCode, err := getIntArg(args[index])
-	if err != nil {
-		return 0, err
-	}
-
-	return statusCode, nil
+	return getIntArg(args[index])
 }
 
 // Request checks ratelimit using filter settings and serves `429 Too Many Requests` response if limit is reached

--- a/filters/ratelimit/ratelimit_test.go
+++ b/filters/ratelimit/ratelimit_test.go
@@ -154,6 +154,26 @@ func TestRateLimit(t *testing.T) {
 		"1s",
 	))
 
+	t.Run("ratelimit service with response status code", test(
+		NewRatelimit,
+		ratelimit.Settings{
+			Type:       ratelimit.ServiceRatelimit,
+			MaxHits:    3,
+			TimeWindow: 1 * time.Second,
+			Lookuper:   ratelimit.NewSameBucketLookuper(),
+		},
+		&http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header: http.Header{
+				"X-Rate-Limit": []string{"10800"},
+				"Retry-After":  []string{"31415"},
+			},
+		},
+		3.3,
+		"1s",
+		503,
+	))
+
 	t.Run("ratelimit local", test(
 		NewLocalRatelimit,
 		ratelimit.Settings{
@@ -256,6 +276,28 @@ func TestRateLimit(t *testing.T) {
 		"mygroup",
 		3,
 		"1s",
+	))
+
+	t.Run("ratelimit cluster with response status code", test(
+		NewClusterRateLimit,
+		ratelimit.Settings{
+			Type:       ratelimit.ClusterServiceRatelimit,
+			MaxHits:    3,
+			TimeWindow: 1 * time.Second,
+			Lookuper:   ratelimit.NewSameBucketLookuper(),
+			Group:      "mygroup",
+		},
+		&http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header: http.Header{
+				"X-Rate-Limit": []string{"10800"},
+				"Retry-After":  []string{"31415"},
+			},
+		},
+		"mygroup",
+		3,
+		"1s",
+		503,
 	))
 
 	t.Run("ratelimit clusterClient", test(


### PR DESCRIPTION
Add the possibility to provide the status code as an argument for `ratelimit` and `clusterRatelimit` filters.
The value will be used as response status code for a rate limited request, default value if not provided is the standard `429`.

close #1728