### PR TITLE
metrics: add MeasureSince benchmark

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zalando/skipper/metrics"
 )
@@ -205,5 +206,23 @@ func TestHandlerCodaHaleUnknownMetricRequest(t *testing.T) {
 	mh.ServeHTTP(rw, r)
 	if rw.Code != http.StatusNotFound {
 		t.Error("Request for unknown metrics should return a Not Found status")
+	}
+}
+
+func BenchmarkMeasureSincePrometheus(b *testing.B) {
+	m := metrics.NewMetrics(metrics.Options{Format: metrics.PrometheusKind})
+	benchmarkMeasureSince(b, m)
+}
+
+func BenchmarkMeasureSinceCodaHale(b *testing.B) {
+	m := metrics.NewMetrics(metrics.Options{Format: metrics.CodaHaleKind})
+	benchmarkMeasureSince(b, m)
+}
+
+func benchmarkMeasureSince(b *testing.B, m metrics.Metrics) {
+	start := time.Now()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.MeasureSince("a.metrics.key", start)
 	}
 }


### PR DESCRIPTION
```
$ go test -count=10 github.com/zalando/skipper/metrics -run NONE -bench BenchmarkMeasureSince -benchmem
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/metrics
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
BenchmarkMeasureSincePrometheus-8        7068398               165.5 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        7408232               164.5 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        7264077               161.6 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        6803798               161.9 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        7437289               161.7 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        7436797               161.7 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        7433630               176.8 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        7126840               181.1 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        6839091               167.8 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSincePrometheus-8        7372002               169.5 ns/op            16 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          1898020               641.2 ns/op           110 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          2415656               627.5 ns/op            95 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          2226484               521.4 ns/op            90 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          2283265               512.2 ns/op            75 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          2348788               718.6 ns/op            72 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          2129406               528.8 ns/op            66 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          1936142               590.2 ns/op            66 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          1969534               602.1 ns/op            65 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          1956208               606.3 ns/op            64 B/op          1 allocs/op
BenchmarkMeasureSinceCodaHale-8          1965328               601.4 ns/op            64 B/op          1 allocs/op
```

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>