### PR TITLE
fix: oidc*Claims filter paniced if no claims were used as input argument

### DIFF
--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -129,7 +129,7 @@ func (s *tokenOidcSpec) CreateFilter(args []interface{}) (filters.Filter, error)
 	if err != nil {
 		return nil, err
 	}
-	if len(sargs) < paramClaims {
+	if len(sargs) <= paramClaims {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -592,6 +592,17 @@ func TestCreateFilterOIDC(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "missing claims result in error",
+			args: []interface{}{
+				oidcServer.URL, // provider/issuer
+				"cliendId",
+				"clientSecret",
+				oidcServer.URL + "/redirect", // redirect URL
+				"email name",
+			},
+			wantErr: true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := &tokenOidcSpec{


### PR DESCRIPTION
fix https://github.com/zalando/skipper/issues/1968
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>