### PR TITLE
Adds key sharding to `clusterRatelimit`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -241,6 +241,8 @@ type Config struct {
 	SwarmLeaveTimeout                 time.Duration `yaml:"swarm-leave-timeout"`
 	SwarmStaticSelf                   string        `yaml:"swarm-static-self"`
 	SwarmStaticOther                  string        `yaml:"swarm-static-other"`
+
+	ClusterRatelimitMaxGroupShards int `yaml:"cluster-ratelimit-max-group-shards"`
 }
 
 const (
@@ -479,6 +481,8 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.SwarmLeaveTimeout, "swarm-leave-timeout", swarm.DefaultLeaveTimeout, "swarm leave timeout to use for leaving the memberlist on timeout")
 	flag.StringVar(&cfg.SwarmStaticSelf, "swarm-static-self", "", "set static swarm self node, for example 127.0.0.1:9001")
 	flag.StringVar(&cfg.SwarmStaticOther, "swarm-static-other", "", "set static swarm all nodes, for example 127.0.0.1:9002,127.0.0.1:9003")
+
+	flag.IntVar(&cfg.ClusterRatelimitMaxGroupShards, "cluster-ratelimit-max-group-shards", 1, "sets the maximum number of group shards for the clusterRatelimit filter")
 
 	return cfg
 }
@@ -802,6 +806,8 @@ func (c *Config) ToOptions() skipper.Options {
 		// swim on localhost for testing
 		SwarmStaticSelf:  c.SwarmStaticSelf,
 		SwarmStaticOther: c.SwarmStaticOther,
+
+		ClusterRatelimitMaxGroupShards: c.ClusterRatelimitMaxGroupShards,
 	}
 
 	if c.PluginDir != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -164,6 +164,7 @@ func Test_NewConfig(t *testing.T) {
 				RoutesURLs:                              commaListFlag(),
 				ForwardedHeadersList:                    commaListFlag(),
 				ForwardedHeadersExcludeCIDRList:         commaListFlag(),
+				ClusterRatelimitMaxGroupShards:          1,
 			},
 			wantErr: false,
 		},

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1041,7 +1041,7 @@ func newRatelimitError(settings ratelimit.Settings, retryAfter int) error {
 	return &proxyError{
 		err:              errRatelimit,
 		code:             http.StatusTooManyRequests,
-		additionalHeader: ratelimit.Headers(&settings, retryAfter),
+		additionalHeader: ratelimit.Headers(settings.MaxHits, settings.TimeWindow, retryAfter),
 	}
 }
 

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 )
@@ -210,6 +211,61 @@ func TestTupleLookuper(t *testing.T) {
 			t.Errorf("Failed to lookup request")
 		}
 	})
+}
+
+func TestRoundRobinLookuper(t *testing.T) {
+	for _, tc := range []struct {
+		n, concurrency, iterations int
+	}{
+		{1, 1, 1},
+		{1, 100, 100},
+		{2, 100, 100},
+		{3, 100, 100},
+		{10, 100, 100},
+		{11, 100, 100},
+		{13, 17, 23},
+	} {
+		t.Run(fmt.Sprintf("n=%d, concurrency=%d, iterations=%d", tc.n, tc.concurrency, tc.iterations), func(t *testing.T) {
+			lookuper := NewRoundRobinLookuper(uint64(tc.n))
+			buckets := testRoundRobinLookuper(lookuper, tc.concurrency, tc.iterations)
+			if len(buckets) != tc.n {
+				t.Errorf("expected %d buckets, got %d", tc.n, len(buckets))
+			}
+			maxPerBucket := (tc.concurrency * tc.iterations / tc.n) + 1
+			for key, count := range buckets {
+				if count > maxPerBucket {
+					t.Errorf("expected max %d request for bucket %s, got %d", maxPerBucket, key, count)
+				}
+			}
+		})
+	}
+}
+
+func testRoundRobinLookuper(lookuper Lookuper, concurrency, iterations int) map[string]int {
+	ch := make(chan map[string]int, concurrency)
+	var wg sync.WaitGroup
+	for c := 0; c < concurrency; c++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buckets := make(map[string]int)
+			for i := 0; i < iterations; i++ {
+				r, _ := http.NewRequest("GET", "/foo", nil)
+				buckets[lookuper.Lookup(r)]++
+			}
+			ch <- buckets
+		}()
+	}
+	wg.Wait()
+	close(ch)
+
+	result := make(map[string]int)
+	for b := range ch {
+		for key, count := range b {
+			result[key] += count
+		}
+	}
+	return result
 }
 
 func BenchmarkServiceRatelimit(b *testing.B) {


### PR DESCRIPTION
`clusterRatelimit` uses single ratelimit key for all requests and therefore uses
single Redis shard to track hits.

To spread the load across multiple Redis shards this change introduces key sharding.
Based on the max allowed hits and max allowed key shards the number of key shards `K`
is the largest number from `[1, maxKeyShards]` interval such that `maxHits % K == 0`.

When number of key shards `K` is greater than one `clusterRatelimit` will use one of
`K` distinct ratelimit keys for the requests selected by round robin algorithm and
will allow up to `maxHits / K` hits per sharded key.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>