### PR TITLE
Propagate 403 status code from auth service in webhook filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -903,8 +903,11 @@ is being done to the webhook endpoint. It is possible to copy headers
 from the webhook response into the continuing request by specifying the
 headers to copy as an optional second argument to the filter.
 
-Responses from the webhook with status code less than 300 will be
-authorized, the rest will be unauthorized.
+Responses from the webhook will be treated as follows:
+
+* Authorized if the status code is less than 300
+* Forbidden if the status code is 403
+* Unauthorized for remaining status codes
 
 Examples:
 

--- a/filters/auth/auth_test.go
+++ b/filters/auth/auth_test.go
@@ -5,17 +5,18 @@ import (
 )
 
 const (
-	testToken    = "test-token"
-	testUID      = "jdoe"
-	testScope    = "test-scope"
-	testScope2   = "test-scope2"
-	testScope3   = "test-scope3"
-	testRealmKey = "/realm"
-	testRealm    = "/immortals"
-	testKey      = "uid"
-	testValue    = "jdoe"
-	testAuthPath = "/test-auth"
-	testSub      = "somesub"
+	testToken                    = "test-token"
+	testWebhookInvalidScopeToken = "test-webhook-invalid-scope-token"
+	testUID                      = "jdoe"
+	testScope                    = "test-scope"
+	testScope2                   = "test-scope2"
+	testScope3                   = "test-scope3"
+	testRealmKey                 = "/realm"
+	testRealm                    = "/immortals"
+	testKey                      = "uid"
+	testValue                    = "jdoe"
+	testAuthPath                 = "/test-auth"
+	testSub                      = "somesub"
 )
 
 func Test_all(t *testing.T) {

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -109,6 +109,12 @@ func (f *webhookFilter) Request(ctx filters.FilterContext) {
 		log.Errorf("Failed to make authentication webhook request: %v.", err)
 	}
 
+	// forbidden
+	if err == nil && resp.StatusCode == http.StatusForbidden {
+		forbidden(ctx, "", invalidScope, filters.WebhookName)
+		return
+	}
+
 	// errors, redirects, auth errors, webhook errors
 	if err != nil || resp.StatusCode >= 300 {
 		unauthorized(ctx, "", invalidAccess, f.authClient.url.Hostname(), filters.WebhookName)

--- a/filters/auth/webhook_test.go
+++ b/filters/auth/webhook_test.go
@@ -18,13 +18,12 @@ const headerToCopy = "X-Copy-Header"
 
 func TestWebhook(t *testing.T) {
 	for _, ti := range []struct {
-		msg          string
-		token        string
-		expected     int
-		authorized   bool
-		timeout      bool
-		copyHeaders  bool
-		invalidScope bool
+		msg         string
+		token       string
+		expected    int
+		authorized  bool
+		timeout     bool
+		copyHeaders bool
 	}{{
 		msg:         "invalid-token-should-be-unauthorized",
 		token:       "invalid-token",
@@ -44,11 +43,10 @@ func TestWebhook(t *testing.T) {
 		authorized: false,
 		timeout:    true,
 	}, {
-		msg:          "invalid-scope-should-be-forbidden",
-		token:        testToken,
-		expected:     http.StatusForbidden,
-		authorized:   false,
-		invalidScope: true,
+		msg:        "invalid-scope-should-be-forbidden",
+		token:      testWebhookInvalidScopeToken,
+		expected:   http.StatusForbidden,
+		authorized: false,
 	}} {
 		t.Run(ti.msg, func(t *testing.T) {
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -80,13 +78,12 @@ func TestWebhook(t *testing.T) {
 				tok = tok[len(authHeaderPrefix):]
 				switch tok {
 				case testToken:
-					if ti.invalidScope {
-						w.WriteHeader(http.StatusForbidden)
-						fmt.Fprintln(w, "Forbidden - Got token: "+tok)
-						return
-					}
 					w.WriteHeader(http.StatusOK)
 					fmt.Fprintln(w, "OK - Got token: "+tok)
+					return
+				case testWebhookInvalidScopeToken:
+					w.WriteHeader(http.StatusForbidden)
+					fmt.Fprintln(w, "Forbidden - Got token: "+tok)
 					return
 				}
 				w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
Handle status code 403 from auth service in the `webhook` filter, propagating the 403 status code to the caller.

Fixes #1838 