### PR TITLE
Feature / Adding url path components opentracing tag

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1484,6 +1484,14 @@ func (p *Proxy) setCommonSpanInfo(u *url.URL, r *http.Request, s ot.Span) {
 		setTag(s, HostnameTag, p.hostname).
 		setTag(s, HTTPPathTag, u.Path).
 		setTag(s, HTTPHostTag, r.Host)
+	pathComponents := strings.Split(u.Path, "/")
+	for i, part := range pathComponents {
+		if len(part) < 1 {
+			continue
+		}
+		HTTPPathPartTag := fmt.Sprintf("%s_%d", HTTPPathPartPrefixTag, i)
+		p.tracing.setTag(s, HTTPPathPartTag, part)
+	}
 	if val := r.Header.Get("X-Flow-Id"); val != "" {
 		p.tracing.setTag(s, FlowIDTag, val)
 	}

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -17,6 +17,7 @@ const (
 	HTTPMethodTag         = "http.method"
 	HTTPRemoteIPTag       = "http.remote_ip"
 	HTTPPathTag           = "http.path"
+	HTTPPathPartPrefixTag = "http.path.part"
 	HTTPUrlTag            = "http.url"
 	HTTPStatusCodeTag     = "http.status_code"
 	SkipperRouteIDTag     = "skipper.route_id"


### PR DESCRIPTION
Currently, it is not possible to filter URLs that have variable in the middle of their path (e.g: Hash, product code, ...) In opentracing systems. The lack of this ability makes opentracing very ineffective in reporting, especially in preparing SLO reports. In this feature, we separate path components based on forward slashes and place each in a special tag.