### PR TITLE
Predicates for Forwarded Header

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -128,6 +128,44 @@ Host(/^my-host-header\.example\.org$/)
 Host(/header\.example\.org$/)
 ```
 
+## Forwarded header predicates
+
+Uses standardized Forwarded header ([RFC 7239](https://tools.ietf.org/html/rfc7239))
+
+More info about the header: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded)
+
+### ForwardedHost
+
+Regular expressions that the forwarded host header in the request must match.
+
+Parameters:
+
+* Host (regex)
+
+Examples:
+
+```
+ForwardedHost(/^my-host-header\.example\.org$/)
+ForwardedHost(/header\.example\.org$/)
+```
+
+### ForwardedProtocol
+
+Regular expressions that the forwarded host header in the request must match.
+
+Parameters:
+
+* Protocol (string)
+
+Only "http" and "https" values are allowed
+
+Examples:
+
+```
+ForwardedProtocol("http")
+ForwardedProtocol("https")
+```
+
 ## Weight (priority)
 
 By default, the weight (priority) of a route is determined by the number of defined predicates.

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -151,7 +151,7 @@ ForwardedHost(/header\.example\.org$/)
 
 ### ForwardedProtocol
 
-Regular expressions that the forwarded host header in the request must match.
+Protocol the forwarded header in the request must match.
 
 Parameters:
 

--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -1,0 +1,156 @@
+/*
+Package forwarded implements a set of custom predicate to match routes
+based on the standardized Forwarded header.
+
+https://datatracker.ietf.org/doc/html/rfc7239
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+
+Examples:
+
+    // only match requests to "example.com"
+    example1: ForwardedHost("example.com") -> "http://example.org";
+
+    // only match requests to http
+    example2: ForwardedProtocol("http") -> "http://example.org";
+
+    // only match requests to https
+    example3: ForwardedProtocol("https") -> "http://example.org";
+*/
+package forwarded
+
+import (
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/routing"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+const (
+	NameHost  = "ForwardedHost"
+	NameProto = "ForwardedProtocol"
+)
+
+const (
+	HTTP  string = "http"
+	HTTPS string = "https"
+)
+
+type hostPredicateSpec struct{}
+
+type protoPredicateSpec struct{}
+
+type hostPredicate struct {
+	host *regexp.Regexp
+}
+
+func (p *hostPredicateSpec) Create(args []interface{}) (routing.Predicate, error) {
+
+	if len(args) != 1 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	value, ok := args[0].(string)
+	if !ok {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	if value == "" {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	re, err := regexp.Compile(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return hostPredicate{host: re}, err
+}
+
+type protoPredicate struct {
+	proto string
+}
+
+func (p *protoPredicateSpec) Create(args []interface{}) (routing.Predicate, error) {
+
+	if len(args) != 1 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	value, ok := args[0].(string)
+	if !ok {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	value = strings.ToLower(value)
+
+	switch value {
+	case HTTP, HTTPS:
+	default:
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	return protoPredicate{proto: value}, nil
+}
+
+func NewForwardedHost() routing.PredicateSpec  { return &hostPredicateSpec{} }
+func NewForwardedProto() routing.PredicateSpec { return &protoPredicateSpec{} }
+
+func (p *hostPredicateSpec) Name() string {
+	return NameHost
+}
+
+func (p *protoPredicateSpec) Name() string {
+	return NameProto
+}
+
+func (p hostPredicate) Match(r *http.Request) bool {
+
+	fh := r.Header.Get("Forwarded")
+
+	if fh == "" {
+		return false
+	}
+
+	fw := parseForwarded(fh)
+
+	return p.host.MatchString(fw.host)
+}
+
+func (p protoPredicate) Match(r *http.Request) bool {
+
+	fh := r.Header.Get("Forwarded")
+
+	if fh == "" {
+		return false
+	}
+
+	fw := parseForwarded(fh)
+
+	return p.proto == fw.proto
+}
+
+type forwarded struct {
+	host  string
+	proto string
+}
+
+func parseForwarded(fh string) *forwarded {
+
+	f := &forwarded{}
+
+	for _, forwardedPair := range strings.Split(fh, ";") {
+		if tv := strings.SplitN(forwardedPair, "=", 2); len(tv) == 2 {
+			token, value := tv[0], tv[1]
+			token = strings.TrimSpace(token)
+			value = strings.TrimSpace(strings.Trim(value, `"`))
+			switch strings.ToLower(token) {
+			case "proto":
+				f.proto = value
+			case "host":
+				f.host = value
+			}
+		}
+	}
+	return f
+}

--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -76,15 +76,12 @@ func (p *protoPredicateSpec) Create(args []interface{}) (routing.Predicate, erro
 		return nil, predicates.ErrInvalidPredicateParameters
 	}
 
-	value = strings.ToLower(value)
-
 	switch value {
 	case "http", "https":
+		return protoPredicate{proto: value}, nil
 	default:
 		return nil, predicates.ErrInvalidPredicateParameters
 	}
-
-	return protoPredicate{proto: value}, nil
 }
 
 func NewForwardedHost() routing.PredicateSpec  { return &hostPredicateSpec{} }
@@ -136,9 +133,8 @@ func parseForwarded(fh string) *forwarded {
 	for _, forwardedPair := range strings.Split(fh, ";") {
 		if tv := strings.SplitN(forwardedPair, "=", 2); len(tv) == 2 {
 			token, value := tv[0], tv[1]
-			token = strings.TrimSpace(token)
-			value = strings.TrimSpace(strings.Trim(value, `"`))
-			switch strings.ToLower(token) {
+			value = strings.Trim(value, `"`)
+			switch token {
 			case "proto":
 				f.proto = value
 			case "host":

--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -31,11 +31,6 @@ const (
 	NameProto = "ForwardedProtocol"
 )
 
-const (
-	HTTP  string = "http"
-	HTTPS string = "https"
-)
-
 type hostPredicateSpec struct{}
 
 type protoPredicateSpec struct{}
@@ -45,7 +40,6 @@ type hostPredicate struct {
 }
 
 func (p *hostPredicateSpec) Create(args []interface{}) (routing.Predicate, error) {
-
 	if len(args) != 1 {
 		return nil, predicates.ErrInvalidPredicateParameters
 	}
@@ -85,7 +79,7 @@ func (p *protoPredicateSpec) Create(args []interface{}) (routing.Predicate, erro
 	value = strings.ToLower(value)
 
 	switch value {
-	case HTTP, HTTPS:
+	case "http", "https":
 	default:
 		return nil, predicates.ErrInvalidPredicateParameters
 	}

--- a/predicates/forwarded/forwarded_test.go
+++ b/predicates/forwarded/forwarded_test.go
@@ -1,0 +1,308 @@
+package forwarded
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type request struct {
+	url     string
+	headers http.Header
+}
+
+func TestForwardedHost(t *testing.T) {
+	testCases := []struct {
+		msg     string
+		host    string
+		r       request
+		matches bool
+		isError bool
+	}{{
+		msg:     "Empty host should fail",
+		host:    "",
+		r:       request{},
+		matches: false,
+		isError: true,
+	}, {
+		msg:     "Empty Forwarded Header should not match",
+		host:    "example.com",
+		r:       request{},
+		matches: false,
+		isError: false,
+	}, {
+		msg:  "Same forwarded Header should match",
+		host: "example.com",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.com"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:  "Same forwarded Header should match",
+		host: "example.com",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=http;host=example.com;by=203.0.113.43"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:  "Same forwarded Header should match",
+		host: "example.com",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;host=example.com;proto=http;by=203.0.113.43"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:  "Same forwarded Header should match",
+		host: "example.com",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"host=example.com;for=192.0.2.60;proto=http;by=203.0.113.43"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:  "Different forwarded Header should not match",
+		host: "example.com",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.org"},
+			},
+		},
+		matches: false,
+		isError: false,
+	}, {
+		msg:  "Forwarded Header with no host should not match",
+		host: "example.com",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43"},
+			},
+		},
+		matches: false,
+		isError: false,
+	}, {
+		msg:  "Forwarded Header only host should match",
+		host: "example.com",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"host=example.com"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.msg, func(t *testing.T) {
+			spec := NewForwardedHost()
+
+			p, err := spec.Create([]interface{}{tc.host})
+			hasError := err != nil
+			if hasError || tc.isError {
+				if !tc.isError {
+					t.Error("Predicate creation failed")
+				}
+
+				if !hasError {
+					t.Error("Predicate should have failed")
+				}
+
+				return
+			}
+
+			r, err := newRequest(tc.r)
+			if !tc.isError && err != nil {
+				t.Error("Request creation failed")
+			}
+
+			m := p.Match(r)
+			if m != tc.matches {
+				t.Errorf("Unexpected predicate match result: %t instead of %t", m, tc.matches)
+			}
+		})
+	}
+}
+
+func TestForwardedProto(t *testing.T) {
+	testCases := []struct {
+		msg     string
+		proto   string
+		r       request
+		matches bool
+		isError bool
+	}{{
+		msg:     "Invalid protocol should error",
+		proto:   "foobar",
+		r:       request{},
+		matches: false,
+		isError: true,
+	}, {
+		msg:     "Empty protocol should error",
+		proto:   "",
+		r:       request{},
+		matches: false,
+		isError: true,
+	}, {
+		msg:     "Empty Forwarded Header should not match",
+		proto:   "http",
+		r:       request{},
+		matches: false,
+		isError: false,
+	}, {
+		msg:     "Empty Forwarded Header should not match",
+		proto:   "https",
+		r:       request{},
+		matches: false,
+		isError: false,
+	}, {
+		msg:   "Same forwarded Header should match",
+		proto: "http",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.com"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:   "Same forwarded Header should match",
+		proto: "https",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=https;by=203.0.113.43;host=example.com"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:   "Different forwarded Header should not match",
+		proto: "https",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.org"},
+			},
+		},
+		matches: false,
+		isError: false,
+	}, {
+		msg:   "Different forwarded Header should not match",
+		proto: "http",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=https;by=203.0.113.43;host=example.org"},
+			},
+		},
+		matches: false,
+		isError: false,
+	}, {
+		msg:   "Forwarded Header with no proto should not match",
+		proto: "http",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;host=example.org;by=203.0.113.43"},
+			},
+		},
+		matches: false,
+		isError: false,
+	}, {
+		msg:   "Forwarded Header with no proto should not match",
+		proto: "https",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;host=example.org;by=203.0.113.43"},
+			},
+		},
+		matches: false,
+		isError: false,
+	}, {
+		msg:   "Forwarded Header only proto should match",
+		proto: "http",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"proto=http"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:   "Forwarded Header only proto should match",
+		proto: "https",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"proto=https"},
+			},
+		},
+		matches: true,
+		isError: false,
+	}}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.msg, func(t *testing.T) {
+			spec := NewForwardedProto()
+
+			p, err := spec.Create([]interface{}{tc.proto})
+			hasError := err != nil
+			if hasError || tc.isError {
+				if !tc.isError {
+					t.Error("Predicate creation failed")
+				}
+
+				if !hasError {
+					t.Error("Predicate should have failed")
+				}
+
+				return
+			}
+
+			r, err := newRequest(tc.r)
+			if !tc.isError && err != nil {
+				t.Error("Request creation failed")
+			}
+
+			m := p.Match(r)
+			if m != tc.matches {
+				t.Errorf("Unexpected predicate match result: %t instead of %t", m, tc.matches)
+			}
+		})
+	}
+}
+
+func newRequest(r request) (*http.Request, error) {
+	u, err := url.Parse(r.url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Request{
+		URL:    u,
+		Header: r.headers,
+	}, nil
+}

--- a/predicates/forwarded/forwarded_test.go
+++ b/predicates/forwarded/forwarded_test.go
@@ -26,79 +26,90 @@ func TestForwardedHost(t *testing.T) {
 		isError: true,
 	}, {
 		msg:     "Empty Forwarded Header should not match",
-		host:    "example.com",
+		host:    "^example\\.com$",
 		r:       request{},
 		matches: false,
 		isError: false,
 	}, {
-		msg:  "Same forwarded Header should match",
-		host: "^example.com$",
+		msg:  "Same forwarded non-quoted Header should match",
+		host: "^example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
-				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.com"},
+				"Forwarded": []string{`for=192.0.2.60;proto=http;by=203.0.113.43;host=example.com`},
 			},
 		},
 		matches: true,
 		isError: false,
 	}, {
 		msg:  "Same forwarded Header should match",
-		host: "^example.com$",
+		host: "^example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
-				"Forwarded": []string{"for=192.0.2.60;proto=http;host=example.com;by=203.0.113.43"},
+				"Forwarded": []string{`for=192.0.2.60;proto=http;by=203.0.113.43;host="example.com"`},
 			},
 		},
 		matches: true,
 		isError: false,
 	}, {
 		msg:  "Same forwarded Header should match",
-		host: "^example.com$",
+		host: "^example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
-				"Forwarded": []string{"host=example.com;for=192.0.2.60;proto=http;by=203.0.113.43"},
+				"Forwarded": []string{`for=192.0.2.60;proto=http;host="example.com";by=203.0.113.43`},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:  "Same forwarded Header should match",
+		host: "^example\\.com$",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{`host="example.com";for=192.0.2.60;proto=http;by=203.0.113.43`},
 			},
 		},
 		matches: true,
 		isError: false,
 	}, {
 		msg:  "Forwarded Header should match subdomains",
-		host: "example.com$",
+		host: "example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
-				"Forwarded": []string{"host=subdomain.example.com;for=192.0.2.60;proto=http;by=203.0.113.43"},
+				"Forwarded": []string{`host="subdomain.example.com";for=192.0.2.60;proto=http;by=203.0.113.43`},
 			},
 		},
 		matches: true,
 		isError: false,
 	}, {
 		msg:  "Different forwarded Header should not match",
-		host: "^example.com$",
+		host: "^example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
-				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.comma.org"},
+				"Forwarded": []string{`for=192.0.2.60;proto=http;by=203.0.113.43;host="example.comma.org"`},
 			},
 		},
 		matches: false,
 		isError: false,
 	}, {
 		msg:  "Different forwarded Header should not match",
-		host: "example.com",
+		host: "^example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
-				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.org"},
+				"Forwarded": []string{`for=192.0.2.60;proto=http;by=203.0.113.43;host="example.org"`},
 			},
 		},
 		matches: false,
 		isError: false,
 	}, {
 		msg:  "Forwarded Header with no host should not match",
-		host: "example.com",
+		host: "^example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
@@ -109,11 +120,11 @@ func TestForwardedHost(t *testing.T) {
 		isError: false,
 	}, {
 		msg:  "Forwarded Header only host should match",
-		host: "example.com",
+		host: "^example\\.com$",
 		r: request{
 			url: "https://myproxy.com/index.html",
 			headers: http.Header{
-				"Forwarded": []string{"host=example.com"},
+				"Forwarded": []string{`host="example.com"`},
 			},
 		},
 		matches: true,
@@ -207,6 +218,17 @@ func TestForwardedProto(t *testing.T) {
 		},
 		matches: true,
 		isError: false,
+	}, {
+		msg:   "Incorrect protocol should not match forwarded header",
+		proto: "HTTP",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{"for=192.0.2.60;proto=http;by=203.0.113.43;host=example.org"},
+			},
+		},
+		matches: false,
+		isError: true,
 	}, {
 		msg:   "Different forwarded Header should not match",
 		proto: "https",


### PR DESCRIPTION
Two predicates have been added:
* `ForwardedHeader`
* `ForwardedProtocol`.

They follow https://datatracker.ietf.org/doc/html/rfc7239
