### PR TITLE
swarm nil pointer dereference panic

### DIFF
--- a/ratelimit/swim.go
+++ b/ratelimit/swim.go
@@ -95,7 +95,8 @@ func (c *clusterLimitSwim) Allow(clearText string) bool {
 	_ = c.local.Allow(s) // update local rate limit
 
 	if err := c.swarm.ShareValue(key, t0); err != nil {
-		log.Errorf("%s clusterRatelimit failed to share value: %v", c.group, err)
+		log.Errorf("clusterRatelimit '%s' disabled, failed to share value: %v", c.group, err)
+		return true // unsafe to continue otherwise
 	}
 
 	swarmValues := c.swarm.Values(key)


### PR DESCRIPTION
In case the Swarm is not operative, an error is logged.

However, that error is only logged and proceeded unverified.

This leads eventually into a panic of a nil pointer dereference.

fixes: #2197

Signed-off-by: Samuel Lang <gh@lang-sam.de>