### PR TITLE
Pin build to Go 1.18

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.18'
+          go-version: '~1.18'
       - run: go version
       - run: make deps
       - run: make check-fmt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.18'
+          go-version: '~1.18'
       - run: go version
       - run: make deps
       - run: make check-race
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.18'
+          go-version: '~1.18'
       - run: go version
       - run: make deps
       - run: make check-fmt

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,7 +3,7 @@ pipeline:
 - id: build
   vm_config:
     type: linux
-    image: "cdp-runtime/go"
+    image: "cdp-runtime/go-1.18"
   type: script
   commands:
   - desc: Setup BuildKit


### PR DESCRIPTION
Pin build to Go 1.18 until it's ready for Go 1.19

Go 1.19 is being addressed in #2053 but is not a straight forward upgrade. So pin to 1.18 for now.