### PR TITLE
proxy: fix connection upgrade test for go 1.19

### DIFF
--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -132,6 +132,13 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Backend sent Connection: close
+	if resp.Close {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(http.StatusText(http.StatusServiceUnavailable)))
+		return
+	}
+
 	requestHijackedConn, _, err := w.(http.Hijacker).Hijack()
 	if err != nil {
 		log.Errorf("Error hijacking request connection: %s", err)


### PR DESCRIPTION
Mikkel Oscar Lyderik Larsen <mikkel.larsen@zalando.de> identified the change https://github.com/golang/go/commit/770e0e584a98dfd5e8d0d00558085c339fda0ed7 that processes 1xx response status headers differently.

This change refactors tests and adds handling of non-standard `101 Switching Protocols` response with `Connection: close` header.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>