### PR TITLE
remove logging in makeBackendRequest

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1114,7 +1114,9 @@ func (p *Proxy) do(ctx *context) error {
 		backendStart := time.Now()
 		rsp, perr := p.makeBackendRequest(ctx, backendContext)
 		if perr != nil {
-			p.log.Errorf("Failed to do backend request: %v", perr)
+			if perr.code != 499 { // 499 is logged later with more context
+				p.log.Errorf("Failed to do backend request: %v", perr)
+			}
 			if done != nil {
 				done(false)
 			}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -370,14 +370,6 @@ func (e *proxyError) DialError() bool {
 	return e.dialingFailed
 }
 
-func (e *proxyError) NetError() net.Error {
-	var perr net.Error
-	if ok := errors.As(e, &perr); ok {
-		return perr
-	}
-	return nil
-}
-
 func copyHeader(to, from http.Header) {
 	for k, v := range from {
 		to[http.CanonicalHeaderKey(k)] = v

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -865,7 +865,7 @@ func (p *Proxy) makeUpgradeRequest(ctx *context, req *http.Request) error {
 func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Context) (*http.Response, *proxyError) {
 	req, endpoint, err := mapRequest(ctx, requestContext, p.flags.HopHeadersRemoval())
 	if err != nil {
-		return nil, &proxyError{err: fmt.Errorf("could not map backend request, caused by: %w", err)}
+		return nil, &proxyError{err: fmt.Errorf("could not map backend request: %w", err)}
 	}
 
 	if res, ok := p.rejectBackend(ctx, req); ok {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -950,7 +950,7 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 				status = http.StatusServiceUnavailable
 			}
 			p.tracing.setTag(ctx.proxySpan, HTTPStatusCodeTag, uint16(status))
-			return nil, &proxyError{err: fmt.Errorf("net.Error during backend roundtrip to %s: timeout=%v temporary=%v: %w", ctx.route.Backend, nerr.Timeout(), nerr.Temporary(), err), code: status}
+			return nil, &proxyError{err: fmt.Errorf("net.Error during backend roundtrip to %s: timeout=%v temporary=%v: %w", req.URL.Host, nerr.Timeout(), nerr.Temporary(), err), code: status}
 		}
 
 		return nil, &proxyError{err: fmt.Errorf("unexpected error from Go stdlib net/http package during roundtrip: %w", err)}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -386,7 +386,7 @@ func TestRetryable(t *testing.T) {
 
 			// find the call such that next should be failing
 			for {
-				rsp, _ := http.DefaultClient.Get(tt.req.URL.String())
+				rsp, _ := http.DefaultClient.Post(tt.req.URL.String(), "text/plain charset=utf-8", bytes.NewBufferString("foo"))
 				if rsp.StatusCode == http.StatusOK {
 					break
 				}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -356,11 +356,9 @@ func TestRetryable(t *testing.T) {
 			wantErr: true,
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
-			var err error
 			payload := []byte("backend reply")
 
-			var backend *httptest.Server
-			backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write(payload)
 			}))

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -323,38 +323,89 @@ func TestRetryable(t *testing.T) {
 	}
 	reqWithBody, err := http.NewRequest("GET", "http://www.zalando.de", bytes.NewBufferString("hello"))
 	if err != nil {
-		t.Fatalf("Failed to create request with body: %v", err)
+		t.Fatalf("Failed to create GET request with body: %v", err)
+	}
+	reqWithPost, err := http.NewRequest("POST", "http://www.zalando.de", bytes.NewBufferString("hello"))
+	if err != nil {
+		t.Fatalf("Failed to create POST request with body: %v", err)
 	}
 
 	for _, tt := range []struct {
-		name string
-		req  *http.Request
-		want bool
+		name    string
+		req     *http.Request
+		wantErr bool
 	}{
 		{
-			name: "test nil request",
-			req:  nil,
-			want: false,
+			name:    "test request without body",
+			req:     reqWithoutBody,
+			wantErr: false,
 		},
 		{
-			name: "test request without body",
-			req:  reqWithoutBody,
-			want: true,
+			name:    "test request with no body",
+			req:     reqWithNoBody,
+			wantErr: false,
 		},
 		{
-			name: "test request with no body",
-			req:  reqWithNoBody,
-			want: true,
+			name:    "test request with body",
+			req:     reqWithBody,
+			wantErr: true,
 		},
 		{
-			name: "test request with body",
-			req:  reqWithBody,
-			want: false,
+			name:    "test POST request with body",
+			req:     reqWithPost,
+			wantErr: true,
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := retryable(tt.req)
-			if got != tt.want {
-				t.Errorf("Failed to find retryable, want %v, got %v", tt.want, got)
+			var err error
+			payload := []byte("backend reply")
+
+			var backend *httptest.Server
+			backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write(payload)
+			}))
+			defer backend.Close()
+
+			doc := fmt.Sprintf(`hello: * -> <roundRobin, "%s", "http://127.0.0.5:9">`, backend.URL)
+			tp, err := newTestProxy(doc, FlagsNone)
+			if err != nil {
+				t.Error()
+				return
+			}
+
+			ps := httptest.NewServer(tp.proxy)
+			defer func() {
+				ps.Close()
+				tp.close()
+			}()
+
+			u, err := url.Parse(ps.URL)
+			if err != nil {
+				t.Fatalf("Failed to parse url '%s': %v", ps.URL, err)
+			}
+
+			tt.req.URL.Host = u.Host
+
+			// find the call such that next should be failing
+			for {
+				rsp, _ := http.DefaultClient.Get(tt.req.URL.String())
+				if rsp.StatusCode == http.StatusOK {
+					break
+				}
+			}
+
+			// proxy will do internally the retry if applicable
+			rsp, err := http.DefaultClient.Do(tt.req)
+			switch tt.wantErr {
+			case true:
+				if rsp.StatusCode != http.StatusBadGateway {
+					t.Errorf("Failed to have a failed request: %v && %d != %d)", tt.wantErr, rsp.StatusCode, http.StatusBadGateway)
+
+				}
+			case false:
+				if err != nil || rsp.StatusCode != http.StatusOK {
+					t.Errorf("Failed to have a successful retried request: %v != nil || %d != %d", err, rsp.StatusCode, http.StatusOK)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
remove logging in makeBackendRequest to log it once in one place instead, such that we have no double logging anymore

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>