### PR TITLE
Fix swarm panic when swarm is `nil`.

### DIFF
--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -362,6 +362,9 @@ func (s *Swarm) Local() *NodeInfo {
 }
 
 func (s *Swarm) broadcast(m *message) error {
+	if s == nil {
+		return fmt.Errorf("cannot broadcast message, swarm is nil")
+	}
 	m.Source = s.Local().Name
 	b, err := encodeMessage(m)
 	if err != nil {


### PR DESCRIPTION
Fixes the panic in swarm `broadcast` function when the swarm pointer is `nil`.

Fixes: #1005 

Signed-off-by: noor <noormuhammadmalik95@gmail.com>