### PR TITLE
Adds `HostAny` predicate

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -128,6 +128,21 @@ Host(/^my-host-header\.example\.org$/)
 Host(/header\.example\.org$/)
 ```
 
+## HostAny
+
+Evaluates to true if request host exactly equals to any of the configured hostnames.
+
+Parameters:
+
+* hostnames (string)
+
+Examples:
+
+```
+HostAny("www.example.org", "www.example.com")
+HostAny("localhost:9090")
+```
+
 ## Forwarded header predicates
 
 Uses standardized Forwarded header ([RFC 7239](https://tools.ietf.org/html/rfc7239))

--- a/predicates/host/any.go
+++ b/predicates/host/any.go
@@ -1,0 +1,49 @@
+package host
+
+import (
+	"net/http"
+
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/routing"
+)
+
+type anySpec struct{}
+
+type anyPredicate struct {
+	hosts []string
+}
+
+// NewAny creates a predicate specification, whose instances match request host.
+//
+// The HostAny predicate requires one or more string hostnames and matches if request host
+// exactly equals to any of the hostnames.
+func NewAny() routing.PredicateSpec { return &anySpec{} }
+
+func (*anySpec) Name() string {
+	return predicates.HostAnyName
+}
+
+// Create a predicate instance that always evaluates to true
+func (*anySpec) Create(args []interface{}) (routing.Predicate, error) {
+	if len(args) == 0 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+	p := &anyPredicate{}
+	for _, arg := range args {
+		if host, ok := arg.(string); ok {
+			p.hosts = append(p.hosts, host)
+		} else {
+			return nil, predicates.ErrInvalidPredicateParameters
+		}
+	}
+	return p, nil
+}
+
+func (ap *anyPredicate) Match(r *http.Request) bool {
+	for _, host := range ap.hosts {
+		if host == r.Host {
+			return true
+		}
+	}
+	return false
+}

--- a/predicates/host/any_test.go
+++ b/predicates/host/any_test.go
@@ -1,0 +1,108 @@
+package host
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestHostAnyArgs(t *testing.T) {
+	s := NewAny()
+	for _, tc := range []struct {
+		args []interface{}
+	}{
+		{
+			args: []interface{}{},
+		},
+		{
+			args: []interface{}{1.2},
+		},
+		{
+			args: []interface{}{"example.org", 3.4},
+		},
+	} {
+		if _, err := s.Create(tc.args); err == nil {
+			t.Errorf("expected error for arguments: %v", tc.args)
+		}
+	}
+}
+
+func TestHostAnyMatch(t *testing.T) {
+	s := NewAny()
+	for _, tc := range []struct {
+		host  string
+		args  []interface{}
+		match bool
+	}{
+		{
+			host:  "example.org",
+			args:  []interface{}{"example.com"},
+			match: false,
+		},
+		{
+			host:  "example.org",
+			args:  []interface{}{"example.com", "example.net"},
+			match: false,
+		},
+		{
+			host:  "example.org",
+			args:  []interface{}{"www.example.org"},
+			match: false,
+		},
+		{
+			host:  "www.example.org",
+			args:  []interface{}{"example.org"},
+			match: false,
+		},
+		{
+			host:  "example.org.",
+			args:  []interface{}{"example.org"},
+			match: false,
+		},
+		{
+			host:  "example.org:8080",
+			args:  []interface{}{"example.org"},
+			match: false,
+		},
+		{
+			host:  "example.org.:8080",
+			args:  []interface{}{"example.org"},
+			match: false,
+		},
+		{
+			host:  "example.org",
+			args:  []interface{}{"example.org"},
+			match: true,
+		},
+		{
+			host:  "example.org:8080",
+			args:  []interface{}{"example.org:8080"},
+			match: true,
+		},
+		{
+			host:  "example.org",
+			args:  []interface{}{"example.org", "example.com"},
+			match: true,
+		},
+		{
+			host:  "example.org",
+			args:  []interface{}{"example.com", "example.org"},
+			match: true,
+		},
+		{
+			host:  "example.org:8080",
+			args:  []interface{}{"example.org", "example.org:8080"},
+			match: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("%s->%v", tc.host, tc.args), func(t *testing.T) {
+			p, err := s.Create(tc.args)
+			if err != nil {
+				t.Error(err)
+			}
+			if p.Match(&http.Request{Host: tc.host}) != tc.match {
+				t.Errorf("expected match: %v", tc.match)
+			}
+		})
+	}
+}

--- a/predicates/predicates.go
+++ b/predicates/predicates.go
@@ -17,6 +17,7 @@ const (
 	PathSubtreeName           = "PathSubtree"
 	PathRegexpName            = "PathRegexp"
 	HostName                  = "Host"
+	HostAnyName               = "HostAny"
 	ForwardedHostName         = "ForwardedHost"
 	ForwardedProtocolName     = "ForwardedProtocol"
 	WeightName                = "Weight"

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -57,7 +57,7 @@ func TestNoMultipleTreePredicates(t *testing.T) {
 			pr := make(map[string]routing.PredicateSpec)
 			fr := make(filters.Registry)
 			for _, d := range defs {
-				if _, err := routing.ProcessRouteDef(pr, fr, d); err != nil {
+				if _, err := routing.ExportProcessRouteDef(pr, fr, d); err != nil {
 					erred = true
 					break
 				}
@@ -117,7 +117,7 @@ func TestProcessRouteDefErrors(t *testing.T) {
 			fr := make(filters.Registry)
 			fr.Register(builtin.NewSetPath())
 			for _, d := range defs {
-				_, err := routing.ProcessRouteDef(pr, fr, d)
+				_, err := routing.ExportProcessRouteDef(pr, fr, d)
 				if err == nil || err.Error() != ti.err {
 					t.Errorf("expected error '%s'. Got: '%s'", ti.err, err)
 				}

--- a/routing/export_test.go
+++ b/routing/export_test.go
@@ -1,5 +1,7 @@
 package routing
 
 var (
-	ProcessRouteDef = processRouteDef
+	ExportProcessRouteDef = processRouteDef
+	ExportNewMatcher      = newMatcher
+	ExportMatch           = (*matcher).match
 )

--- a/routing/host_test.go
+++ b/routing/host_test.go
@@ -1,0 +1,89 @@
+package routing_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/predicates/host"
+	"github.com/zalando/skipper/routing"
+)
+
+// Benchmarks Host regular expression that matches optional port and trailing dot
+func BenchmarkPredicateHostRegexpSingleWithDotAndPort(b *testing.B) {
+	benchmarkPredicateHost(b, `Host("^(site{i}[.]example[.]org[.]?(:[0-9]+)?)$")`)
+}
+
+func BenchmarkPredicateHostRegexpMultipleWithDotAndPort(b *testing.B) {
+	benchmarkPredicateHost(b, `Host("^(site{i}[.]example[.]com[.]?(:[0-9]+)?|site{i}[.]example[.]org[.]?(:[0-9]+)?)$")`)
+}
+
+// Benchmarks Host regular expression that only matches domain name
+func BenchmarkPredicateHostRegexpSingleDomainOnly(b *testing.B) {
+	benchmarkPredicateHost(b, `Host("^site{i}[.]example[.]org$")`)
+}
+
+func BenchmarkPredicateHostRegexpMultipleDomainOnly(b *testing.B) {
+	benchmarkPredicateHost(b, `Host("^(site{i}[.]example[.]com|site{i}[.]example[.]org)$")`)
+}
+
+// Benchmarks HostAny that matches host using string comparison
+func BenchmarkPredicateHostAnySingle(b *testing.B) {
+	benchmarkPredicateHost(b, `HostAny("site{i}.example.org")`)
+}
+
+func BenchmarkPredicateHostAnyMultiple(b *testing.B) {
+	benchmarkPredicateHost(b, `HostAny("site{i}.example.com", "site{i}.example.org")`)
+}
+
+var (
+	benchmarkRouteSink *routing.Route
+	benchmarkParamSink map[string]string
+)
+
+// Benchmarks multi-host setup where request matches only one host out of many using different host predicates.
+// Creates R routes parametrized by sequence number from [0, R) and looks up using request that matches the last route.
+func benchmarkPredicateHost(b *testing.B, predicateFmt string) {
+	const R = 10000
+
+	ha := host.NewAny()
+	pr := map[string]routing.PredicateSpec{ha.Name(): ha}
+	fr := make(filters.Registry)
+
+	var routes []*routing.Route
+	for i := 0; i < R; i++ {
+		p := strings.ReplaceAll(predicateFmt, "{i}", fmt.Sprintf("%d", i))
+		def, err := eskip.Parse(fmt.Sprintf(`r%d: %s -> <shunt>;`, i, p))
+		if err != nil {
+			b.Fatal(err)
+		}
+		route, err := routing.ExportProcessRouteDef(pr, fr, def[0])
+		if err != nil {
+			b.Fatal(err)
+		}
+		routes = append(routes, route)
+	}
+
+	matcher, errs := routing.ExportNewMatcher(routes, routing.MatchingOptionsNone)
+	if len(errs) > 0 {
+		b.Fatal(errs)
+	}
+
+	testUrl := fmt.Sprintf(`https://site%d.example.org`, R-1)
+	req, _ := http.NewRequest("GET", testUrl, nil)
+
+	route, param := routing.ExportMatch(matcher, req)
+	if route != routes[R-1] {
+		b.Fatalf("expected to match last route %v", routes[R-1])
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		route, param = routing.ExportMatch(matcher, req)
+	}
+	benchmarkRouteSink = route
+	benchmarkParamSink = param
+}

--- a/skipper.go
+++ b/skipper.go
@@ -43,6 +43,7 @@ import (
 	"github.com/zalando/skipper/predicates/cookie"
 	"github.com/zalando/skipper/predicates/cron"
 	"github.com/zalando/skipper/predicates/forwarded"
+	"github.com/zalando/skipper/predicates/host"
 	"github.com/zalando/skipper/predicates/interval"
 	"github.com/zalando/skipper/predicates/methods"
 	"github.com/zalando/skipper/predicates/primitive"
@@ -1486,6 +1487,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		tee.New(),
 		forwarded.NewForwardedHost(),
 		forwarded.NewForwardedProto(),
+		host.NewAny(),
 	)
 
 	// provide default value for wrapper if not defined


### PR DESCRIPTION
`HostAny` predicate evaluates to true if request host exactly matches any of the configured values.

Benchmark demonstrates performance of mathching single host across 10k routes:
```
$ go test ./routing/ -run NONE -bench BenchmarkPredicateHost -benchmem -benchtime=10s
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/routing
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
BenchmarkPredicateHostRegexpSingleWithDotAndPort-8          4429           2749788 ns/op              48 B/op          1 allocs/op
BenchmarkPredicateHostRegexpMultipleWithDotAndPort-8        4633           2619966 ns/op              48 B/op          1 allocs/op
BenchmarkPredicateHostRegexpSingleDomainOnly-8              8666           1342919 ns/op              48 B/op          1 allocs/op
BenchmarkPredicateHostRegexpMultipleDomainOnly-8            4980           2450593 ns/op              48 B/op          1 allocs/op
BenchmarkPredicateHostAnySingle-8                          36828            331182 ns/op              48 B/op          1 allocs/op
BenchmarkPredicateHostAnyMultiple-8                        28540            380094 ns/op              48 B/op          1 allocs/op
PASS
ok      github.com/zalando/skipper/routing      82.859s
```

Fixes #386

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>