### PR TITLE
Fix/optional trailing dot kube

### DIFF
--- a/dataclients/kubernetes/eastwest_test.go
+++ b/dataclients/kubernetes/eastwest_test.go
@@ -68,7 +68,7 @@ func TestCreateEastWestRouteIng(t *testing.T) {
 			},
 			want: &eskip.Route{
 				Id:          "kubeew_foo__qux__www3_example_org___a_path__bar",
-				HostRegexps: []string{"^(serviceA[.]default[.]cluster[.]local([.])?(:[0-9]+)?)$"},
+				HostRegexps: []string{"^(serviceA[.]default[.]cluster[.]local[.]?(:[0-9]+)?)$"},
 			},
 		},
 	}

--- a/dataclients/kubernetes/eastwest_test.go
+++ b/dataclients/kubernetes/eastwest_test.go
@@ -1,9 +1,10 @@
 package kubernetes
 
 import (
-	"github.com/zalando/skipper/eskip"
 	"reflect"
 	"testing"
+
+	"github.com/zalando/skipper/eskip"
 )
 
 func TestCreateEastWestRouteIng(t *testing.T) {
@@ -67,7 +68,7 @@ func TestCreateEastWestRouteIng(t *testing.T) {
 			},
 			want: &eskip.Route{
 				Id:          "kubeew_foo__qux__www3_example_org___a_path__bar",
-				HostRegexps: []string{"^(serviceA[.]default[.]cluster[.]local(:[0-9]+)?)$"},
+				HostRegexps: []string{"^(serviceA[.]default[.]cluster[.]local([.])?(:[0-9]+)?)$"},
 			},
 		},
 	}

--- a/dataclients/kubernetes/hosts.go
+++ b/dataclients/kubernetes/hosts.go
@@ -18,7 +18,7 @@ func createHostRx(hosts ...string) string {
 		// trailing dots and port are not allowed in kube
 		// ingress spec, so we can append optional setting
 		// without check
-		hrx[i] = strings.Replace(host, ".", "[.]", -1) + "([.])?(:[0-9]+)?"
+		hrx[i] = strings.Replace(host, ".", "[.]", -1) + "[.]?(:[0-9]+)?"
 	}
 
 	return "^(" + strings.Join(hrx, "|") + ")$"

--- a/dataclients/kubernetes/hosts.go
+++ b/dataclients/kubernetes/hosts.go
@@ -15,7 +15,10 @@ func createHostRx(hosts ...string) string {
 
 	hrx := make([]string, len(hosts))
 	for i, host := range hosts {
-		hrx[i] = strings.Replace(host, ".", "[.]", -1) + "(:[0-9]+)?"
+		// trailing dots and port are not allowed in kube
+		// ingress spec, so we can append optional setting
+		// without check
+		hrx[i] = strings.Replace(host, ".", "[.]", -1) + "([.])?(:[0-9]+)?"
 	}
 
 	return "^(" + strings.Join(hrx, "|") + ")$"

--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -311,12 +311,12 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: *-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)") &&
 
 			// increase priority of the redirect routes.
@@ -325,7 +325,7 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			-> redirectTo(308, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 
@@ -333,15 +333,15 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 	`
 
@@ -418,18 +418,18 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: * -> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress2__api_example_org___bar__service2_disable_https_redirect:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)") &&
 
 			// increase priority of the redirect routes.
@@ -438,10 +438,10 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 			Header("X-Forwarded-Proto", "http")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__api_example_org_____disable_https_redirect:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$") &&
 
 			// increase priority of the redirect routes.
 			Weight(1000) &&
@@ -521,12 +521,12 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: *-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)") &&
 
 			// increase priority of the redirect routes.
@@ -535,7 +535,7 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 
@@ -543,15 +543,15 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube__redirect:
 
@@ -626,12 +626,12 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: *-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)") &&
 
 			// increase priority of the redirect routes.
@@ -640,7 +640,7 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 
@@ -648,15 +648,15 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$")
 			-> <shunt>;
 	`
 

--- a/dataclients/kubernetes/httpsredirect_test.go
+++ b/dataclients/kubernetes/httpsredirect_test.go
@@ -311,12 +311,12 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: *-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)") &&
 
 			// increase priority of the redirect routes.
@@ -325,7 +325,7 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			-> redirectTo(308, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 
@@ -333,15 +333,15 @@ func TestEnableHTTPSRedirectFromIngress(t *testing.T) {
 			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> redirectTo(308, "https:")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 	`
 
@@ -418,18 +418,18 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: * -> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress2__api_example_org___bar__service2_disable_https_redirect:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)") &&
 
 			// increase priority of the redirect routes.
@@ -438,10 +438,10 @@ func TestDisableHTTPSRedirectFromIngress(t *testing.T) {
 			Header("X-Forwarded-Proto", "http")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__api_example_org_____disable_https_redirect:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
 
 			// increase priority of the redirect routes.
 			Weight(1000) &&
@@ -521,12 +521,12 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: *-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)") &&
 
 			// increase priority of the redirect routes.
@@ -535,7 +535,7 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 
@@ -543,15 +543,15 @@ func TestChangeRedirectCodeFromIngress(t *testing.T) {
 			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube__redirect:
 
@@ -626,12 +626,12 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 		kube_namespace1__ingress1______: * -> "http://1.1.1.0:8080";
 		kube_namespace1__ingress2______: *-> "http://1.1.2.0:8181";
 		kube_namespace1__ingress1__www_example_org___foo__service1:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)")
 			-> "http://1.1.1.0:8080";
 		kube_namespace1__ingress1__www_example_org___foo__service1_https_redirect:
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/foo)") &&
 
 			// increase priority of the redirect routes.
@@ -640,7 +640,7 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube___catchall__www_example_org____:
-			Host("^(www[.]example[.]org(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 		kube___catchall__www_example_org_____https_redirect:
 
@@ -648,15 +648,15 @@ func TestEnableRedirectWithCustomCode(t *testing.T) {
 			Weight(1000) &&
 
 			Header("X-Forwarded-Proto", "http") &&
-			Host("^(www[.]example[.]org(:[0-9]+)?)$")
+			Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> redirectTo(301, "https:")
 			-> <shunt>;
 		kube_namespace1__ingress2__api_example_org___bar__service2:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$") &&
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$") &&
 			PathRegexp("^(/bar)")
 			-> "http://1.1.2.0:8181";
 		kube___catchall__api_example_org____:
-			Host("^(api[.]example[.]org(:[0-9]+)?)$")
+			Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
 			-> <shunt>;
 	`
 

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -2769,8 +2769,8 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 1 host definitions with path and 1 additional custom route",
@@ -2784,9 +2784,9 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/a/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org___a_path__bar": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_a_path____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube___catchall__www1_example_org____":         "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www1_example_org___a_path__bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_a_path____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube___catchall__www1_example_org____":         "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 2 host definitions and 1 additional custom route",
@@ -2801,10 +2801,10 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www2.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux__www2_example_org_____bar": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www2_example_org_____": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux__www2_example_org_____bar": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 2 host definitions with path and 1 additional custom route",
@@ -2819,12 +2819,12 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www2.example.org", testPathRule("/another/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org___a_path__bar":       "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_a_path____":       "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube___catchall__www1_example_org____":               "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) -> <shunt>",
-			"kube_foo__qux__www2_example_org___another_path__bar": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www2_example_org_another_path____": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube___catchall__www2_example_org____":               "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www1_example_org___a_path__bar":       "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_a_path____":       "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube___catchall__www1_example_org____":               "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www2_example_org___another_path__bar": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www2_example_org_another_path____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube___catchall__www2_example_org____":               "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg: "ingress with 3 host definitions with one path and 3 additional custom routes",
@@ -2844,21 +2844,21 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www3.example.org", testPathRule("/a/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar":  "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www1_example_org_____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www1_example_org_____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www1_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www1_example_org_____bar":  "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www1_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
-			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg: "ingress with 3 host definitions with one without path and 3 additional custom routes",
@@ -2878,21 +2878,21 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www3.example.org", testPathRule("/a/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org____bar":  "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www1_example_org____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www1_example_org____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www1_example_org____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www1_example_org____bar":  "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www1_example_org____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www1_example_org____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www1_example_org____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
-			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 1 host definitions and 1 additional custom route, changed pathmode to PathSubtree",
@@ -2906,8 +2906,8 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && Method(\"OPTIONS\") && PathSubtree(\"/\") -> <shunt>",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Method(\"OPTIONS\") && PathSubtree(\"/\") -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 1 host definitions and 1 additional custom route with path predicate, changed pathmode to PathSubtree",
@@ -2921,7 +2921,7 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
 		},
 	}} {
 		t.Run(ti.msg, func(t *testing.T) {

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -2769,8 +2769,8 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 1 host definitions with path and 1 additional custom route",
@@ -2784,9 +2784,9 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/a/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org___a_path__bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_a_path____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube___catchall__www1_example_org____":         "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www1_example_org___a_path__bar": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_a_path____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube___catchall__www1_example_org____":         "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 2 host definitions and 1 additional custom route",
@@ -2801,10 +2801,10 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www2.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux__www2_example_org_____bar": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux__www2_example_org_____bar": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www2_example_org_____": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 2 host definitions with path and 1 additional custom route",
@@ -2819,12 +2819,12 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www2.example.org", testPathRule("/another/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org___a_path__bar":       "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_a_path____":       "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube___catchall__www1_example_org____":               "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
-			"kube_foo__qux__www2_example_org___another_path__bar": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www2_example_org_another_path____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube___catchall__www2_example_org____":               "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www1_example_org___a_path__bar":       "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_a_path____":       "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube___catchall__www1_example_org____":               "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www2_example_org___another_path__bar": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www2_example_org_another_path____": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/another\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube___catchall__www2_example_org____":               "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg: "ingress with 3 host definitions with one path and 3 additional custom routes",
@@ -2844,21 +2844,21 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www3.example.org", testPathRule("/a/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar":  "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www1_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www1_example_org_____bar":  "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www1_example_org_____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www1_example_org_____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www1_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
-			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg: "ingress with 3 host definitions with one without path and 3 additional custom routes",
@@ -2878,21 +2878,21 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www3.example.org", testPathRule("/a/path", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org____bar":  "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www1_example_org____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www1_example_org____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www1_example_org____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www1_example_org____bar":  "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www1_example_org____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www1_example_org____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www1_example_org____": "Path(\"/a/path/somewhere\") && Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube_foo__qux__www2_example_org_____bar":  "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www2_example_org_____": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www2_example_org_____": "Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www2_example_org_____": "Path(\"/a/path/somewhere\") && Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^\\//) -> \"https://some.other-url.org/a/path/somewhere\"",
 
-			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
-			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
-			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
-			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) -> <shunt>",
+			"kube_foo__qux__www3_example_org___a_path__bar":  "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux_a_0__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Method(\"OPTIONS\") -> <shunt>",
+			"kube_foo__qux_b_1__www3_example_org_a_path____": "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) && Cookie(\"alpha\", \"^enabled$\") -> \"http://1.1.2.0:8181\"",
+			"kube_foo__qux_c_2__www3_example_org_a_path____": "Path(\"/a/path/somewhere\") && Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\\/a\\/path)/) -> \"https://some.other-url.org/a/path/somewhere\"",
+			"kube___catchall__www3_example_org____":          "Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 1 host definitions and 1 additional custom route, changed pathmode to PathSubtree",
@@ -2906,8 +2906,8 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
-			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Method(\"OPTIONS\") && PathSubtree(\"/\") -> <shunt>",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__0__www1_example_org_____": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && Method(\"OPTIONS\") && PathSubtree(\"/\") -> <shunt>",
 		},
 	}, {
 		msg:       "ingress with 1 host definitions and 1 additional custom route with path predicate, changed pathmode to PathSubtree",
@@ -2921,7 +2921,7 @@ func TestSkipperCustomRoutes(t *testing.T) {
 			testRule("www1.example.org", testPathRule("/", "bar", definitions.BackendPort{Value: "baz"})),
 		)},
 		expectedRoutes: map[string]string{
-			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
+			"kube_foo__qux__www1_example_org_____bar": "Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree(\"/\") -> \"http://1.1.1.0:8181\"",
 		},
 	}} {
 		t.Run(ti.msg, func(t *testing.T) {

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
@@ -1,13 +1,13 @@
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathSubtree("/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathSubtree("/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") &&
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") &&
 	Method("OPTIONS") && PathSubtree("/")
 	-> <shunt>;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
@@ -1,13 +1,13 @@
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathSubtree("/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") &&
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") &&
 	Method("OPTIONS") && PathSubtree("/")
 	-> <shunt>;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute.eskip
@@ -1,12 +1,12 @@
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
 	-> <shunt>;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1customroute.eskip
@@ -1,12 +1,12 @@
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
 	-> <shunt>;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1filter.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1filter.eskip
@@ -1,8 +1,8 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1filter.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-1filter.eskip
@@ -1,8 +1,8 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2filters.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2filters.eskip
@@ -1,10 +1,10 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2filters.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2filters.eskip
@@ -1,10 +1,10 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2predicates.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2predicates.eskip
@@ -1,6 +1,6 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2predicates.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-2predicates.eskip
@@ -1,6 +1,6 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-predicate.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-predicate.eskip
@@ -1,6 +1,6 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-predicate.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule-predicate.eskip
@@ -1,6 +1,6 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule.eskip
@@ -1,6 +1,6 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-1host-1prule.eskip
@@ -1,6 +1,6 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__www_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-2prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-2prule-1customroute.eskip
@@ -1,31 +1,31 @@
 kube_foo__qux__0__www1_example_org_a_path____:
-	Host("^(www1[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^(/a/path)") && Method("OPTIONS") -> <shunt>;
+	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/a/path)") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www1_example_org___a_path__qux:
-	Host("^(www1[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
+	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube___catchall__www1_example_org____:
-	Host("^(www1[.]example[.]org(:[0-9]+)?)$")
+	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;
 kubeew_foo__qux__0__www1_example_org_a_path____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/a/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/a/path)")
 	-> <shunt>;
 kube___catchall__qux_foo_skipper_cluster_local____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	-> <shunt>;
 kubeew_foo__qux__www1_example_org___a_path__qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__0__www2_example_org_another_path____:
-	Host("^(www2[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^(/another/path)") && Method("OPTIONS") -> <shunt>;
+	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/another/path)") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www2_example_org___another_path__qux:
-	Host("^(www2[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
+	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www2_example_org_another_path____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/another/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/another/path)")
 	-> <shunt>;
 kubeew_foo__qux__www2_example_org___another_path__qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube___catchall__www2_example_org____:
-	Host("^(www2[.]example[.]org(:[0-9]+)?)$")
+	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-2prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-2prule-1customroute.eskip
@@ -1,31 +1,31 @@
 kube_foo__qux__0__www1_example_org_a_path____:
-	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/a/path)") && Method("OPTIONS") -> <shunt>;
+	Host("^(www1[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^(/a/path)") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www1_example_org___a_path__qux:
-	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
+	Host("^(www1[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube___catchall__www1_example_org____:
-	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(www1[.]example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;
 kubeew_foo__qux__0__www1_example_org_a_path____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/a/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/a/path)")
 	-> <shunt>;
 kube___catchall__qux_foo_skipper_cluster_local____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	-> <shunt>;
 kubeew_foo__qux__www1_example_org___a_path__qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__0__www2_example_org_another_path____:
-	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/another/path)") && Method("OPTIONS") -> <shunt>;
+	Host("^(www2[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^(/another/path)") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www2_example_org___another_path__qux:
-	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
+	Host("^(www2[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www2_example_org_another_path____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/another/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^(/another/path)")
 	-> <shunt>;
 kubeew_foo__qux__www2_example_org___another_path__qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^(/another/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube___catchall__www2_example_org____:
-	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(www2[.]example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-sameprule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-sameprule-1customroute.eskip
@@ -1,23 +1,23 @@
 kube_foo__qux__0__www1_example_org_____:
-	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www1[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www1_example_org_____qux:
-	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www1[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__0__www2_example_org_____:
-	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www2[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www2_example_org_____qux:
-	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www1_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
 	-> <shunt>;
 kubeew_foo__qux__www1_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www2_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
 	-> <shunt>;
 kubeew_foo__qux__www2_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-sameprule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-2host-sameprule-1customroute.eskip
@@ -1,23 +1,23 @@
 kube_foo__qux__0__www1_example_org_____:
-	Host("^(www1[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www1_example_org_____qux:
-	Host("^(www1[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__0__www2_example_org_____:
-	Host("^(www2[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
+	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && Method("OPTIONS") -> <shunt>;
 kube_foo__qux__www2_example_org_____qux:
-	Host("^(www2[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www1_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
 	-> <shunt>;
 kubeew_foo__qux__www1_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux__0__www2_example_org_____:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && Method("OPTIONS") && PathRegexp("^/")
 	-> <shunt>;
 kubeew_foo__qux__www2_example_org_____qux:
-	Host("^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1prule-3customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1prule-3customroute.eskip
@@ -1,79 +1,79 @@
 kube_foo__qux__www1_example_org_____qux:
-	Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/")
+	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www1_example_org_____:
-	Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
+	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www1_example_org_____:
-	Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
+	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www1_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) &&
+	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) &&
 	PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www2_example_org_____qux:
-	Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/")
+	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www2_example_org_____:
-	Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
+	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www2_example_org_____:
-	Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
+	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) &&
+	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) &&
 	PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux__www1_example_org_____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www1_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www1_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www2_example_org_____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) &&
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) &&
 	PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www1_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> "https://some.other-url.org/a/path/somewhere";
 kube___catchall__www3_example_org____:
-	Host("^(www3[.]example[.]org(:[0-9]+)?)$")
+	Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1prule-3customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1prule-3customroute.eskip
@@ -1,79 +1,79 @@
 kube_foo__qux__www1_example_org_____qux:
-	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/")
+	Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www1_example_org_____:
-	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
+	Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www1_example_org_____:
-	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
+	Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www1_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) &&
+	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) &&
 	PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www2_example_org_____qux:
-	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/")
+	Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www2_example_org_____:
-	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
+	Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www2_example_org_____:
-	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
+	Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) &&
+	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) &&
 	PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux__www1_example_org_____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www1_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www1_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www2_example_org_____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) &&
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) &&
 	PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www1_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> "https://some.other-url.org/a/path/somewhere";
 kube___catchall__www3_example_org____:
-	Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(www3[.]example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1withoutprule-3customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1withoutprule-3customroute.eskip
@@ -1,78 +1,78 @@
 kube_foo__qux__www1_example_org____qux:
-	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/)
+	Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www1_example_org____:
-	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("OPTIONS")
+	Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www1_example_org____:
-	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
+	Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www1_example_org____:
-	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/)
+	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org[.]?(:[0-9]+)?)$/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www2_example_org_____qux:
-	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/")
+	Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www2_example_org_____:
-	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
+	Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www2_example_org_____:
-	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
+	Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) &&
+	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org[.]?(:[0-9]+)?)$/) &&
 	PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux__www1_example_org____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www1_example_org____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www1_example_org____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www2_example_org_____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) &&
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) &&
 	PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www1_example_org____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> "https://some.other-url.org/a/path/somewhere";
 kube___catchall__www3_example_org____:
-	Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(www3[.]example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1withoutprule-3customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwest/ing-with-3host-1withoutprule-3customroute.eskip
@@ -1,78 +1,78 @@
 kube_foo__qux__www1_example_org____qux:
-	Host(/^(www1[.]example[.]org(:[0-9]+)?)$/)
+	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www1_example_org____:
-	Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && Method("OPTIONS")
+	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www1_example_org____:
-	Host(/^(www1[.]example[.]org(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
+	Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www1_example_org____:
-	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org(:[0-9]+)?)$/)
+	Path("/a/path/somewhere") && Host(/^(www1[.]example[.]org([.])?(:[0-9]+)?)$/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www2_example_org_____qux:
-	Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/")
+	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www2_example_org_____:
-	Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
+	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www2_example_org_____:
-	Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
+	Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp("^/") && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org(:[0-9]+)?)$/) &&
+	Path("/a/path/somewhere") && Host(/^(www2[.]example[.]org([.])?(:[0-9]+)?)$/) &&
 	PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 kube_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kube_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kube_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(www3[.]example[.]org([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux__www1_example_org____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www1_example_org____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www1_example_org____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www2_example_org_____qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www2_example_org_____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux__www3_example_org___a_path__qux:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) &&
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) &&
 	PathRegexp("^(/a/path)")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kubeew_foo__qux_a_0__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Method("OPTIONS")
 	-> <shunt>;
 kubeew_foo__qux_b_1__www3_example_org_a_path____:
-	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
+	Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/) && Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 kubeew_foo__qux_c_2__www3_example_org_a_path____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^(\/a\/path)/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www1_example_org____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/)
 	-> "https://some.other-url.org/a/path/somewhere";
 kubeew_foo__qux_c_2__www2_example_org_____:
-	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local(:[0-9]+)?)$/) && PathRegexp(/^\//)
+	Path("/a/path/somewhere") && Host(/^(qux[.]foo[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$/) && PathRegexp(/^\//)
 	-> "https://some.other-url.org/a/path/somewhere";
 kube___catchall__www3_example_org____:
-	Host("^(www3[.]example[.]org(:[0-9]+)?)$")
+	Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;
 

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.eskip
@@ -1,9 +1,9 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-1filter.eskip
@@ -1,9 +1,9 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
 	-> consecutiveBreaker(15)
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.eskip
@@ -1,11 +1,11 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internal-1prule-2filters.eskip
@@ -1,11 +1,11 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") &&  PathRegexp("^/") && ClientIP("10.2.0.0/16")
 	-> consecutiveBreaker(15)
 	-> preserveHost("true")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.eskip
@@ -1,17 +1,17 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute-2ranges-1match.eskip
@@ -1,17 +1,17 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.eskip
@@ -1,17 +1,17 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-1customroute.eskip
@@ -1,17 +1,17 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 
 kube_foo__qux__0__www_example_org_____:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.eskip
@@ -1,9 +1,9 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") &&
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") &&
 	QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") &&  PathRegexp("^/")
 	&& QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	&& ClientIP("10.2.0.0/16") &&  Source("10.8.0.0/16")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-2predicates.eskip
@@ -1,9 +1,9 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") &&
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") &&
 	QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") &&  PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/")
 	&& QueryParam("version", "^alpha$") && Header("Accept", "application/json")
 	&& ClientIP("10.2.0.0/16") &&  Source("10.8.0.0/16")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.eskip
@@ -1,7 +1,7 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") &&  PathRegexp("^/") && QueryParam("version", "^alpha$")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1externalhost-1internalhost-1prule-predicate.eskip
@@ -1,7 +1,7 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") && QueryParam("version", "^alpha$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") &&  PathRegexp("^/") && QueryParam("version", "^alpha$")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&  PathRegexp("^/") && QueryParam("version", "^alpha$")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
@@ -1,8 +1,8 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathSubtree("/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathSubtree("/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute-changedpathmodepathsubtree.eskip
@@ -1,8 +1,8 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathSubtree("/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathSubtree("/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.eskip
@@ -1,8 +1,8 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule-1customroute.eskip
@@ -1,8 +1,8 @@
 kube_foo__qux__0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin,
 	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.eskip
@@ -2,5 +2,5 @@ kube_foo__qux______: *
 	-> <roundRobin, "http://10.2.9.103:2134", "http://10.2.9.104:2134">;
 
 kube_foo__qux__example_ingress_cluster_local_____bar:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-1host-1prule.eskip
@@ -2,5 +2,5 @@ kube_foo__qux______: *
 	-> <roundRobin, "http://10.2.9.103:2134", "http://10.2.9.104:2134">;
 
 kube_foo__qux__example_ingress_cluster_local_____bar:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.eskip
@@ -1,51 +1,51 @@
 kube_foo__qux_a_0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux_b_1__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Cookie("alpha","^enabled$") && ClientIP("10.2.0.0/16")
 	-> "http://1.1.2.0:8181";
 
 kube_foo__qux_c_2__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") &&
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&
 	Path("/a/path/somewhere") && ClientIP("10.2.0.0/16") && PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux_a_0__www_example_org_____:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux_b_1__www_example_org_____:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 
 kube_foo__qux_c_2__www_example_org_____:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux_a_0__www2_anotherexample_org_____:
-	Host("^(www2[.]anotherexample[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux_b_1__www2_anotherexample_org_____:
-	Host("^(www2[.]anotherexample[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 
 kube_foo__qux_c_2__www2_anotherexample_org_____:
-	Host("^(www2[.]anotherexample[.]org(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 
 kube_foo__qux__www2_anotherexample_org_____qux:
-	Host("^(www2[.]anotherexample[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-with-2externalhost-1internalhost-0prule-3customroute.eskip
@@ -1,51 +1,51 @@
 kube_foo__qux_a_0__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_foo__qux_b_1__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Cookie("alpha","^enabled$") && ClientIP("10.2.0.0/16")
 	-> "http://1.1.2.0:8181";
 
 kube_foo__qux_c_2__example_ingress_cluster_local_____:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") &&
 	Path("/a/path/somewhere") && ClientIP("10.2.0.0/16") && PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 
 kube_foo__qux__example_ingress_cluster_local_____qux:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& ClientIP("10.2.0.0/16") -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux_a_0__www_example_org_____:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux_b_1__www_example_org_____:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 
 kube_foo__qux_c_2__www_example_org_____:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux_a_0__www2_anotherexample_org_____:
-	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux_b_1__www2_anotherexample_org_____:
-	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	&& Cookie("alpha","^enabled$")
 	-> "http://1.1.2.0:8181";
 
 kube_foo__qux_c_2__www2_anotherexample_org_____:
-	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org[.]?(:[0-9]+)?)$") && Path("/a/path/somewhere") && PathRegexp("^/")
 	-> "https://some.other-url.org/a/path/somewhere";
 
 kube_foo__qux__www2_anotherexample_org_____qux:
-	Host("^(www2[.]anotherexample[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www2[.]anotherexample[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin,	"http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/eastwestrange/ing-without-internal-host-1prule.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/external-name/all-allowed.eskip
+++ b/dataclients/kubernetes/testdata/ingress/external-name/all-allowed.eskip
@@ -1,9 +1,9 @@
 kube_default__myapp__example_org____external1_example_org:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external1.example.org")
 	-> "https://external1.example.org:443";
 
 kube_default__myapp__example_org____external2_example_org:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external2.example.org")
 	-> "https://external2.example.org:443";

--- a/dataclients/kubernetes/testdata/ingress/external-name/all-allowed.eskip
+++ b/dataclients/kubernetes/testdata/ingress/external-name/all-allowed.eskip
@@ -1,9 +1,9 @@
 kube_default__myapp__example_org____external1_example_org:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external1.example.org")
 	-> "https://external1.example.org:443";
 
 kube_default__myapp__example_org____external2_example_org:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external2.example.org")
 	-> "https://external2.example.org:443";

--- a/dataclients/kubernetes/testdata/ingress/external-name/external-name-validation-not-enabled.eskip
+++ b/dataclients/kubernetes/testdata/ingress/external-name/external-name-validation-not-enabled.eskip
@@ -1,9 +1,9 @@
 kube_default__myapp__example_org____external1_example_org:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external1.example.org")
 	-> "https://external1.example.org:443";
 
 kube_default__myapp__example_org____external2_example_org:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external2.example.org")
 	-> "https://external2.example.org:443";

--- a/dataclients/kubernetes/testdata/ingress/external-name/external-name-validation-not-enabled.eskip
+++ b/dataclients/kubernetes/testdata/ingress/external-name/external-name-validation-not-enabled.eskip
@@ -1,9 +1,9 @@
 kube_default__myapp__example_org____external1_example_org:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external1.example.org")
 	-> "https://external1.example.org:443";
 
 kube_default__myapp__example_org____external2_example_org:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setRequestHeader("Host", "external2.example.org")
 	-> "https://external2.example.org:443";

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-default-and-prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-default-and-prule.eskip
@@ -2,5 +2,5 @@ kube_foo__qux______: *
 	-> <roundRobin, "http://10.2.9.103:2134", "http://10.2.9.104:2134">;
 
 kube_foo__qux__www_example_org_____bar:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-default-and-prule.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-default-and-prule.eskip
@@ -2,5 +2,5 @@ kube_foo__qux______: *
 	-> <roundRobin, "http://10.2.9.103:2134", "http://10.2.9.104:2134">;
 
 kube_foo__qux__www_example_org_____bar:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-externalname-svc.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-externalname-svc.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org____www_zalando_de:
-  Host("^(www[.]example[.]org(:[0-9]+)?)$")
+  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
   -> setRequestHeader("Host", "www.zalando.de")
   -> "https://www.zalando.de:443"

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-externalname-svc.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-externalname-svc.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org____www_zalando_de:
-  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$")
+  Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
   -> setRequestHeader("Host", "www.zalando.de")
   -> "https://www.zalando.de:443"

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-consistenthash.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-consistenthash.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <consistentHash, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-consistenthash.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-consistenthash.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <consistentHash, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-powerofrandomnchoices.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-powerofrandomnchoices.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <powerOfRandomNChoices, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-powerofrandomnchoices.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-powerofrandomnchoices.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <powerOfRandomNChoices, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-random.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-random.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <random, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-random.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-random.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <random, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-roundrobin.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-roundrobin.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-roundrobin.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-lb-annotation-roundrobin.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-backend-and-port-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-backend-and-port-name.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____bar:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-backend-and-port-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-backend-and-port-name.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____bar:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-named-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-named-port.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-named-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-named-port.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____qux:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-num-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-num-port.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____bar:
-	Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-num-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-num-port.eskip
@@ -1,3 +1,3 @@
 kube_foo__qux__www_example_org_____bar:
-	Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/")
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
@@ -1,1 +1,1 @@
-kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;
+kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
@@ -1,1 +1,1 @@
-kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;
+kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-routes-annotation.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-routes-annotation.eskip
@@ -1,33 +1,33 @@
 kube_foo__qux__0__www1_example_org_____:
-  Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www1[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/") &&
   Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www1_example_org_____bar:
-  Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www1[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__0__www2_example_org_____:
-  Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www2[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/") &&
   Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www2_example_org_____bar:
-  Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www2[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__0__www3_example_org_foo____:
-  Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www3[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^(/foo)") &&
   Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www3_example_org___foo__bar:
-  Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www3[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^(/foo)")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube___catchall__www3_example_org____:
-  Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$")
+  Host("^(www3[.]example[.]org[.]?(:[0-9]+)?)$")
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-routes-annotation.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-routes-annotation.eskip
@@ -1,33 +1,33 @@
 kube_foo__qux__0__www1_example_org_____:
-  Host("^(www1[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/") &&
   Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www1_example_org_____bar:
-  Host("^(www1[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www1[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__0__www2_example_org_____:
-  Host("^(www2[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/") &&
   Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www2_example_org_____bar:
-  Host("^(www2[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www2[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube_foo__qux__0__www3_example_org_foo____:
-  Host("^(www3[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^(/foo)") &&
   Method("OPTIONS") -> <shunt>;
 
 kube_foo__qux__www3_example_org___foo__bar:
-  Host("^(www3[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^(/foo)")
   -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
 
 kube___catchall__www3_example_org____:
-  Host("^(www3[.]example[.]org(:[0-9]+)?)$")
+  Host("^(www3[.]example[.]org([.])?(:[0-9]+)?)$")
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-setpath-filter-annotation.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-setpath-filter-annotation.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> setPath("/foo") -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-setpath-filter-annotation.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-setpath-filter-annotation.eskip
@@ -1,4 +1,4 @@
 kube_foo__qux__www_example_org_____bar:
-  Host("^(www[.]example[.]org([.])?(:[0-9]+)?)$") &&
+  Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") &&
   PathRegexp("^/")
   -> setPath("/foo") -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-multi.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-multi.eskip
@@ -5,11 +5,11 @@ kube_namespace1__ingress1______:
 
 // path rule, target 1:
 kube_namespace1__ingress1__test_example_org___test1__service1:
-  Host(/^(test[.]example[.]org(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
   && PathRegexp(/^(\/test1)/)
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 // catch all:
 kube___catchall__test_example_org____:
-  Host(/^(test[.]example[.]org(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-multi.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-multi.eskip
@@ -5,11 +5,11 @@ kube_namespace1__ingress1______:
 
 // path rule, target 1:
 kube_namespace1__ingress1__test_example_org___test1__service1:
-  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   && PathRegexp(/^(\/test1)/)
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 // catch all:
 kube___catchall__test_example_org____:
-  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-single.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-single.eskip
@@ -5,11 +5,11 @@ kube_namespace1__ingress1______:
 
 // path rule:
 kube_namespace1__ingress1__test_example_org___test1__service1:
-  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   && PathRegexp(/^(\/test1)/)
   -> "http://42.0.1.2:8080";
 
 // catch all:
 kube___catchall__test_example_org____:
-  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-single.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/lb-target-single.eskip
@@ -5,11 +5,11 @@ kube_namespace1__ingress1______:
 
 // path rule:
 kube_namespace1__ingress1__test_example_org___test1__service1:
-  Host(/^(test[.]example[.]org(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
   && PathRegexp(/^(\/test1)/)
   -> "http://42.0.1.2:8080";
 
 // catch all:
 kube___catchall__test_example_org____:
-  Host(/^(test[.]example[.]org(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/lb-traffic-switch.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/lb-traffic-switch.eskip
@@ -3,16 +3,16 @@ kube_namespace1__ingress1______:
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 kube_namespace1__ingress1__test_example_org___test1__service1v1:
-  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/) &&
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/) &&
   PathRegexp(/^(\/test1)/) &&
   Traffic(0.3)
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 kube_namespace1__ingress1__test_example_org___test1__service1v2:
-  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/) &&
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/) &&
   PathRegexp(/^(\/test1)/)
   -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;
 
 kube___catchall__test_example_org____:
-  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/lb-traffic-switch.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/lb-traffic-switch.eskip
@@ -3,16 +3,16 @@ kube_namespace1__ingress1______:
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 kube_namespace1__ingress1__test_example_org___test1__service1v1:
-  Host(/^(test[.]example[.]org(:[0-9]+)?)$/) &&
+  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/) &&
   PathRegexp(/^(\/test1)/) &&
   Traffic(0.3)
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 kube_namespace1__ingress1__test_example_org___test1__service1v2:
-  Host(/^(test[.]example[.]org(:[0-9]+)?)$/) &&
+  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/) &&
   PathRegexp(/^(\/test1)/)
   -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;
 
 kube___catchall__test_example_org____:
-  Host(/^(test[.]example[.]org(:[0-9]+)?)$/)
+  Host(/^(test[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport2.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport2.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport2.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport2.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport3.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport3.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:80", "http://10.2.9.104:80">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport3.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport3.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:80", "http://10.2.9.104:80">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport4.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport4.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:80", "http://10.2.9.104:80">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport4.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport4.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:80", "http://10.2.9.104:80">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport5.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport5.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport5.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-multiport5.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-no-match.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-no-match.eskip
@@ -1,5 +1,5 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-no-match.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-no-match.eskip
@@ -1,5 +1,5 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-same-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-same-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-same-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports-same-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/named-ports.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/named-ports.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/numbered-ports-no-match.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/numbered-ports-no-match.eskip
@@ -1,5 +1,5 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/numbered-ports-no-match.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/numbered-ports-no-match.eskip
@@ -1,5 +1,5 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/ports-without-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/ports-without-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/named-ports/ports-without-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/named-ports/ports-without-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp__example_org____myapp:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;

--- a/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org(:[0-9]+)?)$")
+  Host("^(example[.]org([.])?(:[0-9]+)?)$")
   -> "http://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org([.])?(:[0-9]+)?)$")
+  Host("^(example[.]org[.]?(:[0-9]+)?)$")
   -> "http://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-value.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-value.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org([.])?(:[0-9]+)?)$")
+  Host("^(example[.]org[.]?(:[0-9]+)?)$")
   -> "http://10.3.0.3:8080";

--- a/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-value.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/multiple-by-value.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org(:[0-9]+)?)$")
+  Host("^(example[.]org([.])?(:[0-9]+)?)$")
   -> "http://10.3.0.3:8080";

--- a/dataclients/kubernetes/testdata/ingress/service-ports/single-no-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/single-no-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org(:[0-9]+)?)$")
+  Host("^(example[.]org([.])?(:[0-9]+)?)$")
   -> "http://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/ingress/service-ports/single-no-name.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/single-no-name.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org([.])?(:[0-9]+)?)$")
+  Host("^(example[.]org[.]?(:[0-9]+)?)$")
   -> "http://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/ingress/service-ports/single.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/single.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org(:[0-9]+)?)$")
+  Host("^(example[.]org([.])?(:[0-9]+)?)$")
   -> "http://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/ingress/service-ports/single.eskip
+++ b/dataclients/kubernetes/testdata/ingress/service-ports/single.eskip
@@ -1,3 +1,3 @@
 kube_default__myapp_ingress__example_org____myapp_service:
-  Host("^(example[.]org([.])?(:[0-9]+)?)$")
+  Host("^(example[.]org[.]?(:[0-9]+)?)$")
   -> "http://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/routegroups/convert/accepts-non-eskip-names.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/accepts-non-eskip-names.eskip
@@ -1,6 +1,6 @@
 kube_rg__my_namespace__my_routegroup__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/accepts-non-eskip-names.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/accepts-non-eskip-names.eskip
@@ -1,6 +1,6 @@
 kube_rg__my_namespace__my_routegroup__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/dynamic-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/dynamic-backend.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setDynamicBackendUrl("https://app.example.org")
 	-> <dynamic>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/dynamic-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/dynamic-backend.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setDynamicBackendUrl("https://app.example.org")
 	-> <dynamic>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-default-algorithm.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-default-algorithm.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "https://app1.example.org", "https://app2.example.org">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-default-algorithm.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-default-algorithm.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "https://app1.example.org", "https://app2.example.org">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-with-algorithm.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-with-algorithm.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <consistentHash, "https://app1.example.org", "https://app2.example.org">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-with-algorithm.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/explicit-lb-backend-with-algorithm.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <consistentHash, "https://app1.example.org", "https://app2.example.org">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.eskip
@@ -1,5 +1,5 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$") && Path("/app")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$") && Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.eskip
@@ -1,5 +1,5 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$") && Path("/app")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/filter.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/filter.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setRequestHeader("X-Foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/filter.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/filter.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setRequestHeader("X-Foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/implicit-route-group-with-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/implicit-route-group-with-host.eskip
@@ -1,3 +1,3 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/implicit-route-group-with-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/implicit-route-group-with-host.eskip
@@ -1,3 +1,3 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/loopback-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/loopback-backend.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setPath("/app")
 	-> <loopback>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/loopback-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/loopback-backend.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setPath("/app")
 	-> <loopback>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/missing-service-endpoints-and-cluster-ip.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/missing-service-endpoints-and-cluster-ip.eskip
@@ -1,8 +1,8 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/missing-service-endpoints-and-cluster-ip.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/missing-service-endpoints-and-cluster-ip.eskip
@@ -1,8 +1,8 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/multiple-route-groups-using-the-same-service.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/multiple-route-groups-using-the-same-service.eskip
@@ -1,2 +1,2 @@
-kube_rg__default__rg1__all__0_0: Host("^(v1[.]example[.]org([.])?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
-kube_rg__default__rg2__all__0_0: Host("^(v2[.]example[.]org([.])?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+kube_rg__default__rg1__all__0_0: Host("^(v1[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+kube_rg__default__rg2__all__0_0: Host("^(v2[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/multiple-route-groups-using-the-same-service.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/multiple-route-groups-using-the-same-service.eskip
@@ -1,2 +1,2 @@
-kube_rg__default__rg1__all__0_0: Host("^(v1[.]example[.]org(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
-kube_rg__default__rg2__all__0_0: Host("^(v2[.]example[.]org(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+kube_rg__default__rg1__all__0_0: Host("^(v1[.]example[.]org([.])?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+kube_rg__default__rg2__all__0_0: Host("^(v2[.]example[.]org([.])?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/network-address.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/network-address.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://app.example.org";
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/network-address.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/network-address.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://app.example.org";
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/non-default-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/non-default-backend.eskip
@@ -1,11 +1,11 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/ui")
 	-> "https://www.example.org";
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/non-default-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/non-default-backend.eskip
@@ -1,11 +1,11 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/ui")
 	-> "https://www.example.org";
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/path-regexp.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/path-regexp.eskip
@@ -1,8 +1,8 @@
 
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/resource/:id")
 	&& PathRegexp("[a-z0-9-]+$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/path-regexp.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/path-regexp.eskip
@@ -1,8 +1,8 @@
 
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/resource/:id")
 	&& PathRegexp("[a-z0-9-]+$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/path-subtree.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/path-subtree.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& PathSubtree("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/path-subtree.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/path-subtree.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& PathSubtree("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/predicate.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
 	Header("X-Foo", "bar")
-	&& Host("^(example[.]org(:[0-9]+)?)$")
+	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/predicate.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
 	Header("X-Foo", "bar")
-	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	&& Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-with-backend-protocol-annotation.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-with-backend-protocol-annotation.eskip
@@ -1,3 +1,3 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "https://10.2.4.8:80", "https://10.2.4.16:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-with-backend-protocol-annotation.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-with-backend-protocol-annotation.eskip
@@ -1,3 +1,3 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "https://10.2.4.8:80", "https://10.2.4.16:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/shunt-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/shunt-backend.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> redirect(302, "app.example.org")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/shunt-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/shunt-backend.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> redirect(302, "app.example.org")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/single-failing-route-makes-the-group-fail.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/single-failing-route-makes-the-group-fail.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__app__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/single-failing-route-makes-the-group-fail.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/single-failing-route-makes-the-group-fail.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__app__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/single-target-endpoint.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/single-target-endpoint.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "http://10.2.4.8:80";
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/single-target-endpoint.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/single-target-endpoint.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "http://10.2.4.8:80";
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
@@ -1,8 +1,8 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
@@ -1,8 +1,8 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/use-method-in-id.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/use-method-in-id.eskip
@@ -1,25 +1,25 @@
 kube_rg__default__myapp__get__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Method("GET")
 	&& Path("/resources")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__post__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Method("POST")
 	&& Path("/resources")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__get__1_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Method("GET")
 	&& Path("/resources/:id")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__put__1_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Method("PUT")
 	&& Path("/resources/:id")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/use-method-in-id.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/use-method-in-id.eskip
@@ -1,25 +1,25 @@
 kube_rg__default__myapp__get__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Method("GET")
 	&& Path("/resources")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__post__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Method("POST")
 	&& Path("/resources")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__get__1_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Method("GET")
 	&& Path("/resources/:id")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__put__1_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Method("PUT")
 	&& Path("/resources/:id")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/use-unique-hosts.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/use-unique-hosts.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(app[.]example[.]org(:[0-9]+)?|example[.]org(:[0-9]+)?)$")
+	Host("^(app[.]example[.]org([.])?(:[0-9]+)?|example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____app_example_org__catchall__0_0: Host("^(app[.]example[.]org(:[0-9]+)?)$") -> <shunt>;
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____app_example_org__catchall__0_0: Host("^(app[.]example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/use-unique-hosts.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/use-unique-hosts.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(app[.]example[.]org([.])?(:[0-9]+)?|example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(app[.]example[.]org[.]?(:[0-9]+)?|example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____app_example_org__catchall__0_0: Host("^(app[.]example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____app_example_org__catchall__0_0: Host("^(app[.]example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/use-unique-methods.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/use-unique-methods.eskip
@@ -1,13 +1,13 @@
 kube_rg__default__myapp__get__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Method("GET")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__post__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Method("POST")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/use-unique-methods.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/use-unique-methods.eskip
@@ -1,13 +1,13 @@
 kube_rg__default__myapp__get__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Method("GET")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
 kube_rg__default__myapp__post__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Method("POST")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/apply-explicit.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/apply-explicit.eskip
@@ -1,8 +1,8 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/apply-explicit.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/apply-explicit.eskip
@@ -1,8 +1,8 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/apply-implicit.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/apply-implicit.eskip
@@ -1,5 +1,5 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/apply-implicit.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/apply-implicit.eskip
@@ -1,5 +1,5 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-explicit-route.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-explicit-route.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-implicit-route.eskip
@@ -1,1 +1,1 @@
-kube_rg__default__myapp__all__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+kube_rg__default__myapp__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-implicit-route.eskip
@@ -1,1 +1,1 @@
-kube_rg__default__myapp__all__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+kube_rg__default__myapp__all__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/parse-once.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/parse-once.eskip
@@ -1,15 +1,15 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/ui")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/parse-once.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/parse-once.eskip
@@ -1,15 +1,15 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/ui")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/symlink-parse-once.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/symlink-parse-once.eskip
@@ -1,15 +1,15 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/ui")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/symlink-parse-once.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/symlink-parse-once.eskip
@@ -1,15 +1,15 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/ui")
 	-> setRequestHeader("X-Foo", "bar")
 	-> setCookie("foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal_default__myapp__all__0_1:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__internal_default__myapp__all__0_2:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/default-backends-implicit-route-no-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal_default__myapp__all__0_1:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__internal_default__myapp__all__0_2:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0:
-	Host("^(app[.]example[.]org(:[0-9]+)?)$")
+	Host("^(app[.]example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host-implicit-route.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0:
-	Host("^(app[.]example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(app[.]example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.eskip
@@ -1,12 +1,12 @@
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+	Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
 
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$") && Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+	Host("^(example[.]org([.])?(:[0-9]+)?)$") && Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && Path("/app") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && Path("/app") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80","http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-and-external-host.eskip
@@ -1,12 +1,12 @@
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+	Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
 
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$") && Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+	Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && Path("/app") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && Path("/app") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80","http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") &&
 	ClientIP("10.2.0.0/16") && Header("X-Foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route-predicate.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") &&
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") &&
 	ClientIP("10.2.0.0/16") && Header("X-Foo", "bar")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-explicit-route.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.eskip
@@ -1,3 +1,3 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-implicit-route.eskip
@@ -1,3 +1,3 @@
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	&& Path("/app") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host.eskip
@@ -1,7 +1,7 @@
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
 
 kube_rg__internal_default__myapp__all__0_0:
-	Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$")
+	Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	&& Path("/app") && ClientIP("10.2.0.0/16")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.eskip
@@ -1,12 +1,12 @@
 kube_rg__internal___example2_ingress_cluster_local__catchall__0_0:
 	ClientIP("10.2.0.0/16")
-	&& Host("^(example2[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") -> <shunt>;
+	&& Host("^(example2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") -> <shunt>;
 
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
 	ClientIP("10.2.0.0/16")
-	&& Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") -> <shunt>;
+	&& Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") -> <shunt>;
 
 kube_rg__internal_default__myapp__all__0_0:
 	ClientIP("10.2.0.0/16")
-	&& Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?|example2[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	&& Host("^(example[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?|example2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	&& Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-hosts-explicit-route.eskip
@@ -1,12 +1,12 @@
 kube_rg__internal___example2_ingress_cluster_local__catchall__0_0:
 	ClientIP("10.2.0.0/16")
-	&& Host("^(example2[.]ingress[.]cluster[.]local(:[0-9]+)?)$") -> <shunt>;
+	&& Host("^(example2[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") -> <shunt>;
 
 kube_rg__internal___example_ingress_cluster_local__catchall__0_0:
 	ClientIP("10.2.0.0/16")
-	&& Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?)$") -> <shunt>;
+	&& Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$") -> <shunt>;
 
 kube_rg__internal_default__myapp__all__0_0:
 	ClientIP("10.2.0.0/16")
-	&& Host("^(example[.]ingress[.]cluster[.]local(:[0-9]+)?|example2[.]ingress[.]cluster[.]local(:[0-9]+)?)$")
+	&& Host("^(example[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?|example2[.]ingress[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	&& Path("/app") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/custom-east-west-domain.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/custom-east-west-domain.eskip
@@ -1,11 +1,11 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]custom[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]custom[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/custom-east-west-domain.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/custom-east-west-domain.eskip
@@ -1,11 +1,11 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]custom[.]cluster[.]local(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]custom[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/east-west-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/east-west-explicit-route.eskip
@@ -1,11 +1,11 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/east-west-explicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/east-west-explicit-route.eskip
@@ -1,11 +1,11 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]skipper[.]cluster[.]local(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/east-west-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/east-west-implicit-route.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/east-west-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/east-west-implicit-route.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]skipper[.]cluster[.]local(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/explicit-east-west-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/explicit-east-west-host.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?|custom[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?|custom[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____custom_skipper_cluster_local__catchall__0_0: Host("^(custom[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") -> <shunt>;
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____custom_skipper_cluster_local__catchall__0_0: Host("^(custom[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/east-west/explicit-east-west-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/east-west/explicit-east-west-host.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?|custom[.]skipper[.]cluster[.]local(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?|custom[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____custom_skipper_cluster_local__catchall__0_0: Host("^(custom[.]skipper[.]cluster[.]local(:[0-9]+)?)$") -> <shunt>;
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____custom_skipper_cluster_local__catchall__0_0: Host("^(custom[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-0.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-0.eskip
@@ -1,5 +1,5 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-0.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-0.eskip
@@ -1,5 +1,5 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-1.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-1.eskip
@@ -1,8 +1,8 @@
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "team-foo") && PathSubtree("/")
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "team-foo") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-1.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-1.eskip
@@ -1,8 +1,8 @@
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "team-foo") && PathSubtree("/")
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "team-foo") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-2.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-2.eskip
@@ -1,16 +1,16 @@
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
   -> responseCookie("canary", "A")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
+kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
+kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-2.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-2.eskip
@@ -1,16 +1,16 @@
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
   -> responseCookie("canary", "A")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/")
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
+kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
+kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-3.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-3.eskip
@@ -1,23 +1,23 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
   -> responseCookie("canary", "A")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.8)
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.8)
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
+kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/") && Traffic(0.8)
+kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/") && Traffic(0.8)
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__3_1: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
+kube_rg__default__my_routes__all__3_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-3.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-3.eskip
@@ -1,23 +1,23 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
   -> responseCookie("canary", "A")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.8)
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.8)
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/")
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
+kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/") && Traffic(0.8)
+kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/") && Traffic(0.8)
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__3_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
+kube_rg__default__my_routes__all__3_1: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-4.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-4.eskip
@@ -1,16 +1,16 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
   -> responseCookie("canary", "A")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/")
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
+kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
+kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-4.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/ab-test-with-traffic-switching-step-4.eskip
@@ -1,16 +1,16 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/") && Traffic(0.1)
   -> responseCookie("canary", "A")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
   -> responseCookie("canary", "B")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
+kube_rg__default__my_routes__all__2_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "A") && PathSubtree("/")
   -> <roundRobin, "http://10.2.8.16:80", "http://10.2.8.8:80">;
 
-kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
+kube_rg__default__my_routes__all__3_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Cookie("canary", "B") && PathSubtree("/")
   -> <roundRobin, "http://10.2.6.16:80", "http://10.2.6.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/authnz-separate-read-write.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/authnz-separate-read-write.eskip
@@ -1,29 +1,29 @@
-kube_rg__default__myapp__push__0_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && Method("PUSH") && PathSubtree("/")
+kube_rg__default__myapp__push__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("PUSH") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__put__0_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && Method("PUT") && PathSubtree("/")
+kube_rg__default__myapp__put__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("PUT") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__patch__0_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && Method("PATCH") && PathSubtree("/")
+kube_rg__default__myapp__patch__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("PATCH") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__delete__0_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && Method("DELETE") && PathSubtree("/")
+kube_rg__default__myapp__delete__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("DELETE") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__get__1_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && Method("GET") && PathSubtree("/")
+kube_rg__default__myapp__get__1_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("GET") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.read")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__head__1_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && Method("HEAD") && PathSubtree("/")
+kube_rg__default__myapp__head__1_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("HEAD") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.read")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/authnz-separate-read-write.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/authnz-separate-read-write.eskip
@@ -1,29 +1,29 @@
-kube_rg__default__myapp__push__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("PUSH") && PathSubtree("/")
+kube_rg__default__myapp__push__0_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("PUSH") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__put__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("PUT") && PathSubtree("/")
+kube_rg__default__myapp__put__0_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("PUT") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__patch__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("PATCH") && PathSubtree("/")
+kube_rg__default__myapp__patch__0_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("PATCH") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__delete__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("DELETE") && PathSubtree("/")
+kube_rg__default__myapp__delete__0_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("DELETE") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.write")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__get__1_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("GET") && PathSubtree("/")
+kube_rg__default__myapp__get__1_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("GET") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.read")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__myapp__head__1_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("HEAD") && PathSubtree("/")
+kube_rg__default__myapp__head__1_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("HEAD") && PathSubtree("/")
   -> oauthTokeninfoAllScope("myapp.read")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/default-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/default-backend.eskip
@@ -1,14 +1,14 @@
-kube_rg__default__myapp__all__0_0: Path("/articles") && Host(/^(example[.]org(:[0-9]+)?|myapp[.]example[.]org(:[0-9]+)?)$/)
+kube_rg__default__myapp__all__0_0: Path("/articles") && Host(/^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg__default__myapp__all__1_0: Path("/articles/shoes") && Host(/^(example[.]org(:[0-9]+)?|myapp[.]example[.]org(:[0-9]+)?)$/)
+kube_rg__default__myapp__all__1_0: Path("/articles/shoes") && Host(/^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg__default__myapp__all__2_0: Path("/order") && Host(/^(example[.]org(:[0-9]+)?|myapp[.]example[.]org(:[0-9]+)?)$/)
+kube_rg__default__myapp__all__2_0: Path("/order") && Host(/^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____myapp_example_org__catchall__0_0: Host(/^(myapp[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____myapp_example_org__catchall__0_0: Host(/^(myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host(/^(example[.]org(:[0-9]+)?)$/)
+kube_rg____example_org__catchall__0_0: Host(/^(example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/default-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/default-backend.eskip
@@ -1,14 +1,14 @@
-kube_rg__default__myapp__all__0_0: Path("/articles") && Host(/^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg__default__myapp__all__0_0: Path("/articles") && Host(/^(example[.]org[.]?(:[0-9]+)?|myapp[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg__default__myapp__all__1_0: Path("/articles/shoes") && Host(/^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg__default__myapp__all__1_0: Path("/articles/shoes") && Host(/^(example[.]org[.]?(:[0-9]+)?|myapp[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg__default__myapp__all__2_0: Path("/order") && Host(/^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg__default__myapp__all__2_0: Path("/order") && Host(/^(example[.]org[.]?(:[0-9]+)?|myapp[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____myapp_example_org__catchall__0_0: Host(/^(myapp[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____myapp_example_org__catchall__0_0: Host(/^(myapp[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host(/^(example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____example_org__catchall__0_0: Host(/^(example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/minimal.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/minimal.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/minimal.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/minimal.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/multiple-hosts.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/multiple-hosts.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?|myapp[.]example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$")
 	&& PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____myapp_example_org__catchall__0_0: Host("^(myapp[.]example[.]org(:[0-9]+)?)$") -> <shunt>;
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____myapp_example_org__catchall__0_0: Host("^(myapp[.]example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/multiple-hosts.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/multiple-hosts.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?|myapp[.]example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?|myapp[.]example[.]org[.]?(:[0-9]+)?)$")
 	&& PathSubtree("/")
 	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____myapp_example_org__catchall__0_0: Host("^(myapp[.]example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____myapp_example_org__catchall__0_0: Host("^(myapp[.]example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/rate-limits-based-on-tokens.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/rate-limits-based-on-tokens.eskip
@@ -1,5 +1,5 @@
 kube_rg__default__api__post__0_0:
-	Host("^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
 	&& JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
 	&& Method("POST")
 	&& Path("/api/resource")
@@ -8,7 +8,7 @@ kube_rg__default__api__post__0_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__put__0_0:
-	Host("^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
 	&& JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
 	&& Method("PUT")
 	&& Path("/api/resource")
@@ -17,7 +17,7 @@ kube_rg__default__api__put__0_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__post__1_0:
-	Host("^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
 	&& Method("POST")
 	&& Path("/api/resource")
 	-> ratelimit(2, "1m")
@@ -25,7 +25,7 @@ kube_rg__default__api__post__1_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__put__1_0:
-	Host("^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
 	&& Method("PUT")
 	&& Path("/api/resource")
 	-> ratelimit(2, "1m")
@@ -33,16 +33,16 @@ kube_rg__default__api__put__1_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__all__2_0:
-	Host("^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
 	&& Path("/api/resource")
 	-> clientRatelimit(10, "1h", "Authorization")
 	-> oauthTokeninfoAllScope("read.resource", "list.resource")
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg____api_example_org__catchall__0_0:
-	Host("^(api[.]example[.]org(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;
 
 kube_rg____api_service_example_net__catchall__0_0:
-	Host("^(api[.]service[.]example[.]net(:[0-9]+)?)$")
+	Host("^(api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/rate-limits-based-on-tokens.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/rate-limits-based-on-tokens.eskip
@@ -1,5 +1,5 @@
 kube_rg__default__api__post__0_0:
-	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$")
 	&& JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
 	&& Method("POST")
 	&& Path("/api/resource")
@@ -8,7 +8,7 @@ kube_rg__default__api__post__0_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__put__0_0:
-	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$")
 	&& JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
 	&& Method("PUT")
 	&& Path("/api/resource")
@@ -17,7 +17,7 @@ kube_rg__default__api__put__0_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__post__1_0:
-	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$")
 	&& Method("POST")
 	&& Path("/api/resource")
 	-> ratelimit(2, "1m")
@@ -25,7 +25,7 @@ kube_rg__default__api__post__1_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__put__1_0:
-	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$")
 	&& Method("PUT")
 	&& Path("/api/resource")
 	-> ratelimit(2, "1m")
@@ -33,16 +33,16 @@ kube_rg__default__api__put__1_0:
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg__default__api__all__2_0:
-	Host("^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$")
 	&& Path("/api/resource")
 	-> clientRatelimit(10, "1h", "Authorization")
 	-> oauthTokeninfoAllScope("read.resource", "list.resource")
 	-> <roundRobin, "http://10.0.2.0:80", "http://10.0.2.1:80">;
 
 kube_rg____api_example_org__catchall__0_0:
-	Host("^(api[.]example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(api[.]example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;
 
 kube_rg____api_service_example_net__catchall__0_0:
-	Host("^(api[.]service[.]example[.]net([.])?(:[0-9]+)?)$")
+	Host("^(api[.]service[.]example[.]net[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/redirect-and-migration.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/redirect-and-migration.eskip
@@ -1,16 +1,16 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && PathSubtree("/api")
+kube_rg__default__my_routes__all__1_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/api")
   -> modPath("/api", "/")
   -> <loopback>;
 
-kube_rg__default__my_routes__get__2_0: Path("/login") && Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?|complex[.]example[.]org(:[0-9]+)?)$/) && Method("GET")
+kube_rg__default__my_routes__get__2_0: Path("/login") && Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("GET")
   -> redirectTo(308, "https://login.example.org/")
   -> <shunt>;
 
-kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/redirect-and-migration.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/redirect-and-migration.eskip
@@ -1,16 +1,16 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/")
+kube_rg__default__my_routes__all__0_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/")
   -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && PathSubtree("/api")
+kube_rg__default__my_routes__all__1_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && PathSubtree("/api")
   -> modPath("/api", "/")
   -> <loopback>;
 
-kube_rg__default__my_routes__get__2_0: Path("/login") && Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?|complex[.]example[.]org([.])?(:[0-9]+)?)$/) && Method("GET")
+kube_rg__default__my_routes__get__2_0: Path("/login") && Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?|complex[.]example[.]org[.]?(:[0-9]+)?)$/) && Method("GET")
   -> redirectTo(308, "https://login.example.org/")
   -> <shunt>;
 
-kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____www_complex_example_org__catchall__0_0: Host(/^(www[.]complex[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____complex_example_org__catchall__0_0: Host(/^(complex[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-simple.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-simple.eskip
@@ -1,25 +1,25 @@
-kube_rg__default__my_routes__all__0_0: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com") && Traffic(0.8)
+kube_rg__default__my_routes__all__0_0: Path("/api/resource") && Host(/^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com") && Traffic(0.8)
   -> ratelimit(200, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__0_1: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
+kube_rg__default__my_routes__all__0_1: Path("/api/resource") && Host(/^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
   -> ratelimit(200, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/) && Traffic(0.8)
+kube_rg__default__my_routes__all__1_0: Path("/api/resource") && Host(/^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$/) && Traffic(0.8)
   -> ratelimit(20, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_1: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/)
+kube_rg__default__my_routes__all__1_1: Path("/api/resource") && Host(/^(api[.]example[.]org[.]?(:[0-9]+)?|api[.]service[.]example[.]net[.]?(:[0-9]+)?)$/)
   -> ratelimit(20, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____api_service_example_net__catchall__0_0: Host(/^(api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/)
+kube_rg____api_service_example_net__catchall__0_0: Host(/^(api[.]service[.]example[.]net[.]?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-simple.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-simple.eskip
@@ -1,25 +1,25 @@
-kube_rg__default__my_routes__all__0_0: Path("/api/resource") && Host(/^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com") && Traffic(0.8)
+kube_rg__default__my_routes__all__0_0: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com") && Traffic(0.8)
   -> ratelimit(200, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__0_1: Path("/api/resource") && Host(/^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
+kube_rg__default__my_routes__all__0_1: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/) && JWTPayloadAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
   -> ratelimit(200, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com", "email", "skipper-router@googlegroups.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Path("/api/resource") && Host(/^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$/) && Traffic(0.8)
+kube_rg__default__my_routes__all__1_0: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/) && Traffic(0.8)
   -> ratelimit(20, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg__default__my_routes__all__1_1: Path("/api/resource") && Host(/^(api[.]example[.]org(:[0-9]+)?|api[.]service[.]example[.]net(:[0-9]+)?)$/)
+kube_rg__default__my_routes__all__1_1: Path("/api/resource") && Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/)
   -> ratelimit(20, "1m")
   -> oauthTokeninfoAllKV("iss", "https://accounts.google.com")
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/)
+kube_rg____api_example_org__catchall__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <shunt>;
 
-kube_rg____api_service_example_net__catchall__0_0: Host(/^(api[.]service[.]example[.]net(:[0-9]+)?)$/)
+kube_rg____api_service_example_net__catchall__0_0: Host(/^(api[.]service[.]example[.]net([.])?(:[0-9]+)?)$/)
   -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-with-two-hostnames.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-with-two-hostnames.eskip
@@ -1,5 +1,5 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.7)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?|example[.]org[.]?(:[0-9]+)?)$/) && Traffic(0.7)
   -> <roundRobin, "http://10.2.1.16:80", "http://10.2.1.8:80">;
 
-kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?|example[.]org[.]?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.2.16:80", "http://10.2.2.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-with-two-hostnames.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/examples/traffic-switching-with-two-hostnames.eskip
@@ -1,5 +1,5 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?|example[.]org(:[0-9]+)?)$/) && Traffic(0.7)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.7)
   -> <roundRobin, "http://10.2.1.16:80", "http://10.2.1.8:80">;
 
-kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org(:[0-9]+)?|example[.]org(:[0-9]+)?)$/)
+kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?|example[.]org([.])?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.2.16:80", "http://10.2.2.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/custom-code.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/custom-code.eskip
@@ -1,16 +1,16 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	&& Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> redirectTo(302, "https:")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/custom-code.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/custom-code.eskip
@@ -1,16 +1,16 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org(:[0-9]+)?)$")
+	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> redirectTo(302, "https:")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-for-east-west.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-for-east-west.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	&& Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> redirectTo(308, "https:")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy redirect:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-for-east-west.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-for-east-west.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kubeew_rg__default__myapp__all__0_0:
-	Host("^(myapp[.]default[.]skipper[.]cluster[.]local(:[0-9]+)?)$")
+	Host("^(myapp[.]default[.]skipper[.]cluster[.]local([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org(:[0-9]+)?)$")
+	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> redirectTo(308, "https:")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy redirect:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-if-proto-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-if-proto-predicate.eskip
@@ -1,9 +1,9 @@
 kube_rg__default__myapp__all__0_0:
 	Header("X-Forwarded-Proto", "foo-proto")
-	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	&& Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-if-proto-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/no-redirect-if-proto-predicate.eskip
@@ -1,9 +1,9 @@
 kube_rg__default__myapp__all__0_0:
 	Header("X-Forwarded-Proto", "foo-proto")
-	&& Host("^(example[.]org(:[0-9]+)?)$")
+	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-implicit-route.eskip
@@ -1,10 +1,10 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org(:[0-9]+)?)$")
+	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> redirectTo(308, "https:")
 	-> <shunt>;
 

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-implicit-route.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-implicit-route.eskip
@@ -1,10 +1,10 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	&& Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> redirectTo(308, "https:")
 	-> <shunt>;
 

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-simple.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-simple.eskip
@@ -1,16 +1,16 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	&& Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> redirectTo(308, "https:")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-simple.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/https-redirect/redirect-simple.eskip
@@ -1,16 +1,16 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_0_https_redirect:
 	Header("X-Forwarded-Proto", "http")
-	&& Host("^(example[.]org(:[0-9]+)?)$")
+	&& Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> redirectTo(308, "https:")
 	-> <shunt>;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
 
 // global, legacy:
 kube__redirect:

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$") && PathSubtree("/")
     -> tracingTag("skipper.backend_name", "myapp")
 	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes-no-backend.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$") && PathSubtree("/")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/")
     -> tracingTag("skipper.backend_name", "myapp")
 	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& PathSubtree("/")
 	-> tracingTag("skipper.backend_name", "myapp")
     -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/explicit-routes.eskip
@@ -1,7 +1,7 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& PathSubtree("/")
 	-> tracingTag("skipper.backend_name", "myapp")
     -> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
 
-kube_rg____example_org__catchall__0_0: Host("^(example[.]org(:[0-9]+)?)$") -> <shunt>;
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
     -> tracingTag("skipper.backend_name", "myapp")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;

--- a/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/tracing-tag/implicit-routes.eskip
@@ -1,4 +1,4 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
     -> tracingTag("skipper.backend_name", "myapp")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-no-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-no-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-partial-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-partial-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Traffic(0.6666666666666666)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Traffic(0)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-partial-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-partial-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Traffic(0.6666666666666666)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Traffic(0)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-with-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-with-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-with-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-implicit-route-with-weights.eskip
@@ -1,14 +1,14 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> "https://test.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-no-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-no-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-partial-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-partial-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6666666666666666)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-partial-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-partial-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6666666666666666)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-with-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-with-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-with-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/default-backends-with-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/last-route-with-zero-weight.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/last-route-with-zero-weight.eskip
@@ -1,27 +1,27 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6666666666666666)
 	&& True() && True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://test1.example.org";
 
 kube_rg__default__myapp__all__0_3:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://test2.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/last-route-with-zero-weight.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/last-route-with-zero-weight.eskip
@@ -1,27 +1,27 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6666666666666666)
 	&& True() && True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://test1.example.org";
 
 kube_rg__default__myapp__all__0_3:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://test2.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/no-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/no-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.3333333333333333)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.5)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/override-default-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/override-default-weights.eskip
@@ -1,39 +1,39 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app/test-more")
 	&& Traffic(0.3)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app/test-more")
 	&& Traffic(0.14285714285714285)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__1_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app/test-more")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/override-default-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/override-default-weights.eskip
@@ -1,39 +1,39 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg__default__myapp__all__1_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app/test-more")
 	&& Traffic(0.3)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__1_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app/test-more")
 	&& Traffic(0.14285714285714285)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__1_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app/test-more")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/partial-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/partial-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6666666666666666)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/partial-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/partial-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6666666666666666)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/with-traffic-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/with-traffic-predicate.eskip
@@ -1,11 +1,11 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.8)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Traffic(0.8)
   -> <roundRobin, "http://10.2.1.16:80", "http://10.2.1.8:80">;
 
-kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
+kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.2.16:80", "http://10.2.2.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.1) && Traffic(0.6)
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Traffic(0.1) && Traffic(0.6)
   -> <roundRobin, "http://10.2.3.16:80", "http://10.2.3.8:80">;
 
-kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.1)
+kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org[.]?(:[0-9]+)?)$/) && Traffic(0.1)
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/with-traffic-predicate.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/with-traffic-predicate.eskip
@@ -1,11 +1,11 @@
-kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Traffic(0.8)
+kube_rg__default__my_routes__all__0_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.8)
   -> <roundRobin, "http://10.2.1.16:80", "http://10.2.1.8:80">;
 
-kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org(:[0-9]+)?)$/)
+kube_rg__default__my_routes__all__0_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/)
   -> <roundRobin, "http://10.2.2.16:80", "http://10.2.2.8:80">;
 
-kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Traffic(0.1) && Traffic(0.6)
+kube_rg__default__my_routes__all__1_0: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.1) && Traffic(0.6)
   -> <roundRobin, "http://10.2.3.16:80", "http://10.2.3.8:80">;
 
-kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org(:[0-9]+)?)$/) && Traffic(0.1)
+kube_rg__default__my_routes__all__1_1: Host(/^(api[.]example[.]org([.])?(:[0-9]+)?)$/) && Traffic(0.1)
   -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/with-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/with-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org(:[0-9]+)?)$")
+	Host("^(example[.]org([.])?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/with-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/with-weights.eskip
@@ -1,21 +1,21 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.6)
 	&& True()
 	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
 
 kube_rg__default__myapp__all__0_1:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	&& Traffic(0.75)
 	-> "https://www.example.org";
 
 kube_rg__default__myapp__all__0_2:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	&& Path("/app")
 	-> "https://test.example.org";
 
 kube_rg____example_org__catchall__0_0:
-	Host("^(example[.]org([.])?(:[0-9]+)?)$")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/with-ingress/failing-ingress-item.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/with-ingress/failing-ingress-item.eskip
@@ -1,2 +1,2 @@
-kube_rg__default__myapp__all__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$")
+kube_rg__default__myapp__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$")
 -> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">

--- a/dataclients/kubernetes/testdata/routegroups/with-ingress/failing-ingress-item.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/with-ingress/failing-ingress-item.eskip
@@ -1,2 +1,2 @@
-kube_rg__default__myapp__all__0_0: Host("^(example[.]org(:[0-9]+)?)$")
+kube_rg__default__myapp__all__0_0: Host("^(example[.]org([.])?(:[0-9]+)?)$")
 -> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">


### PR DESCRIPTION
Kubernetes generated routes have optional port but not optional trailing dot, such that

`example.org.` in the host header would not match.
There is a longer discussion in https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0447.html that turns out to show that proxies and some clients remove trailing dot in SNI and Host header which is good, but we don't fix bogus clients in this case.

A follow up is to create a filter that removes the trailing dot from the host header, such that in case preserHost(true) we would send the host header without trailing dot if the client sends a trailing dot