### PR TITLE
refactor: use strings.Cut for strings parsing

### DIFF
--- a/config/breakerflags.go
+++ b/config/breakerflags.go
@@ -40,14 +40,14 @@ func (b *breakerFlags) Set(value string) error {
 
 	vs := strings.Split(value, ",")
 	for _, vi := range vs {
-		kv := strings.Split(vi, "=")
-		if len(kv) != 2 {
+		k, v, found := strings.Cut(vi, "=")
+		if !found {
 			return errInvalidBreakerConfig
 		}
 
-		switch kv[0] {
+		switch k {
 		case "type":
-			switch kv[1] {
+			switch v {
 			case "consecutive":
 				s.Type = circuit.ConsecutiveFailures
 			case "rate":
@@ -58,37 +58,37 @@ func (b *breakerFlags) Set(value string) error {
 				return errInvalidBreakerConfig
 			}
 		case "host":
-			s.Host = kv[1]
+			s.Host = v
 		case "window":
-			i, err := strconv.Atoi(kv[1])
+			i, err := strconv.Atoi(v)
 			if err != nil {
 				return err
 			}
 
 			s.Window = i
 		case "failures":
-			i, err := strconv.Atoi(kv[1])
+			i, err := strconv.Atoi(v)
 			if err != nil {
 				return err
 			}
 
 			s.Failures = i
 		case "timeout":
-			d, err := time.ParseDuration(kv[1])
+			d, err := time.ParseDuration(v)
 			if err != nil {
 				return err
 			}
 
 			s.Timeout = d
 		case "half-open-requests":
-			i, err := strconv.Atoi(kv[1])
+			i, err := strconv.Atoi(v)
 			if err != nil {
 				return err
 			}
 
 			s.HalfOpenRequests = i
 		case "idle-ttl":
-			d, err := time.ParseDuration(kv[1])
+			d, err := time.ParseDuration(v)
 			if err != nil {
 				return err
 			}

--- a/config/mapflags.go
+++ b/config/mapflags.go
@@ -38,14 +38,13 @@ func (m *mapFlags) Set(value string) error {
 
 	vs := strings.Split(value, ",")
 	for _, vi := range vs {
-		kv := strings.SplitN(vi, "=", 2)
-
-		if len(kv) != 2 {
+		k, v, found := strings.Cut(vi, "=")
+		if !found {
 			return fmt.Errorf(formatErrorString, vi)
 		}
 
-		k := strings.TrimSpace(kv[0])
-		v := strings.TrimSpace(kv[1])
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
 
 		if k == "" || v == "" {
 			return fmt.Errorf(formatErrorString, vi)

--- a/config/ratelimiterflags.go
+++ b/config/ratelimiterflags.go
@@ -39,14 +39,14 @@ func (r *ratelimitFlags) Set(value string) error {
 
 	vs := strings.Split(value, ",")
 	for _, vi := range vs {
-		kv := strings.Split(vi, "=")
-		if len(kv) != 2 {
+		k, v, found := strings.Cut(vi, "=")
+		if !found {
 			return errInvalidRatelimitConfig
 		}
 
-		switch kv[0] {
+		switch k {
 		case "type":
-			switch kv[1] {
+			switch v {
 			case "local":
 				log.Warning("LocalRatelimit is deprecated, please use ClientRatelimit instead")
 				fallthrough
@@ -64,20 +64,20 @@ func (r *ratelimitFlags) Set(value string) error {
 				return errInvalidRatelimitConfig
 			}
 		case "max-hits":
-			i, err := strconv.Atoi(kv[1])
+			i, err := strconv.Atoi(v)
 			if err != nil {
 				return err
 			}
 			s.MaxHits = i
 		case "time-window":
-			d, err := time.ParseDuration(kv[1])
+			d, err := time.ParseDuration(v)
 			if err != nil {
 				return err
 			}
 			s.TimeWindow = d
 			s.CleanInterval = d * 10
 		case "group":
-			s.Group = kv[1]
+			s.Group = v
 		default:
 			return errInvalidRatelimitConfig
 		}

--- a/dataclients/kubernetes/defaultfilters.go
+++ b/dataclients/kubernetes/defaultfilters.go
@@ -30,8 +30,13 @@ func readDefaultFilters(dir string) (defaultFilters, error) {
 	filters := make(defaultFilters)
 	for _, f := range files {
 		r := strings.Split(f.Name(), ".") // format: {service}.{namespace}
+		if len(r) != 2 {
+			log.WithField("file", f.Name()).Debug("malformed file name")
+			continue
+		}
+
 		info, err := f.Info()
-		if err != nil || len(r) != 2 || !(f.Type().IsRegular() || f.Type()&os.ModeSymlink != 0) || info.Size() > maxFileSize {
+		if err != nil || !(f.Type().IsRegular() || f.Type()&os.ModeSymlink != 0) || info.Size() > maxFileSize {
 			log.WithError(err).WithField("file", f.Name()).Debug("incompatible file")
 			continue
 		}

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -592,20 +592,20 @@ func TestRequestWithBasicAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	parts := strings.Split(authHeader, " ")
-	if len(parts) != 2 {
+	k, v, found := strings.Cut(authHeader, " ")
+	if !found || k == "" || v == "" {
 		t.Error("invalid auth header sent")
 		t.Log(authHeader)
 		return
 	}
 
-	if parts[0] != "Basic" {
+	if k != "Basic" {
 		t.Error("invalid auth header sent")
 		t.Log(authHeader)
 		return
 	}
 
-	decodedArr, err := base64.StdEncoding.DecodeString(parts[1])
+	decodedArr, err := base64.StdEncoding.DecodeString(v)
 	if err != nil {
 		t.Error(err)
 		t.Log("header sent:", authHeader)

--- a/filters/apiusagemonitoring/pathinfo.go
+++ b/filters/apiusagemonitoring/pathinfo.go
@@ -23,11 +23,10 @@ type pathInfo struct {
 }
 
 func newPathInfo(applicationId, tag, apiId, pathTemplate string, clientTracking *clientTrackingInfo) *pathInfo {
-	if strings.Contains(applicationId, ":") {
-		//can be removed after feature toggle is enabled on monitoring controller
-		split := strings.Split(applicationId, ":")
-		applicationId = split[0]
-		tag = split[1]
+	id, t, found := strings.Cut(applicationId, ":")
+	if found {
+		applicationId = id
+		tag = t
 	}
 
 	if tag == "" {

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -290,11 +290,11 @@ func (s *tokenOidcSpec) CreateFilter(args []interface{}) (filters.Filter, error)
 		f.upstreamHeaders = make(map[string]string)
 
 		for _, header := range strings.Split(sargs[paramUpstrHeaders], " ") {
-			sl := strings.SplitN(header, ":", 2)
-			if len(sl) != 2 || sl[0] == "" || sl[1] == "" {
-				return nil, fmt.Errorf("%w: malformatted filter for upstream headers %s", filters.ErrInvalidFilterParameters, sl)
+			k, v, found := strings.Cut(header, ":")
+			if !found || k == "" || v == "" {
+				return nil, fmt.Errorf("%w: malformatted filter for upstream headers %s", filters.ErrInvalidFilterParameters, header)
 			}
-			f.upstreamHeaders[sl[0]] = sl[1]
+			f.upstreamHeaders[k] = v
 		}
 		log.Debugf("Upstream Headers: %v", f.upstreamHeaders)
 	}

--- a/filters/auth/oidc_introspection.go
+++ b/filters/auth/oidc_introspection.go
@@ -64,12 +64,12 @@ func (spec *oidcIntrospectionSpec) CreateFilter(args []interface{}) (filters.Fil
 	switch filter.typ {
 	case checkOIDCQueryClaims:
 		for _, arg := range sargs {
-			slice := strings.SplitN(arg, ":", 2)
-			if len(slice) != 2 {
+			path, queries, found := strings.Cut(arg, ":")
+			if !found || path == "" {
 				return nil, fmt.Errorf("%v: malformatted filter arg %s", filters.ErrInvalidFilterParameters, arg)
 			}
-			pq := pathQuery{path: slice[0]}
-			for _, query := range splitQueries(slice[1]) {
+			pq := pathQuery{path: path}
+			for _, query := range splitQueries(queries) {
 				if query == "" {
 					return nil, fmt.Errorf("%v: %s", errUnsupportedClaimSpecified, arg)
 				}

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -868,8 +868,8 @@ func TestOIDCSetup(t *testing.T) {
 			if tc.queries != nil {
 				q := reqURL.Query()
 				for _, rq := range tc.queries {
-					splitRQ := strings.Split(rq, "=")
-					q.Add(splitRQ[0], splitRQ[1])
+					k, v, _ := strings.Cut(rq, "=")
+					q.Add(k, v)
 				}
 				reqURL.RawQuery = q.Encode()
 			}

--- a/filters/builtin/compress.go
+++ b/filters/builtin/compress.go
@@ -4,7 +4,6 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"errors"
-	"github.com/andybalholm/brotli"
 	"io"
 	"math"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/andybalholm/brotli"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/filters"

--- a/go.mod
+++ b/go.mod
@@ -129,4 +129,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )
 
-go 1.17
+go 1.18

--- a/go.sum
+++ b/go.sum
@@ -133,7 +133,6 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3k
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -862,7 +861,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 h1:k/gmLsJDWwWqbLCur2yWnJzwQEKRcAHXo6seXGuSwWw=
 github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
@@ -998,9 +996,7 @@ golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211108170745-6635138e15ea/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220105145211-5b0dc2dfae98 h1:+6WJMRLHlD7X7frgp7TUZ36RnQzSf9wVVTNakEp+nqY=
 golang.org/x/net v0.0.0-20220105145211-5b0dc2dfae98/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1103,11 +1099,9 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211109184856-51b60fd695b3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c h1:DHcbWVXeY+0Y8HHKR+rbLwnoh2F4tNCY7rTiHJ30RmA=
@@ -1376,7 +1370,6 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/net/net.go
+++ b/net/net.go
@@ -33,7 +33,7 @@ func parse(addr string) net.IP {
 //     X-Forwarded-For: client, proxy1, proxy2
 func RemoteHost(r *http.Request) net.IP {
 	ffs := r.Header.Get("X-Forwarded-For")
-	ff := strings.Split(ffs, ",")[0]
+	ff, _, _ := strings.Cut(ffs, ",")
 	if ffh := parse(ff); ffh != nil {
 		return ffh
 	}

--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -19,11 +19,12 @@ Examples:
 package forwarded
 
 import (
-	"github.com/zalando/skipper/predicates"
-	"github.com/zalando/skipper/routing"
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/routing"
 )
 
 const (
@@ -134,9 +135,9 @@ func parseForwarded(fh string) *forwarded {
 
 	for _, forwardedFull := range strings.Split(fh, ",") {
 		for _, forwardedPair := range strings.Split(strings.TrimSpace(forwardedFull), ";") {
-			if tv := strings.SplitN(forwardedPair, "=", 2); len(tv) == 2 {
-				token, value := tv[0], tv[1]
-				value = strings.Trim(value, `"`)
+			token, value, found := strings.Cut(forwardedPair, "=")
+			value = strings.Trim(value, `"`)
+			if found && value != "" {
 				switch token {
 				case "proto":
 					f.proto = value

--- a/proxy/breaker_test.go
+++ b/proxy/breaker_test.go
@@ -44,7 +44,8 @@ const (
 )
 
 func urlHostNerr(u string) string {
-	return strings.Split(u, "//")[1]
+	_, v, _ := strings.Cut(u, "//")
+	return v
 }
 
 func newBreakerProxy(

--- a/script/script.go
+++ b/script/script.go
@@ -216,11 +216,8 @@ func (s *script) runFunc(name string, f filters.FilterContext) {
 
 	pt := L.CreateTable(len(s.routeParams), len(s.routeParams))
 	for i, p := range s.routeParams {
-		parts := strings.SplitN(p, "=", 2)
-		if len(parts) == 1 {
-			parts = append(parts, "")
-		}
-		pt.RawSetString(parts[0], lua.LString(parts[1]))
+		k, v, _ := strings.Cut(p, "=")
+		pt.RawSetString(k, lua.LString(v))
 		pt.RawSetInt(i+1, lua.LString(p))
 	}
 

--- a/tracing/tracers/basic/basic.go
+++ b/tracing/tracers/basic/basic.go
@@ -21,34 +21,34 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 	)
 
 	for _, o := range opts {
-		parts := strings.SplitN(o, "=", 2)
-		switch parts[0] {
+		k, v, _ := strings.Cut(o, "=")
+		switch k {
 		case "drop-all-logs":
 			dropAllLogs = true
 
 		case "sample-modulo":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			sampleModulo, err = strconv.ParseUint(parts[1], 10, 64)
+			sampleModulo, err = strconv.ParseUint(v, 10, 64)
 			if err != nil {
-				return nil, invalidArg(parts[0], err)
+				return nil, invalidArg(k, err)
 			}
 
 		case "max-logs-per-span":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			maxLogsPerSpan, err = strconv.Atoi(parts[1])
+			maxLogsPerSpan, err = strconv.Atoi(v)
 			if err != nil {
-				return nil, invalidArg(parts[0], err)
+				return nil, invalidArg(k, err)
 			}
 
 		case "recorder":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			switch parts[1] {
+			switch v {
 			case "in-memory":
 				recorder = basic.NewInMemoryRecorder()
 			default:

--- a/tracing/tracers/instana/instana.go
+++ b/tracing/tracers/instana/instana.go
@@ -15,11 +15,11 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 	serviceName := defServiceName
 
 	for _, o := range opts {
-		parts := strings.SplitN(o, "=", 2)
-		switch parts[0] {
+		k, v, _ := strings.Cut(o, "=")
+		switch k {
 		case "service-name":
-			if len(parts) > 1 {
-				serviceName = parts[1]
+			if v != "" {
+				serviceName = v
 			}
 		}
 	}

--- a/tracing/tracers/jaeger/jaeger.go
+++ b/tracing/tracers/jaeger/jaeger.go
@@ -29,69 +29,67 @@ func parseOptions(opts []string) (*config.Configuration, error) {
 	var globalTags []opentracing.Tag
 
 	for _, o := range opts {
-		parts := strings.SplitN(o, "=", 2)
-		switch parts[0] {
+		k, v, _ := strings.Cut(o, "=")
+		switch k {
 		case "service-name":
-			if len(parts) > 1 {
-				serviceName = parts[1]
+			if v != "" {
+				serviceName = v
 			}
 
 		case "use-rpc-metrics":
 			useRPCMetrics = true
 
 		case "sampler-type":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			samplerValue := parts[1]
-			parts = strings.SplitN(samplerValue, ":", 2)
-			samplerType = parts[0]
+			samplerType, v, _ = strings.Cut(v, ":")
 			switch samplerType {
 			case "const":
 				samplerParam = 1.0
 			case "probabilistic", "rateLimiting", "remote":
-				if len(parts) == 1 {
-					return nil, missingArg(parts[1])
+				if v == "" {
+					return nil, missingArg(k)
 				}
-				samplerParam, err = strconv.ParseFloat(parts[1], 64)
+				samplerParam, err = strconv.ParseFloat(v, 64)
 				if err != nil {
-					return nil, invalidArg(parts[1], err)
+					return nil, invalidArg(v, err)
 				}
 			default:
-				return nil, invalidArg(parts[0], errors.New("invalid sampler type"))
+				return nil, invalidArg(k, errors.New("invalid sampler type"))
 			}
 		case "sampler-url":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			samplerURL = parts[1]
+			samplerURL = v
 
 		case "reporter-queue":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			reporterQueue, _ = strconv.Atoi(parts[1])
+			reporterQueue, _ = strconv.Atoi(v)
 		case "reporter-interval":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			reporterInterval, err = time.ParseDuration(parts[1])
+			reporterInterval, err = time.ParseDuration(v)
 			if err != nil {
-				return nil, invalidArg(parts[1], err)
+				return nil, invalidArg(v, err)
 			}
 		case "local-agent":
-			if len(parts) == 1 {
-				return nil, missingArg(parts[0])
+			if v == "" {
+				return nil, missingArg(k)
 			}
-			localAgent = parts[1]
+			localAgent = v
 		case "tag":
-			if len(parts) > 1 {
-				kv := strings.SplitN(parts[1], "=", 2)
-				if len(kv) != 2 {
-					return nil, fmt.Errorf("missing value for tag %s", kv[0])
+			if v != "" {
+				k, v, _ := strings.Cut(v, "=")
+				if v == "" {
+					return nil, fmt.Errorf("missing value for tag %s", k)
 				}
 
-				globalTags = append(globalTags, opentracing.Tag{Key: kv[0], Value: kv[1]})
+				globalTags = append(globalTags, opentracing.Tag{Key: k, Value: v})
 			}
 		}
 	}

--- a/tracing/tracers/lightstep/lightstep.go
+++ b/tracing/tracers/lightstep/lightstep.go
@@ -47,45 +47,45 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 	propagators[opentracing.HTTPHeaders] = defPropagator
 
 	for _, o := range opts {
-		parts := strings.SplitN(o, "=", 2)
-		switch parts[0] {
+		key, val, _ := strings.Cut(o, "=")
+		switch key {
 		case "component-name":
-			if len(parts) > 1 {
-				componentName = parts[1]
+			if val != "" {
+				componentName = val
 			}
 		case "token":
-			token = parts[1]
+			token = val
 		case "grpc-max-msg-size":
-			v, err := strconv.Atoi(parts[1])
+			v, err := strconv.Atoi(val)
 			if err != nil {
-				return lightstep.Options{}, fmt.Errorf("failed to parse %s as int grpc-max-msg-size: %v", parts[1], err)
+				return lightstep.Options{}, fmt.Errorf("failed to parse %s as int grpc-max-msg-size: %v", val, err)
 			}
 			grpcMaxMsgSize = v
 		case "min-period":
-			v, err := time.ParseDuration(parts[1])
+			v, err := time.ParseDuration(val)
 			if err != nil {
-				return lightstep.Options{}, fmt.Errorf("failed to parse %s as time.Duration min-period : %v", parts[1], err)
+				return lightstep.Options{}, fmt.Errorf("failed to parse %s as time.Duration min-period : %v", val, err)
 			}
 			minReportingPeriod = v
 		case "max-period":
-			v, err := time.ParseDuration(parts[1])
+			v, err := time.ParseDuration(val)
 			if err != nil {
-				return lightstep.Options{}, fmt.Errorf("failed to parse %s as time.Duration max-period: %v", parts[1], err)
+				return lightstep.Options{}, fmt.Errorf("failed to parse %s as time.Duration max-period: %v", val, err)
 			}
 			maxReportingPeriod = v
 		case "tag":
-			if len(parts) > 1 {
-				tags := strings.SplitN(parts[1], "=", 2)
-				if len(tags) != 2 {
-					return lightstep.Options{}, fmt.Errorf("missing value for tag %s", tags[0])
+			if val != "" {
+				tag, tagVal, found := strings.Cut(val, "=")
+				if !found {
+					return lightstep.Options{}, fmt.Errorf("missing value for tag %s", val)
 				}
-				globalTags[tags[0]] = tags[1]
+				globalTags[tag] = tagVal
 			}
 		case "collector":
 			var err error
 			var sport string
 
-			host, sport, err = net.SplitHostPort(parts[1])
+			host, sport, err = net.SplitHostPort(val)
 			if err != nil {
 				return lightstep.Options{}, err
 			}
@@ -96,48 +96,48 @@ func parseOptions(opts []string) (lightstep.Options, error) {
 			}
 		case "plaintext":
 			var err error
-			plaintext, err = strconv.ParseBool(parts[1])
+			plaintext, err = strconv.ParseBool(val)
 			if err != nil {
-				return lightstep.Options{}, fmt.Errorf("failed to parse %s as bool: %v", parts[1], err)
+				return lightstep.Options{}, fmt.Errorf("failed to parse %s as bool: %v", val, err)
 			}
 		case "cmd-line":
-			cmdLine = parts[1]
+			cmdLine = val
 			logCmdLine = true
 		case "protocol":
-			switch parts[1] {
+			switch val {
 			case "http":
 				useGRPC = false
 			case "grpc":
 				useGRPC = true
 			default:
-				return lightstep.Options{}, fmt.Errorf("failed to parse protocol allowed 'http' or 'grpc', got: %s", parts[1])
+				return lightstep.Options{}, fmt.Errorf("failed to parse protocol allowed 'http' or 'grpc', got: %s", val)
 			}
 		case "log-events":
 			logEvents = true
 		case "max-buffered-spans":
 			var err error
-			if maxBufferedSpans, err = strconv.Atoi(parts[1]); err != nil {
+			if maxBufferedSpans, err = strconv.Atoi(val); err != nil {
 				return lightstep.Options{}, fmt.Errorf("failed to parse max buffered spans: %v", err)
 			}
 		case "max-log-key-len":
 			var err error
-			if maxLogKeyLen, err = strconv.Atoi(parts[1]); err != nil {
+			if maxLogKeyLen, err = strconv.Atoi(val); err != nil {
 				return lightstep.Options{}, fmt.Errorf("failed to parse max log key length: %v", err)
 			}
 		case "max-log-value-len":
 			var err error
-			if maxLogValueLen, err = strconv.Atoi(parts[1]); err != nil {
+			if maxLogValueLen, err = strconv.Atoi(val); err != nil {
 				return lightstep.Options{}, fmt.Errorf("failed to parse max log value length: %v", err)
 			}
 		case "max-logs-per-span":
 			var err error
-			if maxLogsPerSpan, err = strconv.Atoi(parts[1]); err != nil {
+			if maxLogsPerSpan, err = strconv.Atoi(val); err != nil {
 				return lightstep.Options{}, fmt.Errorf("failed to parse max logs per span: %v", err)
 			}
 		case "propagators":
-			if len(parts) > 1 {
+			if val != "" {
 				prStack := lightstep.PropagatorStack{}
-				prs := strings.SplitN(parts[1], ",", 2)
+				prs := strings.SplitN(val, ",", 2)
 				for _, pr := range prs {
 					switch pr {
 					case "lightstep", "ls":


### PR DESCRIPTION
This PR uses Go 1.18 `strings.Cut` function and replaces usage of `strings.Split` and `strings.SplitN` where possible.

Resolves https://github.com/zalando/skipper/issues/1963