### PR TITLE
Update alpine base image to latest minor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/alpine-3.13:latest
+FROM registry.opensource.zalan.do/library/alpine-3:latest
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 
 ADD skipper /usr/bin/

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/yookoala/gofast v0.6.0
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9
 	go.uber.org/atomic v1.9.0
-	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
+	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -115,7 +115,7 @@ require (
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
+	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.8 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -981,8 +981,8 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
-golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 h1:GIAS/yBem/gq2MUqgNIzUHW7cJMmx3TGZOrnyYaNQ6c=
+golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1190,8 +1190,8 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211109184856-51b60fd695b3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 h1:Sx/u41w+OwrInGdEckYmEuU5gHoGSL4QbDz3S9s6j4U=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3.13:latest
+ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3:latest
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates

--- a/packaging/Dockerfile.arm64
+++ b/packaging/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 alpine:3.13
+FROM --platform=linux/arm64 alpine:3
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 ADD build/linux/arm64/skipper \

--- a/packaging/Dockerfile.armv7
+++ b/packaging/Dockerfile.armv7
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm/v7 alpine:3.13
+FROM --platform=linux/arm/v7 alpine:3
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 ADD build/linux/arm/v7/skipper \

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -59,7 +59,7 @@ docker.push.armv7: docker.build.armv7
 # build multi-arch container image using a trusted multi-arch base image
 docker.push.multiarch: clean build.linux docker.build.enable
 	docker buildx build --rm -t $(MULTIARCH_IMAGE) --platform linux/amd64,linux/arm64 --push \
-	  --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3.13:latest .
+	  --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3:latest .
 
 # https://docs.docker.com/build/working-with-build/
 # ~/.docker/config.json add: "experimental": "enabled",


### PR DESCRIPTION
This updates the base image to alpine 3 which always ensures the latest minor version being used. For opensource images this is `alpine:3` and for Zalando images this is `container-registry.zalando.net/library/alpine-3:latest`. Right now this will resolve to `3.16`.

Additionally it updates the `golang.org/x/crypto/ssh` library.

Both things addresses vulnerabilities reported for the latest images:

```
trivy i container-registry.zalando.net/teapot/skipper:v0.13.237
2022-08-22T19:28:15.151+0200	INFO	Vulnerability scanning is enabled
2022-08-22T19:28:15.151+0200	INFO	Secret scanning is enabled
2022-08-22T19:28:15.151+0200	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-08-22T19:28:15.151+0200	INFO	Please see also https://aquasecurity.github.io/trivy/v0.31.2/docs/secret/scanning/#recommendation for faster secret detection
2022-08-22T19:28:16.361+0200	INFO	Detected OS: alpine
2022-08-22T19:28:16.361+0200	INFO	Detecting Alpine vulnerabilities...
2022-08-22T19:28:16.362+0200	INFO	Number of language-specific files: 4
2022-08-22T19:28:16.362+0200	INFO	Detecting gobinary vulnerabilities...
2022-08-22T19:28:16.362+0200	WARN	version error ((devel)): malformed version: (devel)
2022-08-22T19:28:16.363+0200	WARN	version error ((devel)): malformed version: (devel)
2022-08-22T19:28:16.365+0200	WARN	version error ((devel)): malformed version: (devel)
2022-08-22T19:28:16.366+0200	WARN	version error ((devel)): malformed version: (devel)

container-registry.zalando.net/teapot/skipper:v0.13.237 (alpine 3.13.11)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                           Title                           │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ zlib    │ CVE-2022-37434 │ CRITICAL │ 1.2.12-r1         │ 1.2.12-r2     │ zlib: a heap-based buffer over-read or buffer overflow in │
│         │                │          │                   │               │ inflate in inflate.c...                                   │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-37434                │
└─────────┴────────────────┴──────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘

usr/bin/eskip (gobinary)

Total: 2 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌─────────────────────┬─────────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬────────────────────────────────────────────────────────────┐
│       Library       │    Vulnerability    │ Severity │         Installed Version          │           Fixed Version           │                           Title                            │
├─────────────────────┼─────────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2022-27191      │ HIGH     │ v0.0.0-20211215153901-e495a2d5b3d3 │ 0.0.0-20220314234659-1baeb1ce4c0b │ golang: crash in a golang.org/x/crypto/ssh server          │
│                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                 │
│                     ├─────────────────────┼──────────┤                                    │                                   ├────────────────────────────────────────────────────────────┤
│                     │ GHSA-8c26-wmh5-6g9v │ UNKNOWN  │                                    │                                   │ Attackers can cause a crash in SSH servers when the server │
│                     │                     │          │                                    │                                   │ has...                                                     │
│                     │                     │          │                                    │                                   │ https://github.com/advisories/GHSA-8c26-wmh5-6g9v          │
└─────────────────────┴─────────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴────────────────────────────────────────────────────────────┘

usr/bin/routesrv (gobinary)

Total: 2 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌─────────────────────┬─────────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬────────────────────────────────────────────────────────────┐
│       Library       │    Vulnerability    │ Severity │         Installed Version          │           Fixed Version           │                           Title                            │
├─────────────────────┼─────────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2022-27191      │ HIGH     │ v0.0.0-20211215153901-e495a2d5b3d3 │ 0.0.0-20220314234659-1baeb1ce4c0b │ golang: crash in a golang.org/x/crypto/ssh server          │
│                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                 │
│                     ├─────────────────────┼──────────┤                                    │                                   ├────────────────────────────────────────────────────────────┤
│                     │ GHSA-8c26-wmh5-6g9v │ UNKNOWN  │                                    │                                   │ Attackers can cause a crash in SSH servers when the server │
│                     │                     │          │                                    │                                   │ has...                                                     │
│                     │                     │          │                                    │                                   │ https://github.com/advisories/GHSA-8c26-wmh5-6g9v          │
└─────────────────────┴─────────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴────────────────────────────────────────────────────────────┘

usr/bin/skipper (gobinary)

Total: 2 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌─────────────────────┬─────────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬────────────────────────────────────────────────────────────┐
│       Library       │    Vulnerability    │ Severity │         Installed Version          │           Fixed Version           │                           Title                            │
├─────────────────────┼─────────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2022-27191      │ HIGH     │ v0.0.0-20211215153901-e495a2d5b3d3 │ 0.0.0-20220314234659-1baeb1ce4c0b │ golang: crash in a golang.org/x/crypto/ssh server          │
│                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                 │
│                     ├─────────────────────┼──────────┤                                    │                                   ├────────────────────────────────────────────────────────────┤
│                     │ GHSA-8c26-wmh5-6g9v │ UNKNOWN  │                                    │                                   │ Attackers can cause a crash in SSH servers when the server │
│                     │                     │          │                                    │                                   │ has...                                                     │
│                     │                     │          │                                    │                                   │ https://github.com/advisories/GHSA-8c26-wmh5-6g9v          │
└─────────────────────┴─────────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴────────────────────────────────────────────────────────────┘

usr/bin/webhook (gobinary)

Total: 2 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌─────────────────────┬─────────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬────────────────────────────────────────────────────────────┐
│       Library       │    Vulnerability    │ Severity │         Installed Version          │           Fixed Version           │                           Title                            │
├─────────────────────┼─────────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2022-27191      │ HIGH     │ v0.0.0-20211215153901-e495a2d5b3d3 │ 0.0.0-20220314234659-1baeb1ce4c0b │ golang: crash in a golang.org/x/crypto/ssh server          │
│                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                 │
│                     ├─────────────────────┼──────────┤                                    │                                   ├────────────────────────────────────────────────────────────┤
│                     │ GHSA-8c26-wmh5-6g9v │ UNKNOWN  │                                    │                                   │ Attackers can cause a crash in SSH servers when the server │
│                     │                     │          │                                    │                                   │ has...                                                     │
│                     │                     │          │                                    │                                   │ https://github.com/advisories/GHSA-8c26-wmh5-6g9v          │
└─────────────────────┴─────────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴────────────────────────────────────────────────────────────┘
```