### PR TITLE
Optimizes loadbalanced backend string

### DIFF
--- a/eskip/string.go
+++ b/eskip/string.go
@@ -144,16 +144,22 @@ func (r *Route) backendString() string {
 }
 
 func lbBackendString(r *Route) string {
-	var endpointStrings []string
-	for _, ep := range r.LBEndpoints {
-		endpointStrings = append(endpointStrings, fmt.Sprintf(`"%s"`, ep))
+	var b strings.Builder
+	b.WriteByte('<')
+	if r.LBAlgorithm != "" {
+		b.WriteString(r.LBAlgorithm)
+		b.WriteString(", ")
 	}
-
-	if r.LBAlgorithm == "" {
-		return fmt.Sprintf("<%s>", strings.Join(endpointStrings, ", "))
+	for i, ep := range r.LBEndpoints {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteByte('"')
+		b.WriteString(ep)
+		b.WriteByte('"')
 	}
-
-	return fmt.Sprintf("<%s, %s>", r.LBAlgorithm, strings.Join(endpointStrings, ", "))
+	b.WriteByte('>')
+	return b.String()
 }
 
 func (r *Route) backendStringQuoted() string {


### PR DESCRIPTION
```
benchmark                      old ns/op     new ns/op     delta
BenchmarkLBBackendString-8     9714          1951          -79.92%
BenchmarkLBBackendString-8     8967          1960          -78.14%
BenchmarkLBBackendString-8     8975          1955          -78.22%
BenchmarkLBBackendString-8     9176          1944          -78.81%
BenchmarkLBBackendString-8     8938          1947          -78.22%
BenchmarkLBBackendString-8     8733          1953          -77.64%
BenchmarkLBBackendString-8     8690          1960          -77.45%
BenchmarkLBBackendString-8     8519          1960          -76.99%
BenchmarkLBBackendString-8     9161          1952          -78.69%
BenchmarkLBBackendString-8     9048          1814          -79.95%

benchmark                      old allocs     new allocs     delta
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%
BenchmarkLBBackendString-8     114            12             -89.47%

benchmark                      old bytes     new bytes     delta
BenchmarkLBBackendString-8     7956          4648          -41.58%
BenchmarkLBBackendString-8     7957          4648          -41.59%
BenchmarkLBBackendString-8     7956          4648          -41.58%
BenchmarkLBBackendString-8     7956          4648          -41.58%
BenchmarkLBBackendString-8     7957          4648          -41.59%
BenchmarkLBBackendString-8     7957          4648          -41.59%
BenchmarkLBBackendString-8     7957          4648          -41.59%
BenchmarkLBBackendString-8     7957          4648          -41.59%
BenchmarkLBBackendString-8     7956          4648          -41.58%
BenchmarkLBBackendString-8     7956          4648          -41.58%
```

Currently Skipper uses `Route.String()` in the hot-path https://github.com/zalando/skipper/blob/1e26fcd250309d05da5a7b086c784ba100cf07da/proxy/proxy.go#L915
and this change aims to reduce the backend list string serialization as runtime profiling showed it is a considerable portion of `makeBackendRequest`:

![Screenshot from 2021-11-23 19-11-40](https://user-images.githubusercontent.com/697976/143080841-64ef1ec2-9d71-4435-a319-d30a66b7827b.png)

There are other optimization possible to make `Route.String()` faster but the better alternative seems to be to remove it from the `makeBackendRequest` altogether.

