### PR TITLE
fix: on close of ratelimit registry it should close all filters

### DIFF
--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -73,6 +73,9 @@ func (r *Registry) Close() {
 	r.once.Do(func() {
 		r.closed = true
 		r.redisRing.Close()
+		for _, rl := range r.lookup {
+			rl.Close()
+		}
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>