### PR TITLE
filters/scheduler: wait for spans finishing in lifo errors test

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -409,6 +409,12 @@ func (r *Registry) updateMetrics() {
 	}
 }
 
+func (r *Registry) UpdateMetrics() {
+	if r.options.Metrics != nil {
+		r.updateMetrics()
+	}
+}
+
 // Close closes the registry, including graceful tearing down the stored queues.
 func (r *Registry) Close() {
 	r.mu.Lock()


### PR DESCRIPTION
The tests was introduced by #1944
It may happen that not all spans are finished by the time test verifies response results (because spans are closed after response has been served).
This change waits for all mock spans to finish and forces scheduler metrics update.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>