### PR TITLE
routing: detect and avoid loops

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -275,7 +275,7 @@ func (c *context) Split() (filters.FilterContext, error) {
 }
 
 func (c *context) Loopback() {
-	err := c.proxy.do(c)
+	err := c.proxy.doLoopback(c)
 	if c.response != nil && c.response.Body != nil {
 		if _, err := io.Copy(io.Discard, c.response.Body); err != nil {
 			c.proxy.log.Errorf("context: error while discarding remainder response body: %v.", err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1052,6 +1052,12 @@ func newRatelimitError(settings ratelimit.Settings, retryAfter int) error {
 	}
 }
 
+func (p *Proxy) doLoopback(ctx *context) error {
+	ctx.request = routing.WithRoute(ctx.request, ctx.route)
+
+	return p.do(ctx)
+}
+
 func (p *Proxy) do(ctx *context) error {
 	if ctx.executionCounter > p.maxLoops {
 		return errMaxLoopbacksReached
@@ -1119,7 +1125,7 @@ func (p *Proxy) do(ctx *context) error {
 		ctx.ensureDefaultResponse()
 	} else if ctx.route.BackendType == eskip.LoopBackend {
 		loopCTX := ctx.clone()
-		if err := p.do(loopCTX); err != nil {
+		if err := p.doLoopback(loopCTX); err != nil {
 			return err
 		}
 

--- a/routing/loopback.go
+++ b/routing/loopback.go
@@ -1,0 +1,39 @@
+package routing
+
+import (
+	"context"
+	"net/http"
+)
+
+type (
+	routeChain struct {
+		head *Route
+		tail *routeChain
+	}
+
+	contextKey struct {
+		name string
+	}
+)
+
+var routeChainContextKey = &contextKey{"route-chain-context-key"}
+
+// WithRoute returns a shallow copy of request with route stored in its context.
+func WithRoute(request *http.Request, route *Route) *http.Request {
+	parentCtx := request.Context()
+	chain, _ := parentCtx.Value(routeChainContextKey).(*routeChain)
+	chainCtx := context.WithValue(parentCtx, routeChainContextKey, &routeChain{route, chain})
+
+	return request.WithContext(chainCtx)
+}
+
+func inLoop(l *leafMatcher, request *http.Request) bool {
+	chain, _ := request.Context().Value(routeChainContextKey).(*routeChain)
+	for chain != nil {
+		if l.route == chain.head {
+			return true
+		}
+		chain = chain.tail
+	}
+	return false
+}

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -444,6 +444,10 @@ func matchPredicates(cps []Predicate, req *http.Request) bool {
 
 // matches a request to the conditions in a leaf matcher
 func matchLeaf(l *leafMatcher, req *http.Request, path, exactPath string) bool {
+	if inLoop(l, req) {
+		return false
+	}
+
 	if l.exactPath != "" && l.exactPath != path {
 		return false
 	}


### PR DESCRIPTION
Proxy keeps track of traversed routes on each loopback and Matcher ignores already traversed routes.

Consider example routing table:
```
bin/skipper -inline-routes='r1: Path("/test") && Weight(1) -> appendRequestHeader("x-route", "r1") -> <loopback>; r2: Path("/test") && Weight(2) -> appendRequestHeader("x-route", "r2") -> <loopback>; r3: Path("/test") -> logHeader() -> inlineContent("ok") -> <shunt>;'
```
The request would traverse r2, then r1 and finally r3.

- [ ] Tests please

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>