### PR TITLE
Remove unnecessary loop on k8s internal hosts

### DIFF
--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -593,14 +593,13 @@ func (r *routeGroups) convert(s *clusterState, df defaultFilters) ([]*eskip.Rout
 		}
 
 		// Internal hosts
-		for _, host := range internalHosts {
-			hosts := []string{host}
+		if len(internalHosts) > 0 {
 			internalCtx := &routeGroupContext{
 				clusterState:          s,
 				defaultFilters:        df,
 				routeGroup:            rg,
-				hosts:                 hosts,
-				hostRx:                createHostRx(host),
+				hosts:                 internalHosts,
+				hostRx:                createHostRx(internalHosts...),
 				hostRoutes:            make(map[string][]*eskip.Route),
 				provideHTTPSRedirect:  r.options.ProvideHTTPSRedirect,
 				httpsRedirectCode:     r.options.HTTPSRedirectCode,

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.eskip
@@ -1,0 +1,12 @@
+kube_rg__internal___example2_ingress_cluster_local__catchall__0_0:
+	ClientIP("10.2.0.0/16")
+	&& Host("^(example2[.]ingress[.]cluster[.]local)$") -> <shunt>;
+
+kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
+	ClientIP("10.2.0.0/16")
+	&& Host("^(example[.]ingress[.]cluster[.]local)$") -> <shunt>;
+
+kube_rg__internal_default__myapp__all__0_0:
+	ClientIP("10.2.0.0/16")
+	&& Host("^(example[.]ingress[.]cluster[.]local|example2[.]ingress[.]cluster[.]local)$")
+	&& Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.kube
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.kube
@@ -1,0 +1,5 @@
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.yaml
@@ -1,0 +1,41 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - example.ingress.cluster.local
+  - example2.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - path: /app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80


### PR DESCRIPTION
In #1676 a new loop for the internal hosts were introduced by a first
implementation and not removed. The initial implementation assumed that
multiple domains with different CIDRs could be configured, therefore,
required different route for every host. The implementation changed
during the PR discussion and with the current one multiple domains can
be set but the predicates are all added to the routes without
distinction of domain and the loop is unnecessary. Check [this
comment][0] for more details.

This commit removes the unnecessary loop and create the routes combining
all internal hosts.

[0]: https://github.com/zalando/skipper/pull/1676#discussion_r614897845