### PR TITLE
Make sure to import the built image to the local daemon

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -42,11 +42,11 @@ docker.build: clean $(BINARIES)
 
 docker-build: docker.build.amd64 docker.build.arm64 docker.build.armv7
 docker.build.amd64: clean build.linux.amd64 docker.build.enable
-	docker buildx build -t $(IMAGE) --platform linux/amd64 -f Dockerfile .
+	docker buildx build -t $(IMAGE) --platform linux/amd64 -f Dockerfile --load .
 docker.build.arm64: clean build.linux.arm64 docker.build.enable
-	docker buildx build -t $(ARM64_IMAGE) --platform linux/arm64 -f Dockerfile.arm64 .
+	docker buildx build -t $(ARM64_IMAGE) --platform linux/arm64 -f Dockerfile.arm64 --load .
 docker.build.armv7: clean build.linux.armv7 docker.build.enable
-	docker buildx build -t $(ARM_IMAGE) --platform linux/arm/v7 -f Dockerfile.armv7 .
+	docker buildx build -t $(ARM_IMAGE) --platform linux/arm/v7 -f Dockerfile.armv7 --load .
 
 docker-push: docker.push.amd64 docker.push.arm64 docker.push.armv7
 docker.push.amd64:


### PR DESCRIPTION
When using `buildx` the images stay in the remote build cache. So you either have to use `--push` to push them directly or use `--load` to import them to the local daemon and `docker push` from there.

Curiously, this worked fine for the `amd64` version but failed for the arm ones. I think the amd64 build is run by the local daemon (since it's the native platform) whereas the arm ones are used by the separate buildkit builder, hence it failed there. 

Let's do it correctly by loading the image to the local daemon first. Note, `--load` only works with single-arch images, which is the case here.