### PR TITLE
Fix test file creation when /tmp is on a different partition

### DIFF
--- a/eskipfile/watch_test.go
+++ b/eskipfile/watch_test.go
@@ -44,12 +44,18 @@ func deleteFile(t *testing.T) {
 }
 
 func createFileWith(content string, t *testing.T) {
-	f, err := os.Create(testWatchFile)
+	tmpfile, err := os.Create(testWatchFile + ".tmp")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
-	_, err = f.WriteString(content)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.WriteString(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Rename(tmpfile.Name(), testWatchFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eskipfile/watch_test.go
+++ b/eskipfile/watch_test.go
@@ -1,7 +1,6 @@
 package eskipfile
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -45,18 +44,12 @@ func deleteFile(t *testing.T) {
 }
 
 func createFileWith(content string, t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "watch_test-*")
+	f, err := os.Create(testWatchFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpfile.Name())
-
-	_, err = tmpfile.WriteString(content)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = os.Rename(tmpfile.Name(), testWatchFile)
+	defer f.Close()
+	_, err = f.WriteString(content)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
On my linux laptop, there is a root partition and a home partition. os.Rename gives errors when trying to move a file across partitions, in this case from the root partition(/tmp) to the home partition (where my cloned repo is). The fix being applied is to use os.Create on the file, since it will truncate the file if it already exists.

Errors:
```
--- FAIL: TestWatchInitialRecovers (0.09s)
    /home/fmoloney/zalando/go-code/github.com/zalando/skipper/eskipfile/watch_test.go:61: rename /tmp/watch_test-048887076 fixtures/watch-test.eskip: invalid cross-device link
--- FAIL: TestWatchUpdateFails (0.00s)
    /home/fmoloney/zalando/go-code/github.com/zalando/skipper/eskipfile/watch_test.go:61: rename /tmp/watch_test-532227635 fixtures/watch-test.eskip: invalid cross-device link
--- FAIL: TestWatchUpdateRecover (0.00s)
    /home/fmoloney/zalando/go-code/github.com/zalando/skipper/eskipfile/watch_test.go:61: rename /tmp/watch_test-702310390 fixtures/watch-test.eskip: invalid cross-device link
--- FAIL: TestInitialAndUnchanged (0.00s)
    /home/fmoloney/zalando/go-code/github.com/zalando/skipper/eskipfile/watch_test.go:61: rename /tmp/watch_test-801293021 fixtures/watch-test.eskip: invalid cross-device link
--- FAIL: TestInitialAndDeleteFile (0.00s)
    /home/fmoloney/zalando/go-code/github.com/zalando/skipper/eskipfile/watch_test.go:61: rename /tmp/watch_test-250682520 fixtures/watch-test.eskip: invalid cross-device link
--- FAIL: TestWatchUpdate (0.00s)
    /home/fmoloney/zalando/go-code/github.com/zalando/skipper/eskipfile/watch_test.go:61: rename /tmp/watch_test-212299543 fixtures/watch-test.eskip: invalid cross-device link
```

My partition setup:

```
➜ lsblk
NAME                MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINT
nvme0n1             259:0    0 238.5G  0 disk  
├─nvme0n1p1         259:1    0   256M  0 part  /boot/efi
├─nvme0n1p2         259:2    0     1G  0 part  /boot
└─nvme0n1p3         259:3    0 237.2G  0 part  
  └─nvme0n1p3_crypt 253:0    0 237.2G  0 crypt 
    ├─vg01-root     253:1    0    45G  0 lvm   /
    ├─vg01-swap     253:2    0     1G  0 lvm   [SWAP]
    └─vg01-home     253:3    0 191.2G  0 lvm   /home
```