### PR TITLE
Build with Go 1.18

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.17'
+          go-version: '^1.18'
       - run: go version
       - run: make deps
       - run: make check-fmt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.17'
+          go-version: '^1.18'
       - run: go version
       - run: make deps
       - run: make check-race
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.17'
+          go-version: '^1.18'
       - run: go version
       - run: make deps
       - run: make check-fmt

--- a/Makefile
+++ b/Makefile
@@ -120,16 +120,8 @@ deps:
 	go env
 	./etcd/install.sh $(TEST_ETCD_VERSION)
 	mkdir -p .bin
-	@curl -o /tmp/staticcheck_linux_amd64.tar.gz -LO https://github.com/dominikh/go-tools/releases/download/2021.1.2/staticcheck_linux_amd64.tar.gz
-	@sha256sum /tmp/staticcheck_linux_amd64.tar.gz | grep -q edf3b59dea0eb0e55ebe4cb3c47fdd05e25f9365771eb073a78cf66b8f093d9e
-	@tar -C /tmp -xzf /tmp/staticcheck_linux_amd64.tar.gz
-	@mv /tmp/staticcheck/staticcheck .bin
-	@chmod +x .bin/staticcheck
-	@curl -o /tmp/gosec.tgz -LO https://github.com/securego/gosec/releases/download/v2.9.5/gosec_2.9.5_linux_amd64.tar.gz
-	@sha256sum /tmp/gosec.tgz | grep -q 524330ccda004a9af0ef1b78b712df02144a307a15b57a6528f12762f73c8d8e
-	@tar -C /tmp -xzf /tmp/gosec.tgz
-	@mv /tmp/gosec .bin
-	@chmod +x .bin/gosec
+	@go install honnef.co/go/tools/cmd/staticcheck@latest
+	@go install github.com/securego/gosec/v2/cmd/gosec@latest
 
 vet: $(SOURCES)
 	GO111MODULE=$(GO111) go vet $(PACKAGES)
@@ -142,7 +134,7 @@ vet: $(SOURCES)
 # -ST1021 too many wrong comments on exported functions to fix right away
 # -ST1022 too many wrong comments on exported functions to fix right away
 staticcheck: $(SOURCES)
-	GO111MODULE=$(GO111) .bin/staticcheck -checks "all,-ST1000,-ST1003,-ST1012,-ST1020,-ST1021" $(PACKAGES)
+	GO111MODULE=$(GO111) staticcheck -checks "all,-ST1000,-ST1003,-ST1012,-ST1020,-ST1021" $(PACKAGES)
 
 # TODO(sszuecs) review disabling these checks, f.e.:
 # G101 find by variable name match "oauth" are not hardcoded credentials
@@ -150,7 +142,7 @@ staticcheck: $(SOURCES)
 # G304 reading kubernetes secret filepaths are not a file inclusions
 # G402 See https://github.com/securego/gosec/issues/551 and https://github.com/securego/gosec/issues/528
 gosec: $(SOURCES)
-	GO111MODULE=$(GO111) .bin/gosec -quiet -exclude="G101,G104,G304,G402" ./...
+	GO111MODULE=$(GO111) gosec -quiet -exclude="G101,G104,G304,G402" ./...
 
 fmt: $(SOURCES)
 	@gofmt -w -s $(SOURCES)

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,7 +3,7 @@ pipeline:
 - id: build
   vm_config:
     type: linux
-    image: "cdp-runtime/go-1.17"
+    image: "cdp-runtime/go"
   type: script
   commands:
   - desc: build-push

--- a/innkeeper/client.go
+++ b/innkeeper/client.go
@@ -196,7 +196,6 @@ func (c *Client) authenticate() error {
 
 // Checks if an http response status indicates an error, and returns an error
 // object if it does.
-//lint:ignore ST1008 inkeeper is deprecated and will be deleted
 func getHttpError(r *http.Response) (error, bool) {
 	switch {
 	case r.StatusCode < http.StatusBadRequest:

--- a/loadbalancer/healthchecker.go
+++ b/loadbalancer/healthchecker.go
@@ -214,6 +214,7 @@ func doActiveHealthCheck(rt http.RoundTripper, backend string) state {
 	resp, err := rt.RoundTrip(req)
 	if err != nil {
 		perr, ok := err.(net.Error)
+		//lint:ignore SA1019 Temporary is deprecated in Go 1.18, but keep it for now (https://github.com/zalando/skipper/issues/1992)
 		if ok && !perr.Temporary() {
 			log.Infof("Backend %v connection refused -> mark as dead", backend)
 			return dead

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -952,6 +952,7 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 				status = http.StatusServiceUnavailable
 			}
 			p.tracing.setTag(ctx.proxySpan, HTTPStatusCodeTag, uint16(status))
+			//lint:ignore SA1019 Temporary is deprecated in Go 1.18, but keep it for now (https://github.com/zalando/skipper/issues/1992)
 			return nil, &proxyError{err: fmt.Errorf("net.Error during backend roundtrip to %s: timeout=%v temporary='%v': %w", req.URL.Host, nerr.Timeout(), nerr.Temporary(), err), code: status}
 		}
 

--- a/queuelistener/listener.go
+++ b/queuelistener/listener.go
@@ -230,6 +230,7 @@ func (l *listener) listenExternal() {
 		c, err = l.externalListener.Accept()
 		if err != nil {
 			// based on net/http.Server.Serve():
+			//lint:ignore SA1019 Temporary is deprecated in Go 1.18, but keep it for now (https://github.com/zalando/skipper/issues/1992)
 			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
 				delay = bounce(delay)
 				l.options.Log.Errorf(


### PR DESCRIPTION
`staticcheck` has been updated to work with Go 1.18 so attempt to update the version used for building.