### PR TITLE
Fix swarm.Join() when NodeInfo pointer is nil

### DIFF
--- a/swarm/nodeinfo.go
+++ b/swarm/nodeinfo.go
@@ -18,7 +18,7 @@ type EntryPoint interface {
 	Nodes() []*NodeInfo
 }
 
-// NodeInfo is a value object tat contains information about swarm
+// NodeInfo is a value object that contains information about swarm
 // cluster nodes, that is required to access member nodes.
 type NodeInfo struct {
 	Name string

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -200,6 +200,9 @@ func Start(o Options) (*Swarm, error) {
 // Join will join given Swarm peers and return an initialiazed Swarm
 // object if successful.
 func Join(o Options, self *NodeInfo, nodes []*NodeInfo, cleanupF func()) (*Swarm, error) {
+	if self == nil {
+		return nil, fmt.Errorf("cannot join node to swarm, NodeInfo pointer is nil")
+	}
 	log.Infof("SWARM: %s is going to join swarm of %d nodes (%v)", self, len(nodes), nodes)
 	cfg := memberlist.DefaultLocalConfig()
 	if !o.Debug {


### PR DESCRIPTION
Fixes issue of panicking swam by handling the case where `NodeInfo` pointer is `nil`.

https://github.com/zalando/skipper/issues/2003