### PR TITLE
deprecate ingress v1beta1 

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -88,7 +88,7 @@ type Options struct {
 	// in the cluster-scope.
 	KubernetesNamespace string
 
-	// KubernetesIngressV1 is used to switch between v1beta1 and v1. Kubernetes version 1.22 stopped support
+	// *DEPRECATED* KubernetesIngressV1 is used to switch between v1beta1 and v1. Kubernetes version 1.22 stopped support
 	// for v1beta1, so we have to provide a migration path and this will someday become the default.
 	KubernetesIngressV1 bool
 
@@ -201,6 +201,9 @@ type Client struct {
 
 // New creates and initializes a Kubernetes DataClient.
 func New(o Options) (*Client, error) {
+	if !o.KubernetesIngressV1 {
+		log.Warning("You are using a deprecated version of ingress. Skipper will remove support in the next couple of weeks. Kubernetes version 1.18 deprecated v1beta1 and 1.22 stopped support v1beta1. We will increase skipper's minor version to highlight the deletion. For more details please check https://opensource.zalando.com/skipper/kubernetes/ingress-controller/#upgrades")
+	}
 	if o.OriginMarker {
 		log.Warning("OriginMarker is deprecated")
 	}

--- a/docs/kubernetes/deploy/daemonset/rbac.yaml
+++ b/docs/kubernetes/deploy/daemonset/rbac.yaml
@@ -37,11 +37,18 @@ metadata:
   name: skipper-ingress
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: skipper-ingress
 rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
 - apiGroups:
     - extensions
   resources:
@@ -66,7 +73,7 @@ rules:
   - get
   - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: skipper-ingress
@@ -79,7 +86,7 @@ subjects:
   name: skipper-ingress
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: skipper-ingress-hostnetwork-psp

--- a/docs/kubernetes/deploy/deployment/rbac.yaml
+++ b/docs/kubernetes/deploy/deployment/rbac.yaml
@@ -37,11 +37,18 @@ metadata:
   name: skipper-ingress
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: skipper-ingress
 rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
 - apiGroups:
     - extensions
   resources:
@@ -66,7 +73,7 @@ rules:
   - get
   - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: skipper-ingress
@@ -79,7 +86,7 @@ subjects:
   name: skipper-ingress
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: skipper-ingress-hostnetwork-psp

--- a/docs/kubernetes/east-west-usage.md
+++ b/docs/kubernetes/east-west-usage.md
@@ -10,7 +10,7 @@ ingress configuration.
 Example:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
@@ -21,8 +21,11 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: example
-          servicePort: 80
+          service:
+            name: example
+            port:
+              number: 80
+        pathType: ImplementationSpecific
 ```
 
 Or as a [RouteGroup](./routegroups.md):
@@ -57,7 +60,7 @@ You can also use the same ingress or RouteGroup object to accept
 internal and external traffic:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
@@ -68,14 +71,20 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: example
-          servicePort: 80
+          service:
+            name: example
+            port:
+              number: 80
+        pathType: ImplementationSpecific
   - host: demo.skipper.cluster.local
     http:
       paths:
       - backend:
-          serviceName: example
-          servicePort: 80
+          service:
+            name: example
+            port:
+              number: 80
+        pathType: ImplementationSpecific
 ```
 
 Or, again, as a [RouteGroup](./routegroups.md):

--- a/docs/kubernetes/routegroups.md
+++ b/docs/kubernetes/routegroups.md
@@ -127,14 +127,16 @@ spec:
 This is equivalent to the ingress:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
 spec:
-  backend:
-    serviceName: my-service
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: my-service
+      port:
+        number: 80
 ```
 
 Notice that the route group contains a list of actual backends, and the defined service backend is then
@@ -322,14 +324,16 @@ fields.
 Ingress:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
 spec:
-  backend:
-    serviceName: my-service
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: my-service
+      port:
+        number: 80
 ```
 
 RouteGroup:
@@ -354,7 +358,7 @@ spec:
 Ingress:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
@@ -364,9 +368,12 @@ spec:
     http:
       paths:
       - path: /api
+        pathType: Prefix
         backend:
-          serviceName: my-service
-          servicePort: 80
+          service:
+            name: my-service
+            port:
+              number: 80
 ```
 
 RouteGroup:
@@ -393,7 +400,7 @@ spec:
 Ingress (we need to define two rules):
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
@@ -403,16 +410,22 @@ spec:
     http:
       paths:
       - path: /api
+        pathType: Prefix
         backend:
-          serviceName: my-service
-          servicePort: 80
+          service:
+            name: my-service
+            port:
+              number: 80
   - host: legacy-name.example.org
     http:
       paths:
       - path: /api
+        pathType: Prefix
         backend:
-          serviceName: my-service
-          servicePort: 80
+          service:
+            name: my-service
+            port:
+              number: 80
 ```
 
 RouteGroup (we just define an additional host):
@@ -441,7 +454,7 @@ For those cases when using multiple hostnames in the same ingress with different
 small workaround for the equivalent route group spec. Ingress:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
@@ -451,16 +464,22 @@ spec:
     http:
       paths:
       - path: /api
+        pathType: Prefix
         backend:
-          serviceName: my-service
-          servicePort: 80
+          service:
+            name: my-service
+            port:
+              number: 80
   - host: legacy-name.example.org
     http:
       paths:
       - path: /application
+        pathType: Prefix
         backend:
-          serviceName: my-service
-          servicePort: 80
+          service:
+            name: my-service
+            port:
+              number: 80
 ```
 
 RouteGroup (we need to use additional host predicates):
@@ -514,7 +533,7 @@ for different routes.
 and backends without limitations. E.g where an ingress annotation's metadata may look like this:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
@@ -522,8 +541,10 @@ metadata:
     Method("OPTIONS") -> status(200) -> <shunt>
 spec:
   backend:
-    serviceName: my-service
-    servicePort: 80
+    service:
+      name: my-service
+      port:
+        number: 80
 ```
 
 the equivalent RouteGroup would look like this:
@@ -616,7 +637,12 @@ The route objects support the different path lookup modes, by using the path, pa
 pathRegexp field. See also the [route matching](../reference/architecture.md#route-matching)
 explained for the internals. The mapping is as follows:
 
-Ingress: | RouteGroup:
+Ingress pathType: | RouteGroup:
+--- | ---
+`Exact` and `/foo`  | path: `/foo`
+`Prefix` and `/foo` | pathSubtree: `/foo`
+
+Ingress (`pathType: ImplementationSpecific`): | RouteGroup:
 --- | ---
 `kubernetes-ingress` and `/foo` | pathRegexp: `^/foo`
 `path-regexp` and `/foo` | pathRegexp: `/foo`
@@ -631,7 +657,7 @@ the flag `--kubernetes-routegroup-class=<string>` to only select RouteGroup
 objects that have the annotation `zalando.org/routegroup.class` set to
 `<string>`. Skipper will only create routes for RouteGroup objects with
 it's annotation or RouteGroup objects that do not have this annotation. The
-default class is `skipper`, if not set. 
+default class is `skipper`, if not set.
 
 Example RouteGroup:
 


### PR DESCRIPTION
deprecate ingress v1beta1 and change all the docs, examples and deployment files

relates to https://github.com/zalando/skipper/pull/1999

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>