### PR TITLE
Update minimal version to build skipper in docs

### DIFF
--- a/docs/tutorials/basics.md
+++ b/docs/tutorials/basics.md
@@ -262,8 +262,6 @@ Route creation steps:
 
 ## Building skipper
 
-We use Go modules to build skipper, therefore you need [Go](https://golang.org/dl) version `>= 1.11`.
-
 ### Local build
 
 To get a local build of skipper for your CPU architecture, you can run


### PR DESCRIPTION
What?

Remove the sentence describing that the used needed go version >= 1.11
because of go modules.

Why?

This sentence was misleading since currently you need go version >= 1.19
and this was added just to make clear the necessity of go modules which
by now is something that can be assumed, since the go project uses
go modules for quite some time now.

The idea to just remove it instead to update the version is that this is
something pretty straight forward to find out and without this sentence
here we don't need to remember to update the docs everytime we update
the version.

-----

Signed-off-by: Lucas Thiesen <lucas.thiesen@zalando.de>