### PR TITLE
feat: added leakage verification 

### DIFF
--- a/dataclients/kubernetes/main_test.go
+++ b/dataclients/kubernetes/main_test.go
@@ -1,0 +1,11 @@
+package kubernetes_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/eskipfile/main_test.go
+++ b/eskipfile/main_test.go
@@ -1,0 +1,11 @@
+package eskipfile_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/eskipfile/watch_test.go
+++ b/eskipfile/watch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/logging/loggingtest"
 	"github.com/zalando/skipper/routing"
+	"go.uber.org/goleak"
 )
 
 const testWatchFile = "fixtures/watch-test.eskip"
@@ -172,12 +173,16 @@ func (t *watchTest) close() {
 }
 
 func TestWatchInitialFails(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	test := initWatchTest(t)
 	defer test.close()
 	test.timeoutInitial()
 }
 
 func TestWatchInitialRecovers(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	test := initWatchTest(t)
 	defer test.close()
 	test.timeoutInitial()
@@ -187,6 +192,8 @@ func TestWatchInitialRecovers(t *testing.T) {
 }
 
 func TestWatchUpdateFails(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	createFile(t)
 	defer deleteFile(t)
 	test := initWatchTest(t)
@@ -197,6 +204,8 @@ func TestWatchUpdateFails(t *testing.T) {
 }
 
 func TestWatchUpdateRecover(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	createFile(t)
 	defer deleteFile(t)
 	test := initWatchTest(t)
@@ -209,6 +218,8 @@ func TestWatchUpdateRecover(t *testing.T) {
 }
 
 func TestInitialAndUnchanged(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	createFile(t)
 	defer deleteFile(t)
 	test := initWatchTest(t)
@@ -218,6 +229,8 @@ func TestInitialAndUnchanged(t *testing.T) {
 }
 
 func TestInitialAndDeleteFile(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	createFile(t)
 	defer deleteFile(t)
 	test := initWatchTest(t)
@@ -228,6 +241,8 @@ func TestInitialAndDeleteFile(t *testing.T) {
 }
 
 func TestWatchUpdate(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	createFile(t)
 	defer deleteFile(t)
 	test := initWatchTest(t)

--- a/filters/serve/serve_test.go
+++ b/filters/serve/serve_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/zalando/skipper/filters/filtertest"
+	"go.uber.org/goleak"
 )
 
 const testDelay = 12 * time.Millisecond
@@ -95,6 +96,8 @@ func TestBlock(t *testing.T) {
 }
 
 func TestServe(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	parts := []string{"foo", "bar", "baz"}
 	ctx := &filtertest.Context{FRequest: &http.Request{}}
 	ServeHTTP(ctx, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/yookoala/gofast v0.6.0
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9
 	go.uber.org/atomic v1.9.0
+	go.uber.org/goleak v1.1.12
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8

--- a/go.sum
+++ b/go.sum
@@ -958,6 +958,7 @@ go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -1008,6 +1009,7 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=


### PR DESCRIPTION
To avoid defects and resource waste we can use uber's goleak to detect goroutine leakages.

## Added
- uber-go/goleak library
- main_test files to test leakage in all test package tests (eskipfile, filters/serve and dataclients/kubernets)

Related to #1989 
