### PR TITLE
eskip: reuse lexer and parser

### DIFF
--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -790,3 +790,17 @@ func TestFilterString(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkParsePredicates(b *testing.B) {
+	doc := `Foo("bar", "baz")`
+	_, err := ParsePredicates(doc)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParsePredicates(doc)
+	}
+}

--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -95,10 +95,9 @@ func (fs fixedScanner) scan(code string) (t token, rest string, err error) {
 	return
 }
 
-func newLexer(code string) *eskipLex {
-	return &eskipLex{
-		code:          code,
-		initialLength: len(code)}
+func (l *eskipLex) init(code string) {
+	l.code = code
+	l.initialLength = len(code)
 }
 
 func isWhitespace(c byte) bool  { return unicode.IsSpace(rune(c)) }


### PR DESCRIPTION
```
name               old time/op    new time/op    delta
ParsePredicates-8    4.80µs ± 4%    3.11µs ± 8%  -35.27%  (p=0.000 n=10+9)

name               old alloc/op   new alloc/op   delta
ParsePredicates-8    6.22kB ± 0%    0.74kB ± 0%  -88.03%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
ParsePredicates-8      37.0 ± 0%      35.0 ± 0%   -5.41%  (p=0.000 n=10+10)
```