### PR TITLE
Pins go version to 1.17

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,7 +3,7 @@ pipeline:
 - id: build
   vm_config:
     type: linux
-    image: "cdp-runtime/go"
+    image: "cdp-runtime/go-1.17"
   type: script
   commands:
   - desc: build-push


### PR DESCRIPTION
Pins go version until tooling (e.g. `staticcheck` https://twitter.com/dominikhonnef/status/1503793590991994882) is ready to support 1.18

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>