### PR TITLE
fix: query

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -168,6 +168,7 @@ func Test_NewConfig(t *testing.T) {
 				ForwardedHeadersExcludeCIDRList:         commaListFlag(),
 				ClusterRatelimitMaxGroupShards:          1,
 				RefusePayload:                           multiFlag{"foo", "bar", "baz"},
+				ValidateQuery:                           true,
 			},
 			wantErr: false,
 		},

--- a/net/query.go
+++ b/net/query.go
@@ -1,0 +1,18 @@
+package net
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type ValidateQueryHandler struct {
+	Handler http.Handler
+}
+
+func (q *ValidateQueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if _, err := url.ParseQuery(r.URL.RawQuery); err != nil {
+		http.Error(w, "Invalid query", http.StatusBadRequest)
+		return
+	}
+	q.Handler.ServeHTTP(w, r)
+}

--- a/net/query_test.go
+++ b/net/query_test.go
@@ -1,0 +1,55 @@
+package net
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestQueryHandler(t *testing.T) {
+	for _, ti := range []struct {
+		name     string
+		routes   string
+		query    string
+		expected int
+	}{
+		{
+			name:     "request without query",
+			routes:   `r: * -> inlineContent("OK") -> <shunt>;`,
+			query:    "",
+			expected: http.StatusOK,
+		},
+		{
+			name:     "request with query",
+			routes:   `r1: Query("foo") -> status(400) -> inlineContent("FAIL") -> <shunt> ;r2: * -> inlineContent("OK") -> <shunt>;`,
+			query:    "foo=bar",
+			expected: http.StatusOK,
+		},
+		{
+			name:     "request with bad query",
+			routes:   `r1: Query("foo") -> status(400) -> inlineContent("FAIL") -> <shunt> ;r2: * -> inlineContent("OK") -> <shunt>;`,
+			query:    "foo=bar;",
+			expected: http.StatusBadRequest,
+		},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+
+			req, err := http.NewRequest("GET", "/path", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.URL.RawQuery = ti.query
+
+			noop := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+			recorder := httptest.NewRecorder()
+			h := &ValidateQueryHandler{
+				Handler: noop,
+			}
+			h.ServeHTTP(recorder, req)
+
+			if recorder.Code != ti.expected {
+				t.Fatalf("Failed to get expected code %d, got %d", ti.expected, recorder.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix: Query predicate could be bypassed by prepared request, config is enabled by default and you can disable with -validate-query=false or

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>