### PR TITLE
Feature/filter remove trailing dot

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1195,14 +1195,14 @@ secureOauthTokenintrospectionAllKV("issuerURL", "", "", "k1", "v1", "k2", "v2")
 ## jwtValidation
 
 The filter parses bearer jwt token from Authorization header and validates the signature using public keys
-discovered via /.well-known/openid-configuration endpoint. Takes issuer url as single parameter. 
+discovered via /.well-known/openid-configuration endpoint. Takes issuer url as single parameter.
 The filter stores token claims into the state bag where they can be used by oidcClaimsQuery() or forwardTokenPart()
- 
+
 
 Examples:
 
 ```
-jwtValidation("https://login.microsoftonline.com/{tenantId}/v2.0") 
+jwtValidation("https://login.microsoftonline.com/{tenantId}/v2.0")
 ```
 
 
@@ -1225,8 +1225,8 @@ forwardToken("X-Tokeninfo-Forward", "access_token", "token_type")
 
 ## forwardTokenField
 
-The filter takes a header name and a field as its first and second arguments. The corresponding field from the result of token info, token introspection or oidc user info is added as 
-corresponding header when the request is passed to the backend. 
+The filter takes a header name and a field as its first and second arguments. The corresponding field from the result of token info, token introspection or oidc user info is added as
+corresponding header when the request is passed to the backend.
 
 If this filter is used when there is no token introspection, token info or oidc user info data
 then it does not have any effect.
@@ -2261,6 +2261,19 @@ group, a warning will be logged.
 It is possible to use the lifoGroup filter together with the single lifo filter, e.g. if
 a route belongs to a group, but needs to have additional stricter settings then the whole
 group.
+
+## rfcHost
+
+This filter removes the optional trailing dot in the outgoing host
+header.
+
+
+Example:
+
+```
+rfcHost()
+```
+
 
 ## rfcPath
 

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -174,6 +174,7 @@ func MakeRegistry() filters.Registry {
 		scheduler.NewLIFO(),
 		scheduler.NewLIFOGroup(),
 		rfc.NewPath(),
+		rfc.NewHost(),
 		fadein.NewFadeIn(),
 		fadein.NewEndpointCreated(),
 		consistenthash.NewConsistentHashKey(),

--- a/filters/rfc/rfc.go
+++ b/filters/rfc/rfc.go
@@ -43,6 +43,6 @@ func (host) CreateFilter([]interface{}) (filters.Filter, error) { return host{},
 func (host) Response(filters.FilterContext)                     {}
 
 func (host) Request(ctx filters.FilterContext) {
-	req := ctx.Request()
-	req.Host = rfc.PatchHost(req.Host)
+	ctx.Request().Host = rfc.PatchHost(ctx.Request().Host)
+	ctx.SetOutgoingHost(rfc.PatchHost(ctx.OutgoingHost()))
 }

--- a/filters/rfc/rfc.go
+++ b/filters/rfc/rfc.go
@@ -5,7 +5,10 @@ import (
 	"github.com/zalando/skipper/rfc"
 )
 
-const Name = "rfcPath"
+const (
+	Name     = "rfcPath"
+	NameHost = "rfcHost"
+)
 
 type path struct{}
 
@@ -24,4 +27,22 @@ func (p path) Response(filters.FilterContext)                     {}
 func (p path) Request(ctx filters.FilterContext) {
 	req := ctx.Request()
 	req.URL.Path = rfc.PatchPath(req.URL.Path, req.URL.RawPath)
+}
+
+type host struct{}
+
+// NewHost creates a filter specification for the rfcHost() filter, that
+// removes a trailing dot in the host header.
+//
+// See also the PatchHost documentation in the rfc package.
+//
+func NewHost() filters.Spec { return host{} }
+
+func (host) Name() string                                       { return NameHost }
+func (host) CreateFilter([]interface{}) (filters.Filter, error) { return host{}, nil }
+func (host) Response(filters.FilterContext)                     {}
+
+func (host) Request(ctx filters.FilterContext) {
+	req := ctx.Request()
+	req.Host = rfc.PatchHost(req.Host)
 }

--- a/filters/rfc/rfc_test.go
+++ b/filters/rfc/rfc_test.go
@@ -24,3 +24,24 @@ func TestPatch(t *testing.T) {
 		t.Error("failed to patch the path", req.URL.Path)
 	}
 }
+
+func TestPatchHost(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://www.example.org.", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &filtertest.Context{
+		FRequest: req,
+	}
+
+	f, err := NewHost().CreateFilter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Request(ctx)
+	if req.Host != "www.example.org" {
+		t.Error("failed to patch the host", req.Host)
+	}
+}

--- a/rfc/patchhost.go
+++ b/rfc/patchhost.go
@@ -6,5 +6,6 @@ import "strings"
 // see also the discussion in
 // https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0430.html.
 func PatchHost(host string) string {
+	host = strings.Replace(host, ".:", ":", -1)
 	return strings.TrimSuffix(host, ".")
 }

--- a/rfc/patchhost.go
+++ b/rfc/patchhost.go
@@ -1,0 +1,10 @@
+package rfc
+
+import "strings"
+
+// PatchHost returns a host string without trailing dot. For details
+// see also the discussion in
+// https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0430.html.
+func PatchHost(host string) string {
+	return strings.TrimSuffix(host, ".")
+}

--- a/rfc/patchhost_test.go
+++ b/rfc/patchhost_test.go
@@ -1,0 +1,29 @@
+package rfc
+
+import "testing"
+
+func TestPatchHost(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args string
+		want string
+	}{
+		{
+			name: "test no trailing dot",
+			args: "www.example.org",
+			want: "www.example.org",
+		},
+		{
+			name: "test trailing dot",
+			args: "www.example.org.",
+			want: "www.example.org",
+		}} {
+		t.Run(tt.name, func(t *testing.T) {
+			if s := PatchHost(tt.args); s != tt.want {
+				t.Fatalf("Failed to get the right output: %s, want: %s", s, tt.want)
+			}
+
+		})
+	}
+
+}

--- a/rfc/patchhost_test.go
+++ b/rfc/patchhost_test.go
@@ -17,6 +17,16 @@ func TestPatchHost(t *testing.T) {
 			name: "test trailing dot",
 			args: "www.example.org.",
 			want: "www.example.org",
+		},
+		{
+			name: "test with port and no trailing dot",
+			args: "www.example.org:245",
+			want: "www.example.org:245",
+		},
+		{
+			name: "test with port and trailing dot",
+			args: "www.example.org.:213",
+			want: "www.example.org:213",
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			if s := PatchHost(tt.args); s != tt.want {


### PR DESCRIPTION
Follow up of #1863 
We are able to fix our behavior as a client. 

There is a longer discussion in https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0447.html that turns out to show that proxies and some clients remove trailing dot in SNI and Host header which is good, but we don't fix bogus clients in this case.