### PR TITLE
test cob - continuous benchmark with routing package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ bench: build $(TEST_PLUGINS)
 	#
 	for p in $(PACKAGES); do GO111MODULE=$(GO111) go test -bench . $$p; done
 
+bench-compare:
+	for p in net pathmux proxy routing script; do echo "#### bench compare github.com/zalando/skipper/$$p ###"; cob --bench-args "test -bench . -benchmem github.com/zalando/skipper/$$p" 2>/dev/null; done
+
 lint: build staticcheck
 
 clean:
@@ -127,6 +130,7 @@ deps:
 	@tar -C /tmp -xzf /tmp/gosec.tgz
 	@mv /tmp/gosec .bin
 	@chmod +x .bin/gosec
+	@go install github.com/szuecs/cob@latest
 
 vet: $(SOURCES)
 	GO111MODULE=$(GO111) go vet $(PACKAGES)

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,6 +1,22 @@
 version: "2017-09-20"
+allow_concurrent_steps: true
 pipeline:
+- id: bench
+  vm: large
+  depends_on: []
+  overlay: ci/golang
+  type: script
+  commands:
+  - desc: bench compare
+    cmd: |
+      ulimit -Hn
+      ulimit -n 30000
+      ulimit -n
+      apt-get update  -o Acquire::http::AllowRedirect=false
+      apt-get install -o Acquire::http::AllowRedirect=false -y bzr redis-server jq
+      make deps bench-compare
 - id: build
+  depends_on: []
   overlay: ci/golang
   type: script
   commands:
@@ -60,6 +76,7 @@ pipeline:
         echo "Not creating a release. No release version defined."
       fi
 - id: docs
+  depends_on: [build]
   type: script
   overlay: ci/python
   commands:


### PR DESCRIPTION
test cob https://github.com/zalando/skipper/issues/1757 in a concurrent pipeline

@aryszka @AlexanderYastrebov Do we want to have this?

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>