### PR TITLE
Adds incoming request host normalization

### DIFF
--- a/net/host.go
+++ b/net/host.go
@@ -1,0 +1,61 @@
+package net
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// HostPatch is used to modify host[:port] string
+type HostPatch struct {
+	// Remove port if present
+	RemovePort bool
+
+	// Remove trailing dot if present
+	RemoteTrailingDot bool
+
+	// Convert to lowercase
+	ToLower bool
+}
+
+func (h *HostPatch) Apply(original string) string {
+	host, port := original, ""
+
+	// avoid net.SplitHostPort for value without port
+	if strings.IndexByte(original, ':') != -1 {
+		if sh, sp, err := net.SplitHostPort(original); err == nil {
+			host, port = sh, sp
+		}
+	}
+
+	if h.RemovePort {
+		port = ""
+	}
+
+	if h.RemoteTrailingDot {
+		last := len(host) - 1
+		if last >= 0 && host[last] == '.' {
+			host = host[:last]
+		}
+	}
+
+	if h.ToLower {
+		host = strings.ToLower(host)
+	}
+
+	if port != "" {
+		return net.JoinHostPort(host, port)
+	} else {
+		return host
+	}
+}
+
+type HostPatchHandler struct {
+	Patch   HostPatch
+	Handler http.Handler
+}
+
+func (h *HostPatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.Host = h.Patch.Apply(r.Host)
+	h.Handler.ServeHTTP(w, r)
+}

--- a/net/host_test.go
+++ b/net/host_test.go
@@ -1,0 +1,125 @@
+package net
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestHostPatch(t *testing.T) {
+	for config, cases := range map[HostPatch]map[string]string{
+		{}: {
+			"":                  "",
+			"example.org":       "example.org",
+			"example.org.":      "example.org.",
+			"example.org:8080":  "example.org:8080",
+			"example.org.:8080": "example.org.:8080",
+			"127.0.0.1":         "127.0.0.1",
+			"127.0.0.1:9090":    "127.0.0.1:9090",
+			"::1":               "::1",
+			"[::1]:9090":        "[::1]:9090",
+			"EXAMPLE.ORG":       "EXAMPLE.ORG",
+			"EXAMPLE.ORG:8080":  "EXAMPLE.ORG:8080",
+			"EXAMPLE.ORG.:8080": "EXAMPLE.ORG.:8080",
+		},
+		{RemovePort: true}: {
+			"":                  "",
+			"example.org":       "example.org",
+			"example.org.":      "example.org.",
+			"example.org:8080":  "example.org",
+			"example.org.:8080": "example.org.",
+			"127.0.0.1":         "127.0.0.1",
+			"127.0.0.1:9090":    "127.0.0.1",
+			"::1":               "::1",
+			"[::1]:9090":        "::1",
+			"EXAMPLE.ORG":       "EXAMPLE.ORG",
+			"EXAMPLE.ORG:8080":  "EXAMPLE.ORG",
+			"EXAMPLE.ORG.:8080": "EXAMPLE.ORG.",
+		},
+		{RemoteTrailingDot: true}: {
+			"":                  "",
+			"example.org":       "example.org",
+			"example.org.":      "example.org",
+			"example.org:8080":  "example.org:8080",
+			"example.org.:8080": "example.org:8080",
+			"EXAMPLE.ORG":       "EXAMPLE.ORG",
+			"EXAMPLE.ORG:8080":  "EXAMPLE.ORG:8080",
+			"EXAMPLE.ORG.:8080": "EXAMPLE.ORG:8080",
+		},
+		{RemovePort: true, RemoteTrailingDot: true}: {
+			"":                  "",
+			"example.org":       "example.org",
+			"example.org.":      "example.org",
+			"example.org:8080":  "example.org",
+			"example.org.:8080": "example.org",
+			"127.0.0.1":         "127.0.0.1",
+			"127.0.0.1:9090":    "127.0.0.1",
+			"::1":               "::1",
+			"[::1]:9090":        "::1",
+			"EXAMPLE.ORG":       "EXAMPLE.ORG",
+			"EXAMPLE.ORG:8080":  "EXAMPLE.ORG",
+			"EXAMPLE.ORG.:8080": "EXAMPLE.ORG",
+		},
+		{RemovePort: true, RemoteTrailingDot: true, ToLower: true}: {
+			"":                  "",
+			"example.org":       "example.org",
+			"example.org.":      "example.org",
+			"example.org:8080":  "example.org",
+			"example.org.:8080": "example.org",
+			"127.0.0.1":         "127.0.0.1",
+			"127.0.0.1:9090":    "127.0.0.1",
+			"::1":               "::1",
+			"[::1]:9090":        "::1",
+			"EXAMPLE.ORG":       "example.org",
+			"EXAMPLE.ORG:8080":  "example.org",
+			"EXAMPLE.ORG.:8080": "example.org",
+		},
+	} {
+		for host, expected := range cases {
+			t.Run(fmt.Sprintf("%s->%+v", host, config), func(t *testing.T) {
+				got := config.Apply(host)
+				if expected != got {
+					t.Errorf("host mismatch, expected: %s, got: %s", expected, got)
+				}
+			})
+		}
+	}
+}
+
+func TestHostPatchHandler(t *testing.T) {
+	host := ""
+	rh := HostPatchHandler{
+		HostPatch{
+			RemovePort:        true,
+			RemoteTrailingDot: true,
+		},
+		http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { host = r.Host }),
+	}
+	rh.ServeHTTP(nil, &http.Request{Host: "example.com.:8080"})
+
+	if host != "example.com" {
+		t.Errorf("expected example.com, got: %s", host)
+	}
+}
+
+func BenchmarkHostPatchCommon(b *testing.B) {
+	hp := HostPatch{RemovePort: true, RemoteTrailingDot: true, ToLower: true}
+	if hp.Apply("www.example.org") != "www.example.org" {
+		b.Fatal("expected www.example.org")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hp.Apply("www.example.org")
+	}
+}
+
+func BenchmarkHostPatchUncommon(b *testing.B) {
+	hp := HostPatch{RemovePort: true, RemoteTrailingDot: true, ToLower: true}
+	if hp.Apply("WWW.EXAMPLE.ORG.:8080") != "www.example.org" {
+		b.Fatal("expected www.example.org")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hp.Apply("WWW.EXAMPLE.ORG.:8080")
+	}
+}


### PR DESCRIPTION
Incoming request `Host` header may contain port number, a trailing dot or
have an uppercase value which are all valid according to various RFCs but are not common.

AWS Application Load Balancer (ALB) removes port number, trailing dot and
converts `Host` header to lower case so uncommon cases are never observed
by Skipper behind ALB.
AWS Network Load Balancer (NLB) passes `Host` header as is.

Several changes were introduced to account for uncommon port number and traling dot:
* `Host` predicate generated by kubernetes dataclient was changed to
match optional port and trailing dot by #1281 and #1863
* `rfcHost` filter was introduced to remove trailing dot #1864

Matching optional port and trailing dot makes `Host` regexp more complex and
adds a small performance penalty for the uncommon case.
Uppercase `Host` values are not supported at all.

This change introduces host normalization step that converts incoming request host
to lowercase and removes port and trailing dot if any before routing,
enabled by the new `-normalize-host` or by `-kubernetes` flags.

It allows `Host` regexp simplification and use of a prospective predicate that
compares strings instead of using regexp (see #386).

Updates #1281, #1863, #1864, #386

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>