### PR TITLE
change SECURITY to e-mail to maintainers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,12 @@
 We acknowledge that every line of code that we write may potentially contain security issues.
-We are trying to deal with it responsibly and provide patches as quickly as possible. 
+We are trying to deal with it responsibly and provide patches as quickly as possible.
 
 We host our bug bounty program on HackerOne, it is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this form:
 
 https://corporate.zalando.com/en/services-and-contact#security-form
 
 You can also send you report via this form if your do not want to join our bug bounty program and just want to report a vulnerability or security issue.
+
+In the past there were issues with the process mentioned above. If you
+want to report a security vulnerability and face an issue, please reach
+out to the team of [maintainers](MAINTAINERS) via e-mail.


### PR DESCRIPTION
fix https://github.com/zalando/skipper/issues/1929 , add report via e-mail to maintainers in case there are issues with the reporting to security org

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>