### PR TITLE
dataclients/kubernetes: ignore `Ingress` user filters when no endpoints

### DIFF
--- a/dataclients/kubernetes/ingressv1.go
+++ b/dataclients/kubernetes/ingressv1.go
@@ -155,11 +155,13 @@ func (ing *ingress) addEndpointsRuleV1(ic ingressContext, host string, prule *de
 		return fmt.Errorf("error while getting service: %v", err)
 	}
 
-	// safe prepend, see: https://play.golang.org/p/zg5aGKJpRyK
-	filters := make([]*eskip.Filter, len(endpointsRoute.Filters)+len(ic.annotationFilters))
-	copy(filters, ic.annotationFilters)
-	copy(filters[len(ic.annotationFilters):], endpointsRoute.Filters)
-	endpointsRoute.Filters = filters
+	if endpointsRoute.BackendType != eskip.ShuntBackend {
+		// safe prepend, see: https://play.golang.org/p/zg5aGKJpRyK
+		filters := make([]*eskip.Filter, len(endpointsRoute.Filters)+len(ic.annotationFilters))
+		copy(filters, ic.annotationFilters)
+		copy(filters[len(ic.annotationFilters):], endpointsRoute.Filters)
+		endpointsRoute.Filters = filters
+	}
 
 	// add pre-configured default filters
 	df, err := ic.defaultFilters.getNamed(meta.Namespace, prule.Backend.Service.Name)

--- a/dataclients/kubernetes/ingressv1beta1.go
+++ b/dataclients/kubernetes/ingressv1beta1.go
@@ -154,11 +154,13 @@ func (ing *ingress) addEndpointsRule(ic ingressContext, host string, prule *defi
 		return fmt.Errorf("error while getting service: %v", err)
 	}
 
-	// safe prepend, see: https://play.golang.org/p/zg5aGKJpRyK
-	filters := make([]*eskip.Filter, len(endpointsRoute.Filters)+len(ic.annotationFilters))
-	copy(filters, ic.annotationFilters)
-	copy(filters[len(ic.annotationFilters):], endpointsRoute.Filters)
-	endpointsRoute.Filters = filters
+	if endpointsRoute.BackendType != eskip.ShuntBackend {
+		// safe prepend, see: https://play.golang.org/p/zg5aGKJpRyK
+		filters := make([]*eskip.Filter, len(endpointsRoute.Filters)+len(ic.annotationFilters))
+		copy(filters, ic.annotationFilters)
+		copy(filters[len(ic.annotationFilters):], endpointsRoute.Filters)
+		endpointsRoute.Filters = filters
+	}
 
 	// add pre-configured default filters
 	df, err := ic.defaultFilters.getNamed(meta.Namespace, prule.Backend.ServiceName)

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.default-filters/bar.foo
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.default-filters/bar.foo
@@ -1,0 +1,1 @@
+setResponseHeader("default", "filter")

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.eskip
@@ -1,1 +1,6 @@
-kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;
+kube_foo__qux__www_example_org_____bar:
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
+	-> setResponseHeader("default", "filter")
+	-> status(502)
+	-> inlineContent("no endpoints")
+	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.yaml
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.yaml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   namespace: foo
   name: qux
+  annotations:
+    # user filters ignored when no endpoints
+    zalando.org/skipper-filter: setRequestHeader("user", "filter")
 spec:
   rules:
   - host: www.example.org

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.default-filters/bar.foo
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.default-filters/bar.foo
@@ -1,0 +1,1 @@
+setResponseHeader("default", "filter")

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.eskip
@@ -1,1 +1,6 @@
-kube_foo__qux__www_example_org_____bar: Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/") -> status(502) -> inlineContent("no endpoints") -> <shunt>;
+kube_foo__qux__www_example_org_____bar:
+	Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathRegexp("^/")
+	-> setResponseHeader("default", "filter")
+	-> status(502)
+	-> inlineContent("no endpoints")
+	-> <shunt>;

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ing-port.yaml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   namespace: foo
   name: qux
+  annotations:
+    # user filters ignored when no endpoints
+    zalando.org/skipper-filter: setRequestHeader("user", "filter")
 spec:
   rules:
   - host: www.example.org

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.default-filters/myapp.default
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.default-filters/myapp.default
@@ -1,0 +1,1 @@
+setResponseHeader("default", "filter")

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.eskip
@@ -1,6 +1,6 @@
 kube_rg__default__myapp__all__0_0:
-	Host("^(example[.]org[.]?(:[0-9]+)?)$")
-	&& Path("/app")
+	Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app")
+	-> setResponseHeader("default", "filter")
 	-> status(502)
 	-> inlineContent("no endpoints")
 	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-endpoints-not-found.yaml
@@ -14,6 +14,9 @@ spec:
   - backendName: myapp
   routes:
   - path: /app
+    filters:
+    # user filters ignored when no endpoints
+    - setRequestHeader("user", "filter")
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>