### PR TITLE
Make use of default filters in `RouteSRV`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -658,6 +658,30 @@ func (c *Config) ToRouteSrvOptions() routesrv.Options {
 		SourcePollTimeout:                  time.Duration(c.SourcePollTimeout) * time.Millisecond,
 		WaitForHealthcheckInterval:         c.WaitForHealthcheckInterval,
 		WhitelistedHealthCheckCIDR:         whitelistCIDRS,
+
+		// Auth:
+		EnableOAuth2GrantFlow:          c.EnableOAuth2GrantFlow,
+		OAuth2AuthURL:                  c.Oauth2AuthURL,
+		OAuth2TokenURL:                 c.Oauth2TokenURL,
+		OAuth2RevokeTokenURL:           c.Oauth2RevokeTokenURL,
+		OAuthTokeninfoURL:              c.Oauth2TokeninfoURL,
+		OAuthTokeninfoTimeout:          c.Oauth2TokeninfoTimeout,
+		OAuth2SecretFile:               c.Oauth2SecretFile,
+		OAuth2ClientID:                 c.Oauth2ClientID,
+		OAuth2ClientSecret:             c.Oauth2ClientSecret,
+		OAuth2ClientIDFile:             c.Oauth2ClientIDFile,
+		OAuth2ClientSecretFile:         c.Oauth2ClientSecretFile,
+		OAuth2CallbackPath:             c.Oauth2CallbackPath,
+		OAuthTokenintrospectionTimeout: c.Oauth2TokenintrospectionTimeout,
+		OAuth2AuthURLParameters:        c.Oauth2AuthURLParameters.values,
+		OAuth2AccessTokenHeaderName:    c.Oauth2AccessTokenHeaderName,
+		OAuth2TokeninfoSubjectKey:      c.Oauth2TokeninfoSubjectKey,
+		OAuth2TokenCookieName:          c.Oauth2TokenCookieName,
+		WebhookTimeout:                 c.WebhookTimeout,
+		OIDCSecretsFile:                c.OidcSecretsFile,
+		OIDCDistributedClaimsTimeout:   c.OidcDistributedClaimsTimeout,
+		CredentialsPaths:               c.CredentialPaths.values,
+		CredentialsUpdateInterval:      c.CredentialsUpdateInterval,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -660,28 +660,8 @@ func (c *Config) ToRouteSrvOptions() routesrv.Options {
 		WhitelistedHealthCheckCIDR:         whitelistCIDRS,
 
 		// Auth:
-		EnableOAuth2GrantFlow:          c.EnableOAuth2GrantFlow,
-		OAuth2AuthURL:                  c.Oauth2AuthURL,
-		OAuth2TokenURL:                 c.Oauth2TokenURL,
-		OAuth2RevokeTokenURL:           c.Oauth2RevokeTokenURL,
-		OAuthTokeninfoURL:              c.Oauth2TokeninfoURL,
-		OAuthTokeninfoTimeout:          c.Oauth2TokeninfoTimeout,
-		OAuth2SecretFile:               c.Oauth2SecretFile,
-		OAuth2ClientID:                 c.Oauth2ClientID,
-		OAuth2ClientSecret:             c.Oauth2ClientSecret,
-		OAuth2ClientIDFile:             c.Oauth2ClientIDFile,
-		OAuth2ClientSecretFile:         c.Oauth2ClientSecretFile,
-		OAuth2CallbackPath:             c.Oauth2CallbackPath,
-		OAuthTokenintrospectionTimeout: c.Oauth2TokenintrospectionTimeout,
-		OAuth2AuthURLParameters:        c.Oauth2AuthURLParameters.values,
-		OAuth2AccessTokenHeaderName:    c.Oauth2AccessTokenHeaderName,
-		OAuth2TokeninfoSubjectKey:      c.Oauth2TokeninfoSubjectKey,
-		OAuth2TokenCookieName:          c.Oauth2TokenCookieName,
-		WebhookTimeout:                 c.WebhookTimeout,
-		OIDCSecretsFile:                c.OidcSecretsFile,
-		OIDCDistributedClaimsTimeout:   c.OidcDistributedClaimsTimeout,
-		CredentialsPaths:               c.CredentialPaths.values,
-		CredentialsUpdateInterval:      c.CredentialsUpdateInterval,
+		EnableOAuth2GrantFlow: c.EnableOAuth2GrantFlow,
+		OAuth2CallbackPath:    c.Oauth2CallbackPath,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -634,6 +634,7 @@ func (c *Config) ToRouteSrvOptions() routesrv.Options {
 	return routesrv.Options{
 		Address:                            c.Address,
 		DefaultFiltersDir:                  c.DefaultFiltersDir,
+		DefaultFilters:                     &eskip.DefaultFilters{Prepend: c.PrependFilters.filters, Append: c.AppendFilters.filters},
 		KubernetesAllowedExternalNames:     c.KubernetesAllowedExternalNames,
 		KubernetesInCluster:                c.KubernetesInCluster,
 		KubernetesURL:                      c.KubernetesURL,

--- a/routesrv/options.go
+++ b/routesrv/options.go
@@ -7,7 +7,6 @@ import (
 	"github.com/zalando/skipper/dataclients/kubernetes"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
-	"github.com/zalando/skipper/secrets"
 )
 
 // Options for initializing/running RouteServer
@@ -132,84 +131,7 @@ type Options struct {
 	// EnableOAuth2GrantFlow, enables OAuth2 Grant Flow filter
 	EnableOAuth2GrantFlow bool
 
-	// OAuth2AuthURL, the url to redirect the requests to when login is required.
-	OAuth2AuthURL string
-
-	// OAuth2TokenURL, the url where the access code should be exchanged for the
-	// access token.
-	OAuth2TokenURL string
-
-	// OAuth2RevokeTokenURL, the url where the access and refresh tokens can be
-	// revoked during a logout.
-	OAuth2RevokeTokenURL string
-
-	// OAuthTokeninfoURL sets the the URL to be queried for
-	// information for all auth.NewOAuthTokeninfo*() filters.
-	OAuthTokeninfoURL string
-
-	// OAuthTokeninfoTimeout sets timeout duration while calling oauth token service
-	OAuthTokeninfoTimeout time.Duration
-
-	// OAuth2SecretFile contains the filename with the encryption key for the
-	// authentication cookie and grant flow state stored in Secrets.
-	OAuth2SecretFile string
-
-	// OAuth2ClientID, the OAuth2 client id of the current service, used to exchange
-	// the access code.
-	OAuth2ClientID string
-
-	// OAuth2ClientSecret, the secret associated with the ClientID, used to exchange
-	// the access code.
-	OAuth2ClientSecret string
-
-	// OAuth2ClientIDFile, the path of the file containing the OAuth2 client id of
-	// the current service, used to exchange the access code.
-	OAuth2ClientIDFile string
-
-	// OAuth2ClientSecretFile, the path of the file containing the secret associated
-	// with the ClientID, used to exchange the access code.
-	OAuth2ClientSecretFile string
-
 	// OAuth2CallbackPath contains the path where the OAuth2 callback requests with the
 	// authorization code should be redirected to. Defaults to /.well-known/oauth2-callback
 	OAuth2CallbackPath string
-
-	// OAuthTokenintrospectionTimeout sets timeout duration while calling oauth tokenintrospection service
-	OAuthTokenintrospectionTimeout time.Duration
-
-	// OAuth2AuthURLParameters the additional parameters to send to OAuth2 authorize and token endpoints.
-	OAuth2AuthURLParameters map[string]string
-
-	// OAuth2AccessTokenHeaderName the name of the header to which the access token
-	// should be assigned after the oauthGrant filter.
-	OAuth2AccessTokenHeaderName string
-
-	// OAuth2TokeninfoSubjectKey the key of the subject ID attribute in the
-	// tokeninfo map. Used for downstream oidcClaimsQuery compatibility.
-	OAuth2TokeninfoSubjectKey string
-
-	// OAuth2TokenCookieName the name of the cookie that Skipper sets after a
-	// successful OAuth2 token exchange. Stores the encrypted access token.
-	OAuth2TokenCookieName string
-
-	// CompressEncodings, if not empty replace default compression encodings
-	CompressEncodings []string
-
-	// OIDCSecretsFile path to the file containing key to encrypt OpenID token
-	OIDCSecretsFile string
-
-	// OIDCDistributedClaimsTimeout sets timeout duration while calling Distributed Claims endpoint.
-	OIDCDistributedClaimsTimeout time.Duration
-
-	// SecretsRegistry to store and load secretsencrypt
-	SecretsRegistry *secrets.Registry
-
-	// CredentialsPaths directories or files where credentials are stored one secret per file
-	CredentialsPaths []string
-
-	// CredentialsUpdateInterval sets the interval to update secrets
-	CredentialsUpdateInterval time.Duration
-
-	// WebhookTimeout sets timeout duration while calling a custom webhook auth service
-	WebhookTimeout time.Duration
 }

--- a/routesrv/options.go
+++ b/routesrv/options.go
@@ -114,6 +114,9 @@ type Options struct {
 	// Default filters directory enables default filters mechanism and sets the directory where the filters are located
 	DefaultFiltersDir string
 
+	// DefaultFilters enables appending/prepending filters to all routes
+	DefaultFilters *eskip.DefaultFilters
+
 	// OriginMarker is *deprecated* and not used anymore. It will be deleted in v1.
 	OriginMarker bool
 

--- a/routesrv/options.go
+++ b/routesrv/options.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/zalando/skipper/dataclients/kubernetes"
 	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/secrets"
 )
 
 // Options for initializing/running RouteServer
@@ -120,7 +122,94 @@ type Options struct {
 	// OriginMarker is *deprecated* and not used anymore. It will be deleted in v1.
 	OriginMarker bool
 
+	// List of custom filter specifications.
+	CustomFilters []filters.Spec
+
 	// OpenTracingBackendNameTag enables an additional tracing tag containing a backend name
 	// for a route when it's available (e.g. for RouteGroups)
 	OpenTracingBackendNameTag bool
+
+	// EnableOAuth2GrantFlow, enables OAuth2 Grant Flow filter
+	EnableOAuth2GrantFlow bool
+
+	// OAuth2AuthURL, the url to redirect the requests to when login is required.
+	OAuth2AuthURL string
+
+	// OAuth2TokenURL, the url where the access code should be exchanged for the
+	// access token.
+	OAuth2TokenURL string
+
+	// OAuth2RevokeTokenURL, the url where the access and refresh tokens can be
+	// revoked during a logout.
+	OAuth2RevokeTokenURL string
+
+	// OAuthTokeninfoURL sets the the URL to be queried for
+	// information for all auth.NewOAuthTokeninfo*() filters.
+	OAuthTokeninfoURL string
+
+	// OAuthTokeninfoTimeout sets timeout duration while calling oauth token service
+	OAuthTokeninfoTimeout time.Duration
+
+	// OAuth2SecretFile contains the filename with the encryption key for the
+	// authentication cookie and grant flow state stored in Secrets.
+	OAuth2SecretFile string
+
+	// OAuth2ClientID, the OAuth2 client id of the current service, used to exchange
+	// the access code.
+	OAuth2ClientID string
+
+	// OAuth2ClientSecret, the secret associated with the ClientID, used to exchange
+	// the access code.
+	OAuth2ClientSecret string
+
+	// OAuth2ClientIDFile, the path of the file containing the OAuth2 client id of
+	// the current service, used to exchange the access code.
+	OAuth2ClientIDFile string
+
+	// OAuth2ClientSecretFile, the path of the file containing the secret associated
+	// with the ClientID, used to exchange the access code.
+	OAuth2ClientSecretFile string
+
+	// OAuth2CallbackPath contains the path where the OAuth2 callback requests with the
+	// authorization code should be redirected to. Defaults to /.well-known/oauth2-callback
+	OAuth2CallbackPath string
+
+	// OAuthTokenintrospectionTimeout sets timeout duration while calling oauth tokenintrospection service
+	OAuthTokenintrospectionTimeout time.Duration
+
+	// OAuth2AuthURLParameters the additional parameters to send to OAuth2 authorize and token endpoints.
+	OAuth2AuthURLParameters map[string]string
+
+	// OAuth2AccessTokenHeaderName the name of the header to which the access token
+	// should be assigned after the oauthGrant filter.
+	OAuth2AccessTokenHeaderName string
+
+	// OAuth2TokeninfoSubjectKey the key of the subject ID attribute in the
+	// tokeninfo map. Used for downstream oidcClaimsQuery compatibility.
+	OAuth2TokeninfoSubjectKey string
+
+	// OAuth2TokenCookieName the name of the cookie that Skipper sets after a
+	// successful OAuth2 token exchange. Stores the encrypted access token.
+	OAuth2TokenCookieName string
+
+	// CompressEncodings, if not empty replace default compression encodings
+	CompressEncodings []string
+
+	// OIDCSecretsFile path to the file containing key to encrypt OpenID token
+	OIDCSecretsFile string
+
+	// OIDCDistributedClaimsTimeout sets timeout duration while calling Distributed Claims endpoint.
+	OIDCDistributedClaimsTimeout time.Duration
+
+	// SecretsRegistry to store and load secretsencrypt
+	SecretsRegistry *secrets.Registry
+
+	// CredentialsPaths directories or files where credentials are stored one secret per file
+	CredentialsPaths []string
+
+	// CredentialsUpdateInterval sets the interval to update secrets
+	CredentialsUpdateInterval time.Duration
+
+	// WebhookTimeout sets timeout duration while calling a custom webhook auth service
+	WebhookTimeout time.Duration
 }

--- a/routesrv/polling.go
+++ b/routesrv/polling.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters/auth"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/tracing"
 )
@@ -49,8 +50,8 @@ type poller struct {
 	quit    chan struct{}
 
 	// Preprocessors
-	defaultFilters     *eskip.DefaultFilters
-	oauth2Preprocessor routing.PreProcessor
+	defaultFilters *eskip.DefaultFilters
+	oauth2Config   *auth.OAuthConfig
 
 	// tracer
 	tracer ot.Tracer
@@ -74,8 +75,8 @@ func (p *poller) poll(wg *sync.WaitGroup) {
 		if p.defaultFilters != nil {
 			routes = p.defaultFilters.Do(routes)
 		}
-		if p.oauth2Preprocessor != nil {
-			routes = p.oauth2Preprocessor.Do(routes)
+		if p.oauth2Config != nil {
+			routes = p.oauth2Config.NewGrantPreprocessor().Do(routes)
 		}
 		routesCount = len(routes)
 

--- a/routesrv/polling.go
+++ b/routesrv/polling.go
@@ -43,12 +43,16 @@ var (
 )
 
 type poller struct {
-	client         routing.DataClient
-	b              *eskipBytes
-	timeout        time.Duration
-	quit           chan struct{}
-	defaultFilters *eskip.DefaultFilters
+	client  routing.DataClient
+	b       *eskipBytes
+	timeout time.Duration
+	quit    chan struct{}
 
+	// Preprocessors
+	defaultFilters     *eskip.DefaultFilters
+	oauth2Preprocessor routing.PreProcessor
+
+	// tracer
 	tracer ot.Tracer
 }
 
@@ -69,6 +73,9 @@ func (p *poller) poll(wg *sync.WaitGroup) {
 		routes, err := p.client.LoadAll()
 		if p.defaultFilters != nil {
 			routes = p.defaultFilters.Do(routes)
+		}
+		if p.oauth2Preprocessor != nil {
+			routes = p.oauth2Preprocessor.Do(routes)
 		}
 		routesCount = len(routes)
 

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -80,11 +80,12 @@ func New(opts Options) (*RouteServer, error) {
 		return nil, err
 	}
 	rs.poller = &poller{
-		client:  dataclient,
-		timeout: opts.SourcePollTimeout,
-		b:       b,
-		quit:    make(chan struct{}),
-		tracer:  tracer,
+		client:         dataclient,
+		timeout:        opts.SourcePollTimeout,
+		b:              b,
+		quit:           make(chan struct{}),
+		tracer:         tracer,
+		defaultFilters: opts.DefaultFilters,
 	}
 
 	rs.wg = &sync.WaitGroup{}

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -12,6 +12,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/dataclients/kubernetes"
+	"github.com/zalando/skipper/filters/auth"
+	"github.com/zalando/skipper/secrets"
 	"github.com/zalando/skipper/tracing"
 )
 
@@ -79,13 +81,60 @@ func New(opts Options) (*RouteServer, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if opts.SecretsRegistry == nil {
+		opts.SecretsRegistry = secrets.NewRegistry()
+	}
+	defer opts.SecretsRegistry.Close()
+
+	sp := secrets.NewSecretPaths(opts.CredentialsUpdateInterval)
+	defer sp.Close()
+	for _, p := range opts.CredentialsPaths {
+		if err := sp.Add(p); err != nil {
+			log.Errorf("Failed to add credentials file: %s: %v", p, err)
+		}
+	}
+
+	oauthConfig := &auth.OAuthConfig{}
+	if opts.EnableOAuth2GrantFlow /* explicitly enable grant flow */ {
+		grantSecrets := secrets.NewSecretPaths(opts.CredentialsUpdateInterval)
+		defer grantSecrets.Close()
+
+		oauthConfig.AuthURL = opts.OAuth2AuthURL
+		oauthConfig.TokenURL = opts.OAuth2TokenURL
+		oauthConfig.RevokeTokenURL = opts.OAuth2RevokeTokenURL
+		oauthConfig.TokeninfoURL = opts.OAuthTokeninfoURL
+		oauthConfig.SecretFile = opts.OAuth2SecretFile
+		oauthConfig.ClientID = opts.OAuth2ClientID
+		oauthConfig.ClientSecret = opts.OAuth2ClientSecret
+		oauthConfig.ClientIDFile = opts.OAuth2ClientIDFile
+		oauthConfig.ClientSecretFile = opts.OAuth2ClientSecretFile
+		oauthConfig.CallbackPath = opts.OAuth2CallbackPath
+		oauthConfig.AuthURLParameters = opts.OAuth2AuthURLParameters
+		oauthConfig.SecretsProvider = grantSecrets
+		oauthConfig.Secrets = opts.SecretsRegistry
+		oauthConfig.AccessTokenHeaderName = opts.OAuth2AccessTokenHeaderName
+		oauthConfig.TokeninfoSubjectKey = opts.OAuth2TokeninfoSubjectKey
+		oauthConfig.TokenCookieName = opts.OAuth2TokenCookieName
+		oauthConfig.ConnectionTimeout = opts.OAuthTokeninfoTimeout
+		oauthConfig.Tracer = tracer
+
+		if err := oauthConfig.Init(); err != nil {
+			log.Errorf("Failed to initialize oauth grant filter: %v.", err)
+			return nil, err
+		}
+	} else {
+		oauthConfig = nil
+	}
+
 	rs.poller = &poller{
-		client:         dataclient,
-		timeout:        opts.SourcePollTimeout,
-		b:              b,
-		quit:           make(chan struct{}),
-		tracer:         tracer,
-		defaultFilters: opts.DefaultFilters,
+		client:             dataclient,
+		timeout:            opts.SourcePollTimeout,
+		b:                  b,
+		quit:               make(chan struct{}),
+		defaultFilters:     opts.DefaultFilters,
+		oauth2Preprocessor: oauthConfig.NewGrantPreprocessor(),
+		tracer:             tracer,
 	}
 
 	rs.wg = &sync.WaitGroup{}

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -81,21 +81,20 @@ func New(opts Options) (*RouteServer, error) {
 		return nil, err
 	}
 
-	oauthConfig := &auth.OAuthConfig{}
+	var oauthConfig *auth.OAuthConfig
 	if opts.EnableOAuth2GrantFlow /* explicitly enable grant flow */ {
+		oauthConfig = &auth.OAuthConfig{}
 		oauthConfig.CallbackPath = opts.OAuth2CallbackPath
-	} else {
-		oauthConfig = nil
 	}
 
 	rs.poller = &poller{
-		client:             dataclient,
-		timeout:            opts.SourcePollTimeout,
-		b:                  b,
-		quit:               make(chan struct{}),
-		defaultFilters:     opts.DefaultFilters,
-		oauth2Preprocessor: oauthConfig.NewGrantPreprocessor(),
-		tracer:             tracer,
+		client:         dataclient,
+		timeout:        opts.SourcePollTimeout,
+		b:              b,
+		quit:           make(chan struct{}),
+		defaultFilters: opts.DefaultFilters,
+		oauth2Config:   oauthConfig,
+		tracer:         tracer,
 	}
 
 	rs.wg = &sync.WaitGroup{}

--- a/routesrv/testdata/internal-host-explicit-route-predicate.eskip
+++ b/routesrv/testdata/internal-host-explicit-route-predicate.eskip
@@ -1,0 +1,7 @@
+kube_rg__internal_default__myapp__all__0_0:
+	Host("^(ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") &&
+	ClientIP("10.2.0.0/15") && Header("X-Foo", "bar")
+	-> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;
+
+kube_rg__internal___ingress_cluster_local__catchall__0_0:
+	Host("^(ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/15") -> <shunt>;

--- a/routesrv/testdata/internal-host-explicit-route-predicate.yaml
+++ b/routesrv/testdata/internal-host-explicit-route-predicate.yaml
@@ -1,0 +1,41 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+  - ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+  routes:
+  - predicates:
+    - Header("X-Foo", "bar")
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.4.8
+  - ip: 10.2.4.16
+  ports:
+  - port: 80

--- a/routesrv/testdata/lb-target-multi-with-default-filters.eskip
+++ b/routesrv/testdata/lb-target-multi-with-default-filters.eskip
@@ -2,6 +2,7 @@
 kube_namespace1__ingress1______:
   *
   -> enableAccessLog(4, 5)
+  -> status(200)
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 // path rule, target 1:
@@ -9,10 +10,12 @@ kube_namespace1__ingress1__test_example_org___test1__service1:
   Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   && PathRegexp(/^(\/test1)/)
   -> enableAccessLog(4, 5)
+  -> status(200)
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 // catch all:
 kube___catchall__test_example_org____:
   Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   -> enableAccessLog(4, 5)
+  -> status(200)
   -> <shunt>;

--- a/routesrv/testdata/lb-target-multi-with-oauth2-callback.eskip
+++ b/routesrv/testdata/lb-target-multi-with-oauth2-callback.eskip
@@ -1,0 +1,20 @@
+// OAuth2 callback route
+__oauth2_grant_callback: Path("/.well-known/oauth2-callback")
+  -> grantCallback()
+  -> <shunt>;
+
+// default backend, target 1:
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+// path rule, target 1:
+kube_namespace1__ingress1__test_example_org___test1__service1:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
+  && PathRegexp(/^(\/test1)/)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+// catch all:
+kube___catchall__test_example_org____:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
+  -> <shunt>;

--- a/routesrv/testdata/lb-target-multi-with-prepend-default-filters.eskip
+++ b/routesrv/testdata/lb-target-multi-with-prepend-default-filters.eskip
@@ -1,0 +1,18 @@
+// default backend, target 1:
+kube_namespace1__ingress1______:
+  *
+  -> enableAccessLog(4, 5)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+// path rule, target 1:
+kube_namespace1__ingress1__test_example_org___test1__service1:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
+  && PathRegexp(/^(\/test1)/)
+  -> enableAccessLog(4, 5)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+// catch all:
+kube___catchall__test_example_org____:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
+  -> enableAccessLog(4, 5)
+  -> <shunt>;


### PR DESCRIPTION
In efforts to solve https://github.bus.zalan.do/pg9/issues/issues/33

# Summary

We need to decrease number of skipper instances pulling routes from kubeapiserver, right now if we have 100 skipper instances all of them will pull from kubeapiserver, which will put some unneeded pressure on it.

# Solution

The solution was to make a server to only pull routes from kubeapiserver and skipper will pull from that server.

**Old**
```
skipper -> apiserver
```
**New**
```
skipper -> routeSRV -> apiserver
```

RouteSRV was already implemented, but not deployed. In this PR we try to make sure there is no difference between `/routes` endpoints in skipper and routeSRV, while also moving all route handling to routeSRV instead of skipper.

- DefaultFilters
    -  - [x] Implementation
    -  - [x] Tests
    -  - [ ] Docs
- OAuth2
    -  - [x] Implementation
    -  - [x] Tests
    -  - [ ] Docs
- [ ] Go through all clusters and get the diff.
    

Signed-off-by: Mustafa Abdelrahman <mustafa.abdelrahman@zalando.de>