### PR TITLE
dataclients/kubernetes: preserve `RouteGroup` filters in shunt route

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -361,16 +361,16 @@ func (c *Client) loadAndConvert() ([]*eskip.Route, error) {
 }
 
 func shuntRoute(r *eskip.Route) {
-	r.Filters = []*eskip.Filter{
-		{
+	r.Filters = append(r.Filters,
+		&eskip.Filter{
 			Name: filters.StatusName,
 			Args: []interface{}{502.0},
 		},
-		{
+		&eskip.Filter{
 			Name: filters.InlineContentName,
 			Args: []interface{}{"no endpoints"},
 		},
-	}
+	)
 	r.BackendType = eskip.ShuntBackend
 	r.Backend = ""
 }

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
@@ -1,1 +1,6 @@
-kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;
+kube_foo__qux__www_example_org_____bar:
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
+	-> setRequestHeader("X-Foo", "bar")
+	-> status(502)
+	-> inlineContent("no endpoints")
+	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.yaml
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   namespace: foo
   name: qux
+  annotations:
+    zalando.org/skipper-filter: setRequestHeader("X-Foo", "bar")
 spec:
   rules:
   - host: www.example.org

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.eskip
@@ -1,1 +1,6 @@
-kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;
+kube_foo__qux__www_example_org_____bar:
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
+	-> setRequestHeader("X-Foo", "bar")
+	-> status(502)
+	-> inlineContent("no endpoints")
+	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   namespace: foo
   name: qux
+  annotations:
+    zalando.org/skipper-filter: setRequestHeader("X-Foo", "bar")
 spec:
   rules:
   - host: www.example.org

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org[.]?(:[0-9]+)?)$")
-	&& Path("/app")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app")
+	-> setRequestHeader("X-Foo", "bar")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.yaml
@@ -14,6 +14,8 @@ spec:
   - backendName: myapp
   routes:
   - path: /app
+    filters:
+    - setRequestHeader("X-Foo", "bar")
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This change makes RouteGroup logic consistent with Ingress logic:

- Ingress logic prepends annotation and default filters after route is shunted
- RouteGroup adds user-configured filters before processing the backend and
  therefore `shuntRoute` removed user-defined filter.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>