### PR TITLE
dataclients/kubernetestest: support `kind: List` fixtures

### DIFF
--- a/dataclients/kubernetes/kubernetestest/testdata/kind-list.yaml
+++ b/dataclients/kubernetes/kubernetestest/testdata/kind-list.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      application: baz
+    name: baz
+    namespace: baz
+  spec:
+    ports:
+    - name: main
+      port: 80
+      targetPort: 7878
+    selector:
+      application: baz
+    type: ClusterIP
+
+- apiVersion: zalando.org/v1
+  kind: RouteGroup
+  metadata:
+    name: baz
+    namespace: baz
+  spec:
+    hosts:
+    - baz.example.org
+    backends:
+    - name: baz
+      type: service
+      serviceName: baz
+      servicePort: 80
+    routes:
+    - pathSubtree: /
+      backends:
+      - backendName: baz
+
+- apiVersion: v1
+  kind: Endpoints
+  metadata:
+    labels:
+      application: baz
+    name: baz
+    namespace: baz
+  subsets:
+  - addresses:
+    - ip: 10.0.0.2
+      nodeName: node-10-1-0-2
+    ports:
+    - name: main
+      port: 7878
+      protocol: TCP


### PR DESCRIPTION
This is useful for testing cluster snapshots obtained e.g. like:

```sh
kubectl get routegroups,ingresses,services,endpoints -A -o yaml > snapshot.yaml
```

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>