### PR TITLE
scheduler: ensure single lifo instance per route

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2237,8 +2237,7 @@ lifo(100, 150, "10s")
 The above configuration will set MaxConcurrency to 100, MaxQueueSize
 to 150 and Timeout to 10 seconds.
 
-When multiple lifo filters are set in a route, only one of them will be
-applied. It is undefined which one.
+When there are multiple lifo filters on the route, only the last one will be applied.
 
 ## lifoGroup
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/aryszka/jobqueue"
 	log "github.com/sirupsen/logrus"
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/metrics"
 	"github.com/zalando/skipper/routing"
 )
@@ -220,6 +222,40 @@ func (r *Registry) newQueue(name string, c Config) *Queue {
 	return q
 }
 
+// Returns routing.PreProcessor that ensures single lifo filter instance per route
+//
+// Registry can not implement routing.PreProcessor directly due to unfortunate method name clash with routing.PostProcessor
+func (r *Registry) PreProcessor() routing.PreProcessor {
+	return registryPreProcessor{}
+}
+
+type registryPreProcessor struct{}
+
+func (registryPreProcessor) Do(routes []*eskip.Route) []*eskip.Route {
+	for _, r := range routes {
+		lifoCount := 0
+		for _, f := range r.Filters {
+			if f.Name == filters.LifoName {
+				lifoCount++
+			}
+		}
+		// remove all but last lifo instances
+		if lifoCount > 1 {
+			old := r.Filters
+			r.Filters = make([]*eskip.Filter, 0, len(old)-lifoCount+1)
+			for _, f := range old {
+				if lifoCount > 1 && f.Name == filters.LifoName {
+					log.Debugf("Removing non-last %v from %s", f, r.Id)
+					lifoCount--
+				} else {
+					r.Filters = append(r.Filters, f)
+				}
+			}
+		}
+	}
+	return routes
+}
+
 // Do implements routing.PostProcessor and sets the queue for the scheduler filters.
 //
 // It preserves the existing queue when available.
@@ -250,6 +286,9 @@ func (r *Registry) Do(routes []*routing.Route) []*routing.Route {
 			c := lf.Config()
 			qi, ok := r.queues.Load(key)
 			if ok {
+				// Will not reach here if routes were pre-processed
+				// because key is derived from the unique route id and
+				// pre-processor ensures single lifo filter instance per route
 				q = qi.(*Queue)
 				if q.config != c {
 					q.config = c
@@ -264,7 +303,7 @@ func (r *Registry) Do(routes []*routing.Route) []*routing.Route {
 		}
 
 		if lifoCount > 1 {
-			log.Warnf("Found multiple lifo filters in route: %s", ri.Id)
+			log.Warnf("Found multiple lifo filters on route: %q", ri.Id)
 		}
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -1539,6 +1539,8 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		ro.PreProcessors = append(ro.PreProcessors, o.EditRoute)
 	}
 
+	ro.PreProcessors = append(ro.PreProcessors, schedulerRegistry.PreProcessor())
+
 	if o.EnableOAuth2GrantFlow /* explicitly enable grant flow when callback route was not disabled */ {
 		ro.PreProcessors = append(ro.PreProcessors, oauthConfig.NewGrantPreprocessor())
 	}


### PR DESCRIPTION
Multiple `lifo` filter instances on the route share the same job queue but claim multiple slots per request.
This is not obvious when users configure `lifo` filter in the ingress manifest and another instance is added
by the `-default-filters-prepend` flag.

The change keeps only the last `lifo` filter instance on the route to enable default configuration override.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>