### PR TITLE
docs: add a second header for Weight predicate

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -192,7 +192,8 @@ ForwardedProtocol("http")
 ForwardedProtocol("https")
 ```
 
-## Weight (priority)
+## Weight
+###### Weight (priority)
 
 By default, the weight (priority) of a route is determined by the number of defined predicates.
 


### PR DESCRIPTION
The second header adds another anchor that matches predicate name.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>