### PR TITLE
Fixes `function arguments too large for new goroutine` error

### DIFF
--- a/dataclients/routestring/example_test.go
+++ b/dataclients/routestring/example_test.go
@@ -21,10 +21,12 @@ func Example() {
 		return
 	}
 
-	go skipper.Run(skipper.Options{
-		Address:           ":9999",
-		CustomDataClients: []routing.DataClient{rs},
-	})
+	go func() {
+		skipper.Run(skipper.Options{
+			Address:           ":9999",
+			CustomDataClients: []routing.DataClient{rs},
+		})
+	}()
 	time.Sleep(1 * time.Millisecond)
 
 	rsp, err := http.Get("http://localhost:9999")


### PR DESCRIPTION
```
$ go test -count=1 github.com/zalando/skipper/dataclients/routestring
fatal error: newproc: function arguments too large for new goroutine
...
```

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>