### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/dataclients/kubernetes/hosts.go
+++ b/dataclients/kubernetes/hosts.go
@@ -18,7 +18,7 @@ func createHostRx(hosts ...string) string {
 		// trailing dots and port are not allowed in kube
 		// ingress spec, so we can append optional setting
 		// without check
-		hrx[i] = strings.Replace(host, ".", "[.]", -1) + "[.]?(:[0-9]+)?"
+		hrx[i] = strings.ReplaceAll(host, ".", "[.]") + "[.]?(:[0-9]+)?"
 	}
 
 	return "^(" + strings.Join(hrx, "|") + ")$"

--- a/dataclients/kubernetes/ingress.go
+++ b/dataclients/kubernetes/ingress.go
@@ -213,7 +213,7 @@ func addExtraRoutes(ic ingressContext, ruleHost, path, pathType, eastWestDomain 
 			ns,
 			name,
 			route.Id,
-			ruleHost+strings.Replace(path, "/", "_", -1),
+			ruleHost+strings.ReplaceAll(path, "/", "_"),
 			extraIndex)
 		setPathV1(ic.pathMode, &route, pathType, path)
 		if n := countPathRoutes(&route); n <= 1 {

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -14,17 +14,17 @@ type PrettyPrintInfo struct {
 }
 
 func escape(s string, chars string) string {
-	s = strings.Replace(s, `\`, `\\`, -1) // escape backslash before others
-	s = strings.Replace(s, "\a", `\a`, -1)
-	s = strings.Replace(s, "\b", `\b`, -1)
-	s = strings.Replace(s, "\f", `\f`, -1)
-	s = strings.Replace(s, "\n", `\n`, -1)
-	s = strings.Replace(s, "\r", `\r`, -1)
-	s = strings.Replace(s, "\t", `\t`, -1)
-	s = strings.Replace(s, "\v", `\v`, -1)
+	s = strings.ReplaceAll(s, `\`, `\\`) // escape backslash before others
+	s = strings.ReplaceAll(s, "\a", `\a`)
+	s = strings.ReplaceAll(s, "\b", `\b`)
+	s = strings.ReplaceAll(s, "\f", `\f`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
+	s = strings.ReplaceAll(s, "\v", `\v`)
 	for i := 0; i < len(chars); i++ {
 		c := chars[i : i+1]
-		s = strings.Replace(s, c, `\`+c, -1)
+		s = strings.ReplaceAll(s, c, `\`+c)
 	}
 
 	return s

--- a/eskip/template.go
+++ b/eskip/template.go
@@ -109,7 +109,7 @@ func (t *Template) apply(get TemplateGetter) (string, bool) {
 		if value == "" {
 			missing = true
 		}
-		result = strings.Replace(result, "${"+placeholder+"}", value, -1)
+		result = strings.ReplaceAll(result, "${"+placeholder+"}", value)
 	}
 	return result, !missing
 }

--- a/filters/apiusagemonitoring/filter_endpointmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_endpointmetrics_test.go
@@ -331,7 +331,7 @@ func Test_Filter_PathTemplateMatchesInternalSlashesTooFollowingVarPart(t *testin
 		{"foo/1/2/3/4/5", "foo/{a}/{b}/{c}"},
 		{"bar/1/2-3/4/5", "bar/{a}-{b}/{c}"},
 	} {
-		subTestName := strings.Replace(c.requestPath, "/", "_", -1)
+		subTestName := strings.ReplaceAll(c.requestPath, "/", "_")
 		t.Run(subTestName, func(t *testing.T) {
 			testWithFilter(
 				t,
@@ -379,7 +379,7 @@ func Test_Filter_PathTemplateMatchesPathFromRequestChain(t *testing.T) {
 	}{
 		{"foo/x", "bar/x", "foo/{a}"},
 	} {
-		subTestName := strings.Replace(c.requestPath, "/", "_", -1)
+		subTestName := strings.ReplaceAll(c.requestPath, "/", "_")
 		t.Run(subTestName, func(t *testing.T) {
 			testWithFilterModifyContext(
 				t,

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -135,10 +135,10 @@ func createOIDCServer(cb, client, clientsecret string, extraClaims jwt.MapClaims
 		case "/.well-known/openid-configuration":
 			// dynamic config handling
 			// set oidcServer local dynamic listener to us
-			st := strings.Replace(testOpenIDConfig, "https://accounts.google.com", oidcServer.URL, -1)
-			st = strings.Replace(st, "https://oauth2.googleapis.com", oidcServer.URL, -1)
-			st = strings.Replace(st, "https://www.googleapis.com", oidcServer.URL, -1)
-			st = strings.Replace(st, "https://openidconnect.googleapis.com", oidcServer.URL, -1)
+			st := strings.ReplaceAll(testOpenIDConfig, "https://accounts.google.com", oidcServer.URL)
+			st = strings.ReplaceAll(st, "https://oauth2.googleapis.com", oidcServer.URL)
+			st = strings.ReplaceAll(st, "https://www.googleapis.com", oidcServer.URL)
+			st = strings.ReplaceAll(st, "https://openidconnect.googleapis.com", oidcServer.URL)
 			_, _ = w.Write([]byte(st))
 		case "/o/oauth2/v2/auth":
 			// https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps

--- a/metrics/utils.go
+++ b/metrics/utils.go
@@ -19,8 +19,8 @@ func createTimer(sample metrics.Sample) metrics.Timer {
 }
 
 func hostForKey(h string) string {
-	h = strings.Replace(h, ".", "_", -1)
-	h = strings.Replace(h, ":", "__", -1)
+	h = strings.ReplaceAll(h, ".", "_")
+	h = strings.ReplaceAll(h, ":", "__")
 	return h
 }
 

--- a/proxy/loopback_test.go
+++ b/proxy/loopback_test.go
@@ -88,7 +88,7 @@ func testLoopback(
 		w.Header().Set("X-Backend-Done", "true")
 	}))
 
-	routes = strings.Replace(routes, "$backend", backend.URL, -1)
+	routes = strings.ReplaceAll(routes, "$backend", backend.URL)
 
 	fr := builtin.MakeRegistry()
 	fr.Register(&preserveOriginalSpec{})

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1545,9 +1545,9 @@ func TestBranding(t *testing.T) {
 	backendDown.Close()
 
 	routes := routesTpl
-	routes = strings.Replace(routes, "${backend-down}", backendDown.URL, -1)
-	routes = strings.Replace(routes, "${backend-default}", backendDefault.URL, -1)
-	routes = strings.Replace(routes, "${backend-set}", backendSet.URL, -1)
+	routes = strings.ReplaceAll(routes, "${backend-down}", backendDown.URL)
+	routes = strings.ReplaceAll(routes, "${backend-default}", backendDefault.URL)
+	routes = strings.ReplaceAll(routes, "${backend-set}", backendSet.URL)
 
 	p, err := newTestProxy(routes, FlagsNone)
 	if err != nil {

--- a/rfc/patchhost.go
+++ b/rfc/patchhost.go
@@ -6,6 +6,6 @@ import "strings"
 // see also the discussion in
 // https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0430.html.
 func PatchHost(host string) string {
-	host = strings.Replace(host, ".:", ":", -1)
+	host = strings.ReplaceAll(host, ".:", ":")
 	return strings.TrimSuffix(host, ".")
 }


### PR DESCRIPTION
Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.