### PR TITLE
filters/auth: make `oauthGrant` check token cookie is allowed for request domain

### DIFF
--- a/filters/auth/grant.go
+++ b/filters/auth/grant.go
@@ -25,11 +25,11 @@ var (
 )
 
 type grantSpec struct {
-	config OAuthConfig
+	config *OAuthConfig
 }
 
 type grantFilter struct {
-	config OAuthConfig
+	config *OAuthConfig
 }
 
 func (s *grantSpec) Name() string { return filters.OAuthGrantName }
@@ -40,7 +40,7 @@ func (s *grantSpec) CreateFilter([]interface{}) (filters.Filter, error) {
 	}, nil
 }
 
-func providerContext(c OAuthConfig) context.Context {
+func providerContext(c *OAuthConfig) context.Context {
 	return context.WithValue(context.Background(), oauth2.HTTPClient, c.AuthClient)
 }
 
@@ -56,11 +56,11 @@ func badRequest(ctx filters.FilterContext) {
 	})
 }
 
-func loginRedirect(ctx filters.FilterContext, config OAuthConfig) {
+func loginRedirect(ctx filters.FilterContext, config *OAuthConfig) {
 	loginRedirectWithOverride(ctx, config, "")
 }
 
-func loginRedirectWithOverride(ctx filters.FilterContext, config OAuthConfig, originalOverride string) {
+func loginRedirectWithOverride(ctx filters.FilterContext, config *OAuthConfig, originalOverride string) {
 	req := ctx.Request()
 	redirect, original := config.RedirectURLs(req)
 

--- a/filters/auth/grant_test.go
+++ b/filters/auth/grant_test.go
@@ -202,7 +202,7 @@ func newGrantHTTPClient() *http.Client {
 	}
 }
 
-func newGrantCookie(config auth.OAuthConfig) (*http.Cookie, error) {
+func newGrantCookie(config *auth.OAuthConfig) (*http.Cookie, error) {
 	return auth.NewGrantCookieWithExpiration(config, time.Now().Add(testAccessTokenExpiresIn))
 }
 
@@ -378,7 +378,7 @@ func TestGrantFlow(t *testing.T) {
 	})
 
 	t.Run("check login is triggered when access token is invalid", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithInvalidAccessToken(*config)
+		cookie, err := auth.NewGrantCookieWithInvalidAccessToken(config)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -404,9 +404,9 @@ func TestGrantFlow(t *testing.T) {
 	})
 
 	t.Run("check handles multiple cookies with same name and uses the first decodable one", func(t *testing.T) {
-		badCookie, _ := newGrantCookie(*config)
+		badCookie, _ := newGrantCookie(config)
 		badCookie.Value = "invalid"
-		goodCookie, _ := newGrantCookie(*config)
+		goodCookie, _ := newGrantCookie(config)
 
 		rsp := grantQueryWithCookie(t, client, proxyUrl, badCookie, goodCookie)
 
@@ -414,7 +414,7 @@ func TestGrantFlow(t *testing.T) {
 	})
 
 	t.Run("check does not send cookie again if token was not refreshed", func(t *testing.T) {
-		goodCookie, _ := newGrantCookie(*config)
+		goodCookie, _ := newGrantCookie(config)
 
 		rsp := grantQueryWithCookie(t, client, proxyUrl, goodCookie)
 
@@ -442,7 +442,7 @@ func TestGrantRefresh(t *testing.T) {
 	defer proxy.Close()
 
 	t.Run("check token is refreshed if it expired", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithExpiration(*config, time.Now().Add(time.Duration(-1)*time.Minute))
+		cookie, err := auth.NewGrantCookieWithExpiration(config, time.Now().Add(time.Duration(-1)*time.Minute))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -453,7 +453,7 @@ func TestGrantRefresh(t *testing.T) {
 	})
 
 	t.Run("check login is triggered if refresh token is invalid", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithInvalidRefreshToken(*config)
+		cookie, err := auth.NewGrantCookieWithInvalidRefreshToken(config)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -479,7 +479,7 @@ func TestGrantTokeninfoSubjectPresent(t *testing.T) {
 
 	client := newGrantHTTPClient()
 
-	cookie, err := newGrantCookie(*config)
+	cookie, err := newGrantCookie(config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +504,7 @@ func TestGrantTokeninfoSubjectMissing(t *testing.T) {
 
 	client := newGrantHTTPClient()
 
-	cookie, err := newGrantCookie(*config)
+	cookie, err := newGrantCookie(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filters/auth/grantcallback.go
+++ b/filters/auth/grantcallback.go
@@ -14,11 +14,11 @@ import (
 const GrantCallbackName = filters.GrantCallbackName
 
 type grantCallbackSpec struct {
-	config OAuthConfig
+	config *OAuthConfig
 }
 
 type grantCallbackFilter struct {
-	config OAuthConfig
+	config *OAuthConfig
 }
 
 func (*grantCallbackSpec) Name() string { return filters.GrantCallbackName }

--- a/filters/auth/grantclaimsquery_test.go
+++ b/filters/auth/grantclaimsquery_test.go
@@ -25,7 +25,7 @@ func TestGrantClaimsQuery(t *testing.T) {
 
 	client := newGrantHTTPClient()
 
-	cookie, err := newGrantCookie(*config)
+	cookie, err := newGrantCookie(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -211,11 +211,11 @@ func (c *OAuthConfig) Init() error {
 }
 
 func (c *OAuthConfig) NewGrant() filters.Spec {
-	return &grantSpec{config: *c}
+	return &grantSpec{config: c}
 }
 
 func (c *OAuthConfig) NewGrantCallback() filters.Spec {
-	return &grantCallbackSpec{config: *c}
+	return &grantCallbackSpec{config: c}
 }
 
 func (c *OAuthConfig) NewGrantClaimsQuery() filters.Spec {
@@ -227,11 +227,11 @@ func (c *OAuthConfig) NewGrantClaimsQuery() filters.Spec {
 }
 
 func (c *OAuthConfig) NewGrantLogout() filters.Spec {
-	return &grantLogoutSpec{config: *c}
+	return &grantLogoutSpec{config: c}
 }
 
 func (c *OAuthConfig) NewGrantPreprocessor() routing.PreProcessor {
-	return &grantPrep{config: *c}
+	return &grantPrep{config: c}
 }
 
 func (c *OAuthConfig) GetConfig() *oauth2.Config {

--- a/filters/auth/grantcookie.go
+++ b/filters/auth/grantcookie.go
@@ -16,7 +16,7 @@ type cookie struct {
 	Expiry       time.Time `json:"expiry,omitempty"`
 }
 
-func decodeCookie(cookieHeader string, config OAuthConfig) (c *cookie, err error) {
+func decodeCookie(cookieHeader string, config *OAuthConfig) (c *cookie, err error) {
 	var eb []byte
 	if eb, err = base64.StdEncoding.DecodeString(cookieHeader); err != nil {
 		return
@@ -48,7 +48,7 @@ func (c *cookie) isAccessTokenExpired() bool {
 // cookie of the same name.
 // The grant token cookie is extracted so it does not get exposed to untrusted downstream
 // services.
-func extractCookie(request *http.Request, config OAuthConfig) (cookie *cookie, err error) {
+func extractCookie(request *http.Request, config *OAuthConfig) (cookie *cookie, err error) {
 	old := request.Cookies()
 	new := make([]*http.Cookie, 0, len(old))
 
@@ -75,7 +75,7 @@ func extractCookie(request *http.Request, config OAuthConfig) (cookie *cookie, e
 
 // createDeleteCookie creates a cookie, which instructs the client to clear the grant
 // token cookie when used with a Set-Cookie header.
-func createDeleteCookie(config OAuthConfig, host string) *http.Cookie {
+func createDeleteCookie(config *OAuthConfig, host string) *http.Cookie {
 	return &http.Cookie{
 		Name:     config.TokenCookieName,
 		Value:    "",
@@ -87,7 +87,7 @@ func createDeleteCookie(config OAuthConfig, host string) *http.Cookie {
 	}
 }
 
-func createCookie(config OAuthConfig, host string, t *oauth2.Token) (*http.Cookie, error) {
+func createCookie(config *OAuthConfig, host string, t *oauth2.Token) (*http.Cookie, error) {
 	c := cookie{
 		AccessToken:  t.AccessToken,
 		RefreshToken: t.RefreshToken,

--- a/filters/auth/grantcookie_test.go
+++ b/filters/auth/grantcookie_test.go
@@ -15,7 +15,7 @@ const (
 	testAccessTokenExpiresIn = time.Hour
 )
 
-func NewGrantCookieWithExpiration(config OAuthConfig, expiry time.Time) (*http.Cookie, error) {
+func NewGrantCookieWithExpiration(config *OAuthConfig, expiry time.Time) (*http.Cookie, error) {
 	token := &oauth2.Token{
 		AccessToken:  testToken,
 		RefreshToken: testRefreshToken,
@@ -26,7 +26,7 @@ func NewGrantCookieWithExpiration(config OAuthConfig, expiry time.Time) (*http.C
 	return cookie, err
 }
 
-func NewGrantCookieWithInvalidAccessToken(config OAuthConfig) (*http.Cookie, error) {
+func NewGrantCookieWithInvalidAccessToken(config *OAuthConfig) (*http.Cookie, error) {
 	token := &oauth2.Token{
 		AccessToken:  "invalid",
 		RefreshToken: testRefreshToken,
@@ -37,7 +37,7 @@ func NewGrantCookieWithInvalidAccessToken(config OAuthConfig) (*http.Cookie, err
 	return cookie, err
 }
 
-func NewGrantCookieWithInvalidRefreshToken(config OAuthConfig) (*http.Cookie, error) {
+func NewGrantCookieWithInvalidRefreshToken(config *OAuthConfig) (*http.Cookie, error) {
 	token := &oauth2.Token{
 		AccessToken:  testToken,
 		RefreshToken: "invalid",
@@ -48,7 +48,7 @@ func NewGrantCookieWithInvalidRefreshToken(config OAuthConfig) (*http.Cookie, er
 	return cookie, err
 }
 
-func NewGrantCookieWithTokens(config OAuthConfig, refreshToken string, accessToken string) (*http.Cookie, error) {
+func NewGrantCookieWithTokens(config *OAuthConfig, refreshToken string, accessToken string) (*http.Cookie, error) {
 	token := &oauth2.Token{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,

--- a/filters/auth/grantcookie_test.go
+++ b/filters/auth/grantcookie_test.go
@@ -58,3 +58,13 @@ func NewGrantCookieWithTokens(config *OAuthConfig, refreshToken string, accessTo
 	cookie, err := createCookie(config, "", token)
 	return cookie, err
 }
+
+func NewGrantCookieWithHost(config *OAuthConfig, host string) (*http.Cookie, error) {
+	token := &oauth2.Token{
+		AccessToken:  testToken,
+		RefreshToken: testRefreshToken,
+		Expiry:       time.Now().Add(testAccessTokenExpiresIn),
+	}
+
+	return createCookie(config, host, token)
+}

--- a/filters/auth/grantlogout.go
+++ b/filters/auth/grantlogout.go
@@ -25,11 +25,11 @@ const (
 )
 
 type grantLogoutSpec struct {
-	config OAuthConfig
+	config *OAuthConfig
 }
 
 type grantLogoutFilter struct {
-	config OAuthConfig
+	config *OAuthConfig
 }
 
 type revokeErrorResponse struct {

--- a/filters/auth/grantlogout_test.go
+++ b/filters/auth/grantlogout_test.go
@@ -127,7 +127,7 @@ func TestGrantLogout(t *testing.T) {
 	}
 
 	t.Run("check that logout with both tokens revokes refresh token", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithTokens(*config, testRefreshToken, testToken)
+		cookie, err := auth.NewGrantCookieWithTokens(config, testRefreshToken, testToken)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -138,7 +138,7 @@ func TestGrantLogout(t *testing.T) {
 	})
 
 	t.Run("check that logout with no refresh token revokes access token", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithTokens(*config, "", testToken)
+		cookie, err := auth.NewGrantCookieWithTokens(config, "", testToken)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -149,7 +149,7 @@ func TestGrantLogout(t *testing.T) {
 	})
 
 	t.Run("check that logout deletes grant token cookie", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithTokens(*config, testRefreshToken, testToken)
+		cookie, err := auth.NewGrantCookieWithTokens(config, testRefreshToken, testToken)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -161,7 +161,7 @@ func TestGrantLogout(t *testing.T) {
 	})
 
 	t.Run("check that logout with no tokens results in a 401", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithTokens(*config, "", "")
+		cookie, err := auth.NewGrantCookieWithTokens(config, "", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -187,7 +187,7 @@ func TestGrantLogout(t *testing.T) {
 	})
 
 	t.Run("check that logout with a refresh token which fails to revoke on the upstream server results in 500", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithTokens(*config, "another_refresh_token", testToken)
+		cookie, err := auth.NewGrantCookieWithTokens(config, "another_refresh_token", testToken)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -198,7 +198,7 @@ func TestGrantLogout(t *testing.T) {
 	})
 
 	t.Run("check that logout with an access token which fails to revoke on the upstream server results in 500", func(t *testing.T) {
-		cookie, err := auth.NewGrantCookieWithTokens(*config, testRefreshToken, "another_access_token")
+		cookie, err := auth.NewGrantCookieWithTokens(config, testRefreshToken, "another_access_token")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/filters/auth/grantprep.go
+++ b/filters/auth/grantprep.go
@@ -12,7 +12,7 @@ const (
 )
 
 type grantPrep struct {
-	config OAuthConfig
+	config *OAuthConfig
 }
 
 func (p *grantPrep) Do(r []*eskip.Route) []*eskip.Route {


### PR DESCRIPTION
filters/auth: make oauthGrant check token cookie is allowed for request domain

This prevents reuse of leaked cookie in another domain
