### PR TITLE
Moved logging in admissionControl under the right if condition

### DIFF
--- a/filters/shedder/admission.go
+++ b/filters/shedder/admission.go
@@ -373,10 +373,10 @@ func (ac *admissionControl) pReject() float64 {
 
 	total, success := ac.count()
 	avgRps := total * ac.averageRpsFactor
-	if ac.mode == logInactive {
-		log.Infof("avgRps %0.2f does not reach minRps %d", avgRps, ac.minRps)
-	}
 	if avgRps < float64(ac.minRps) {
+		if ac.mode == logInactive {
+			log.Infof("avgRps %0.2f does not reach minRps %d", avgRps, ac.minRps)
+		}
 		return -1
 	}
 


### PR DESCRIPTION
Text of the log message makes me think that such log message should not be printer not always but only in case where calculated RPS is less than required minimum.

Signed-off-by: Roman Zavodskikh <roman.zavodskikh@zalando.de>