### PR TITLE
Add permissions hardening for the CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # to fetch the code (actions/checkout)
+      actions: read   # to be able to run codeql-actions
 
     strategy:
       fail-fast: false

--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -11,6 +11,9 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,7 @@
 name: pr
 on: [ pull_request ]
+permissions:
+  contents: read
 jobs:
   check-race:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Addresses https://github.com/zalando/skipper/issues/2137 by adding permissions for CI jobs for security hardening.

Signed-off-by: noor <noormuhammadmalik95@gmail.com>