### PR TITLE
Removes `skipper.route` tag from proxy span

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -912,7 +912,6 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 	p.tracing.
 		setTag(ctx.proxySpan, SpanKindTag, SpanKindClient).
 		setTag(ctx.proxySpan, SkipperRouteIDTag, ctx.route.Id).
-		setTag(ctx.proxySpan, SkipperRouteTag, ctx.route.String()).
 		setTag(ctx.proxySpan, HTTPUrlTag, u.String())
 	p.setCommonSpanInfo(u, req, ctx.proxySpan)
 

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -17,7 +17,7 @@ const (
 	HTTPPathTag           = "http.path"
 	HTTPUrlTag            = "http.url"
 	HTTPStatusCodeTag     = "http.status_code"
-	SkipperRouteTag       = "skipper.route"
+	SkipperRouteTag       = "skipper.route" // unused
 	SkipperRouteIDTag     = "skipper.route_id"
 	SpanKindTag           = "span.kind"
 

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -273,7 +272,6 @@ func TestTracingProxySpan(t *testing.T) {
 
 	verifyTag(t, span, SpanKindTag, SpanKindClient)
 	verifyTag(t, span, SkipperRouteIDTag, "hello")
-	verifyTag(t, span, SkipperRouteTag, strings.TrimPrefix(doc, "hello: "))
 	verifyTag(t, span, ComponentTag, "skipper")
 	verifyTag(t, span, HTTPUrlTag, "http://"+backendAddr+"/bye") // proxy removes query
 	verifyTag(t, span, HTTPMethodTag, "GET")


### PR DESCRIPTION
`skipper.route` tag contains serialized route in eskip format.
The value could be quite large, especially when route has loadbalanced
backend with many endpoints.

For payload size efficiency reasons this tag was already excluded at Zalando,
see https://github.com/zalando-incubator/kubernetes-on-aws/pull/2173

During profiling it was also dicovered that route eskip serialization
performance is suboptimal and may take more than 7% of the total
`proxy.ServeHTTP` call runtime.
![Screenshot from 2021-11-23 21-58-35](https://user-images.githubusercontent.com/697976/143120544-329e12ff-0eaf-4dda-8fd2-ababc72f4875.png)

While it is possible to optimize route eskip serialization (see e.g.
https://github.com/zalando/skipper/pull/1906) this change simply drops
it from the request path.

Users may still rely on `skipper.route_id` tag to resolve route configuration and
`http.url` tag to get actual backend address.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>