### PR TITLE
Fix forwarded host when multiple entries

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -135,11 +135,15 @@ Uses standardized Forwarded header ([RFC 7239](https://tools.ietf.org/html/rfc72
 More info about the header: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded)
 
 If multiple proxies chain values in the header, as a comma separated list, the predicates below will only match 
-the last values in the chain.
+the last value in the chain for each part of the header.
 
-For example, proxy1 could set host+proto and proxy2 could only set host. In that case, the header will end up 
-with value `host=example.com;proto=https, host=example.org` and predicate config would have 
-`f.proto = "https"` but `f.host == "example.org"`
+Example: Forwarded: host=example.com;proto=https, host=example.org
+
+- `ForwardedHost(/^example\.com$/)` - does not match
+- `ForwardedHost(/^example\.org$/)` - matches
+- `ForwardedHost(/^example\.org$/) && ForwardedProto("https")` - matches
+- `ForwardedHost(/^example\.com$/) && ForwardedProto("https")` - does not match
+
 
 ### ForwardedHost
 

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -134,6 +134,13 @@ Uses standardized Forwarded header ([RFC 7239](https://tools.ietf.org/html/rfc72
 
 More info about the header: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded)
 
+If multiple proxies chain values in the header, as a comma separated list, the predicates below will only match 
+the last values in the chain.
+
+For example, proxy1 could set host+proto and proxy2 could only set host. In that case, the header will end up 
+with value `host=example.com;proto=https, host=example.org` and predicate config would have 
+`f.proto = "https"` but `f.host == "example.org"`
+
 ### ForwardedHost
 
 Regular expressions that the forwarded host header in the request must match.

--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -131,7 +131,7 @@ func parseForwarded(fh string) *forwarded {
 	f := &forwarded{}
 
 	for _, forwardedFull := range strings.Split(fh, ",") {
-		for _, forwardedPair := range strings.Split(forwardedFull, ";") {
+		for _, forwardedPair := range strings.Split(strings.TrimSpace(forwardedFull), ";") {
 			if tv := strings.SplitN(forwardedPair, "=", 2); len(tv) == 2 {
 				token, value := tv[0], tv[1]
 				value = strings.Trim(value, `"`)

--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -130,17 +130,20 @@ func parseForwarded(fh string) *forwarded {
 
 	f := &forwarded{}
 
-	for _, forwardedPair := range strings.Split(fh, ";") {
-		if tv := strings.SplitN(forwardedPair, "=", 2); len(tv) == 2 {
-			token, value := tv[0], tv[1]
-			value = strings.Trim(value, `"`)
-			switch token {
-			case "proto":
-				f.proto = value
-			case "host":
-				f.host = value
+	for _, forwardedFull := range strings.Split(fh, ",") {
+		for _, forwardedPair := range strings.Split(forwardedFull, ";") {
+			if tv := strings.SplitN(forwardedPair, "=", 2); len(tv) == 2 {
+				token, value := tv[0], tv[1]
+				value = strings.Trim(value, `"`)
+				switch token {
+				case "proto":
+					f.proto = value
+				case "host":
+					f.host = value
+				}
 			}
 		}
 	}
+
 	return f
 }

--- a/predicates/forwarded/forwarded_test.go
+++ b/predicates/forwarded/forwarded_test.go
@@ -141,6 +141,17 @@ func TestForwardedHost(t *testing.T) {
 		matches: true,
 		isError: false,
 	}, {
+		msg:  "In multiple forwarded header only host with spaces should match",
+		host: "^example\\.com$",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{` host="example.com", host="example.com"`},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
 		msg:  "In multiple forwarded header complete should match",
 		host: "^example\\.com$",
 		r: request{

--- a/predicates/forwarded/forwarded_test.go
+++ b/predicates/forwarded/forwarded_test.go
@@ -129,6 +129,28 @@ func TestForwardedHost(t *testing.T) {
 		},
 		matches: true,
 		isError: false,
+	}, {
+		msg:  "In multiple forwarded header only host should match",
+		host: "^example\\.com$",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{`host="example.com",host="example.com"`},
+			},
+		},
+		matches: true,
+		isError: false,
+	}, {
+		msg:  "In multiple forwarded header complete should match",
+		host: "^example\\.com$",
+		r: request{
+			url: "https://myproxy.com/index.html",
+			headers: http.Header{
+				"Forwarded": []string{`for=2b12:c7f:565d:b000:d4a5:ed98:1eea:d290;by=2b12:26f0:4000:2ae::3751,by=10.0.0.60;host=example.com;proto=https, for=10.0.0.60;by=10.0.0.61,by=10.0.0.62;host=example.com;proto=https`},
+			},
+		},
+		matches: true,
+		isError: false,
 	}}
 
 	for _, tc := range testCases {

--- a/predicates/forwarded/forwarded_test.go
+++ b/predicates/forwarded/forwarded_test.go
@@ -421,7 +421,7 @@ func TestForwardedDocumentationExamples(t *testing.T) {
 			if tc.proto != "" {
 				protoSpec := NewForwardedProto()
 
-				p, err := protoSpec.Create([]interface{}{tc.proto})
+				p, _ := protoSpec.Create([]interface{}{tc.proto})
 
 				r, err := newRequest(tc.r)
 				if err != nil {
@@ -434,7 +434,7 @@ func TestForwardedDocumentationExamples(t *testing.T) {
 			if tc.host != "" {
 				hostSpec := NewForwardedHost()
 
-				p, err := hostSpec.Create([]interface{}{tc.host})
+				p, _ := hostSpec.Create([]interface{}{tc.host})
 
 				r, err := newRequest(tc.r)
 				if err != nil {


### PR DESCRIPTION
Caught corner case when multiple entries appear in the forwarded host predicate [see docs](https://www.rfc-editor.org/rfc/rfc7239#section-4)

> If the request is passing through several proxies, each proxy can add a set of parameters; it can also remove previously added "Forwarded" header fields.

> A proxy server that wants to add a new "Forwarded" header field value can either append it to the last existing "Forwarded" header field after a comma separator or add a new field at the end of the header block.  A proxy MAY remove all "Forwarded" header fields from a request.  It MUST, however, ensure that the correct header field is updated in case of multiple "Forwarded" header fields.