### PR TITLE
remove URL tag in ingress span

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -902,13 +902,13 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 	}
 	ctx.proxySpan = tracing.CreateSpan(spanName, req.Context(), p.tracing.tracer)
 
+	u := cloneURL(req.URL)
+	u.RawQuery = ""
 	p.tracing.
 		setTag(ctx.proxySpan, SpanKindTag, SpanKindClient).
 		setTag(ctx.proxySpan, SkipperRouteIDTag, ctx.route.Id).
-		setTag(ctx.proxySpan, SkipperRouteTag, ctx.route.String())
-
-	u := cloneURL(req.URL)
-	u.RawQuery = ""
+		setTag(ctx.proxySpan, SkipperRouteTag, ctx.route.String()).
+		setTag(ctx.proxySpan, HTTPUrlTag, u.String())
 	p.setCommonSpanInfo(u, req, ctx.proxySpan)
 
 	carrier := ot.HTTPHeadersCarrier(req.Header)
@@ -1449,7 +1449,6 @@ func (p *Proxy) Close() error {
 func (p *Proxy) setCommonSpanInfo(u *url.URL, r *http.Request, s ot.Span) {
 	p.tracing.
 		setTag(s, ComponentTag, "skipper").
-		setTag(s, HTTPUrlTag, u.String()).
 		setTag(s, HTTPMethodTag, r.Method).
 		setTag(s, HostnameTag, p.hostname).
 		setTag(s, HTTPRemoteAddrTag, r.RemoteAddr).

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -127,7 +127,8 @@ func TestTracingIngressSpan(t *testing.T) {
 
 	verifyTag(t, span, SpanKindTag, SpanKindServer)
 	verifyTag(t, span, ComponentTag, "skipper")
-	verifyTag(t, span, HTTPUrlTag, "/hello?world") // For server requests there is no scheme://host:port, see https://golang.org/pkg/net/http/#Request
+	// to save memory we dropped the URL tag from ingress span
+	//verifyTag(t, span, HTTPUrlTag, "/hello?world") // For server requests there is no scheme://host:port, see https://golang.org/pkg/net/http/#Request
 	verifyTag(t, span, HTTPMethodTag, "GET")
 	verifyTag(t, span, HostnameTag, "ingress.tracing.test")
 	// verifyTag(t, span, HTTPRemoteAddrTag, "")


### PR DESCRIPTION
removing URL tag in ingress span can save a lot of bytes for example with elastic search cases
Interesting observation: proxy span has no kv pairs from query, that's why I let it there.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>