### PR TITLE
Adds golang1.17 build constraints

### DIFF
--- a/dataclients/routestring/example_test.go
+++ b/dataclients/routestring/example_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package routestring_test

--- a/etcd/etcdtime_test.go
+++ b/etcd/etcdtime_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package etcd

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package skipper

--- a/proxy/backendratelimit_test.go
+++ b/proxy/backendratelimit_test.go
@@ -1,3 +1,4 @@
+//go:build !race || redis
 // +build !race redis
 
 package proxy_test

--- a/proxy/breaker_test.go
+++ b/proxy/breaker_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package proxy_test

--- a/ratelimit/cluster_test.go
+++ b/ratelimit/cluster_test.go
@@ -1,3 +1,4 @@
+//go:build !race || redis
 // +build !race redis
 
 package ratelimit

--- a/ratelimit/swim_test.go
+++ b/ratelimit/swim_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package ratelimit

--- a/skptesting/gohttpclient.go
+++ b/skptesting/gohttpclient.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/skptesting/prof.go
+++ b/skptesting/prof.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main


### PR DESCRIPTION
Golang 1.17 adds new syntax for build constraints, `gofmt` adds new
`//go:build` lines along with `// +build` during transition phase.
```
docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.17.0 sh -c "make fmt"
```
See https://tip.golang.org/doc/go1.17#gofmt

Note: the builds started to fail because we ask for golang version >= 1.6 (see https://github.com/zalando/skipper/pull/1835) and workflow started to build using 1.17

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>