### PR TITLE
Upgrade keyfunc to latest stable version

### DIFF
--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zalando/skipper/filters"
 	logfilter "github.com/zalando/skipper/filters/log"
 )
@@ -37,7 +38,7 @@ type rejectReason string
 const (
 	missingBearerToken rejectReason = "missing-bearer-token"
 	missingToken       rejectReason = "missing-token"
-	missingJWKs        rejectReason = "missing-jwks"
+	missingJWKS        rejectReason = "missing-jwks"
 	authServiceAccess  rejectReason = "auth-service-access"
 	invalidSub         rejectReason = "invalid-sub-in-token"
 	inactiveToken      rejectReason = "inactive-token"

--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/zalando/skipper/filters"
 	logfilter "github.com/zalando/skipper/filters/log"
 )

--- a/filters/auth/jwt_validation.go
+++ b/filters/auth/jwt_validation.go
@@ -33,8 +33,8 @@ var refreshRateLimit = time.Minute * 5
 var refreshTimeout = time.Second * 10
 var refreshUnknownKID = true
 
-//the map of jwks keyfunctions stored per jwksUri
-var jwksMap map[string]*keyfunc.JWKs = make(map[string]*keyfunc.JWKs)
+// the map of jwks keyfunctions stored per jwksUri
+var jwksMap map[string]*keyfunc.JWKS = make(map[string]*keyfunc.JWKS)
 
 func NewJwtValidationWithOptions(o TokenintrospectionOptions) filters.Spec {
 	return &jwtValidationSpec{
@@ -82,7 +82,7 @@ func hasKeyFunction(url string) bool {
 	return ok
 }
 
-func putKeyFunction(url string, jwks *keyfunc.JWKs) {
+func putKeyFunction(url string, jwks *keyfunc.JWKS) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -98,22 +98,22 @@ func registerKeyFunction(url string) (err error) {
 		RefreshErrorHandler: func(err error) {
 			log.Errorf("There was an error on key refresh for the given URL %s\nError:%s\n", url, err.Error())
 		},
-		RefreshInterval:   &refreshInterval,
-		RefreshRateLimit:  &refreshRateLimit,
-		RefreshTimeout:    &refreshTimeout,
-		RefreshUnknownKID: &refreshUnknownKID,
+		RefreshInterval:   refreshInterval,
+		RefreshRateLimit:  refreshRateLimit,
+		RefreshTimeout:    refreshTimeout,
+		RefreshUnknownKID: refreshUnknownKID,
 	}
 
 	jwks, err := keyfunc.Get(url, options)
 	if err != nil {
-		return fmt.Errorf("failed to get the JWKs from the given URL %s Error:%w", url, err)
+		return fmt.Errorf("failed to get the JWKS from the given URL %s Error:%w", url, err)
 	}
 
 	putKeyFunction(url, jwks)
 	return nil
 }
 
-func getKeyFunction(url string) (jwks *keyfunc.JWKs) {
+func getKeyFunction(url string) (jwks *keyfunc.JWKS) {
 	m.RLock()
 	defer m.RUnlock()
 

--- a/filters/auth/jwt_validation.go
+++ b/filters/auth/jwt_validation.go
@@ -6,9 +6,8 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc"
-	"github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt/v4"
 	log "github.com/sirupsen/logrus"
-
 	"github.com/zalando/skipper/filters"
 )
 

--- a/filters/auth/jwt_validation.go
+++ b/filters/auth/jwt_validation.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc"
-	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v4"
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zalando/skipper/filters"
 )
 
@@ -33,7 +34,7 @@ var refreshRateLimit = time.Minute * 5
 var refreshTimeout = time.Second * 10
 var refreshUnknownKID = true
 
-// the map of jwks keyfunctions stored per jwksUri
+//the map of jwks keyfunctions stored per jwksUri
 var jwksMap map[string]*keyfunc.JWKS = make(map[string]*keyfunc.JWKS)
 
 func NewJwtValidationWithOptions(o TokenintrospectionOptions) filters.Spec {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zalando/skipper
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.0 // indirect
-	github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c
+	github.com/MicahParks/keyfunc v1.0.0
 	github.com/abbot/go-http-auth v0.4.0
 	github.com/aryszka/jobqueue v0.0.2
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zalando/skipper
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.0 // indirect
-	github.com/MicahParks/keyfunc v0.9.0
+	github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c
 	github.com/abbot/go-http-auth v0.4.0
 	github.com/aryszka/jobqueue v0.0.2
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0 h1:6dpdDPTRoo78HxAJ6T1HfMiKSnqhgRRqzCuPshRkQ7I=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
-github.com/MicahParks/keyfunc v0.9.0 h1:ada84OuqzwCQLZ/mssYpzzpaAilaIWP45bXzxXmnRuo=
-github.com/MicahParks/keyfunc v0.9.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
-github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c h1:gj6H15VTjg+xISYdRSprR2MA6b/djCoLm1/W/cl1Ly8=
-github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/MicahParks/keyfunc v1.0.0 h1:O9VAkG6q/LqX4eS+HuIsW9KfC/Luh2NBQr9v4NiwHU0=
 github.com/MicahParks/keyfunc v1.0.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/MicahParks/keyfunc v0.9.0 h1:ada84OuqzwCQLZ/mssYpzzpaAilaIWP45bXzxXmn
 github.com/MicahParks/keyfunc v0.9.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c h1:gj6H15VTjg+xISYdRSprR2MA6b/djCoLm1/W/cl1Ly8=
 github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
+github.com/MicahParks/keyfunc v1.0.0 h1:O9VAkG6q/LqX4eS+HuIsW9KfC/Luh2NBQr9v4NiwHU0=
+github.com/MicahParks/keyfunc v1.0.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.0 h1:6dpdDPTRoo78HxAJ6T1HfMiKSnqhgR
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v0.9.0 h1:ada84OuqzwCQLZ/mssYpzzpaAilaIWP45bXzxXmnRuo=
 github.com/MicahParks/keyfunc v0.9.0/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
+github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c h1:gj6H15VTjg+xISYdRSprR2MA6b/djCoLm1/W/cl1Ly8=
+github.com/MicahParks/keyfunc v0.10.1-0.20211203185044-1ed9d36ab59c/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=


### PR DESCRIPTION
The purpose of this PR is to upgrade the `github.com/MicahParks/keyfunc` dependency from a pre-release to the newly release `v1.0.0`.

Running the tests in the `filters/auth` directory passes. I have _not_ run a project wide `go test -race -cover ./...` as I don't have all the required assets, like etcd. I assume they would pass as the change should be small, but it'd be best to run the full test suite.

Thank you to the maintainers from this project that have contributed to `github.com/MicahParks/keyfunc`!