### PR TITLE
[Proposal] Introduce AnySource predicate

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -167,6 +167,7 @@ func Test_NewConfig(t *testing.T) {
 				RoutesURLs:                              commaListFlag(),
 				ForwardedHeadersList:                    commaListFlag(),
 				ForwardedHeadersExcludeCIDRList:         commaListFlag(),
+				SourceLBCIDRList:                        commaListFlag(),
 				ClusterRatelimitMaxGroupShards:          1,
 				RefusePayload:                           multiFlag{"foo", "bar", "baz"},
 				ValidateQuery:                           true,

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,7 +3,7 @@ pipeline:
 - id: build
   vm_config:
     type: linux
-    image: "cdp-runtime/go"
+    image: "cdp-runtime/go-1.18"
   type: script
   commands:
   - desc: Setup BuildKit

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -555,6 +555,37 @@ ClientIP("1.2.3.0/24")
 ClientIP("1.2.3.4", "2.2.2.0/24")
 ```
 
+## AnySource
+
+Similar to [Source](#source) and [SourceFromLast](#sourcefromlast) but can
+correctly work with different types of load balancers in front of Skipper.
+The common case is running with AWS Network Load Balancers (NLB) and AWS Application
+Load Balancers (ALB) in front of skipper. Here `SourceFromlast` will work for traffic
+coming through the ALB, but not for traffic coming through the NLB as the
+client could set a custom `X-Forwarded-For` header. For NLB `ClientIP` would
+work, but that would again not work for ALB because the source IP of traffic
+coming through ALB is the private IP of the ALB nodes.
+`AnySource` solves this and allows the users to not care about the details of
+the setup but simply define the list of sources they want to allow and nothing
+else.
+
+Parameters:
+
+* AnySource (string, ..) varargs with IPs or CIDR
+
+Examples:
+
+```
+// only match requests from 1.2.3.4
+AnySource("1.2.3.4")
+
+// only match requests from 1.2.3.0 - 1.2.3.255
+AnySource("1.2.3.0/24")
+
+// only match requests from 1.2.3.4 and the 2.2.2.0/24 network
+AnySource("1.2.3.4", "2.2.2.0/24")
+```
+
 ## Tee
 
 The Tee predicate matches a route when a request is spawn from the

--- a/predicates/predicates.go
+++ b/predicates/predicates.go
@@ -41,6 +41,7 @@ const (
 	SourceName                = "Source"
 	SourceFromLastName        = "SourceFromLast"
 	ClientIPName              = "ClientIP"
+	AnySource                 = "AnySource"
 	TeeName                   = "Tee"
 	TrafficName               = "Traffic"
 )

--- a/skipper.go
+++ b/skipper.go
@@ -829,6 +829,10 @@ type Options struct {
 	// KubernetesEnableTLS enables kubernetes to use resources to terminate tls
 	KubernetesEnableTLS bool
 
+	// SourceLBCIDRs is a list of CIDRs expected from the load balancers in
+	// front of skipper.
+	SourceLBCIDRs skpnet.IPNets
+
 	testOptions
 }
 
@@ -1614,6 +1618,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		source.New(),
 		source.NewFromLast(),
 		source.NewClientIP(),
+		source.NewAnySource(o.SourceLBCIDRs),
 		interval.NewBetween(),
 		interval.NewBefore(),
 		interval.NewAfter(),


### PR DESCRIPTION
This proposes the introduction of a new Predicate: `AnySource` which is in family with the `Source`, `SourceFromLast` and `ClientIP` predicates, but works correctly no matter what load balancer may be in front of skipper.

Imagine the following setup where skipper is used as ingress in a Kubernetes cluster running in AWS, and [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) is used to manage Cloud Load balancers in front of skipper.

![image](https://user-images.githubusercontent.com/128566/183413270-d877d5a7-ddd0-4fce-9c5c-afe8f676c6b8.png)

In this case you have a situation where one path to skipper is via a Network Load Balancer (NLB) and another path is via an Application Load Balancer (ALB). In this setup there is no existing predicate that can be used to ensure that only traffic from certain source IPs are matching a given Ingress configuration/route.
That is, if you use the `SourceFromLast` predicate you can correctly match on all traffic going through the ALB, because we can be sure that the ALB sets the last item of the `X-Forwarded-For` (XFF) header to the client IP of the client connecting to the ALB. However, with `SourceFromLast` we can't correctly match on traffic coming through the NLB because the XFF header could just be set by the client to any value.
similarly for traffic coming through the NLB we could correctly match it via `ClientIP` because the remote Address of the request will be the client connecting to the NLB, but for traffic coming through the ALB the remote Address will be the internal address of the load balancer, and thus we can't know what the real remote address was (unless we again look at XFF header).

`AnySource` solves this problem by implementing a more advanced logic which takes the load balancer addresses into account so it can distinguish traffic coming through ALB vs. NLB and apply the correct check respectively using the following logic:

```
if source_addr in allowed range:
  return true
if source_addr in known LB range AND XFF addr in allowed range:
  return true
else:
  return false
```

Configuration of the Load balancer ranges are done via the flag `-source-lb-cidrs` and is thus up to the operator of skipper, while the user of the `AnySource` predicate only have to define the relevant ranges for which she wants to allow access for a given route.

#### note

Right now it assumes the last item of XFF is trusted which is specific to how AWS ALBs work, to be more flexible we may need to make this configurable via another flag?

### TODO

* [ ] Align on the name of the predicate
* [x] Add documentation
* [x] Add test cases for IPV6.


### Alternative solution

As an alternative to adding a new Predicate, we could also add flags that change the behavior of the `Source` predicate only if set. That is, one flag `-source-lb-cidrs` to set an optional range of Load Balancer CIDRs and a flag `-source-xff-direction=first|last` to set which direction the XFF is read from. That way the behavior of `Source` depends on the skipper configuration and it can therefore be a detail on operators have to care about and not the users. The downside is that it requires a coordination between operators and users to introduce which is not needed if a new predicate is added (only users need to migrate in that case) but it seems like a nicer interface for users if you don't have to understand the complexity of the skipper setup to understand which predicate to use.