### PR TITLE
Checks file info read error to avoid nil pointer dereference

### DIFF
--- a/dataclients/kubernetes/defaultfilters.go
+++ b/dataclients/kubernetes/defaultfilters.go
@@ -31,7 +31,7 @@ func readDefaultFilters(dir string) (defaultFilters, error) {
 	for _, f := range files {
 		r := strings.Split(f.Name(), ".") // format: {service}.{namespace}
 		info, err := f.Info()
-		if len(r) != 2 || !(f.Type().IsRegular() || f.Type()&os.ModeSymlink != 0) || info.Size() > maxFileSize {
+		if err != nil || len(r) != 2 || !(f.Type().IsRegular() || f.Type()&os.ModeSymlink != 0) || info.Size() > maxFileSize {
 			log.WithError(err).WithField("file", f.Name()).Debug("incompatible file")
 			continue
 		}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -3229,17 +3229,7 @@ func TestSkipperDefaultFilters(t *testing.T) {
 			t.Error(err)
 		}
 
-		dc, err := New(Options{
-			KubernetesURL:     api.server.URL,
-			DefaultFiltersDir: defaultFiltersDir,
-		})
-		if err != nil {
-			t.Error(err)
-		}
-
-		defer dc.Close()
-
-		df, err := readDefaultFilters(dc.defaultFiltersDir)
+		df, err := readDefaultFilters(defaultFiltersDir)
 
 		if err != nil || len(df) != 0 {
 			t.Error("should return empty slice", err, df)


### PR DESCRIPTION
https://pkg.go.dev/io/fs#DirEntry says
> If the file has been removed or renamed since the directory read, Info may return an error

The error should be checked anyway although I could not reproduce the panic by removing the file after `os.ReadDir`.

Fixes #1875

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>