### PR TITLE
Adds backendRatelimit filter

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -23,6 +23,9 @@ const (
 
 	// BackendTimeout is the key used in the state bag to configure backend timeout in proxy
 	BackendTimeout = "backend:timeout"
+
+	// BackendRatelimit is the key used in the state bag to configure backend ratelimit in proxy
+	BackendRatelimit = "backend:ratelimit"
 )
 
 // Context object providing state and information that is unique to a request.

--- a/filters/ratelimit/backendratelimit.go
+++ b/filters/ratelimit/backendratelimit.go
@@ -1,0 +1,53 @@
+package ratelimit
+
+import (
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/ratelimit"
+)
+
+type backendRatelimit struct {
+	settings ratelimit.Settings
+}
+
+// NewBackendRatelimit creates a filter Spec, whose instances
+// instruct proxy to limit request rate towards a particular backend endpoint
+func NewBackendRatelimit() filters.Spec { return &backendRatelimit{} }
+
+func (*backendRatelimit) Name() string { return "backendRatelimit" }
+
+func (*backendRatelimit) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) != 3 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	group, err := getStringArg(args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	maxHits, err := getIntArg(args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	timeWindow, err := getDurationArg(args[2])
+	if err != nil {
+		return nil, err
+	}
+
+	s := ratelimit.Settings{
+		Type:       ratelimit.ClusterServiceRatelimit,
+		Group:      "backend." + group,
+		MaxHits:    maxHits,
+		TimeWindow: timeWindow,
+	}
+
+	return &backendRatelimit{settings: s}, nil
+}
+
+func (f *backendRatelimit) Request(ctx filters.FilterContext) {
+	// allows overwrite
+	ctx.StateBag()[filters.BackendRatelimit] = f.settings
+}
+
+func (*backendRatelimit) Response(filters.FilterContext) {}

--- a/filters/ratelimit/backendratelimit_test.go
+++ b/filters/ratelimit/backendratelimit_test.go
@@ -1,0 +1,58 @@
+package ratelimit
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/ratelimit"
+)
+
+func TestBackendRatelimit(t *testing.T) {
+	spec := NewBackendRatelimit()
+	if spec.Name() != "backendRatelimit" {
+		t.Error("wrong name")
+	}
+
+	f, err := spec.CreateFilter([]interface{}{"api", 22, "7s"})
+	if err != nil {
+		t.Fatal("failed to create filter")
+	}
+
+	c := &filtertest.Context{FRequest: &http.Request{}, FStateBag: make(map[string]interface{})}
+	f.Request(c)
+
+	settings, ok := c.FStateBag[filters.BackendRatelimit].(ratelimit.Settings)
+	if !ok {
+		t.Fatal("settings expected")
+	}
+	expected := ratelimit.Settings{
+		Type:       ratelimit.ClusterServiceRatelimit,
+		Group:      "backend.api",
+		MaxHits:    22,
+		TimeWindow: 7 * time.Second,
+	}
+	if settings != expected {
+		t.Fatalf("wrong settings, expected: %v, got %v", expected, settings)
+	}
+
+	// second filter overwrites
+	f, _ = spec.CreateFilter([]interface{}{"api2", 355, "113s"})
+	f.Request(c)
+
+	settings, ok = c.FStateBag[filters.BackendRatelimit].(ratelimit.Settings)
+	if !ok {
+		t.Fatal("settings overwrite expected")
+	}
+	expected = ratelimit.Settings{
+		Type:       ratelimit.ClusterServiceRatelimit,
+		Group:      "backend.api2",
+		MaxHits:    355,
+		TimeWindow: 113 * time.Second,
+	}
+	if settings != expected {
+		t.Fatalf("wrong settings overwrite, expected: %v, got %v", expected, settings)
+	}
+}

--- a/net/redistest/redistest.go
+++ b/net/redistest/redistest.go
@@ -1,0 +1,63 @@
+package redistest
+
+import (
+	"context"
+	"net"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+func NewTestRedis(t *testing.T) (address string, done func()) {
+	return NewTestRedisWithPassword(t, "")
+}
+
+func NewTestRedisWithPassword(t *testing.T, password string) (address string, done func()) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address = l.Addr().String()
+	port := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+	l.Close()
+
+	args := []string{"--port", port}
+	if password != "" {
+		args = append(args, "--requirepass", password)
+	}
+
+	ctx, stop := context.WithCancel(context.Background())
+
+	cmd := exec.CommandContext(ctx, "redis-server", args...) // #nosec
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start redis server: %v", err)
+	}
+
+	if err := ping(address, password); err != nil {
+		t.Fatalf("Failed to ping redis server: %v", err)
+	}
+
+	t.Logf("Started redis server at %s", address)
+	done = func() {
+		t.Logf("Stopping redis server at %s", address)
+		stop()
+		cmd.Wait()
+	}
+	return
+}
+
+func ping(address, password string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	rdb := redis.NewClient(&redis.Options{Addr: address, Password: password})
+	defer rdb.Close()
+
+	for _, err := rdb.Ping(ctx).Result(); ctx.Err() == nil && err != nil; _, err = rdb.Ping(ctx).Result() {
+		time.Sleep(100 * time.Millisecond)
+	}
+	return ctx.Err()
+}

--- a/proxy/backendratelimit_test.go
+++ b/proxy/backendratelimit_test.go
@@ -1,0 +1,223 @@
+// +build !race redis
+
+package proxy_test
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters/builtin"
+	ratelimitfilters "github.com/zalando/skipper/filters/ratelimit"
+	snet "github.com/zalando/skipper/net"
+	"github.com/zalando/skipper/net/redistest"
+	"github.com/zalando/skipper/proxy"
+	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/ratelimit"
+)
+
+type (
+	countingBackend struct {
+		server   *httptest.Server
+		requests int
+	}
+	countingBackends []*countingBackend
+)
+
+func (b *countingBackend) ServeHTTP(http.ResponseWriter, *http.Request) {
+	b.requests++
+}
+
+func (b *countingBackend) String() string {
+	return b.server.URL
+}
+
+func newCountingBackend() *countingBackend {
+	b := &countingBackend{}
+	b.server = httptest.NewServer(b)
+	return b
+}
+
+func newCountingBackends(n int) (result countingBackends) {
+	for i := 0; i < n; i++ {
+		result = append(result, newCountingBackend())
+	}
+	return
+}
+
+func (backends countingBackends) close() {
+	for _, b := range backends {
+		b.server.Close()
+	}
+}
+
+func (backends countingBackends) endpoints() (result []string) {
+	for _, b := range backends {
+		result = append(result, b.server.URL)
+	}
+	return
+}
+
+func (backends countingBackends) String() string {
+	var urls []string
+	for _, e := range backends.endpoints() {
+		urls = append(urls, `"`+e+`"`)
+	}
+	return strings.Join(urls, ",")
+}
+
+// Round robin distributes requests evenly between backends,
+// test each backend gets exactly max hits before limit kicks-in
+func TestBackendRateLimitRoundRobin(t *testing.T) {
+	const (
+		nBackends  = 3
+		maxHits    = 7
+		timeWindow = 10 * time.Second
+	)
+
+	filterRegistry := builtin.MakeRegistry()
+	filterRegistry.Register(ratelimitfilters.NewBackendRatelimit())
+
+	redisAddr, done := redistest.NewTestRedis(t)
+	defer done()
+
+	ratelimitRegistry := ratelimit.NewSwarmRegistry(nil, &snet.RedisOptions{Addrs: []string{redisAddr}})
+	defer ratelimitRegistry.Close()
+
+	backends := newCountingBackends(nBackends)
+	defer backends.close()
+
+	doc := fmt.Sprintf(`* -> backendRatelimit("testapi", %d, "%s") -> <roundRobin, %v>`, maxHits, timeWindow.String(), backends)
+	r, err := eskip.Parse(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := proxytest.WithParams(filterRegistry, proxy.Params{RateLimiters: ratelimitRegistry}, r...)
+	if testing.Verbose() {
+		p.Log.Unmute()
+	}
+	defer p.Close()
+
+	const totalMaxHits = nBackends * maxHits
+
+	requestAndExpect(t, p.URL, totalMaxHits, http.StatusOK, nil)
+	requestAndExpect(t, p.URL, 1, http.StatusServiceUnavailable, http.Header{"Content-Length": []string{"0"}})
+
+	for _, b := range backends {
+		if b.requests != maxHits {
+			t.Errorf("Expected %d hits for backend %s, got: %d", maxHits, b, b.requests)
+		}
+	}
+}
+
+func TestBackendRateLimitScenarios(t *testing.T) {
+	for _, ti := range []struct {
+		name     string
+		routes   string
+		backends int
+		requests map[string]int
+		maxHits  int
+	}{
+		{
+			"single route with one backend",
+			`* -> backendRatelimit("testapi", 7, "10s") -> $backends`,
+			1,
+			map[string]int{"/": 10},
+			7,
+		},
+		{
+			"single route with three backends, random",
+			`* -> backendRatelimit("testapi", 7, "10s") -> <random, $backends>`,
+			3,
+			map[string]int{"/": 30},
+			7,
+		},
+		{
+			"single route with three backends, roundRobin",
+			`* -> backendRatelimit("testapi", 7, "10s") -> <roundRobin, $backends>`,
+			3,
+			map[string]int{"/": 30},
+			7,
+		},
+		{
+			"single route with three backends, consistentHash",
+			`* -> backendRatelimit("testapi", 7, "10s") -> <consistentHash, $backends>`,
+			3,
+			map[string]int{"/": 30},
+			7,
+		},
+		{
+			"two routes with three backends and common limit",
+			`api1: Path("/api1") -> backendRatelimit("api", 7, "10s") -> <random, $backends>;
+			api2: Path("/api2") -> backendRatelimit("api", 7, "10s") -> <random, $backends>`,
+			3,
+			map[string]int{"/api1": 15, "/api2": 15},
+			7,
+		},
+		{
+			"two routes with three backends and separate limits",
+			`api1: Path("/api1") -> backendRatelimit("api1", 4, "10s") -> <random, $backends>;
+			api2: Path("/api2") -> backendRatelimit("api2", 8, "10s") -> <random, $backends>`,
+			3,
+			map[string]int{"/api1": 20, "/api2": 30},
+			4 + 8,
+		},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+			filterRegistry := builtin.MakeRegistry()
+			filterRegistry.Register(ratelimitfilters.NewBackendRatelimit())
+
+			redisAddr, done := redistest.NewTestRedis(t)
+			defer done()
+
+			ratelimitRegistry := ratelimit.NewSwarmRegistry(nil, &snet.RedisOptions{Addrs: []string{redisAddr}})
+			defer ratelimitRegistry.Close()
+
+			backends := newCountingBackends(ti.backends)
+			defer backends.close()
+
+			r, err := eskip.Parse(strings.ReplaceAll(ti.routes, "$backends", backends.String()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			p := proxytest.WithParams(filterRegistry, proxy.Params{RateLimiters: ratelimitRegistry}, r...)
+			if testing.Verbose() {
+				p.Log.Unmute()
+			}
+			defer p.Close()
+
+			var urls []string
+			for path, count := range ti.requests {
+				for i := 0; i < count; i++ {
+					urls = append(urls, p.URL+path)
+				}
+			}
+			rand.Shuffle(len(urls), func(i, j int) { urls[i], urls[j] = urls[j], urls[i] })
+
+			for _, url := range urls {
+				rsp, err := http.Get(url)
+				if err != nil {
+					t.Fatalf("%s: %v", url, err)
+				}
+				defer rsp.Body.Close()
+
+				if rsp.StatusCode != http.StatusOK && rsp.StatusCode != http.StatusServiceUnavailable {
+					t.Fatalf("%s: unexpected status %d", url, rsp.StatusCode)
+				}
+			}
+
+			for _, b := range backends {
+				if b.requests > ti.maxHits {
+					t.Errorf("Backend %s received %d above max hits %d ", b, b.requests, ti.maxHits)
+				}
+			}
+		})
+	}
+}

--- a/skipper.go
+++ b/skipper.go
@@ -1283,6 +1283,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			ratelimitfilters.NewClusterRateLimit(provider),
 			ratelimitfilters.NewClusterClientRateLimit(provider),
 			ratelimitfilters.NewDisableRatelimit(provider),
+			ratelimitfilters.NewBackendRatelimit(),
 		)
 	}
 


### PR DESCRIPTION
The filter limits request rate per backend host, it is similar to `clusterClientRatelimit`
but instead of client IP it uses backend endpoint address to group requests.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>