### PR TITLE
config: show allowed values in listFlag error message

### DIFF
--- a/config/listflag.go
+++ b/config/listflag.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -67,10 +68,21 @@ func (lf *listFlag) validate() error {
 
 	for _, v := range lf.values {
 		if !lf.allowed[v] {
-			return fmt.Errorf("value not allowed: %s", v)
+			return fmt.Errorf("%q is not allowed, must be one of %s", v, lf.allowedHelp())
 		}
 	}
 	return nil
 }
 
-func (lf listFlag) String() string { return lf.value }
+func (lf *listFlag) allowedHelp() string {
+	var values []string
+	for v := range lf.allowed {
+		values = append(values, v)
+	}
+	sort.Strings(values)
+	return strings.Join(values, lf.sep)
+}
+
+func (lf *listFlag) String() string {
+	return lf.value
+}

--- a/config/listflag_test.go
+++ b/config/listflag_test.go
@@ -77,12 +77,15 @@ func TestListFlag(t *testing.T) {
 
 		t.Run("bad", func(t *testing.T) {
 			current := commaListFlag("foo", "bar")
-			if err := current.Set("foo,bar,baz"); err == nil {
-				t.Error("failed to fail")
+
+			err := current.Set("foo,bar,baz")
+			if err == nil || err.Error() != `"baz" is not allowed, must be one of bar,foo` {
+				t.Errorf("unexpected error: %v", err)
 			}
 
-			if err := yaml.Unmarshal([]byte(yamlList), current); err == nil {
-				t.Error("failed to fail")
+			err = yaml.Unmarshal([]byte(yamlList), current)
+			if err == nil || err.Error() != `"baz" is not allowed, must be one of bar,foo` {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	})


### PR DESCRIPTION
before:
```
$ bin/skipper -metrics-flavour=bad 2>&1 | head -n 1
invalid value "bad" for flag -metrics-flavour: value not allowed: bad

$ echo "metrics-flavour: [bad]" > /tmp/config.yaml
$ bin/skipper -config-file=/tmp/config.yaml
FATA[0000] Error processing config: unmarshalling config file error: value not allowed: bad
```

after:
```
$ bin/skipper -metrics-flavour=bad 2>&1 | head -n 1
invalid value "bad" for flag -metrics-flavour: "bad" is not allowed, must be one of codahale,prometheus

$ bin/skipper -config-file=/tmp/config.yaml
FATA[0000] Error processing config: unmarshalling config file error: "bad" is not allowed, must be one of codahale,prometheus
```

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>