### PR TITLE
Install all qemu interpreters before the build runs

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -6,6 +6,13 @@ pipeline:
     image: "cdp-runtime/go"
   type: script
   commands:
+  - desc: Setup QEMU
+    cmd: |
+      # Install qemu interpreter for arm64 (https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images)
+      docker run --rm --privileged container-registry.zalando.net/teapot/tonistiigi-binfmt:qemu-v6.2.0-main-3 --install arm,arm64
+
+      # create a Buildkit builder with CDP specific configuration (https://cloud.docs.zalando.net/howtos/cdp-multiarch/)
+      docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
   - desc: build-push
     cmd: |
       IMAGE_REGISTRY="registry-write.opensource.zalan.do"

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -56,14 +56,8 @@ docker.push.arm64: docker.build.arm64
 docker.push.armv7: docker.build.armv7
 	docker push $(ARM_IMAGE)
 
+# build multi-arch container image using a trusted multi-arch base image
 docker.push.multiarch: clean build.linux docker.build.enable
-	# Install qemu interpreter for arm64 (https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images)
-	docker run --rm --privileged container-registry.zalando.net/teapot/tonistiigi-binfmt:qemu-v6.2.0-main-3 --install arm,arm64
-
-	# create a Buildkit builder with CDP specific configuration (https://cloud.docs.zalando.net/howtos/cdp-multiarch/)
-	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
-
-	# build multi-arch container image using a trusted multi-arch base image
 	docker buildx build --rm -t $(MULTIARCH_IMAGE) --platform linux/amd64,linux/arm64 --push \
 	  --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3.13:latest .
 


### PR DESCRIPTION
Just moves the qemu interpreter installation before the build starts and out of the Makefile.

Before it only worked for armv7 because the corresponding Makefile steps runs after the one for multiarch. With this, the order doesn't matter and it's also cleaner to not have this in the Makefile but only in the (already CDP related) delivery.yaml.