### PR TITLE
add possibility to omit adding defaultfilters for specifi routes

### DIFF
--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -26,6 +26,7 @@ var (
 type DefaultFilters struct {
 	Prepend []*Filter
 	Append  []*Filter
+	Omit    map[string]struct{}
 }
 
 // Do implements the interface routing.PreProcessor. It appends and
@@ -40,6 +41,17 @@ func (df *DefaultFilters) Do(routes []*Route) []*Route {
 
 	nextRoutes := make([]*Route, len(routes))
 	for i, r := range routes {
+		omit := false
+		for _, p := range r.Predicates {
+			if _, ok := df.Omit[p.Name]; ok {
+				omit = true
+				break
+			}
+		}
+		if omit {
+			nextRoutes[i] = r
+			continue
+		}
 		nextRoutes[i] = new(Route)
 		*nextRoutes[i] = *r
 


### PR DESCRIPTION
add possibility to omit adding prepend/append defaultfilters in case there are routes with a predicate that we want to omit. For example Tee() is a good example when you might want to omit the processing in case you want to drop headers on ingress that are meant internal only

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>