### PR TITLE
fix: Change group name in case maxShards are set

### DIFF
--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -249,7 +249,7 @@ func clusterRatelimitFilter(maxShards int, args []interface{}) (*filter, error) 
 	if keyShards > 1 {
 		f.settings = ratelimit.Settings{
 			Type:       ratelimit.ClusterServiceRatelimit,
-			Group:      group + "." + strconv.Itoa(maxShards),
+			Group:      group + "." + strconv.Itoa(keyShards),
 			MaxHits:    maxHits / keyShards,
 			TimeWindow: timeWindow,
 			Lookuper:   ratelimit.NewRoundRobinLookuper(uint64(keyShards)),

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -8,6 +8,7 @@ package ratelimit
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -248,7 +249,7 @@ func clusterRatelimitFilter(maxShards int, args []interface{}) (*filter, error) 
 	if keyShards > 1 {
 		f.settings = ratelimit.Settings{
 			Type:       ratelimit.ClusterServiceRatelimit,
-			Group:      group,
+			Group:      group + "." + strconv.Itoa(maxShards),
 			MaxHits:    maxHits / keyShards,
 			TimeWindow: timeWindow,
 			Lookuper:   ratelimit.NewRoundRobinLookuper(uint64(keyShards)),

--- a/filters/ratelimit/ratelimit_test.go
+++ b/filters/ratelimit/ratelimit_test.go
@@ -311,7 +311,7 @@ func TestRateLimit(t *testing.T) {
 			MaxHits:    1,
 			TimeWindow: 1 * time.Second,
 			Lookuper:   ratelimit.NewRoundRobinLookuper(3),
-			Group:      "mygroup",
+			Group:      "mygroup.3",
 		},
 		&http.Response{
 			StatusCode: http.StatusTooManyRequests,


### PR DESCRIPTION
fix: Change group name in case maxShards are set to not cause downtime on reconfiguration of maxShards which configures the vnode shards. This will relax the config to allow double amount of requests during the reconfiguration, which seems to be a better choice than being more strict by a factor, that depends on former and new value of maxShards.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>