### PR TITLE
proxy: remove http.remote_addr tracing tag

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1435,7 +1435,6 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	p.tracing.
 		setTag(span, SpanKindTag, SpanKindServer).
-		setTag(span, HTTPRemoteAddrTag, r.RemoteAddr).
 		setTag(span, HTTPRemoteIPTag, stripPort(r.RemoteAddr))
 	p.setCommonSpanInfo(r.URL, r, span)
 	r = r.WithContext(ot.ContextWithSpan(r.Context(), span))

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -12,12 +12,10 @@ const (
 	HostnameTag           = "hostname"
 	HTTPHostTag           = "http.host"
 	HTTPMethodTag         = "http.method"
-	HTTPRemoteAddrTag     = "http.remote_addr"
 	HTTPRemoteIPTag       = "http.remote_ip"
 	HTTPPathTag           = "http.path"
 	HTTPUrlTag            = "http.url"
 	HTTPStatusCodeTag     = "http.status_code"
-	SkipperRouteTag       = "skipper.route" // unused
 	SkipperRouteIDTag     = "skipper.route_id"
 	SpanKindTag           = "span.kind"
 

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -130,7 +130,6 @@ func TestTracingIngressSpan(t *testing.T) {
 	verifyTag(t, span, HTTPHostTag, ps.Listener.Addr().String())
 	verifyTag(t, span, FlowIDTag, "test-flow-id")
 	verifyTag(t, span, HTTPStatusCodeTag, uint16(200))
-	verifyHasTag(t, span, HTTPRemoteAddrTag)
 	verifyHasTag(t, span, HTTPRemoteIPTag)
 }
 
@@ -281,7 +280,6 @@ func TestTracingProxySpan(t *testing.T) {
 	verifyTag(t, span, HTTPHostTag, backendAddr)
 	verifyTag(t, span, FlowIDTag, "test-flow-id")
 	verifyTag(t, span, HTTPStatusCodeTag, uint16(204))
-	verifyNoTag(t, span, HTTPRemoteAddrTag)
 	verifyNoTag(t, span, HTTPRemoteIPTag)
 }
 
@@ -469,7 +467,7 @@ func TestSetDisabledTags(t *testing.T) {
 	tracing := newProxyTracing(&OpenTracingParams{
 		Tracer: tracer,
 		ExcludeTags: []string{
-			SkipperRouteTag,
+			SkipperRouteIDTag,
 		},
 	})
 	span := tracer.StartSpan("test")
@@ -477,7 +475,7 @@ func TestSetDisabledTags(t *testing.T) {
 
 	tracing.setTag(span, HTTPStatusCodeTag, 200)
 	tracing.setTag(span, ComponentTag, "skipper")
-	tracing.setTag(span, SkipperRouteTag, "long route definition")
+	tracing.setTag(span, SkipperRouteIDTag, "long_route_id")
 
 	mockSpan := span.(*mocktracer.MockSpan)
 
@@ -485,7 +483,7 @@ func TestSetDisabledTags(t *testing.T) {
 
 	_, ok := tags[HTTPStatusCodeTag]
 	_, ok2 := tags[ComponentTag]
-	_, ok3 := tags[SkipperRouteTag]
+	_, ok3 := tags[SkipperRouteIDTag]
 
 	if !ok || !ok2 {
 		t.Errorf("could not set tags although they were not configured to be excluded")


### PR DESCRIPTION
Removes `http.remote_addr` tag that contains request remote IP and port value.
There is still `http.remote_ip` tag that contains remote IP address without port.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>