### PR TITLE
proxy: fix FIFO/LIFO cleanup

### DIFF
--- a/filters/scheduler/loopback_test.go
+++ b/filters/scheduler/loopback_test.go
@@ -1,0 +1,57 @@
+package scheduler_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/builtin"
+	fifo "github.com/zalando/skipper/filters/scheduler"
+	"github.com/zalando/skipper/proxy"
+	"github.com/zalando/skipper/routing"
+	"github.com/zalando/skipper/routing/testdataclient"
+	"github.com/zalando/skipper/scheduler"
+)
+
+func TestFifoLoopback(t *testing.T) {
+	dc, err := testdataclient.NewDoc(`
+		main: Path("/") -> fifo(100, 100, "1s") -> setPath("/loop") -> <loopback>;
+		loop: Path("/loop") -> fifo(100, 100, "1s") -> inlineContent("ok") -> <shunt>;
+	`)
+	require.NoError(t, err)
+
+	filterRegistry := make(filters.Registry)
+	filterRegistry.Register(fifo.NewFifo())
+	filterRegistry.Register(builtin.NewSetPath())
+	filterRegistry.Register(builtin.NewInlineContent())
+
+	schedulerRegistry := scheduler.RegistryWith(scheduler.Options{})
+	defer schedulerRegistry.Close()
+
+	rt := routing.New(routing.Options{
+		DataClients:     []routing.DataClient{dc},
+		FilterRegistry:  filterRegistry,
+		PreProcessors:   []routing.PreProcessor{schedulerRegistry.PreProcessor()},
+		PostProcessors:  []routing.PostProcessor{schedulerRegistry},
+		SignalFirstLoad: true,
+	})
+	<-rt.FirstLoad()
+
+	pr := proxy.WithParams(proxy.Params{Routing: rt})
+	tsp := httptest.NewServer(pr)
+	defer tsp.Close()
+
+	resp, err := http.Get(tsp.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	content, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ok", string(content))
+}


### PR DESCRIPTION
`*Proxy.do()` maybe called for the `<loopback>` backend which resulted in double call of pending `done` handlers.
In case `fifo` is configured on the main and loopback route double call leads to panic:

```sh
./bin/skipper -inline-routes='loop: Path("/loop") -> fifo(100, 100, "1s") -> inlineContent("ok") -> <shunt>; main: Path("/") -> fifo(100, 100, "1s") -> setPath("/loop") -> <loopback>;'

curl -v localhost:9090/

# in the Skipper logs
[APP]ERRO[0015] http: panic serving 127.0.0.1:44918: semaphore: released more than held
```

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>