### PR TITLE
resolve Aggregated and Distributed Claims

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,6 +192,7 @@ type Config struct {
 	Oauth2TokenCookieName           string        `yaml:"oauth2-token-cookie-name"`
 	WebhookTimeout                  time.Duration `yaml:"webhook-timeout"`
 	OidcSecretsFile                 string        `yaml:"oidc-secrets-file"`
+	OidcDistributedClaimsTimeout    time.Duration `yaml:"oidc-distributed-claims-timeout"`
 	CredentialPaths                 *listFlag     `yaml:"credentials-paths"`
 	CredentialsUpdateInterval       time.Duration `yaml:"credentials-update-interval"`
 
@@ -447,6 +448,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.Oauth2TokenCookieName, "oauth2-token-cookie-name", "oauth2-grant", "sets the name of the cookie where the encrypted token is stored")
 	flag.DurationVar(&cfg.WebhookTimeout, "webhook-timeout", 2*time.Second, "sets the webhook request timeout duration")
 	flag.StringVar(&cfg.OidcSecretsFile, "oidc-secrets-file", "", "file storing the encryption key of the OID Connect token")
+	flag.DurationVar(&cfg.OidcDistributedClaimsTimeout, "oidc-distributed-claims-timeout", 2*time.Second, "sets the default OIDC distributed claims request timeout duration to 2000ms")
 	flag.Var(cfg.CredentialPaths, "credentials-paths", "directories or files to watch for credentials to use by bearerinjector filter")
 	flag.DurationVar(&cfg.CredentialsUpdateInterval, "credentials-update-interval", 10*time.Minute, "sets the interval to update secrets")
 
@@ -800,6 +802,7 @@ func (c *Config) ToOptions() skipper.Options {
 		OAuth2TokenCookieName:          c.Oauth2TokenCookieName,
 		WebhookTimeout:                 c.WebhookTimeout,
 		OIDCSecretsFile:                c.OidcSecretsFile,
+		OIDCDistributedClaimsTimeout:   c.OidcDistributedClaimsTimeout,
 		CredentialsPaths:               c.CredentialPaths.values,
 		CredentialsUpdateInterval:      c.CredentialsUpdateInterval,
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -126,6 +126,7 @@ func Test_NewConfig(t *testing.T) {
 				Oauth2TokeninfoSubjectKey:               "uid",
 				Oauth2TokenCookieName:                   "oauth2-grant",
 				WebhookTimeout:                          2 * time.Second,
+				OidcDistributedClaimsTimeout:            2 * time.Second,
 				CredentialPaths:                         commaListFlag(),
 				CredentialsUpdateInterval:               10 * time.Minute,
 				ApiUsageMonitoringClientKeys:            "sub",

--- a/filters/auth/oidc_introspection_test.go
+++ b/filters/auth/oidc_introspection_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
@@ -289,7 +290,7 @@ func TestOIDCQueryClaimsFilter(t *testing.T) {
 				t.Errorf("Failed to parse url %s: %v", proxy.URL, err)
 			}
 			reqURL.Path = tc.path
-			oidcServer := createOIDCServer(proxy.URL+"/redirect", validClient, "mysec")
+			oidcServer := createOIDCServer(proxy.URL+"/redirect", validClient, "mysec", jwt.MapClaims{"groups": []string{"CD-Administrators", "Purchasing-Department", "AppX-Test-Users", "white space"}})
 			defer oidcServer.Close()
 			t.Logf("oidc/auth server URL: %s", oidcServer.URL)
 			// create filter

--- a/skipper.go
+++ b/skipper.go
@@ -748,6 +748,9 @@ type Options struct {
 	// OIDCSecretsFile path to the file containing key to encrypt OpenID token
 	OIDCSecretsFile string
 
+	// OIDCDistributedClaimsTimeout sets timeout duration while calling Distributed Claims endpoint.
+	OIDCDistributedClaimsTimeout time.Duration
+
 	// SecretsRegistry to store and load secretsencrypt
 	SecretsRegistry *secrets.Registry
 
@@ -1323,6 +1326,12 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		Tracer:       tracer,
 	}
 
+	oo := auth.OidcOptions{
+		Timeout:      o.OIDCDistributedClaimsTimeout,
+		MaxIdleConns: o.IdleConnectionsPerHost,
+		Tracer:       tracer,
+	}
+
 	who := auth.WebhookOptions{
 		Timeout:      o.WebhookTimeout,
 		MaxIdleConns: o.IdleConnectionsPerHost,
@@ -1342,9 +1351,9 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		auth.TokenintrospectionWithOptions(auth.NewSecureOAuthTokenintrospectionAnyKV, tio),
 		auth.TokenintrospectionWithOptions(auth.NewSecureOAuthTokenintrospectionAllKV, tio),
 		auth.WebhookWithOptions(who),
-		auth.NewOAuthOidcUserInfos(o.OIDCSecretsFile, o.SecretsRegistry),
-		auth.NewOAuthOidcAnyClaims(o.OIDCSecretsFile, o.SecretsRegistry),
-		auth.NewOAuthOidcAllClaims(o.OIDCSecretsFile, o.SecretsRegistry),
+		auth.NewOAuthOidcUserInfosWithOptions(o.OIDCSecretsFile, o.SecretsRegistry, oo),
+		auth.NewOAuthOidcAnyClaimsWithOptions(o.OIDCSecretsFile, o.SecretsRegistry, oo),
+		auth.NewOAuthOidcAllClaimsWithOptions(o.OIDCSecretsFile, o.SecretsRegistry, oo),
 		auth.NewOIDCQueryClaimsFilter(),
 		apiusagemonitoring.NewApiUsageMonitoring(
 			o.ApiUsageMonitoringEnable,


### PR DESCRIPTION
fixes: #1955

This solution is scoped to Azure behaviour, taking into account the specs from
https://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims

There are some Azure related API calls included but trying to support other providers, which is though unknown at this time.

it transforms a distributed claim

```json
{
    "_claim_names": {
        "groups": "src1"
    },
    "_claim_sources": {
        "src1": {
            "endpoint": "https://graph.windows.net/.../getMemberObjects"
        }
    }
}
```

into a full populated token, which is saved in `statebag` and in the `cookie` for follow up processing

```json
{
    "_claim_names": {
        "groups": "src1"
    },
    "_claim_sources": {
        "src1": {
            "endpoint": "https://graph.windows.net/.../getMemberObjects"
        }
    },
    "groups": [
        "group1",
        "group2",
        ...
    ]
}
```