### PR TITLE
Fixes documentation links

### DIFF
--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -22,8 +22,8 @@ zalando.org/skipper-routes | `Method("OPTIONS") -> status(200) -> <shunt>` | ext
 zalando.org/ratelimit | `ratelimit(50, "1m")` | deprecated, use zalando.org/skipper-filter instead
 zalando.org/skipper-ingress-redirect | `"true"` | change the default HTTPS redirect behavior for specific ingresses (true/false)
 zalando.org/skipper-ingress-redirect-code | `301` | change the default HTTPS redirect code for specific ingresses
-zalando.org/skipper-loadbalancer | `consistentHash` | defaults to `roundRobin`, [see available choices](../../reference/backends/#load-balancer-backend)
-zalando.org/skipper-backend-protocol | `fastcgi` | (*experimental*) defaults to `http`, [see available choices](../../reference/backends/#backend-protocols)
+zalando.org/skipper-loadbalancer | `consistentHash` | defaults to `roundRobin`, [see available choices](../reference/backends.md#load-balancer-backend)
+zalando.org/skipper-backend-protocol | `fastcgi` | (*experimental*) defaults to `http`, [see available choices](../reference/backends.md#backend-protocols)
 zalando.org/skipper-ingress-path-mode | `path-prefix` | defaults to `kubernetes-ingress`, [see available choices](#ingress-path-handling), to change the default use `-kubernetes-path-mode`
 
 ## Supported Service types
@@ -472,7 +472,7 @@ Set a Cookie in the response path of your clients.
 
 ### Authorization
 
-Our [authentication and authorization tutorial](../../tutorials/auth/)
+Our [authentication and authorization tutorial](../tutorials/auth.md)
 or [filter auth godoc](https://godoc.org/github.com/zalando/skipper/filters/auth)
 shows how to use filters for authorization.
 
@@ -1045,7 +1045,7 @@ available it would switch to another one.
 
 Annotations:
 
-- `zalando.org/skipper-loadbalancer` [see available choices](../../reference/backends/#load-balancer-backend)
+- `zalando.org/skipper-loadbalancer` [see available choices](../reference/backends.md#load-balancer-backend)
 
 Example:
 

--- a/docs/kubernetes/routegroup-crd.md
+++ b/docs/kubernetes/routegroup-crd.md
@@ -1,7 +1,7 @@
 # RouteGroup CRD Semantics
 
 This document contains the semantic definition of the RouteGroup CRD. For more information, see the [route group
-documentation](../routegroups/), or see the [CRD yaml
+documentation](routegroups.md), or see the [CRD yaml
 definition](https://github.com/zalando/skipper/blob/master/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml).
 
 ## Concepts
@@ -36,12 +36,12 @@ Routes describe how a matching HTTP request is handled and where it is forwarded
 A predicate is used during route lookup to identify which route should handle an incoming request. Route group
 routes provide dedicated fields for the most common predicates like the path or the HTTP method, but in the
 predicates list field, it is possible to define and configure any predicate supported by Skipper. See the
-[Predicates](../../reference/predicates/) section of the reference.
+[Predicates](../reference/predicates.md) section of the reference.
 
 ### Filter
 
 A filter is used during handling the request to shape the request flow. In a route group, any filter supported
-by Skipper is allowed to be used. See the [Filters](../../reference/filters/)
+by Skipper is allowed to be used. See the [Filters](../reference/filters.md)
 section of the reference.
 
 ## RouteGroup - top level object
@@ -78,7 +78,7 @@ fields are the name and the type, while the rest of the fields may be required b
   servicePort: <number>     optional, required for type=service
 ```
 
-See more about Skipper backends in the [backend documentation](../../reference/backends/).
+See more about Skipper backends in the [backend documentation](../reference/backends.md).
 
 ## Backend reference
 
@@ -111,7 +111,7 @@ shaping with filters.
 ```
 
 The `path`, `pathSubtree` and `pathRegexp` fields work the same way as the predicate counterparts on eskip
-routes. See the [reference manual](../../reference/predicates/) for more details.
+routes. See the [reference manual](../reference/predicates.md) for more details.
 
 The `methods` field defines which methods an incoming request can have in order to match the route.
 
@@ -129,7 +129,7 @@ their eskip format. Example:
 
 See also:
 
-- [predicates](../../reference/predicates/)
-- [filters](../../reference/filters/)
+- [predicates](../reference/predicates.md)
+- [filters](../reference/filters.md)
 
 The <backendRef> references in the backends field, if present, define which backends a route should use.

--- a/docs/kubernetes/routegroups.md
+++ b/docs/kubernetes/routegroups.md
@@ -65,7 +65,7 @@ document.)
 
 Links:
 
-- [RouteGroup semantics](../routegroup-crd/)
+- [RouteGroup semantics](routegroup-crd.md)
 - [CRD definition](https://github.com/zalando/skipper/blob/master/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml)
 
 ## Requirements
@@ -152,7 +152,7 @@ kubectl apply -f my-route-group.yaml
 
 ## Hosts
 
-- *[Format](../routegroup-crd/#routegroup-top-level-object)*
+- *[Format](routegroup-crd.md#routegroup-top-level-object)*
 
 Hosts contain hostnames that are used to match the requests handled by a given route group. They are also used
 to update the required DNS entries and load balancer configuration if the cluster is set up that way.
@@ -162,8 +162,8 @@ predicate included, but the hostnames defined that way will not serve as input f
 
 ## Backends
 
-- *[Format](../routegroup-crd/#backend_1)*
-- *[General backend reference](../../reference/backends/)*
+- *[Format](routegroup-crd.md#backend_1)*
+- *[General backend reference](../reference/backends.md)*
 
 RouteGroups support different backends. The most typical backend type is the 'service', and it works the same
 way as in case of ingress definitions.
@@ -191,11 +191,11 @@ the Kubernetes semantics, and allows URLs that point somewhere else, potentially
 ### type=shunt, type=loopback, type=dynamic
 
 These backend types allow advanced routing setups. Please check the [reference
-manual](../../reference/backends/) for more details.
+manual](../reference/backends.md) for more details.
 
 ## Default Backends
 
-- *[Format](../routegroup-crd/#backend-reference)*
+- *[Format](routegroup-crd.md#backend-reference)*
 
 A default backend is a reference to one of the defined backends. When a route doesn't specify which backend(s)
 to use, the ones referenced in the default backends will be used.
@@ -209,7 +209,7 @@ more](#gradual-traffic-switching).
 
 ## Routes
 
-- *[Format](../routegroup-crd/#route_1)*
+- *[Format](routegroup-crd.md#route_1)*
 
 Routes define where to and how the incoming requests will be proxied. The predicates, including the path,
 pathSubtree, pathRegexp and methods fields, and any free-form predicate listed under the predicates field,
@@ -223,8 +223,8 @@ Important to bear in mind about the path fields, that the plain 'path' means exa
 
 See also:
 
-- [predicates](../../reference/predicates/)
-- [filters](../../reference/filters/)
+- [predicates](../reference/predicates.md)
+- [filters](../reference/filters.md)
 
 ## Gradual traffic switching
 
@@ -309,7 +309,7 @@ spec:
 
 See also:
 
-- [Traffic predicate](../../reference/predicates/#traffic)
+- [Traffic predicate](../reference/predicates.md#traffic)
 
 ## Mapping from Ingress to RouteGroups
 
@@ -608,12 +608,12 @@ attribute of the backend definition, and it can be set individually for each bac
 
 See also:
 
-- [Load Balancer backend](https://opensource.zalando.com/skipper/reference/backends/#load-balancer-backend)
+- [Load Balancer backend](../reference/backends.md#load-balancer-backend)
 
 ### zalando.org/skipper-ingress-path-mode
 
 The route objects support the different path lookup modes, by using the path, pathSubtree or the
-pathRegexp field. See also the [route matching](../../reference/architecture/#route-matching)
+pathRegexp field. See also the [route matching](../reference/architecture.md#route-matching)
 explained for the internals. The mapping is as follows:
 
 Ingress: | RouteGroup:

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -776,8 +776,8 @@ capable of responding some requests fast enough.
 
 ### A solution
 
-Skipper has two filters [`lifo()`](../reference/filters/#lifo) and
-[`lifoGroup()`](../reference/filters/#lifogroup), that can limit
+Skipper has two filters [`lifo()`](../reference/filters.md#lifo) and
+[`lifoGroup()`](../reference/filters.md#lifogroup), that can limit
 the number of requests for a route.  A [documented load
 test](https://github.com/zalando/skipper/pull/1030#issuecomment-485714338)
 shows the behavior with an enabled `lifo(100,100,"10s")` filter for
@@ -794,9 +794,9 @@ blogpost](https://blogs.dropbox.com/tech/2018/03/meet-bandaid-the-dropbox-servic
 
 Skipper's scheduler implementation makes sure, that one route will not
 interfere with other routes, if these routes are not in the same
-scheduler group. [`LifoGroup`](../reference/filters/#lifogroup) has
+scheduler group. [`LifoGroup`](../reference/filters.md#lifogroup) has
 a user chosen scheduler group and
-[`lifo()`](../reference/filters/#lifo) will get a per route unique
+[`lifo()`](../reference/filters.md#lifo) will get a per route unique
 scheduler group.
 
 ## URI standards interpretation
@@ -810,7 +810,7 @@ This is possible to achieve centrally, when Skipper is started with
 the -rfc-patch-path flag. It is also possible to allow the default
 behavior and only force the alternative interpretation on a per-route
 basis with the rfcPath() filter. See
-[`rfcPath()`](../reference/filters/#rfcPath).
+[`rfcPath()`](../reference/filters.md#rfcPath).
 
 If the second interpretation gets considered the right way, and the
 other one a bug, then the default value for this flag may become to

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -509,7 +509,7 @@ header.
 
 ## xforwardFirst
 
-Same as [xforward](xforward), but instead of appending the last remote IP, it prepends it to comply with the
+Same as [xforward](#xforward), but instead of appending the last remote IP, it prepends it to comply with the
 approach of certain LB implementations.
 
 ## randomContent
@@ -1550,7 +1550,7 @@ with an optional fourth parameter. If the fourth parameter is set
 skipper will use the HTTP header defined by this to put the request in
 the same client bucket, else the X-Forwarded-For Header will be used.
 You need to run skipper with command line flags `-enable-swarm` and
-`-enable-ratelimits`. See also our [cluster ratelimit tutorial](../../tutorials/ratelimit/#cluster-ratelimit)
+`-enable-ratelimits`. See also our [cluster ratelimit tutorial](../tutorials/ratelimit.md#cluster-ratelimit)
 
 Parameters:
 
@@ -1574,7 +1574,7 @@ rate limit group. The first parameter is a string to select the same
 ratelimit group across one or more routes.  The rate limit group
 allows the given number of requests to a backend. You need to have run
 skipper with command line flags `-enable-swarm` and
-`-enable-ratelimits`. See also our [cluster ratelimit tutorial](../../tutorials/ratelimit/#cluster-ratelimit)
+`-enable-ratelimits`. See also our [cluster ratelimit tutorial](../tutorials/ratelimit.md#cluster-ratelimit)
 
 
 Parameters:
@@ -2152,7 +2152,7 @@ the api-backend service will receive a request with the path /api/foo%2Fbar/summ
 
 It is also possible to enable this behavior centrally for a Skipper instance with
 the -rfc-patch-path flag. See
-[URI standards interpretation](../../operation/operation/#uri-standards-interpretation).
+[URI standards interpretation](../operation/operation.md#uri-standards-interpretation).
 
 ## bearerinjector
 

--- a/docs/tutorials/auth.md
+++ b/docs/tutorials/auth.md
@@ -262,7 +262,7 @@ It works as follows:
    callback URL parameter which was part of the previous redirect. The callback route must
    have a `grantCallback()` filter defined. Skipper automatically adds this callback route for you
    when the OAuth2 authorization grant flow feature is enabled. Note that the automatically added
-	 callback route does not apply [default filters](../../operation/operation/#default-filters).
+	 callback route does not apply [default filters](../operation/operation.md#default-filters).
 	 If you need default filters to be applied to the callback route as well, please register
 	 the route manually in your routes files.
 1. Skipper calls the provider's token URL with the authorization code, and receives a response 

--- a/docs/tutorials/development.md
+++ b/docs/tutorials/development.md
@@ -8,18 +8,7 @@ Developer documentation for skipper as library users
 
 ### User documentation
 
-#### local Preview
-
-To see rendered documentation locally you need to replace `/skipper`
-path with `/` to see them correctly. This you can easily do with
-skipper in front of `mkdocs serve`. The following skipper inline route
-will do this for you, assuming that you build skipper with `make skipper`:
-
-```
-./bin/skipper -inline-routes 'r: * -> modPath("/skipper", "") -> "http://127.0.0.1:8000"'
-```
-
-Now you should be able to see the documentation at [http://127.0.0.1:9090](http://127.0.0.1:9090).
+To see rendered documentation locally run `mkdocs serve` and navigate to [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
 ## Filters
 
@@ -110,7 +99,7 @@ func (f *myPredicate) Match(r *http.Request) bool {
 ```
 
 Predicates are quite similar to implement as Filters, so for a more
-complete example, find an example [how to develop a filter](../reference/development#how-to-develop-a-filter).
+complete example, find an example [how to develop a filter](../reference/development.md#how-to-develop-a-filter).
 
 ## Dataclients
 

--- a/docs/tutorials/operations.md
+++ b/docs/tutorials/operations.md
@@ -53,13 +53,13 @@ The Kubernetes Ingress spec defines a
 as regular expression, which is not what most people would expect, nor
 want. Skipper defaults in Kubernetes to use the [PathRegexp predicate](../reference/predicates.md#pathregexp)
 for routing, because of the spec. We believe the better default is the
-path prefix mode, that uses [PathSubtree predicate](../reference/predicates#pathsubtree),
+path prefix mode, that uses [PathSubtree predicate](../reference/predicates.md#pathsubtree),
 instead. Path prefix search is much more scalable and can not lead to
 unexpected results by not so experienced regular expressions users.
 
 To find more information about Metrics, including formats and example
 Prometheus queries you find in the [metrics
-section](../../operation/operation#monitoring).
+section](../operation/operation.md#monitoring).
 The settings shown above support system and application metrics to
 carefully monitor Skipper and your backend applications. Backend
 application metrics get error rates and latency buckets based on host
@@ -84,14 +84,14 @@ Depending on the HTTP loadbalancer in front of your Skippers, you might
 want to set `-reverse-source-predicate`. This setting reverses the
 lookup of the client IP to find it in the `X-Forwarded-For` header
 values. If you do not care about
-[clientRatelimits](../../reference/filters#clientratelimit)
+[clientRatelimits](../reference/filters.md#clientratelimit)
 based on X-Forwarded-For headers, you can also ignore this.
 
 #### Cluster Ratelimit
 
 Ratelimits can be calculated for the whole cluster instead of having
 only the instance based ratelimits. The common term we use in skipper
-documentation is [cluster ratelimit](https://opensource.zalando.com/skipper/tutorials/ratelimit/#cluster-ratelimit).
+documentation is [cluster ratelimit](ratelimit.md#cluster-ratelimit).
 There are two option, but we highly recommend the use of Redis based
 cluster ratelimits. To support redis based cluster ratelimits you have to
 use `-enable-swarm` and add a list of URLs to redis
@@ -111,7 +111,7 @@ because storing the data in memory is good enough for this use case.
 
 Skipper supports cluster internal service-to-service communication as
 part of running as an [API Gateway with an East-West
-setup](../../kubernetes/ingress-controller/#run-as-api-gateway-with-east-west-setup).
+setup](../kubernetes/ingress-controller.md#run-as-api-gateway-with-east-west-setup).
 You have to add `-enable-kubernetes-east-west` and optionally choose a
 domain
 `-kubernetes-east-west-domain=.ingress.cluster.local`. Be warned: There is a
@@ -192,9 +192,8 @@ skippper \
 #### API monitoring and Auth
 
 As part of API Gateway features, skipper supports [API
-monitoring](https://opensource.zalando.com/skipper/reference/filters/#apiusagemonitoring)
-and common [authentication and
-authorization](https://opensource.zalando.com/skipper/tutorials/auth/)
+monitoring](../reference/filters.md#apiusagemonitoring)
+and common [authentication and authorization](auth.md)
 protocols in Microservices architectures.
 
 #### OpenTracing
@@ -211,7 +210,7 @@ the process.
 
 #### Global default filters
 
-Skipper can also add [global default filters](../../operation/operation/#global-default-filters),
+Skipper can also add [global default filters](../operation/operation.md#global-default-filters),
 which will be automatically added to all routes. For example you can
 use `-default-filters-prepend="enableAccessLog(4,5)"` to enable only
 access logs in case of HTTP codes 4xx or 5xx. In the specific case of

--- a/docs/tutorials/ratelimit.md
+++ b/docs/tutorials/ratelimit.md
@@ -99,7 +99,7 @@ to run N number of [Redis](https://redis.io) instances, where N is >
 0.  Specify `-swarm-redis-urls`, multiple instances can be separated
 by `,`, for example: `-swarm-redis-urls=redis1:6379,redis2:6379`. For
 running skipper in Kubernetes with this, see also [Running with
-Redis based Cluster Ratelimits](../../kubernetes/ingress-controller/#redis-based)
+Redis based Cluster Ratelimits](../kubernetes/ingress-controller.md#redis-based)
 
 The implementation use [redis ring](https://godoc.org/github.com/go-redis/redis#Ring)
 to be able to shard via client hashing and spread the load across
@@ -123,7 +123,7 @@ Membership Protocol", which is very interesting to use for cluster
 ratelimits. The implementation has some weaknesses in the algorithm,
 that lead sometimes to too much ratelimits or too few and therefore is
 not considered to be stable. For running skipper in Kubernetes with
-this, see also [Running with SWIM based Cluster Ratelimits](../../kubernetes/ingress-controller/#swim-based)
+this, see also [Running with SWIM based Cluster Ratelimits](../kubernetes/ingress-controller.md#swim-based)
 
 In case of Kubernetes you might specify additionally
 `-swarm-label-selector-key`, which defaults to "application" and


### PR DESCRIPTION
Fixes documentation links such that documentation is navigable both on github and via `mkdocs serve`.
Found broken links by crawling the branch tree and inspecting logs for 404 errors:
```
$ rev=fixes-doc-links; wget --recursive --convert-links --domains github.com -I /zalando/skipper/blob/$rev/ -I /zalando/skipper/tree/$rev/ https://github.com/zalando/skipper/tree/$rev/docs/ 2> github.log
$ wget --recursive --convert-links --domains 127.0.0.1 http://127.0.0.1:8000/ 2> localhost.log
```
Followup on #1740
See also #955 

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>