### PR TITLE
Record metric if a lifo filter drops a request

### DIFF
--- a/filters/scheduler/lifo.go
+++ b/filters/scheduler/lifo.go
@@ -294,7 +294,6 @@ func request(q *scheduler.Queue, key string, ctx filters.FilterContext) {
 
 	done, err := q.Wait()
 	if err != nil {
-		// TODO: replace the log with metrics
 		switch err {
 		case jobqueue.ErrStackFull:
 			log.Debugf("Failed to get an entry on to the queue to process QueueFull: %v for host %s", err, ctx.Request().Host)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -208,7 +208,7 @@ func (r *Registry) newQueue(name string, c Config) *Queue {
 		q.activeRequestsMetricsKey = fmt.Sprintf("lifo.%s.active", name)
 		q.queuedRequestsMetricsKey = fmt.Sprintf("lifo.%s.queued", name)
 		q.rejectedRequestsMetricsKey = fmt.Sprintf("lifo.%s.rejected", name)
-		q.timedOutRequestsMetricsKey = fmt.Sprintf("lifo.%s.timed-out", name)
+		q.timedOutRequestsMetricsKey = fmt.Sprintf("lifo.%s.timedout", name)
 		q.metrics = r.options.Metrics
 		r.measure()
 	}


### PR DESCRIPTION
After the release of #1725, it is sometimes hard to correlate HTTP status codes the action of a lifo filter.

This change increases one of two counters each time a lifo queue is either full or an entry times out. It improves the visibility of the actions a lifo filter has taken without spamming the logs.