### PR TITLE
Adds `Shutdown` predicate

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -223,6 +223,15 @@ route1: Path("/test") -> "http://www.zalando.de";
 route2: Path("/test") && False() -> "http://www.github.com";
 ```
 
+## Shutdown
+
+Evaluates to true if Skipper is shutting down. Can be used to create customized healthcheck.
+
+```
+health_up: Path("/health") -> inlineContent("OK") -> <shunt>;
+health_down: Path("/health") && Shutdown() -> status(503) -> inlineContent("shutdown") -> <shunt>;
+```
+
 ## Method
 
 The HTTP method that the request must match. HTTP methods are one of

--- a/predicates/predicates.go
+++ b/predicates/predicates.go
@@ -22,6 +22,7 @@ const (
 	WeightName                = "Weight"
 	TrueName                  = "True"
 	FalseName                 = "False"
+	ShutdownName              = "Shutdown"
 	MethodName                = "Method"
 	MethodsName               = "Methods"
 	HeaderName                = "Header"

--- a/predicates/primitive/shutdown.go
+++ b/predicates/primitive/shutdown.go
@@ -1,0 +1,51 @@
+package primitive
+
+import (
+	"net/http"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/routing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type shutdown struct {
+	inShutdown int32
+}
+
+// NewShutdown provides a predicate spec to create predicates
+// that evaluate to true if Skipper is shutting down
+func NewShutdown() routing.PredicateSpec {
+	s, _ := newShutdown()
+	return s
+}
+
+func newShutdown() (routing.PredicateSpec, chan os.Signal) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+	s := &shutdown{}
+	go func() {
+		<-sigs
+		log.Infof("Got shutdown signal for %s predicates", s.Name())
+		atomic.StoreInt32(&s.inShutdown, 1)
+	}()
+	return s, sigs
+}
+
+func (*shutdown) Name() string { return predicates.ShutdownName }
+
+// Create returns a Predicate that evaluates to true if Skipper is shutting down
+func (s *shutdown) Create(args []interface{}) (routing.Predicate, error) {
+	if len(args) != 0 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+	return s, nil
+}
+
+func (s *shutdown) Match(*http.Request) bool {
+	return atomic.LoadInt32(&s.inShutdown) != 0
+}

--- a/predicates/primitive/shutdown_test.go
+++ b/predicates/primitive/shutdown_test.go
@@ -1,0 +1,28 @@
+package primitive
+
+import (
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestShutdown(t *testing.T) {
+	s, sigs := newShutdown()
+	p, err := s.Create([]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest("GET", "https://www.example.org", nil)
+
+	if p.Match(req) {
+		t.Error("unexpected shutdown")
+	}
+
+	sigs <- syscall.SIGTERM
+	time.Sleep(100 * time.Millisecond)
+
+	if !p.Match(req) {
+		t.Error("expected shutdown")
+	}
+}

--- a/skipper.go
+++ b/skipper.go
@@ -1458,6 +1458,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		traffic.New(),
 		primitive.NewTrue(),
 		primitive.NewFalse(),
+		primitive.NewShutdown(),
 		pauth.NewJWTPayloadAllKV(),
 		pauth.NewJWTPayloadAnyKV(),
 		pauth.NewJWTPayloadAllKVRegexp(),


### PR DESCRIPTION
`Shutdown` predicate evaluates to true if Skipper is shutting down after receiving
`SIGTERM` signal and can be used to implement customized healthcheck.

Updates #1899

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>