### PR TITLE
Add custom weight for custom predicates

### DIFF
--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -394,7 +394,6 @@ func processPredicates(cpm map[string]PredicateSpec, defs []*eskip.Predicate) ([
 			weight += ws.Weight()
 		}
 
-
 		cps = append(cps, cp)
 	}
 

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -364,10 +364,14 @@ func processPredicates(cpm map[string]PredicateSpec, defs []*eskip.Predicate) ([
 	var weight int
 	for _, def := range defs {
 		if def.Name == predicates.WeightName {
+			var w int
 			var err error
-			if weight, err = parseWeightPredicateArgs(def.Args); err != nil {
+
+			if w, err = parseWeightPredicateArgs(def.Args); err != nil {
 				return nil, 0, err
 			}
+
+			weight += w
 
 			continue
 		}
@@ -385,6 +389,11 @@ func processPredicates(cpm map[string]PredicateSpec, defs []*eskip.Predicate) ([
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to create predicate %q: %w", spec.Name(), err)
 		}
+
+		if ws, ok := spec.(WeightedPredicateSpec); ok {
+			weight += ws.Weight()
+		}
+
 
 		cps = append(cps, cp)
 	}

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -148,6 +148,9 @@ func TestProcessRouteDefWeight(t *testing.T) {
 			`Weight(20) -> <shunt>`,
 			20,
 		}, {
+			`Weight(20) && Weight(10)-> <shunt>`,
+			30,
+		}, {
 			`WeightedPredicate10() && Weight(20) -> <shunt>`,
 			30,
 		},

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -284,9 +284,7 @@ func TestLogging(t *testing.T) {
 }
 
 type weightedPredicateSpec struct{}
-type weightedPredicate struct {
-	Weight int
-}
+type weightedPredicate struct{}
 
 func (w weightedPredicate) Match(request *http.Request) bool {
 	return true
@@ -297,9 +295,7 @@ func (w weightedPredicateSpec) Name() string {
 }
 
 func (w weightedPredicateSpec) Create([]interface{}) (routing.Predicate, error) {
-	return weightedPredicate{
-		Weight: w.Weight(),
-	}, nil
+	return weightedPredicate{}, nil
 }
 
 func (w weightedPredicateSpec) Weight() int {

--- a/routing/export_test.go
+++ b/routing/export_test.go
@@ -4,4 +4,5 @@ var (
 	ExportProcessRouteDef = processRouteDef
 	ExportNewMatcher      = newMatcher
 	ExportMatch           = (*matcher).match
+	ExportProcessPredicates = processPredicates
 )

--- a/routing/export_test.go
+++ b/routing/export_test.go
@@ -1,8 +1,8 @@
 package routing
 
 var (
-	ExportProcessRouteDef = processRouteDef
-	ExportNewMatcher      = newMatcher
-	ExportMatch           = (*matcher).match
+	ExportProcessRouteDef   = processRouteDef
+	ExportNewMatcher        = newMatcher
+	ExportMatch             = (*matcher).match
 	ExportProcessPredicates = processPredicates
 )

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -72,6 +72,13 @@ type PredicateSpec interface {
 	Create([]interface{}) (Predicate, error)
 }
 
+type WeightedPredicateSpec interface {
+	PredicateSpec
+
+	// Extra Weight of the predicate
+	Weight() int
+}
+
 // Options for initialization for routing.
 type Options struct {
 


### PR DESCRIPTION
### tl;dr; The change itself

This PR adds the ability to provide extra weight for custom predicates (there were some conversations about it in https://github.com/zalando/skipper/pull/1338, even if no consensus).

Some details:
- It's an opt-in feature: by default, predicates do not have any custom weight associated with it (on top of the weight they already have "[because they exist](https://github.com/ruudk/skipper/blob/master/routing/matcher.go#L58)")
- It's backwards compatible: no effect to all existing predicates

I think the implementation is pretty straight forward, it doesn't impact the core types (Predicate and PredicateSpec remain the same), it's memory efficient (it doesn't store a new weight integer per predicate, and instead has the integer in the PredicateSpec itself) and it gives a ton of flexibility for those using Skipper as a library. 


### Very long context: 

This PR adds the ability to provide extra weight for custom predicates (there were some conversations about it in https://github.com/zalando/skipper/pull/1338, even if no consensus).

The reason why we would benefit of such feature is we have some custom predicates that evaluate the HTTP request and need to build some decision tree, and it's getting complex to manage weight independently of the predicate itself, as it forces use to re-evaluate queries as they are written to dynamically assign a value to the `Weight` predicate.

Some (simplified) example of the routes and custom predicates we have:

```
FEATURE_AND_VARIATION: Path("/") && InAbTest("experiment", "variation1") && FeatureEnabled("newFeature") -> setPath("/featureWithVariation") -> http://example.com
FEATURE_ONLY: Path("/") && FeatureEnabled("newFeature") -> setPath("/feature") -> http://example.com
VARIATION_ONLY: Path("/") && InAbTest("experiment", "variation1") -> setPath("/variation1") -> http://example.com
```
In this sample Eskip file, we're aiming to route to `FEATURE_AND_VARIATION` if both predicates match. But we can't just build composed routes all the time, because it wouldn't scale.

In that example, we want to give a higher weight to `FeatureEnabled` than to `InAbTest`, so we could do...

```
FEATURE_ONLY: Path("/") && FeatureEnabled("newFeature") && Weight(1)-> setPath("/feature") -> http://example.com
VARIATION_ONLY: Path("/") && InAbTest("experiment", "variation1") -> setPath("/variation1") -> http://example.com
```

But if there's something else in there (like another test running, or some other predicate), we still want `feature` to be the one, so by adding another route, we would need to update the weight of the first route to keep it working as we want.

```
FEATURE_ONLY: Path("/") && FeatureEnabled("newFeature") && Weight(2)-> setPath("/feature") -> http://example.com
VARIATION_ONLY: Path("/") && InAbTest("experiment", "variation1") -> setPath("/variation1") -> http://example.com
TWO_EXPERIMENTS_: Path("/") && InAbTest("experiment1", "variation1")  && InAbTest("experiment2", "variation1") -> setPath("/exp1exp2") -> http://example.com
```

An alternative (the one we're using) is to, for example, always add 1000 to the weight of a route including `FeatureEnabled`, 10 to the weight of a route including a `InAbTest`, etc. So when writing the routes, we keep a counter and depending on the predicates (and their types), we end up writing the accumulated weight:

```
FEATURE_AND_VARIATION: Path("/") && InAbTest("experiment", "variation1") && FeatureEnabled("newFeature") && Weight(1010) -> setPath("/featureWithVariation") -> http://example.com
FEATURE_ONLY: Path("/") && FeatureEnabled("newFeature")  && Weight(1000) -> setPath("/feature") -> http://example.com
VARIATION_ONLY: Path("/") && InAbTest("experiment", "variation1")  && Weight(10) -> setPath("/variation1") -> http://example.com
```

After (if) this PR is merged, we'd add those custom weights to the predicates themselves, so `FeatureEnabled` always adds a weight of 1000, and `InAbTest` always adds a weight of 10.

(as I said originally, this is a simplification: we already have more predicate types with different "built-in" weights)