### PR TITLE
Fix: memory leak in admissionControl filter.

### DIFF
--- a/filters/shedder/admission.go
+++ b/filters/shedder/admission.go
@@ -331,6 +331,9 @@ func (ac *admissionControl) Close() {
 func (ac *admissionControl) tickWindows(d time.Duration) {
 	t := time.NewTicker(d)
 	i := 0
+	defer func() {
+		t.Stop()
+	}()
 	for range t.C {
 		select {
 		case <-ac.quit:

--- a/filters/shedder/admission.go
+++ b/filters/shedder/admission.go
@@ -330,10 +330,9 @@ func (ac *admissionControl) Close() {
 
 func (ac *admissionControl) tickWindows(d time.Duration) {
 	t := time.NewTicker(d)
+	defer t.Stop()
 	i := 0
-	defer func() {
-		t.Stop()
-	}()
+
 	for range t.C {
 		select {
 		case <-ac.quit:

--- a/loadbalancer/healthchecker.go
+++ b/loadbalancer/healthchecker.go
@@ -144,6 +144,7 @@ func (lb *LB) FilterHealthyMemberRoutes(routes []*routing.Route) []*routing.Rout
 // healthchecks to all backends, which were reported.
 func (lb *LB) startDoHealthChecks() {
 	healthTicker := time.NewTicker(lb.healthcheckInterval)
+	defer healthTicker.Stop()
 	rt := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   3000 * time.Millisecond,

--- a/secrets/encrypter.go
+++ b/secrets/encrypter.go
@@ -160,6 +160,7 @@ func (e *Encrypter) runCipherRefresher(refreshInterval time.Duration) error {
 	}
 	go func() {
 		ticker := time.NewTicker(refreshInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-e.closer:


### PR DESCRIPTION
Fix: memory leak in admissionControl filter. In case routing changes triggers a lot of routing updates (f.e. every 3s) this would cause a leak of tickers and updates would be sent to the channel by Go runtime.

![image](https://user-images.githubusercontent.com/50872/186852894-2a0240b2-133d-4635-aba0-451c6964d22c.png)

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>