### PR TITLE
feature: wire all kubernetes dataclients features

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -574,8 +574,8 @@ func (c *Config) ToRouteSrvOptions() routesrv.Options {
 
 	return routesrv.Options{
 		Address:                            c.Address,
-		SourcePollTimeout:                  time.Duration(c.SourcePollTimeout) * time.Millisecond,
-		WaitForHealthcheckInterval:         c.WaitForHealthcheckInterval,
+		DefaultFiltersDir:                  c.DefaultFiltersDir,
+		KubernetesAllowedExternalNames:     c.KubernetesAllowedExternalNames,
 		KubernetesInCluster:                c.KubernetesInCluster,
 		KubernetesURL:                      c.KubernetesURL,
 		KubernetesHealthcheck:              c.KubernetesHealthcheck,
@@ -583,15 +583,20 @@ func (c *Config) ToRouteSrvOptions() routesrv.Options {
 		KubernetesHTTPSRedirectCode:        c.KubernetesHTTPSRedirectCode,
 		KubernetesIngressClass:             c.KubernetesIngressClass,
 		KubernetesRouteGroupClass:          c.KubernetesRouteGroupClass,
-		WhitelistedHealthCheckCIDR:         whitelistCIDRS,
 		KubernetesPathMode:                 c.KubernetesPathMode,
 		KubernetesNamespace:                c.KubernetesNamespace,
+		KubernetesEnableEastWest:           c.KubernetesEnableEastWest,
+		KubernetesEastWestDomain:           c.KubernetesEastWestDomain,
 		KubernetesEastWestRangeDomains:     c.KubernetesEastWestRangeDomains.values,
 		KubernetesEastWestRangePredicates:  c.KubernetesEastWestRangePredicates,
 		KubernetesOnlyAllowedExternalNames: c.KubernetesOnlyAllowedExternalNames,
-		KubernetesAllowedExternalNames:     c.KubernetesAllowedExternalNames,
 		OpenTracingBackendNameTag:          c.OpentracingBackendNameTag,
 		OpenTracing:                        strings.Split(c.OpenTracing, " "),
+		OriginMarker:                       c.RouteCreationMetrics,
+		ReverseSourcePredicate:             c.ReverseSourcePredicate,
+		SourcePollTimeout:                  time.Duration(c.SourcePollTimeout) * time.Millisecond,
+		WaitForHealthcheckInterval:         c.WaitForHealthcheckInterval,
+		WhitelistedHealthCheckCIDR:         whitelistCIDRS,
 	}
 }
 

--- a/routesrv/options.go
+++ b/routesrv/options.go
@@ -73,6 +73,12 @@ type Options struct {
 	// in the cluster-scope.
 	KubernetesNamespace string
 
+	// *DEPRECATED* KubernetesEnableEastWest enables cluster internal service to service communication, aka east-west traffic
+	KubernetesEnableEastWest bool
+
+	// *DEPRECATED* KubernetesEastWestDomain sets the cluster internal domain used to create additional routes in skipper, defaults to skipper.cluster.local
+	KubernetesEastWestDomain string
+
 	// KubernetesEastWestRangeDomains set the the cluster internal domains for
 	// east west traffic. Identified routes to such domains will include
 	// the KubernetesEastWestRangePredicates.
@@ -104,6 +110,9 @@ type Options struct {
 
 	// Default filters directory enables default filters mechanism and sets the directory where the filters are located
 	DefaultFiltersDir string
+
+	// OriginMarker is *deprecated* and not used anymore. It will be deleted in v1.
+	OriginMarker bool
 
 	// OpenTracingBackendNameTag enables an additional tracing tag containing a backend name
 	// for a route when it's available (e.g. for RouteGroups)

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -48,23 +48,26 @@ func New(opts Options) (*RouteServer, error) {
 	rs.server = &http.Server{Addr: opts.Address, Handler: handler}
 
 	dataclient, err := kubernetes.New(kubernetes.Options{
+		AllowedExternalNames:              opts.KubernetesAllowedExternalNames,
+		BackendNameTracingTag:             opts.OpenTracingBackendNameTag,
+		DefaultFiltersDir:                 opts.DefaultFiltersDir,
 		KubernetesInCluster:               opts.KubernetesInCluster,
 		KubernetesURL:                     opts.KubernetesURL,
-		ProvideHealthcheck:                opts.KubernetesHealthcheck,
-		ProvideHTTPSRedirect:              opts.KubernetesHTTPSRedirect,
-		HTTPSRedirectCode:                 opts.KubernetesHTTPSRedirectCode,
-		IngressClass:                      opts.KubernetesIngressClass,
-		RouteGroupClass:                   opts.KubernetesRouteGroupClass,
-		ReverseSourcePredicate:            opts.ReverseSourcePredicate,
-		WhitelistedHealthCheckCIDR:        opts.WhitelistedHealthCheckCIDR,
-		PathMode:                          opts.KubernetesPathMode,
 		KubernetesNamespace:               opts.KubernetesNamespace,
+		KubernetesEnableEastWest:          opts.KubernetesEnableEastWest,
+		KubernetesEastWestDomain:          opts.KubernetesEastWestDomain,
 		KubernetesEastWestRangeDomains:    opts.KubernetesEastWestRangeDomains,
 		KubernetesEastWestRangePredicates: opts.KubernetesEastWestRangePredicates,
-		DefaultFiltersDir:                 opts.DefaultFiltersDir,
-		BackendNameTracingTag:             opts.OpenTracingBackendNameTag,
+		HTTPSRedirectCode:                 opts.KubernetesHTTPSRedirectCode,
+		IngressClass:                      opts.KubernetesIngressClass,
 		OnlyAllowedExternalNames:          opts.KubernetesOnlyAllowedExternalNames,
-		AllowedExternalNames:              opts.KubernetesAllowedExternalNames,
+		OriginMarker:                      opts.OriginMarker,
+		PathMode:                          opts.KubernetesPathMode,
+		ProvideHealthcheck:                opts.KubernetesHealthcheck,
+		ProvideHTTPSRedirect:              opts.KubernetesHTTPSRedirect,
+		ReverseSourcePredicate:            opts.ReverseSourcePredicate,
+		RouteGroupClass:                   opts.KubernetesRouteGroupClass,
+		WhitelistedHealthCheckCIDR:        opts.WhitelistedHealthCheckCIDR,
 	})
 	if err != nil {
 		return nil, err

--- a/skipper.go
+++ b/skipper.go
@@ -865,26 +865,26 @@ func createDataClients(o Options, auth innkeeper.Authentication) ([]routing.Data
 
 	if o.Kubernetes {
 		kubernetesClient, err := kubernetes.New(kubernetes.Options{
+			AllowedExternalNames:              o.KubernetesAllowedExternalNames,
+			BackendNameTracingTag:             o.OpenTracingBackendNameTag,
+			DefaultFiltersDir:                 o.DefaultFiltersDir,
 			KubernetesInCluster:               o.KubernetesInCluster,
 			KubernetesURL:                     o.KubernetesURL,
-			ProvideHealthcheck:                o.KubernetesHealthcheck,
-			ProvideHTTPSRedirect:              o.KubernetesHTTPSRedirect,
-			HTTPSRedirectCode:                 o.KubernetesHTTPSRedirectCode,
-			IngressClass:                      o.KubernetesIngressClass,
-			RouteGroupClass:                   o.KubernetesRouteGroupClass,
-			ReverseSourcePredicate:            o.ReverseSourcePredicate,
-			WhitelistedHealthCheckCIDR:        o.WhitelistedHealthCheckCIDR,
-			PathMode:                          o.KubernetesPathMode,
 			KubernetesNamespace:               o.KubernetesNamespace,
 			KubernetesEnableEastWest:          o.KubernetesEnableEastWest,
 			KubernetesEastWestDomain:          o.KubernetesEastWestDomain,
 			KubernetesEastWestRangeDomains:    o.KubernetesEastWestRangeDomains,
 			KubernetesEastWestRangePredicates: o.KubernetesEastWestRangePredicates,
-			DefaultFiltersDir:                 o.DefaultFiltersDir,
-			OriginMarker:                      o.EnableRouteCreationMetrics,
-			BackendNameTracingTag:             o.OpenTracingBackendNameTag,
+			HTTPSRedirectCode:                 o.KubernetesHTTPSRedirectCode,
+			IngressClass:                      o.KubernetesIngressClass,
 			OnlyAllowedExternalNames:          o.KubernetesOnlyAllowedExternalNames,
-			AllowedExternalNames:              o.KubernetesAllowedExternalNames,
+			OriginMarker:                      o.EnableRouteCreationMetrics,
+			PathMode:                          o.KubernetesPathMode,
+			ProvideHealthcheck:                o.KubernetesHealthcheck,
+			ProvideHTTPSRedirect:              o.KubernetesHTTPSRedirect,
+			ReverseSourcePredicate:            o.ReverseSourcePredicate,
+			RouteGroupClass:                   o.KubernetesRouteGroupClass,
+			WhitelistedHealthCheckCIDR:        o.WhitelistedHealthCheckCIDR,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
feature: wire all kubernetes dataclients features that are available, also deprecated one because these might be in use

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>