### PR TITLE
feature: allow insecure connections when using tls

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 
 	// generic:
 	Address                         string         `yaml:"address"`
+	InsecureAddress                 string         `yaml:"insecure-address"`
 	EnableTCPQueue                  bool           `yaml:"enable-tcp-queue"`
 	ExpectedBytesPerRequest         int            `yaml:"expected-bytes-per-request"`
 	MaxTCPListenerConcurrency       int            `yaml:"max-tcp-listener-concurrency"`
@@ -298,6 +299,7 @@ func NewConfig() *Config {
 
 	// generic:
 	flag.StringVar(&cfg.Address, "address", ":9090", "network address that skipper should listen on")
+	flag.StringVar(&cfg.InsecureAddress, "insecure-address", "", "insecure network address that skipper should listen on when TLS is enabled")
 	flag.BoolVar(&cfg.EnableTCPQueue, "enable-tcp-queue", false, "enable the TCP listener queue")
 	flag.IntVar(&cfg.ExpectedBytesPerRequest, "expected-bytes-per-request", 50*1024, "bytes per request, that is used to calculate concurrency limits to buffer connection spikes")
 	flag.IntVar(&cfg.MaxTCPListenerConcurrency, "max-tcp-listener-concurrency", 0, "sets hardcoded max for TCP listener concurrency, normally calculated based on available memory cgroups with max TODO")
@@ -668,6 +670,7 @@ func (c *Config) ToOptions() skipper.Options {
 	options := skipper.Options{
 		// generic:
 		Address:                         c.Address,
+		InsecureAddress:                 c.InsecureAddress,
 		StatusChecks:                    c.StatusChecks.values,
 		EnableTCPQueue:                  c.EnableTCPQueue,
 		ExpectedBytesPerRequest:         c.ExpectedBytesPerRequest,

--- a/skipper.go
+++ b/skipper.go
@@ -1061,13 +1061,13 @@ func (o *Options) tlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 	return config, nil
 }
 
-func listen(o *Options, mtr metrics.Metrics) (net.Listener, error) {
-	if o.Address == "" {
-		o.Address = ":http"
+func listen(o *Options, address string, mtr metrics.Metrics) (net.Listener, error) {
+	if address == "" {
+		address = ":http"
 	}
 
 	if !o.EnableTCPQueue {
-		return net.Listen("tcp", o.Address)
+		return net.Listen("tcp", address)
 	}
 
 	var memoryLimit int
@@ -1108,7 +1108,7 @@ func listen(o *Options, mtr metrics.Metrics) (net.Listener, error) {
 
 	return queuelistener.Listen(queuelistener.Options{
 		Network:          "tcp",
-		Address:          o.Address,
+		Address:          address,
 		MaxConcurrency:   o.MaxTCPListenerConcurrency,
 		MaxQueueSize:     o.MaxTCPListenerQueue,
 		MemoryLimitBytes: memoryLimit,
@@ -1182,8 +1182,7 @@ func listenAndServeQuit(
 			log.Infof("insecure listener on %v", o.InsecureAddress)
 
 			go func() {
-				o.Address = o.InsecureAddress
-				l, err := listen(o, mtr)
+				l, err := listen(o, o.InsecureAddress, mtr)
 				if err != nil {
 					log.Errorf("Failed to start insecure listener on %s: %v", o.Address, err)
 				}
@@ -1200,8 +1199,7 @@ func listenAndServeQuit(
 		}
 	} else {
 		log.Infof("TLS settings not found, defaulting to HTTP")
-
-		l, err := listen(o, mtr)
+		l, err := listen(o, o.Address, mtr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Allow insecure connections on an alternate port when using TLS. This
will remove the requirement to encrypt all traffic when enabling TLS.

Fixes: #2065