### PR TITLE
clear invalid cookies

### DIFF
--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -327,7 +327,7 @@ func (f *tokenOidcFilter) internalServerError(ctx filters.FilterContext) {
 // https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps
 // 1. Client prepares an Authentication Request containing the desired request parameters.
 // 2. Client sends the request to the Authorization Server.
-func (f *tokenOidcFilter) doOauthRedirect(ctx filters.FilterContext) {
+func (f *tokenOidcFilter) doOauthRedirect(ctx filters.FilterContext, cookies ...*http.Cookie) {
 	nonce, err := f.encrypter.CreateNonce()
 	if err != nil {
 		log.Errorf("Failed to create nonce: %v.", err)
@@ -368,6 +368,9 @@ func (f *tokenOidcFilter) doOauthRedirect(ctx filters.FilterContext) {
 		StatusCode: http.StatusTemporaryRedirect,
 		Status:     "Moved Temporarily",
 	}
+	for _, cookie := range cookies {
+		rsp.Header.Add("Set-Cookie", cookie.String())
+	}
 	log.Debugf("serve redirect: plaintextState:%s to Location: %s", statePlain, rsp.Header.Get("Location"))
 	ctx.Serve(rsp)
 }
@@ -401,12 +404,28 @@ func getHost(request *http.Request) string {
 	}
 }
 
-func chunkCookie(cookie http.Cookie) (cookies []http.Cookie) {
+func createOidcCookie(name string, value string, maxAge int, domain string) (cookie *http.Cookie) {
+	return &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+		MaxAge:   maxAge,
+		Domain:   domain,
+	}
+}
+
+func deleteOidcCookie(name string, domain string) (cookie *http.Cookie) {
+	return createOidcCookie(name, "", -1, domain)
+}
+
+func chunkCookie(cookie http.Cookie) (cookies []*http.Cookie) {
 	for index := 'a'; index <= 'z'; index++ {
 		cookieSize := len(cookie.String())
 		if cookieSize < cookieMaxSize {
 			cookie.Name += string(index)
-			return append(cookies, cookie)
+			return append(cookies, &cookie)
 		}
 
 		newCookie := cookie
@@ -414,17 +433,17 @@ func chunkCookie(cookie http.Cookie) (cookies []http.Cookie) {
 		// non-deterministic approach support signature changes
 		cut := len(cookie.Value) - (cookieSize - cookieMaxSize) - 1
 		newCookie.Value, cookie.Value = cookie.Value[:cut], cookie.Value[cut:]
-		cookies = append(cookies, newCookie)
+		cookies = append(cookies, &newCookie)
 	}
 	log.Error("unsupported amount of chunked cookies")
 	return
 }
 
-func mergerCookies(cookies []http.Cookie) (cookie http.Cookie) {
+func mergerCookies(cookies []*http.Cookie) (cookie http.Cookie) {
 	if len(cookies) == 0 {
 		return
 	}
-	cookie = cookies[0]
+	cookie = *(cookies[0])
 	cookie.Name = cookie.Name[:len(cookie.Name)-1]
 	cookie.Value = ""
 	// potentially shuffeled
@@ -445,16 +464,12 @@ func (f *tokenOidcFilter) doDownstreamRedirect(ctx filters.FilterContext, oidcSt
 			"Location": {redirectUrl},
 		},
 	}
-
-	oidcCookies := chunkCookie(http.Cookie{
-		Name:     f.cookiename,
-		Value:    base64.StdEncoding.EncodeToString(oidcState),
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: true,
-		MaxAge:   int(maxAge.Seconds()),
-		Domain:   extractDomainFromHost(getHost(ctx.Request()), f.subdomainsToRemove),
-	})
+	oidcCookies := chunkCookie(*createOidcCookie(
+		f.cookiename,
+		base64.StdEncoding.EncodeToString(oidcState),
+		int(maxAge.Seconds()),
+		extractDomainFromHost(getHost(ctx.Request()),
+			f.subdomainsToRemove)))
 	for _, cookie := range oidcCookies {
 		r.Header.Add("Set-Cookie", cookie.String())
 	}
@@ -676,14 +691,14 @@ func (f *tokenOidcFilter) getMaxAge(claimsMap map[string]interface{}) time.Durat
 func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
 	var (
 		allowed   bool
-		cookies   []http.Cookie
+		cookies   []*http.Cookie
 		container tokenContainer
 	)
 	r := ctx.Request()
 
 	for _, cookie := range r.Cookies() {
 		if strings.HasPrefix(cookie.Name, f.cookiename) {
-			cookies = append(cookies, *cookie)
+			cookies = append(cookies, cookie)
 		}
 	}
 	sessionCookie := mergerCookies(cookies)
@@ -698,7 +713,12 @@ func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
 			return
 		}
 		// 1. Client prepares an Authentication Request containing the desired request parameters.
-		f.doOauthRedirect(ctx)
+		// clear existing, invalid cookies
+		var purgeCookies = make([]*http.Cookie, len(cookies))
+		for i, c := range cookies {
+			purgeCookies[i] = deleteOidcCookie(c.Name, extractDomainFromHost(ctx.Request().Host, 1))
+		}
+		f.doOauthRedirect(ctx, purgeCookies...)
 		return
 	}
 

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -633,6 +633,7 @@ func TestOIDCSetup(t *testing.T) {
 		expectRequest      string
 		expectNoCookies    bool
 		expectCookieDomain string
+		filterCookies      []string
 	}{{
 		msg:             "wrong provider",
 		filter:          `oauthOidcAnyClaims("no url", "", "", "{{ .RedirectURL }}", "", "")`,
@@ -729,6 +730,13 @@ func TestOIDCSetup(t *testing.T) {
 		filter:             `oauthOidcAnyClaims("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid email", "", "", "", "3")`,
 		expected:           200,
 		expectCookieDomain: "bar.foo.skipper.test",
+	}, {
+		msg:                "remove unverified cookies",
+		hostname:           "bar.foo.skipper.test",
+		filter:             `oauthOidcAnyClaims("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid email", "", "", "", "3")`,
+		expected:           200,
+		expectCookieDomain: "bar.foo.skipper.test",
+		filterCookies:      []string{"badheader", "malformed"},
 	}} {
 		t.Run(tc.msg, func(t *testing.T) {
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -805,6 +813,10 @@ func TestOIDCSetup(t *testing.T) {
 			}
 			req.Header.Set(authHeaderName, authHeaderPrefix+testToken)
 
+			for _, v := range tc.filterCookies {
+				req.Header.Set("Set-Cookie", v)
+			}
+
 			// client with cookie handling to support 127.0.0.1 with ports
 			client := http.Client{
 				Timeout: 1 * time.Second,
@@ -842,6 +854,12 @@ func TestOIDCSetup(t *testing.T) {
 					left, right := tokenExp-time.Minute, tokenExp
 					maxAge := time.Duration(c.MaxAge) * time.Second
 					assert.True(t, left <= maxAge && maxAge <= right, "maxAge has to be within [%v, %v]", left, right)
+
+					for _, v := range tc.filterCookies {
+						if v == c.Name {
+							assert.True(t, c.Value == "")
+						}
+					}
 				}
 			}
 		})

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -921,7 +921,7 @@ func TestChunkAndMergerCookie(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("test:%v", ht.name), func(t *testing.T) {
 			assert := assert.New(t)
-			got := chunkCookie(ht.given)
+			got := chunkCookie(&ht.given)
 			assert.NotNil(t, got, "it should not be empty")
 			// shuffle the order of response cookies
 			rand.Shuffle(len(got), func(i, j int) {
@@ -930,7 +930,7 @@ func TestChunkAndMergerCookie(t *testing.T) {
 			assert.Len(got, ht.num, "should result in a different number of chunks")
 			mergedCookie := mergerCookies(got)
 			assert.NotNil(mergedCookie, "should receive a valid cookie")
-			assert.Equal(ht.given, mergedCookie, "after chunking and remerging the content must be equal")
+			assert.Equal(ht.given, *mergedCookie, "after chunking and remerging the content must be equal")
 			// verify no cookie exceeds limits
 			for _, ck := range got {
 				assert.True(func() bool {


### PR DESCRIPTION
If OIDC cookies are invalid, the client is redirected but the cookies are not cleared.

In case that the new cookie will produce smaller set of chunks, an invalid chunk is not overwritten and kept in the browser and Skipper will try to attach this junk to the new set.

This changes the behaviour in that regard that it clears relevant cookies in case of a new auth session.
