### PR TITLE
fix: routesrv should be able to fetch ingress v1 resources

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -601,6 +601,7 @@ func (c *Config) ToRouteSrvOptions() routesrv.Options {
 		KubernetesHealthcheck:              c.KubernetesHealthcheck,
 		KubernetesHTTPSRedirect:            c.KubernetesHTTPSRedirect,
 		KubernetesHTTPSRedirectCode:        c.KubernetesHTTPSRedirectCode,
+		KubernetesIngressV1:                c.KubernetesIngressV1,
 		KubernetesIngressClass:             c.KubernetesIngressClass,
 		KubernetesRouteGroupClass:          c.KubernetesRouteGroupClass,
 		KubernetesPathMode:                 c.KubernetesPathMode,

--- a/routesrv/options.go
+++ b/routesrv/options.go
@@ -51,6 +51,9 @@ type Options struct {
 	// when used together with -kubernetes-https-redirect.
 	KubernetesHTTPSRedirectCode int
 
+	// KubernetesIngressV1 will switch the dataclient to read ingress v1 resources, instead of v1beta1
+	KubernetesIngressV1 bool
+
 	// KubernetesIngressClass is a regular expression, that will make
 	// skipper load only the ingress resources that have a matching
 	// kubernetes.io/ingress.class annotation. For backwards compatibility,

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -51,6 +51,7 @@ func New(opts Options) (*RouteServer, error) {
 		AllowedExternalNames:              opts.KubernetesAllowedExternalNames,
 		BackendNameTracingTag:             opts.OpenTracingBackendNameTag,
 		DefaultFiltersDir:                 opts.DefaultFiltersDir,
+		KubernetesIngressV1:               opts.KubernetesIngressV1,
 		KubernetesInCluster:               opts.KubernetesInCluster,
 		KubernetesURL:                     opts.KubernetesURL,
 		KubernetesNamespace:               opts.KubernetesNamespace,

--- a/routesrv/testdata/ing-v1-lb-target-multi.eskip
+++ b/routesrv/testdata/ing-v1-lb-target-multi.eskip
@@ -1,0 +1,4 @@
+kube_namespace1__ingress1__test_example_org___test1__service1: Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
+	&& PathSubtree("/test1")
+	-> <roundRobin,"http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+

--- a/routesrv/testdata/ing-v1-lb-target-multi.yaml
+++ b/routesrv/testdata/ing-v1-lb-target-multi.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+spec:
+  rules:
+  - host: test.example.org
+    http:
+      paths:
+      - path: "/test1"
+        pathType: Prefix
+        backend:
+          service:
+            name: service1
+            port:
+              name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+  - name: port1
+    port: 8080
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1
+subsets:
+- addresses:
+  - ip: 42.0.1.2
+  - ip: 42.0.1.3
+  ports:
+  - name: port1
+    port: 8080
+    protocol: TCP

--- a/skipper.go
+++ b/skipper.go
@@ -16,10 +16,11 @@ import (
 	"syscall"
 	"time"
 
+	stdlog "log"
+
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
-	stdlog "log"
 
 	"github.com/zalando/skipper/circuit"
 	"github.com/zalando/skipper/dataclients/kubernetes"


### PR DESCRIPTION
fix: #1916 routesrv should be able to fetch ingress v1 resources

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>