### PR TITLE
bug: `CloneRoute` dropping builtin predicates

### DIFF
--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -72,10 +72,11 @@ func (e *Editor) Do(routes []*Route) []*Route {
 		return routes
 	}
 
-	for i, r := range routes {
+	canonicalRoutes := CanonicalList(routes)
+
+	for i, r := range canonicalRoutes {
 		rr := new(Route)
 		*rr = *r
-		rr = Canonical(rr)
 
 		if doOneRoute(e.reg, e.repl, rr) {
 			routes[i] = rr
@@ -90,12 +91,13 @@ func (c *Clone) Do(routes []*Route) []*Route {
 		return routes
 	}
 
+	canonicalRoutes := CanonicalList(routes)
+
 	result := make([]*Route, len(routes), 2*len(routes))
 	copy(result, routes)
-	for _, r := range routes {
+	for _, r := range canonicalRoutes {
 		rr := new(Route)
 		*rr = *r
-		rr = Canonical(rr)
 
 		rr.Id = "clone_" + rr.Id
 		predicates := make([]*Predicate, len(r.Predicates))


### PR DESCRIPTION
CloneRoute Preprocessor was dropping builtin predicates resulting in wrong eskip

Refactor test cases for prepocessor and add one to test builtins.

Fixes up on #2134

Signed-off-by: Mustafa Abdelrahman <mustafa.abdelrahman@zalando.de>