### PR TITLE
Implement fadeIn for consistent hash algorithm

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2667,7 +2667,7 @@ the traffic in a gradually increasing way, starting from their detection for the
 they receive equal amount traffic as the previously existing routes. The detection time of an load balanced
 backend endpoint is preserved over multiple generations of the route configuration (over route changes). This
 filter can be used to saturate the load of autoscaling applications that require a warm-up time and therefore a
-smooth ramp-up. The fade-in feature can be used together with the round-robin and random LB algorithms.
+smooth ramp-up. The fade-in feature can be used together with the roundRobin, random  or consistentHash LB algorithms.
 
 While the default fade-in curve is linear, the optional exponent parameter can be used to adjust the shape of
 the fade-in curve, based on the following equation:

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -127,9 +127,9 @@ func withFadeIn(rnd *rand.Rand, ctx *routing.LBContext, notFadingIndexes []int, 
 
 	switch a := algo.(type) {
 	case *roundRobin:
-		return shiftToRemaining(a.rnd, ctx, a.notFadingIndexes, a.fadingWeights, now)
+		return shiftToRemaining(a.rnd, ctx, notFadingIndexes, a.fadingWeights, now)
 	case *random:
-		return shiftToRemaining(a.rand, ctx, a.notFadingIndexes, a.fadingWeights, now)
+		return shiftToRemaining(a.rand, ctx, notFadingIndexes, a.fadingWeights, now)
 	case consistentHash:
 		// If all endpoints are fading, normal consistent hash result
 		if len(notFadingIndexes) == 0 {

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -102,7 +102,7 @@ func TestSelectAlgorithm(t *testing.T) {
 			t.Fatal("failed to set the endpoints")
 		}
 
-		if _, ok := rr[0].LBAlgorithm.(consistentHash); !ok {
+		if _, ok := rr[0].LBAlgorithm.(*consistentHash); !ok {
 			t.Fatal("failed to set the right algorithm")
 		}
 	})
@@ -277,7 +277,7 @@ func TestApply(t *testing.T) {
 
 func TestConsistentHashSearch(t *testing.T) {
 	apply := func(key string, endpoints []string) string {
-		ch := newConsistentHash(endpoints).(consistentHash)
+		ch := newConsistentHash(endpoints).(*consistentHash)
 		return endpoints[ch.search(key, allowAllEndpoints)]
 	}
 
@@ -313,7 +313,7 @@ func TestConsistentHashBoundedLoadSearch(t *testing.T) {
 			LBEndpoints: endpoints,
 		},
 	}})[0]
-	ch := route.LBAlgorithm.(consistentHash)
+	ch := route.LBAlgorithm.(*consistentHash)
 	ctx := &routing.LBContext{Request: r, Route: route, Params: map[string]interface{}{ConsistentHashBalanceFactor: 1.25}}
 	noLoad := ch.Apply(ctx)
 	nonBounded := ch.Apply(&routing.LBContext{Request: r, Route: route, Params: map[string]interface{}{}})
@@ -384,7 +384,7 @@ func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 			LBEndpoints: endpoints,
 		},
 	}})[0]
-	ch := route.LBAlgorithm.(consistentHash)
+	ch := route.LBAlgorithm.(*consistentHash)
 	balanceFactor := 1.25
 	ctx := &routing.LBContext{Request: r, Route: route, Params: map[string]interface{}{ConsistentHashBalanceFactor: balanceFactor}}
 
@@ -426,7 +426,7 @@ func addInflightRequests(endpoint routing.LBEndpoint, count int) {
 // Measures how fair the hash ring is to each endpoint.
 // i.e. Of the possible hashes, how many will go to each endpoint. The lower the standard deviation the better.
 func measureStdDev(t *testing.T, endpoints []string, hashesPerEndpoint int) float64 {
-	ch := newConsistentHashInternal(endpoints, hashesPerEndpoint).(consistentHash)
+	ch := newConsistentHashInternal(endpoints, hashesPerEndpoint).(*consistentHash)
 	ringOwnership := map[int]uint64{}
 	prevPartitionEndHash := uint64(0)
 	for i := 0; i < len(ch.hashRing); i++ {

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -278,7 +278,7 @@ func TestApply(t *testing.T) {
 func TestConsistentHashSearch(t *testing.T) {
 	apply := func(key string, endpoints []string) string {
 		ch := newConsistentHash(endpoints).(consistentHash)
-		return endpoints[ch.search(key)]
+		return endpoints[ch.search(key, allowAllEndpoints)]
 	}
 
 	endpoints := []string{"http://127.0.0.1:8080", "http://127.0.0.2:8080", "http://127.0.0.3:8080"}

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -429,13 +429,13 @@ func measureStdDev(t *testing.T, endpoints []string, hashesPerEndpoint int) floa
 	ch := newConsistentHashInternal(endpoints, hashesPerEndpoint).(consistentHash)
 	ringOwnership := map[int]uint64{}
 	prevPartitionEndHash := uint64(0)
-	for i := 0; i < len(ch); i++ {
-		endpointIndex := ch[i].index
-		partitionEndHash := uint64(ch[i].hash)
+	for i := 0; i < len(ch.hashRing); i++ {
+		endpointIndex := ch.hashRing[i].index
+		partitionEndHash := uint64(ch.hashRing[i].hash)
 		ringOwnership[endpointIndex] += partitionEndHash - prevPartitionEndHash
 		prevPartitionEndHash = partitionEndHash
 	}
-	ringOwnership[ch[0].index] += math.MaxUint64 - prevPartitionEndHash
+	ringOwnership[ch.hashRing[0].index] += math.MaxUint64 - prevPartitionEndHash
 	return stdDeviation(ringOwnership)
 }
 


### PR DESCRIPTION
closes https://github.com/zalando/skipper/issues/2081

Leaves the same implementation for random and roundRobin


Logic for consistentHash when a chosen endpoint is fading and it is decided not to send traffic to it:
    - If all endpoints are fading, return original choice from consistent hash
    - Else run consistent hash again, but only using non-fading endpoints

