### PR TITLE
Fixes testable example

### DIFF
--- a/eskip/example_test.go
+++ b/eskip/example_test.go
@@ -48,9 +48,6 @@ func Example() {
 
 		// route definition with a loopback to route2 (no backend address)
 		route4: Path("/some/alternative/path") -> setPath("/some/other/path") -> <loopback>;
-
-        // route definition which forwards rest of requests (no backend address)
-		route5: * -> requestHeader("X-Type", "page") -> <forward>;
 		`
 
 	routes, err := eskip.Parse(code)
@@ -72,9 +69,6 @@ func Example() {
 	// route2: [match] -> [1 filter(s) ->] <shunt> ""
 	// route3: [match] -> [1 filter(s) ->] <network> "https://api.example.org"
 	// route4: [match] -> [1 filter(s) ->] <loopback> ""
-
-	// TODO: try to represent this compressed output in a nicer way. This is is now somewhat confusing
-	// considering that it looks almost like eskip but it isn't.
 }
 
 func ExampleFilter() {


### PR DESCRIPTION
The https://github.com/zalando/skipper/issues/1860 pointed out a bug
https://github.com/golang/go/issues/48362 that leads to the false
positive testable example caused by a trailing comment.

Moreover https://github.com/zalando/skipper/pull/918 changed the test
input without changing the output and that went unnoticed due to this bug.

This change removes trailing comment to fix the example.
It also removes the test input instead of adding a correct output because
the input syntax is incorrect therefore misleading.

Fixes #1860

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>