### PR TITLE
Updates go version in workflows

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -7,18 +7,19 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '^1.15'
-    - run: go version
-    - run: sudo apt-get install redis-server
-    - run: make deps
-    - run: make check-fmt
-    - run: make build
-    - run: make vet
-    - run: make staticcheck
-    - run: make check-race
-    - run: make cicheck
-    - run: make gosec
-    - run: make publish-coverage
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
+          go-version: '^1.15'
+      - run: go version
+      - run: sudo apt-get install redis-server
+      - run: make deps
+      - run: make check-fmt
+      - run: make build
+      - run: make vet
+      - run: make staticcheck
+      - run: make check-race
+      - run: make cicheck
+      - run: make gosec
+      - run: make publish-coverage

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.15'
+          go-version: '^1.16'
       - run: go version
       - run: sudo apt-get install redis-server
       - run: make deps

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,5 @@
 name: pr
-on: [pull_request]
+on: [ pull_request ]
 jobs:
   check-race:
     runs-on: ubuntu-latest
@@ -7,6 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
+          # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
           go-version: '^1.15'
       - run: go version
       - run: sudo apt-get install redis-server
@@ -18,6 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
+          # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
           go-version: '^1.15'
       - run: go version
       - run: sudo apt-get install redis-server

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.15'
+          go-version: '^1.16'
       - run: go version
       - run: sudo apt-get install redis-server
       - run: make deps
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.15'
+          go-version: '^1.16'
       - run: go version
       - run: sudo apt-get install redis-server
       - run: make deps


### PR DESCRIPTION
Also adds a link to semver documentation to clarify that version is not a prefix regexp.

The value `^1.15` is a so called ["caret" range](https://www.npmjs.com/package/semver#caret-ranges-123-025-004)
that matches 1.15 and any minor version above, e.g. 1.16 which could be
seen in the action logs:
```
Setup go stable version spec ^1.15
Found in cache @ /opt/hostedtoolcache/go/1.16.7/x64
Added go to the path
Successfully setup go version ^1.15
go version go1.16.7 linux/amd64
```

See also https://github.com/actions/setup-go/issues/101#issuecomment-814127065

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>