### PR TITLE
Fill the authuser field of the access log

### DIFF
--- a/logging/access_test.go
+++ b/logging/access_test.go
@@ -33,7 +33,8 @@ func testAccessEntry() *AccessEntry {
 		ResponseSize: 2326,
 		StatusCode:   http.StatusTeapot,
 		RequestTime:  testDate(),
-		Duration:     42 * time.Millisecond}
+		Duration:     42 * time.Millisecond,
+		AuthUser:     nil}
 }
 
 func testAccessLog(t *testing.T, entry *AccessEntry, expectedOutput string, o Options) {
@@ -195,6 +196,28 @@ func TestPresentFlowIdJSON(t *testing.T) {
 		t,
 		entry,
 		`{"audit":"","duration":42,"flow-id":"sometestflowid","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`,
+		Options{AccessLogJSONEnabled: true},
+	)
+}
+
+func TestPresentAuthUser(t *testing.T) {
+	entry := testAccessEntry()
+	s := "jsmith"
+	entry.AuthUser = &s
+	testAccessLogDefault(
+		t,
+		entry,
+		`127.0.0.1 - jsmith [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.1" 418 2326 "-" "-" 42 example.com - -`)
+}
+
+func TestPresentAuthUserJSON(t *testing.T) {
+	entry := testAccessEntry()
+	s := "jsmith"
+	entry.AuthUser = &s
+	testAccessLog(
+		t,
+		entry,
+		`{"audit":"","auth-user":"jsmith","duration":42,"flow-id":"","host":"127.0.0.1","level":"info","method":"GET","msg":"","proto":"HTTP/1.1","referer":"","requested-host":"example.com","response-size":2326,"status":418,"timestamp":"10/Oct/2000:13:55:36 -0700","uri":"/apache_pb.gif","user-agent":""}`,
 		Options{AccessLogJSONEnabled: true},
 	)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1413,9 +1413,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		statusCode := lw.GetCode()
-		authUser, _ := ctx.stateBag[filterslog.AuthUserKey].(string)
 
 		if shouldLog(statusCode, accessLogEnabled) {
+		        authUser, _ := ctx.stateBag[filterslog.AuthUserKey].(string)
 			entry := &logging.AccessEntry{
 				Request:      r,
 				ResponseSize: lw.GetBytes(),

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -27,6 +27,7 @@ import (
 	al "github.com/zalando/skipper/filters/accesslog"
 	circuitfilters "github.com/zalando/skipper/filters/circuit"
 	flowidFilter "github.com/zalando/skipper/filters/flowid"
+	log "github.com/zalando/skipper/filters/log"
 	ratelimitfilters "github.com/zalando/skipper/filters/ratelimit"
 	tracingfilter "github.com/zalando/skipper/filters/tracing"
 	"github.com/zalando/skipper/loadbalancer"
@@ -1413,12 +1414,18 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		statusCode := lw.GetCode()
 
 		if shouldLog(statusCode, accessLogEnabled) {
+			var authUser *string
+			if v, ok := ctx.stateBag[log.AuthUserKey]; ok {
+				s, _ := v.(string)
+				authUser = &s
+			}
 			entry := &logging.AccessEntry{
 				Request:      r,
 				ResponseSize: lw.GetBytes(),
 				StatusCode:   statusCode,
 				RequestTime:  ctx.startServe,
 				Duration:     time.Since(ctx.startServe),
+				AuthUser:     authUser,
 			}
 
 			additionalData, _ := ctx.stateBag[al.AccessLogAdditionalDataKey].(map[string]interface{})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1414,18 +1414,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		statusCode := lw.GetCode()
 
 		if shouldLog(statusCode, accessLogEnabled) {
-			var authUser *string
-			if v, ok := ctx.stateBag[filterslog.AuthUserKey]; ok {
-				s, _ := v.(string)
-				authUser = &s
-			}
 			entry := &logging.AccessEntry{
 				Request:      r,
 				ResponseSize: lw.GetBytes(),
 				StatusCode:   statusCode,
 				RequestTime:  ctx.startServe,
 				Duration:     time.Since(ctx.startServe),
-				AuthUser:     authUser,
+				AuthUser:     ctx.stateBag[filterslog.AuthUserKey].(string),
 			}
 
 			additionalData, _ := ctx.stateBag[al.AccessLogAdditionalDataKey].(map[string]interface{})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1415,7 +1415,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		statusCode := lw.GetCode()
 
 		if shouldLog(statusCode, accessLogEnabled) {
-		        authUser, _ := ctx.stateBag[filterslog.AuthUserKey].(string)
+			authUser, _ := ctx.stateBag[filterslog.AuthUserKey].(string)
 			entry := &logging.AccessEntry{
 				Request:      r,
 				ResponseSize: lw.GetBytes(),

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -27,7 +27,7 @@ import (
 	al "github.com/zalando/skipper/filters/accesslog"
 	circuitfilters "github.com/zalando/skipper/filters/circuit"
 	flowidFilter "github.com/zalando/skipper/filters/flowid"
-	log "github.com/zalando/skipper/filters/log"
+	filterslog "github.com/zalando/skipper/filters/log"
 	ratelimitfilters "github.com/zalando/skipper/filters/ratelimit"
 	tracingfilter "github.com/zalando/skipper/filters/tracing"
 	"github.com/zalando/skipper/loadbalancer"
@@ -1415,7 +1415,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		if shouldLog(statusCode, accessLogEnabled) {
 			var authUser *string
-			if v, ok := ctx.stateBag[log.AuthUserKey]; ok {
+			if v, ok := ctx.stateBag[filterslog.AuthUserKey]; ok {
 				s, _ := v.(string)
 				authUser = &s
 			}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1411,7 +1411,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				accessLogEnabled = &enabledAccessLog
 			}
 		}
+
 		statusCode := lw.GetCode()
+		authUser, _ := ctx.stateBag[filterslog.AuthUserKey].(string)
 
 		if shouldLog(statusCode, accessLogEnabled) {
 			entry := &logging.AccessEntry{
@@ -1420,7 +1422,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				StatusCode:   statusCode,
 				RequestTime:  ctx.startServe,
 				Duration:     time.Since(ctx.startServe),
-				AuthUser:     ctx.stateBag[filterslog.AuthUserKey].(string),
+				AuthUser:     authUser,
 			}
 
 			additionalData, _ := ctx.stateBag[al.AccessLogAdditionalDataKey].(map[string]interface{})


### PR DESCRIPTION
The auth filter already stores the username of the identified user in the state bag. This PR forwards this value to the access log filter by storing it in the AccessEntry structure.

It is then used in the `authuser` field of the Common Log Format formatter. It can also be accessed by other formatters (such as the JSON formatter) via the `auth-user` field of the logrus Entry.
