### PR TITLE
New NotPath predicate

### DIFF
--- a/predicates/predicates.go
+++ b/predicates/predicates.go
@@ -16,6 +16,7 @@ const (
 	// at https://godoc.org/github.com/zalando/skipper/eskip)
 	PathSubtreeName           = "PathSubtree"
 	PathRegexpName            = "PathRegexp"
+	NotPath                   = "NotPath"
 	HostName                  = "Host"
 	HostAnyName               = "HostAny"
 	ForwardedHostName         = "ForwardedHost"

--- a/routing/not_path.go
+++ b/routing/not_path.go
@@ -1,13 +1,11 @@
 package routing
 
 import (
-	"github.com/zalando/skipper/eskip"
+	"net/http"
+
 	"github.com/zalando/skipper/pathmux"
 	"github.com/zalando/skipper/predicates"
-	"net/http"
 )
-
-const magicRouteId = "42"
 
 type notPathSpec struct{}
 
@@ -36,9 +34,7 @@ func (n notPathSpec) Create(args []interface{}) (Predicate, error) {
 		return nil, predicates.ErrInvalidPredicateParameters
 	}
 
-	leaf, err := newLeaf(
-		&Route{Route: eskip.Route{Id: magicRouteId}},
-		nil)
+	leaf, err := newLeaf(&Route{}, nil)
 	if err != nil {
 		return nil, predicates.ErrInvalidPredicateParameters
 	}

--- a/routing/not_path.go
+++ b/routing/not_path.go
@@ -1,0 +1,60 @@
+package routing
+
+import (
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/pathmux"
+	"github.com/zalando/skipper/predicates"
+	"net/http"
+)
+
+const magicRouteId = "42"
+
+type notPathSpec struct{}
+
+type notPathPredicate struct {
+	path string
+	tree *pathmux.Tree
+}
+
+func NewNotPath() PredicateSpec { return &notPathSpec{} }
+
+func (n notPathSpec) Name() string {
+	return predicates.NotPath
+}
+
+func (n notPathSpec) Create(args []interface{}) (Predicate, error) {
+	if len(args) != 1 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+	path, ok := args[0].(string)
+	if !ok {
+		return nil, predicates.ErrInvalidPredicateParameters
+
+	}
+	path, err := normalizePath(&Route{path: path})
+	if err != nil {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	leaf, err := newLeaf(
+		&Route{Route: eskip.Route{Id: magicRouteId}},
+		nil)
+	if err != nil {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	tree := &pathmux.Tree{}
+	err = tree.Add(path, &pathMatcher{leaves: []*leafMatcher{leaf}})
+	if err != nil {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	return &notPathPredicate{path: path, tree: tree}, nil
+}
+
+func (n notPathPredicate) Match(request *http.Request) bool {
+	_, leafMatcher := matchPathTree(n.tree, request.RequestURI, &leafRequestMatcher{r: request})
+
+	// No match is a successful predicate
+	return leafMatcher == nil
+}

--- a/routing/not_path_test.go
+++ b/routing/not_path_test.go
@@ -5,20 +5,7 @@ import (
 	"testing"
 )
 
-func TestX(t *testing.T) {
-	pathSpec := NewNotPath()
-	predicate, err := pathSpec.Create([]interface{}{"/some/path"})
-	if err != nil {
-		t.Errorf("failed to create predicate: %v", err)
-	}
-
-	match := predicate.Match(&http.Request{RequestURI: "/other/path"})
-	if match {
-		t.Error("should not match")
-	}
-}
-
-func Test(t *testing.T) {
+func TestNotPathPredicate_Match(t *testing.T) {
 	tests := []struct {
 		name                string
 		predicatePath       string

--- a/routing/not_path_test.go
+++ b/routing/not_path_test.go
@@ -1,0 +1,109 @@
+package routing
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestX(t *testing.T) {
+	pathSpec := NewNotPath()
+	predicate, err := pathSpec.Create([]interface{}{"/some/path"})
+	if err != nil {
+		t.Errorf("failed to create predicate: %v", err)
+	}
+
+	match := predicate.Match(&http.Request{RequestURI: "/other/path"})
+	if match {
+		t.Error("should not match")
+	}
+}
+
+func Test(t *testing.T) {
+	tests := []struct {
+		name                string
+		predicatePath       string
+		providedPath        string
+		predicateSuccessful bool
+	}{
+		{
+			name:                "different path, does not match",
+			predicatePath:       "/some/path",
+			providedPath:        "/other/path",
+			predicateSuccessful: true,
+		},
+		{
+			name:                "same path, exact match",
+			predicatePath:       "/some/path",
+			providedPath:        "/some/path",
+			predicateSuccessful: false,
+		},
+		{
+			name:                "path with single matching variable",
+			predicatePath:       "/some/:variable",
+			providedPath:        "/some/path",
+			predicateSuccessful: false,
+		},
+		{
+			name:                "path with single variable, more segments provided, does not match",
+			predicatePath:       "/some/:variable",
+			providedPath:        "/some/path/with/more",
+			predicateSuccessful: true,
+		},
+		{
+			name:                "path with wildcard variable, only root provided, does not match",
+			predicatePath:       "/some/*variables",
+			providedPath:        "/some",
+			predicateSuccessful: true,
+		},
+		{
+			name:                "path with wildcard variable, single segment provided, matches",
+			predicatePath:       "/some/*variables",
+			providedPath:        "/some/path",
+			predicateSuccessful: false,
+		},
+		{
+			name:                "path with wildcard variable, multiple segments provided, matches",
+			predicatePath:       "/some/*variables",
+			providedPath:        "/some/path/with/more",
+			predicateSuccessful: false,
+		},
+		{
+			name:                "path with double star wildcard,only root provided, matches",
+			predicatePath:       "/some/**",
+			providedPath:        "/some",
+			predicateSuccessful: true,
+		},
+		{
+			name:                "path with double star wildcard, single segment provided, matches",
+			predicatePath:       "/some/**",
+			providedPath:        "/some/path",
+			predicateSuccessful: false,
+		},
+		{
+			name:                "path with double star wildcard, multiple segments provided, matches",
+			predicatePath:       "/some/**",
+			providedPath:        "/some/path/with/more",
+			predicateSuccessful: false,
+		},
+		{
+			name:                "same path",
+			predicatePath:       "/some/:variable/:another",
+			providedPath:        "/some/path",
+			predicateSuccessful: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pathSpec := NewNotPath()
+			predicate, err := pathSpec.Create([]interface{}{test.predicatePath})
+			if err != nil {
+				t.Errorf("failed to create predicate: %v", err)
+			}
+
+			match := predicate.Match(&http.Request{RequestURI: test.providedPath})
+			if match != test.predicateSuccessful {
+				t.Errorf("predicate expected %v (configured with %s), but got %v (with path %v)", test.predicateSuccessful, test.predicatePath, match, test.providedPath)
+			}
+		})
+	}
+}

--- a/skipper.go
+++ b/skipper.go
@@ -1633,6 +1633,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		forwarded.NewForwardedHost(),
 		forwarded.NewForwardedProto(),
 		host.NewAny(),
+		routing.NewNotPath(),
 	)
 
 	// provide default value for wrapper if not defined


### PR DESCRIPTION
This PR is a POC for a new predicate, "NotPath", which can be used to exclude certain paths that would otherwise match a wildcard. 

Related to issue: https://github.com/zalando/skipper/issues/2049