### PR TITLE
Fixes TestBreakerLeak test

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/zalando/skipper/logging/loggingtest"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/routing/testdataclient"
+
+	teePredicate "github.com/zalando/skipper/predicates/tee"
 )
 
 const (
@@ -145,6 +147,7 @@ func newTestProxyWithFiltersAndParams(fr filters.Registry, doc string, params Pa
 		DataClients:    []routing.DataClient{dc},
 		PostProcessors: []routing.PostProcessor{loadbalancer.NewAlgorithmProvider()},
 		Log:            tl,
+		Predicates:     []routing.PredicateSpec{teePredicate.New()},
 	}
 	if len(preprocs) > 0 {
 		opts.PreProcessors = preprocs


### PR DESCRIPTION
The test uses `Tee` predicate 
https://github.com/zalando/skipper/blob/33cf1d1dd14039305dc53bc8f9b81d9b30b8cff5/proxy/breaker_with_teeloopback_test.go#L22

that is not registered by the test proxy constructor method `newTestProxyWithFiltersAndParams` which leads to the request loop.

To make the problem apparent testlogger needs to be unmuted:
```
2021/08/10 10:38:46 failed to process route (shadow): predicate not found: 'Tee'
2021/08/10 10:38:46 context: failed to execute loopback request: max loopbacks reached
```

Followup on #1816 and #1819

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>