### PR TITLE
Fixes eskip backslash escaping

### DIFF
--- a/eskip/roundtrip_test.go
+++ b/eskip/roundtrip_test.go
@@ -1,0 +1,124 @@
+package eskip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test various strings are parsed to the same value after
+// serialization into eskip double-quoted string
+func TestRoundtripString(t *testing.T) {
+	for i, value := range []string{
+		`s`,
+		` `,
+		`/`,
+		`//`,
+		`\`,
+		`\\`,
+		`\x`,
+		`\\x`,
+		`/x`,
+		`//x`,
+		`"`,
+		`""`,
+		`\/`,
+		`\//`,
+		`/\`,
+		`/\\`,
+		`//\\`,
+		`/\/\`,
+		`\/\/`,
+		`^\/foo(#.*)?$`,
+		`foo\/bar`,
+		"\n",
+		"\\\n",
+		"\\\\\n",
+		"\n\\",
+		"\n\\\\",
+		"\\\n\\",
+		"\"\n",
+		"\\\"\n",
+	} {
+		t.Run(fmt.Sprintf("test#%d", i), func(t *testing.T) {
+			in := &Route{
+				Path: value, // serialized as double-quoted string
+				Filters: []*Filter{{
+					"afilter",
+					[]interface{}{value}, // serialized as double-quoted string
+				}},
+				BackendType: ShuntBackend,
+			}
+			t.Logf("%v, %s", value, in)
+
+			outs, err := Parse(in.String())
+			require.NoError(t, err)
+			require.Len(t, outs, 1)
+
+			out := outs[0]
+			t.Logf("%s", out)
+
+			assert.Equal(t, value, out.Path)
+
+			require.Len(t, out.Filters, 1)
+			require.Len(t, out.Filters[0].Args, 1)
+			assert.Equal(t, value, out.Filters[0].Args[0])
+		})
+	}
+}
+
+// Test various strings are parsed to the same value after
+// serialization into eskip regexp string
+func TestRoundtripRegexp(t *testing.T) {
+	for i, value := range []string{
+		`s`,
+		` `,
+		`/`,
+		`//`,
+		`\`,
+		`\\`,
+		`\x`,
+		`\\x`,
+		`/x`,
+		`//x`,
+		`"`,
+		`""`,
+		`\/`,
+		`\//`,
+		`/\`,
+		`/\\`,
+		`//\\`,
+		`/\/\`,
+		`\/\/`,
+		`^\/foo(#.*)?$`,
+		`foo\/bar`,
+		// eskip regexp does not support \n, \t and similar escape sequences
+		// "\n",
+		`[/]`,
+		`[\[]`,
+		`[\]]`,
+		`[\]`,
+		`["]`,
+		`[\"]`,
+	} {
+		t.Run(fmt.Sprintf("test#%d", i), func(t *testing.T) {
+			in := &Route{
+				PathRegexps: []string{value}, // serialized as eskip regexp
+				BackendType: ShuntBackend,
+			}
+			t.Logf("%v, %s", value, in)
+
+			outs, err := Parse(in.String())
+			require.NoError(t, err)
+			require.Len(t, outs, 1)
+
+			out := outs[0]
+			t.Logf("%s", out)
+
+			require.Len(t, out.PathRegexps, 1)
+			assert.Equal(t, value, out.PathRegexps[0])
+		})
+	}
+}

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -14,6 +14,7 @@ type PrettyPrintInfo struct {
 }
 
 func escape(s string, chars string) string {
+	s = strings.Replace(s, `\`, `\\`, -1) // escape backslash before others
 	s = strings.Replace(s, "\a", `\a`, -1)
 	s = strings.Replace(s, "\b", `\b`, -1)
 	s = strings.Replace(s, "\f", `\f`, -1)


### PR DESCRIPTION
The #1341 removed backslash escaping which leads to incorrect
serialization of strings with a backslash.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>