### PR TITLE
Add semgrep job in the CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,18 @@ on: [ pull_request ]
 permissions:
   contents: read
 jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      # Retrieve the source code for the repository
+      - uses: actions/checkout@v3
+      # Fetch the semgrep rules
+      - run: git clone https://github.com/dgryski/semgrep-go.git
+      # Run the rule checker using the fetched rules
+      - run: semgrep ci -f semgrep-go
+
   check-race:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The PR adds [semgrep](https://github.com/dgryski/semgrep-go) based checking on the source code. Adds it as a new job to the CI to be triggered upon `pr`.

Addresses: #2055 