### PR TITLE
proxy: refactor filter panic handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/time v0.3.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1128,7 +1128,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -35,7 +35,6 @@ type context struct {
 	originalRequest      *http.Request
 	originalResponse     *http.Response
 	outgoingHost         string
-	debugFilterPanics    []interface{}
 	outgoingDebugRequest *http.Request
 	executionCounter     int
 	startServe           time.Time

--- a/proxy/debug.go
+++ b/proxy/debug.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -36,19 +35,17 @@ type (
 		ResponseModBody string             `json:"response_mod_body,omitempty"`
 		ResponseModErr  string             `json:"response_mod_error,omitempty"`
 		ProxyError      string             `json:"proxy_error,omitempty"`
-		FilterPanics    []string           `json:"filter_panics,omitempty"`
 		Filters         []*eskip.Filter    `json:"filters,omitempty"`
 		Predicates      []*eskip.Predicate `json:"predicates,omitempty"`
 	}
 )
 
 type debugInfo struct {
-	route        *eskip.Route
-	incoming     *http.Request
-	outgoing     *http.Request
-	response     *http.Response
-	err          error
-	filterPanics []interface{}
+	route    *eskip.Route
+	incoming *http.Request
+	outgoing *http.Request
+	response *http.Response
+	err      error
 }
 
 func convertRequest(r *http.Request) *debugRequest {
@@ -119,10 +116,6 @@ func convertDebugInfo(d *debugInfo) debugDocument {
 
 	if d.err != nil {
 		doc.ProxyError = d.err.Error()
-	}
-
-	for _, fp := range d.filterPanics {
-		doc.FilterPanics = append(doc.FilterPanics, fmt.Sprint(fp))
 	}
 
 	return doc

--- a/proxy/debug_test.go
+++ b/proxy/debug_test.go
@@ -173,12 +173,10 @@ func TestDebug(t *testing.T) {
 		"error",
 		debugInfo{
 			err: errors.New("test error"),
-			filterPanics: []interface{}{
-				errors.New("panic one"),
-				errors.New("panic two")}},
+		},
 		debugDocument{
-			ProxyError:   "test error",
-			FilterPanics: []string{"panic one", "panic two"}},
+			ProxyError: "test error",
+		},
 	}} {
 		compareStrings := func(smsg string, got, expect []string) {
 			if len(got) != len(expect) {
@@ -277,7 +275,5 @@ func TestDebug(t *testing.T) {
 		if got.ProxyError != ti.expect.ProxyError {
 			t.Error(ti.msg, "failed to convert proxy error")
 		}
-
-		compareStrings("filter panics", got.FilterPanics, ti.expect.FilterPanics)
 	}
 }


### PR DESCRIPTION
In case of filter panic proxy abrupts filter chain and responds with 500 InternalServerError.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>