### PR TITLE
docs: predicate should have fragment by name to reference easily

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -106,7 +106,7 @@ The route matching logic can be summed up as follows:
 2. _If_ step #1 matches multiple routes, which means there are multiple
    routes in the same position of the path tree, and all other predicates
    match the request, too, then the route with the highest 
-   [weight](predicates.md#weight-priority) is matched.
+   [weight](predicates.md#weight) is matched.
 
     * this is an O(n) lookup, but only on the same leaf
 

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -149,7 +149,7 @@ Uses standardized Forwarded header ([RFC 7239](https://tools.ietf.org/html/rfc72
 
 More info about the header: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded)
 
-If multiple proxies chain values in the header, as a comma separated list, the predicates below will only match 
+If multiple proxies chain values in the header, as a comma separated list, the predicates below will only match
 the last value in the chain for each part of the header.
 
 Example: Forwarded: host=example.com;proto=https, host=example.org
@@ -192,7 +192,7 @@ ForwardedProtocol("http")
 ForwardedProtocol("https")
 ```
 
-## Weight (priority)
+## Weight
 
 By default, the weight (priority) of a route is determined by the number of defined predicates.
 

--- a/docs/tutorials/basics.md
+++ b/docs/tutorials/basics.md
@@ -222,7 +222,7 @@ The route matching logic can be summed up as follows:
 2. _If_ step #1 matches multiple routes, which means there are multiple
    routes in the same position of the path tree, and all other predicates
    match the request, too, then the route with the highest 
-   [weight](../reference/predicates.md#weight-priority) is matched.
+   [weight](../reference/predicates.md#weight) is matched.
 
     * this is an O(n) lookup, but only on the same leaf
 


### PR DESCRIPTION
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>