### PR TITLE
optimize struct packing in kubernetes dataclient

### DIFF
--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -46,16 +46,17 @@ const RouteGroupsNotInstalledMessage = `RouteGroups CRD is not installed in the 
 See: https://opensource.zalando.com/skipper/kubernetes/routegroups/#installation`
 
 type clusterClient struct {
-	ingressV1       bool
-	ingressesURI    string
-	routeGroupsURI  string
-	servicesURI     string
-	endpointsURI    string
-	ingressClass    *regexp.Regexp
+	ingressesURI   string
+	routeGroupsURI string
+	servicesURI    string
+	endpointsURI   string
+	tokenProvider  secrets.SecretsProvider
+	apiURL         string
+
 	routeGroupClass *regexp.Regexp
-	tokenProvider   secrets.SecretsProvider
+	ingressClass    *regexp.Regexp
 	httpClient      *http.Client
-	apiURL          string
+	ingressV1       bool
 
 	loggedMissingRouteGroups bool
 }

--- a/dataclients/kubernetes/ingress.go
+++ b/dataclients/kubernetes/ingress.go
@@ -43,15 +43,15 @@ type ingressContext struct {
 }
 
 type ingress struct {
-	ingressV1                bool
-	provideHTTPSRedirect     bool
-	httpsRedirectCode        int
-	pathMode                 PathMode
-	kubernetesEnableEastWest bool
-	kubernetesEastWestDomain string
 	eastWestRangeDomains     []string
 	eastWestRangePredicates  []*eskip.Predicate
 	allowedExternalNames     []*regexp.Regexp
+	kubernetesEastWestDomain string
+	pathMode                 PathMode
+	httpsRedirectCode        int
+	kubernetesEnableEastWest bool
+	ingressV1                bool
+	provideHTTPSRedirect     bool
 }
 
 var nonWord = regexp.MustCompile(`\W`)

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -22,22 +22,22 @@ type routeGroups struct {
 }
 
 type routeGroupContext struct {
-	clusterState          *clusterState
-	defaultFilters        defaultFilters
-	routeGroup            *definitions.RouteGroupItem
 	hosts                 []string
+	allowedExternalNames  []*regexp.Regexp
 	hostRx                string
-	hostRoutes            map[string][]*eskip.Route
-	hasEastWestHost       bool
-	eastWestEnabled       bool
 	eastWestDomain        string
-	provideHTTPSRedirect  bool
+	routeGroup            *definitions.RouteGroupItem
+	hostRoutes            map[string][]*eskip.Route
+	defaultBackendTraffic map[string]*calculatedTraffic
+	defaultFilters        defaultFilters
+	clusterState          *clusterState
 	httpsRedirectCode     int
 	backendsByName        map[string]*definitions.SkipperBackend
-	defaultBackendTraffic map[string]*calculatedTraffic
+	eastWestEnabled       bool
+	hasEastWestHost       bool
 	backendNameTracingTag bool
 	internal              bool
-	allowedExternalNames  []*regexp.Regexp
+	provideHTTPSRedirect  bool
 }
 
 type routeContext struct {


### PR DESCRIPTION
optimize struct packing in kubernetes dataclient

Basically I ran `structslop -apply -v`, but had to reset files which are only loaded once and have a lot of godoc, which seem better to be grouped by name as by type.
 
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>