### PR TITLE
Adds forwarded headers flags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -374,7 +374,7 @@ func NewConfig() *Config {
 		"X-Forwarded-For sets or appends with comma the remote IP of the request to the X-Forwarded-For header value\n"+
 		"X-Forwarded-Host sets X-Forwarded-Host value to the request host\n"+
 		"X-Forwarded-Proto=http or X-Forwarded-Proto=https sets X-Forwarded-Proto value")
-	flag.Var(cfg.ForwardedHeadersExcludeCIDRList, "forwarded-headers-exclude-cidrs", "disables addition of forwarded headers for the remote host IPs from the configured CIDRs")
+	flag.Var(cfg.ForwardedHeadersExcludeCIDRList, "forwarded-headers-exclude-cidrs", "disables addition of forwarded headers for the remote host IPs from the comma separated list of CIDRs")
 
 	// Kubernetes:
 	flag.BoolVar(&cfg.KubernetesIngress, "kubernetes", false, "enables skipper to generate routes for ingress resources in kubernetes cluster")

--- a/config/config.go
+++ b/config/config.go
@@ -798,7 +798,11 @@ func (c *Config) ToOptions() skipper.Options {
 
 	if c.ForwardedHeaders != (net.ForwardedHeaders{}) {
 		options.CustomHttpHandlerWrap = func(handler http.Handler) http.Handler {
-			return &net.ForwardedHeadersHandler{c.ForwardedHeaders, c.ForwardedHeadersExcludeCIDRs, handler}
+			return &net.ForwardedHeadersHandler{
+				Headers: c.ForwardedHeaders,
+				Exclude: c.ForwardedHeadersExcludeCIDRs,
+				Handler: handler,
+			}
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -371,9 +371,8 @@ func NewConfig() *Config {
 
 	// Forwarded headers
 	flag.Var(cfg.ForwardedHeadersList, "forwarded-headers", "comma separated list of headers to add to the incoming request before routing\n"+
-		"X-Forwarded-For sets or appends request remote IP to the X-Forwarded-For header\n"+
-		"X-Forwarded-For-prepend sets or prepends request remote IP to the X-Forwarded-For header, overrides X-Forwarded-For\n"+
-		"X-Forwarded-Host sets X-Forwarded-Host to the request host\n"+
+		"X-Forwarded-For sets or appends with comma the remote IP of the request to the X-Forwarded-For header value\n"+
+		"X-Forwarded-Host sets X-Forwarded-Host value to the request host\n"+
 		"X-Forwarded-Proto=http or X-Forwarded-Proto=https sets X-Forwarded-Proto value")
 	flag.Var(cfg.ForwardedHeadersExcludeCIDRList, "forwarded-headers-exclude-cidrs", "disables addition of forwarded headers for the remote host IPs from the configured CIDRs")
 
@@ -847,8 +846,6 @@ func (c *Config) parseForwardedHeaders() error {
 		switch header {
 		case "X-Forwarded-For":
 			c.ForwardedHeaders.For = true
-		case "X-Forwarded-For-prepend":
-			c.ForwardedHeaders.PrependFor = true
 		case "X-Forwarded-Host":
 			c.ForwardedHeaders.Host = true
 		case "X-Forwarded-Proto=http":

--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,12 @@ type Config struct {
 	SourcePollTimeout         int64                `yaml:"source-poll-timeout"`
 	WaitFirstRouteLoad        bool                 `yaml:"wait-first-route-load"`
 
+	// Forwarded headers
+	ForwardedHeadersList            *listFlag            `yaml:"forwarded-headers"`
+	ForwardedHeaders                net.ForwardedHeaders `yaml:"-"`
+	ForwardedHeadersExcludeCIDRList *listFlag            `yaml:"forwarded-headers-exclude-cidrs"`
+	ForwardedHeadersExcludeCIDRs    net.IPNets           `yaml:"-"`
+
 	// Kubernetes:
 	KubernetesIngress                       bool                `yaml:"kubernetes"`
 	KubernetesInCluster                     bool                `yaml:"kubernetes-in-cluster"`
@@ -261,6 +267,8 @@ func NewConfig() *Config {
 	cfg.EditRoute = &routeChangerConfig{}
 	cfg.KubernetesEastWestRangeDomains = commaListFlag()
 	cfg.RoutesURLs = commaListFlag()
+	cfg.ForwardedHeadersList = commaListFlag()
+	cfg.ForwardedHeadersExcludeCIDRList = commaListFlag()
 
 	flag.StringVar(&cfg.ConfigFile, "config-file", "", "if provided the flags will be loaded/overwritten by the values on the file (yaml)")
 
@@ -360,6 +368,14 @@ func NewConfig() *Config {
 	flag.Var(cfg.EditRoute, "edit-route", "match and edit filters and predicates of all routes")
 	flag.Var(cfg.CloneRoute, "clone-route", "clone all matching routes and replace filters and predicates of all matched routes")
 	flag.BoolVar(&cfg.WaitFirstRouteLoad, "wait-first-route-load", false, "prevent starting the listener before the first batch of routes were loaded")
+
+	// Forwarded headers
+	flag.Var(cfg.ForwardedHeadersList, "forwarded-headers", "comma separated list of headers to add to the incoming request before routing\n"+
+		"X-Forwarded-For sets or appends request remote IP to the X-Forwarded-For header\n"+
+		"X-Forwarded-For-prepend sets or prepends request remote IP to the X-Forwarded-For header, overrides X-Forwarded-For\n"+
+		"X-Forwarded-Host sets X-Forwarded-Host to the request host\n"+
+		"X-Forwarded-Proto=http or X-Forwarded-Proto=https sets X-Forwarded-Proto value")
+	flag.Var(cfg.ForwardedHeadersExcludeCIDRList, "forwarded-headers-exclude-cidrs", "disables addition of forwarded headers for the remote host IPs from the configured CIDRs")
 
 	// Kubernetes:
 	flag.BoolVar(&cfg.KubernetesIngress, "kubernetes", false, "enables skipper to generate routes for ingress resources in kubernetes cluster")
@@ -539,6 +555,11 @@ func (c *Config) Parse() error {
 		}
 
 		c.Certificates = certificates
+	}
+
+	err = c.parseForwardedHeaders()
+	if err != nil {
+		return err
 	}
 
 	c.parseEnv()
@@ -776,6 +797,12 @@ func (c *Config) ToOptions() skipper.Options {
 		}
 	}
 
+	if c.ForwardedHeaders != (net.ForwardedHeaders{}) {
+		options.CustomHttpHandlerWrap = func(handler http.Handler) http.Handler {
+			return &net.ForwardedHeadersHandler{c.ForwardedHeaders, c.ForwardedHeadersExcludeCIDRs, handler}
+		}
+	}
+
 	return options
 }
 
@@ -813,6 +840,33 @@ func (c *Config) parseHistogramBuckets() ([]float64, error) {
 	}
 	sort.Float64s(result)
 	return result, nil
+}
+
+func (c *Config) parseForwardedHeaders() error {
+	for _, header := range c.ForwardedHeadersList.values {
+		switch header {
+		case "X-Forwarded-For":
+			c.ForwardedHeaders.For = true
+		case "X-Forwarded-For-prepend":
+			c.ForwardedHeaders.PrependFor = true
+		case "X-Forwarded-Host":
+			c.ForwardedHeaders.Host = true
+		case "X-Forwarded-Proto=http":
+			c.ForwardedHeaders.Proto = "http"
+		case "X-Forwarded-Proto=https":
+			c.ForwardedHeaders.Proto = "https"
+		default:
+			return fmt.Errorf("invalid forwarded header: %s", header)
+		}
+	}
+
+	cidrs, err := net.ParseCIDRs(c.ForwardedHeadersExcludeCIDRList.values)
+	if err != nil {
+		return fmt.Errorf("invalid forwarded headers exclude CIDRs: %v", err)
+	}
+	c.ForwardedHeadersExcludeCIDRs = cidrs
+
+	return nil
 }
 
 func (c *Config) parseEnv() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -162,6 +162,8 @@ func Test_NewConfig(t *testing.T) {
 				SwarmLeaveTimeout:                       5 * time.Second,
 				TLSMinVersion:                           defaultMinTLSVersion,
 				RoutesURLs:                              commaListFlag(),
+				ForwardedHeadersList:                    commaListFlag(),
+				ForwardedHeadersExcludeCIDRList:         commaListFlag(),
 			},
 			wantErr: false,
 		},

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -990,5 +990,5 @@ Skipper can be configured to add [`X-Forwarded-*` headers](https://en.wikipedia.
         X-Forwarded-Proto=http or X-Forwarded-Proto=https sets X-Forwarded-Proto value
 
   -forwarded-headers-exclude-cidrs value
-        disables addition of forwarded headers for the remote host IPs from the configured CIDRs
+        disables addition of forwarded headers for the remote host IPs from the comma separated list of CIDRs
 ```

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -977,3 +977,18 @@ response headers. After that Skipper streams the response payload and
 uses one 8kB buffer to stream the data through this 8kB buffer. It
 uses Flush() to make sure the 8kB chunk is written to the client.
 Details can be observed by opentracing in the logs of the [Proxy Span](#proxy-span).
+
+## Forwarded headers
+
+Skipper can be configured to add [`X-Forwarded-*` headers](https://en.wikipedia.org/wiki/X-Forwarded-For):
+
+```
+  -forwarded-headers value
+        comma separated list of headers to add to the incoming request before routing
+        X-Forwarded-For sets or appends with comma the remote IP of the request to the X-Forwarded-For header value
+        X-Forwarded-Host sets X-Forwarded-Host value to the request host
+        X-Forwarded-Proto=http or X-Forwarded-Proto=https sets X-Forwarded-Proto value
+
+  -forwarded-headers-exclude-cidrs value
+        disables addition of forwarded headers for the remote host IPs from the configured CIDRs
+```

--- a/net/headers.go
+++ b/net/headers.go
@@ -44,3 +44,17 @@ func (h *ForwardedHeaders) Set(req *http.Request) {
 		req.Header.Set("X-Forwarded-Proto", h.Proto)
 	}
 }
+
+type ForwardedHeadersHandler struct {
+	Headers ForwardedHeaders
+	Exclude IPNets
+	Handler http.Handler
+}
+
+func (h *ForwardedHeadersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil && !h.Exclude.Contain(net.ParseIP(host)) {
+		h.Headers.Set(r)
+	}
+	h.Handler.ServeHTTP(w, r)
+}

--- a/net/headers.go
+++ b/net/headers.go
@@ -1,0 +1,46 @@
+package net
+
+import (
+	"net"
+	"net/http"
+)
+
+// Sets non-standard X-Forwarded-* Headers
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#proxies
+type ForwardedHeaders struct {
+	// Sets or appends request remote IP to the X-Forwarded-For header
+	For bool
+	// Sets or prepends request remote IP to the X-Forwarded-For header, overrides For
+	PrependFor bool
+	// Sets X-Forwarded-Host to the request host
+	Host bool
+	// Sets X-Forwarded-Proto value
+	Proto string
+}
+
+func (h *ForwardedHeaders) Set(req *http.Request) {
+	if (h.For || h.PrependFor) && req.RemoteAddr != "" {
+		addr := req.RemoteAddr
+		if host, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+			addr = host
+		}
+
+		v := req.Header.Get("X-Forwarded-For")
+		if v == "" {
+			v = addr
+		} else if h.PrependFor {
+			v = addr + ", " + v
+		} else {
+			v = v + ", " + addr
+		}
+		req.Header.Set("X-Forwarded-For", v)
+	}
+
+	if h.Host {
+		req.Header.Set("X-Forwarded-Host", req.Host)
+	}
+
+	if h.Proto != "" {
+		req.Header.Set("X-Forwarded-Proto", h.Proto)
+	}
+}

--- a/net/headers_test.go
+++ b/net/headers_test.go
@@ -1,0 +1,117 @@
+package net
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestForwardedHeaders(t *testing.T) {
+	for _, ti := range []struct {
+		name       string
+		remoteAddr string
+		header     http.Header
+		forwarded  ForwardedHeaders
+		expected   http.Header
+	}{
+		{
+			name:       "no change when disabled",
+			remoteAddr: "1.2.3.4:56",
+			header: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1"},
+			},
+			forwarded: ForwardedHeaders{},
+			expected: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1"},
+			},
+		},
+		{
+			name:       "no remote",
+			remoteAddr: "",
+			header: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1"},
+			},
+			forwarded: ForwardedHeaders{For: true},
+			expected: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1"},
+			},
+		},
+		{
+			name:       "set xff",
+			remoteAddr: "1.2.3.4:56",
+			header:     http.Header{},
+			forwarded:  ForwardedHeaders{For: true},
+			expected: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4"},
+			},
+		},
+		{
+			name:       "append xff",
+			remoteAddr: "1.2.3.4:56",
+			header: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1"},
+			},
+			forwarded: ForwardedHeaders{For: true},
+			expected: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1, 1.2.3.4"},
+			},
+		},
+		{
+			name:       "prepend xff",
+			remoteAddr: "1.2.3.4:56",
+			header: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1"},
+			},
+			forwarded: ForwardedHeaders{PrependFor: true},
+			expected: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4, 4.3.2.1"},
+			},
+		},
+		{
+			name:       "prepend xff overrides",
+			remoteAddr: "1.2.3.4:56",
+			header: http.Header{
+				"X-Forwarded-For": []string{"4.3.2.1"},
+			},
+			forwarded: ForwardedHeaders{For: true, PrependFor: true},
+			expected: http.Header{
+				"X-Forwarded-For": []string{"1.2.3.4, 4.3.2.1"},
+			},
+		},
+		{
+			name:       "set xff, host, proto",
+			remoteAddr: "1.2.3.4:56",
+			header:     http.Header{},
+			forwarded:  ForwardedHeaders{For: true, Host: true, Proto: "https"},
+			expected: http.Header{
+				"X-Forwarded-For":   []string{"1.2.3.4"},
+				"X-Forwarded-Host":  []string{"example.com"},
+				"X-Forwarded-Proto": []string{"https"},
+			},
+		},
+		{
+			name:       "set xff, overwrite host, proto",
+			remoteAddr: "1.2.3.4:56",
+			header: http.Header{
+				"X-Forwarded-Host":  []string{"whatever"},
+				"X-Forwarded-Proto": []string{"whatever"},
+			},
+			forwarded: ForwardedHeaders{For: true, Host: true, Proto: "https"},
+			expected: http.Header{
+				"X-Forwarded-For":   []string{"1.2.3.4"},
+				"X-Forwarded-Host":  []string{"example.com"},
+				"X-Forwarded-Proto": []string{"https"},
+			},
+		},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+			r := &http.Request{Host: "example.com", RemoteAddr: ti.remoteAddr, Header: ti.header}
+
+			ti.forwarded.Set(r)
+
+			if !reflect.DeepEqual(ti.expected, r.Header) {
+				t.Errorf("header mismatch, expected: %v, got: %v", ti.expected, r.Header)
+			}
+		})
+	}
+}

--- a/net/net.go
+++ b/net/net.go
@@ -61,3 +61,31 @@ func RemoteHostFromLast(r *http.Request) net.IP {
 
 	return parse(r.RemoteAddr)
 }
+
+// A list of IPNets
+type IPNets []*net.IPNet
+
+// Check if any of IPNets contains the IP
+func (nets IPNets) Contain(ip net.IP) bool {
+	for _, net := range nets {
+		if net.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Parses list of CIDR addresses into a list of IPNets
+func ParseCIDRs(cidrs []string) (nets IPNets, err error) {
+	for _, cidr := range cidrs {
+		if !strings.Contains(cidr, "/") {
+			cidr += "/32"
+		}
+		_, net, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		nets = append(nets, net)
+	}
+	return nets, nil
+}


### PR DESCRIPTION
Adds two new flags to control addition of `X-Forwarded-*` headers.
The addition happens before request routing so e.g. `SourceFromLast` predicate can rely on the header value.