### PR TITLE
filters/auth: do not close shared auth clients

### DIFF
--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -97,7 +97,7 @@ index 10d5769..da46fe0 100644
 
 Documentation for users should be done in `docs/`.
 
-```
+````
 diff --git a/docs/filters.md b/docs/filters.md
 index d3bb872..a877062 100644
 --- a/docs/filters.md
@@ -127,7 +127,7 @@ index d3bb872..a877062 100644
  ## oauthTokeninfoAnyScope
 
  If skipper is started with `-oauth2-tokeninfo-url` flag, you can use
-```
+````
 
 ### Add godoc
 
@@ -170,8 +170,6 @@ process. A spec has to satisfy the `Spec` interface `Name() string` and
 
 The actual filter implementation has to satisfy the `Filter`
 interface `Request(filters.FilterContext)` and `Response(filters.FilterContext)`.
-If you need to clean up for example a goroutine you can do it in
-`Close()`, which will be called on filter shutdown.
 
 ```
 diff --git a/filters/auth/webhook.go b/filters/auth/webhook.go
@@ -254,16 +252,6 @@ index 0000000..f0632a6
 +}
 +
 +func (*webhookFilter) Response(filters.FilterContext) {}
-+
-+// Close cleans-up the quit channel used for this filter
-+func (f *webhookFilter) Close() {
-+	f.authClient.mu.Lock()
-+	if f.authClient.quit != nil {
-+		close(f.authClient.quit)
-+		f.authClient.quit = nil
-+	}
-+	f.authClient.mu.Unlock()
-+}
 ```
 
 ### Writing tests

--- a/docs/tutorials/development.md
+++ b/docs/tutorials/development.md
@@ -70,8 +70,6 @@ process. A spec has to satisfy the `filters.Spec` interface `Name() string` and
 
 The actual filter implementation has to satisfy the `filter.Filter`
 interface `Request(filters.FilterContext)` and `Response(filters.FilterContext)`.
-If you need to clean up for example a goroutine you can do it in
-`Close()`, which will be called on filter shutdown.
 
 The simplest filter possible is, if `filters.Spec` and
 `filters.Filter` are the same type:

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -860,11 +860,6 @@ func (f *tokenOidcFilter) getTokenWithExchange(state *OauthState, ctx filters.Fi
 	return oauth2Token, err
 }
 
-func (f *tokenOidcFilter) Close() error {
-	f.encrypter.Close()
-	return nil
-}
-
 func newDeflatePoolCompressor(level int) *deflatePoolCompressor {
 	return &deflatePoolCompressor{
 		poolWriter: &sync.Pool{

--- a/filters/auth/oidc_introspection_test.go
+++ b/filters/auth/oidc_introspection_test.go
@@ -310,8 +310,6 @@ func TestOIDCQueryClaimsFilter(t *testing.T) {
 			} else if err != nil {
 				t.Fatalf("Unexpected error while creating filter: %v", err)
 			}
-			fOIDC := f.(*tokenOidcFilter)
-			defer fOIDC.Close()
 
 			// adding the OIDCQueryClaimsFilter to the route
 			querySpec := NewOIDCQueryClaimsFilter()

--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -362,8 +362,3 @@ func (f *tokeninfoFilter) Request(ctx filters.FilterContext) {
 }
 
 func (f *tokeninfoFilter) Response(filters.FilterContext) {}
-
-// Close cleans-up the authClient
-func (f *tokeninfoFilter) Close() {
-	f.authClient.Close()
-}

--- a/filters/auth/tokeninfo_test.go
+++ b/filters/auth/tokeninfo_test.go
@@ -223,13 +223,11 @@ func TestOAuth2Tokeninfo(t *testing.T) {
 			}
 
 			args = append(args, ti.args...)
-			f, err := spec.CreateFilter(args)
+			_, err := spec.CreateFilter(args)
 			if err != nil {
-				t.Logf("error in creating filter")
+				t.Logf("error creating filter")
 				return
 			}
-			f2 := f.(*tokeninfoFilter)
-			defer f2.Close()
 
 			fr := make(filters.Registry)
 			fr.Register(spec)
@@ -324,13 +322,11 @@ func TestOAuth2TokenTimeout(t *testing.T) {
 			spec := NewOAuthTokeninfoAnyScope(u, ti.timeout)
 
 			scopes := []interface{}{"read-x"}
-			f, err := spec.CreateFilter(scopes)
+			_, err := spec.CreateFilter(scopes)
 			if err != nil {
 				t.Error(err)
 				return
 			}
-			f2 := f.(*tokeninfoFilter)
-			defer f2.Close()
 
 			fr := make(filters.Registry)
 			fr.Register(spec)
@@ -370,21 +366,14 @@ func TestOAuth2TokenTimeout(t *testing.T) {
 }
 
 func BenchmarkOAuthTokeninfoFilter(b *testing.B) {
-	allF := make([]*tokeninfoFilter, 0)
 	for i := 0; i < b.N; i++ {
 		var spec filters.Spec
 		args := []interface{}{"uid"}
 		spec = NewOAuthTokeninfoAnyScope("https://127.0.0.1:12345/token", 3*time.Second)
-		f, err := spec.CreateFilter(args)
+		_, err := spec.CreateFilter(args)
 		if err != nil {
-			b.Logf("error in creating filter")
+			b.Logf("error creating filter")
 			break
 		}
-		f2 := f.(*tokeninfoFilter)
-		allF = append(allF, f2)
-	}
-
-	for i := range allF {
-		allF[i].Close()
 	}
 }

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -482,8 +482,3 @@ func (f *tokenintrospectFilter) Request(ctx filters.FilterContext) {
 }
 
 func (f *tokenintrospectFilter) Response(filters.FilterContext) {}
-
-// Close cleans-up the authClient
-func (f *tokenintrospectFilter) Close() {
-	f.authClient.Close()
-}

--- a/filters/auth/tokenintrospection_test.go
+++ b/filters/auth/tokenintrospection_test.go
@@ -556,17 +556,14 @@ func TestOAuth2Tokenintrospection(t *testing.T) {
 
 			args := []interface{}{testOidcConfig.Issuer}
 			args = append(args, ti.args...)
-			f, err := spec.CreateFilter(args)
+			_, err := spec.CreateFilter(args)
 			if err != nil {
 				if ti.expected == invalidFilterExpected {
 					return
 				}
-				t.Errorf("error in creating filter for %s: %v", ti.msg, err)
+				t.Errorf("error creating filter for %s: %v", ti.msg, err)
 				return
 			}
-
-			f2 := f.(*tokenintrospectFilter)
-			defer f2.Close()
 
 			fr := make(filters.Registry)
 			fr.Register(spec)

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -34,6 +34,8 @@ type (
 	}
 )
 
+var webhookAuthClient map[string]*authClient = make(map[string]*authClient)
+
 // NewWebhook creates a new auth filter specification
 // to validate authorization for requests via an
 // external web hook.
@@ -103,8 +105,6 @@ func (ws *webhookSpec) CreateFilter(args []interface{}) (filters.Filter, error) 
 	return &webhookFilter{authClient: ac, forwardResponseHeaderKeys: forwardResponseHeaderKeys}, nil
 }
 
-var webhookAuthClient map[string]*authClient = make(map[string]*authClient)
-
 func copyHeader(to, from http.Header) {
 	for k, v := range from {
 		to[http.CanonicalHeaderKey(k)] = v
@@ -140,8 +140,3 @@ func (f *webhookFilter) Request(ctx filters.FilterContext) {
 }
 
 func (*webhookFilter) Response(filters.FilterContext) {}
-
-// Close cleans-up the authClient
-func (f *webhookFilter) Close() {
-	f.authClient.Close()
-}

--- a/filters/auth/webhook_test.go
+++ b/filters/auth/webhook_test.go
@@ -101,14 +101,11 @@ func TestWebhook(t *testing.T) {
 				args = append(args, headerToCopy)
 			}
 
-			f, err := spec.CreateFilter(args)
+			_, err := spec.CreateFilter(args)
 			if err != nil {
-				t.Errorf("error in creating filter for %s: %v", ti.msg, err)
+				t.Errorf("error creating filter for %s: %v", ti.msg, err)
 				return
 			}
-
-			f2 := f.(*webhookFilter)
-			defer f2.Close()
 
 			fr := make(filters.Registry)
 			fr.Register(spec)


### PR DESCRIPTION
* removes auth filters `Close` methods: they are never called due to #202 and
  it makes no sense to close shared auth clients anyway
* removes mention of `Close` from the developement docs

Updates #202

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>