### PR TITLE
Makes documentation anchors lowercase

### DIFF
--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -518,7 +518,7 @@ Filter documentation:
 - [bandwidth](../reference/filters.md#bandwidth)
 - [chunks](../reference/filters.md#chunks)
 - [backendlatency](../reference/filters.md#backendlatency)
-- [backendChunks](../reference/filters.md#backendChunks)
+- [backendChunks](../reference/filters.md#backendchunks)
 - [randomcontent](../reference/filters.md#randomcontent)
 
 ### Flow Id to trace request flows

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -827,7 +827,7 @@ This is possible to achieve centrally, when Skipper is started with
 the -rfc-patch-path flag. It is also possible to allow the default
 behavior and only force the alternative interpretation on a per-route
 basis with the rfcPath() filter. See
-[`rfcPath()`](../reference/filters.md#rfcPath).
+[`rfcPath()`](../reference/filters.md#rfcpath).
 
 If the second interpretation gets considered the right way, and the
 other one a bug, then the default value for this flag may become to

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -25,8 +25,8 @@ represent time duration values as strings, parseable by [time.Duration](https://
 
 ## The path tree
 
-There is an important difference between the evaluation of the [Path](#Path) or [PathSubtree](#PathSubtree) predicates, and the
-evaluation of all the other predicates ([PathRegexp](#PathRegexp) belonging to the second group). Find an explanation in the
+There is an important difference between the evaluation of the [Path](#path) or [PathSubtree](#pathsubtree) predicates, and the
+evaluation of all the other predicates ([PathRegexp](#pathregexp) belonging to the second group). Find an explanation in the
 [Route matching](../tutorials/basics.md#route-matching) section explanation section.
 
 ### Path
@@ -483,7 +483,7 @@ Source("1.2.3.4", "2.2.2.0/24")
 
 ### SourceFromLast
 
-The same as [Source](#Source), but use the last part of the
+The same as [Source](#source), but use the last part of the
 X-Forwarded-For header to match the network. This seems to be only
 used in the popular loadbalancers from AWS, ELB and ALB, because they
 put the client-IP as last part of the X-Forwarded-For headers.

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -167,7 +167,7 @@ end
 # Examples
 
 >The examples serve as examples. If there is a go based plugin available,
-use that instead. For overhead estimate see [benchmark](#Benchmark).
+use that instead. For overhead estimate see [benchmark](#benchmark).
 
 ## OAuth2 token as basic auth password
 ```lua

--- a/docs/tutorials/auth.md
+++ b/docs/tutorials/auth.md
@@ -225,7 +225,7 @@ because it is reread by Skipper. The path to this file must be passed with the f
 
 ### AuthZ and access control
 
-Authorization validation and access control is available by means of a subsequent filter [oidcClaimsQuery](../reference/filters.md#oidcClaimsQuery). It inspects the ID token, which exists after a successful `oauthOidc*` filter step, and validates the defined query with the request path.
+Authorization validation and access control is available by means of a subsequent filter [oidcClaimsQuery](../reference/filters.md#oidcclaimsquery). It inspects the ID token, which exists after a successful `oauthOidc*` filter step, and validates the defined query with the request path.
 
 Given following example ID token:
 
@@ -348,10 +348,10 @@ skipper -enable-oauth2-grant-flow \
 ```
 
 The `-oauth2-revoke-token-url` is optional, and must only be supplied if you plan
-on using the [grantLogout](../reference/filters.md#grantLogout) filter.
+on using the [grantLogout](../reference/filters.md#grantlogout) filter.
 
 You can configure the `oauthGrant()` filter further for your needs. See the
-[oauthGrant](../reference/filters.md#oauthGrant) filter reference for more details.
+[oauthGrant](../reference/filters.md#oauthgrant) filter reference for more details.
 
 #### Add filters to your routes
 
@@ -378,10 +378,10 @@ logout:
 
 #### (Optional) AuthZ and access control
 
-You can add a [grantClaimsQuery](../reference/filters.md#grantClaimsQuery) filter
-after a [oauthGrant](../reference/filters.md#oauthGrant) to control access based
+You can add a [grantClaimsQuery](../reference/filters.md#grantclaimsquery) filter
+after a [oauthGrant](../reference/filters.md#oauthgrant) to control access based
 on any OAuth2 claim. A claim is any property returned by the tokeninfo endpoint.
-The filter works exactly like the [oidcClaimsQuery](../reference/filters.md#oidcClaimsQuery)
+The filter works exactly like the [oidcClaimsQuery](../reference/filters.md#oidcclaimsquery)
 filter (it is actually just an alias for it).
 
 For example, if your tokeninfo endpoint returns the following JSON:


### PR DESCRIPTION
Anchors with uppercase letters found via
```
find docs/ -name '*.md' -exec grep -HEo '\(.*#[a-z]*[A-Z].*\)' {} \; | grep -v http
```

Followup on #1790