### PR TITLE
Deprecates `FilterContext.ResponseWriter()`

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -32,6 +32,7 @@ const (
 type FilterContext interface {
 	// The response writer object belonging to the incoming request. Used by
 	// filters that handle the requests themselves.
+	// Deprecated: use Response() or Serve()
 	ResponseWriter() http.ResponseWriter
 
 	// The incoming request object. It is forwarded to the route endpoint


### PR DESCRIPTION
Filter implementations should use `FilterContext.Request()` to modify
backend request and `FilterContext.Response()` to modify backend response.
`FilterContext.StateBag()` could be used to transfer state between request and response filter chain phases.
`FilterContext.Serve()` could be used to serve response from the request filter chain phase.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>