### PR TITLE
eskip: add `MustParse`

### DIFF
--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1654,8 +1654,7 @@ func TestHealthcheckRoutes(t *testing.T) {
 			defer func() { log.SetLevel(level) }()
 			log.SetLevel(tc.logLevel)
 
-			expected, err := eskip.Parse(tc.expected)
-			require.NoError(t, err)
+			expected := eskip.MustParse(tc.expected)
 
 			assert.EqualValues(t, expected, healthcheckRoutes(tc.reverseSourcePredicate))
 		})

--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -655,6 +655,16 @@ func Parse(code string) ([]*Route, error) {
 	return routeDefinitions, nil
 }
 
+// MustParse parses a route expression or a routing document to a set of route definitions and
+// panics in case of error
+func MustParse(code string) []*Route {
+	r, err := Parse(code)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
 func partialParse(f string, partialToRoute func(string) string) (*parsedRoute, error) {
 	rs, err := parse(partialToRoute(f))
 	if err != nil {

--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -300,6 +300,31 @@ func TestParseRouteExpression(t *testing.T) {
 	}
 }
 
+func TestMustParse(t *testing.T) {
+	const (
+		valid   = "* -> <shunt>"
+		invalid = "this is an invalid route definition"
+	)
+
+	expected, err := Parse(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := MustParse(valid)
+	if !cmp.Equal(r, expected) {
+		t.Errorf("Invalid parse result: %s", cmp.Diff(r, expected))
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic parsing %q", invalid)
+		}
+	}()
+
+	_ = MustParse(invalid)
+}
+
 func TestParseFilters(t *testing.T) {
 	for _, ti := range []struct {
 		msg        string

--- a/filters/auth/forwardtoken_test.go
+++ b/filters/auth/forwardtoken_test.go
@@ -119,10 +119,7 @@ func TestForwardToken(t *testing.T) {
 			fr.Register(NewOAuthTokenintrospectionAllClaims(10 * time.Second))
 			fr.Register(NewForwardToken())
 
-			routes, err := eskip.Parse(fmt.Sprintf(`* -> %s -> "%s"`, ti.filters, backend.URL))
-			if err != nil {
-				t.Fatal(err)
-			}
+			routes := eskip.MustParse(fmt.Sprintf(`* -> %s -> "%s"`, ti.filters, backend.URL))
 
 			proxy := proxytest.New(fr, routes[0])
 			defer proxy.Close()

--- a/filters/auth/grant_test.go
+++ b/filters/auth/grant_test.go
@@ -327,14 +327,11 @@ func TestGrantFlow(t *testing.T) {
 
 	var proxyUrl string
 	{
-		routes, err := eskip.Parse(`* -> oauthGrant()
+		routes := eskip.MustParse(`* -> oauthGrant()
 			-> status(204)
 			-> setResponseHeader("Backend-Request-Cookie", "${request.header.Cookie}")
 			-> <shunt>
 		`)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		proxy, err := newAuthProxy(config, routes...)
 		if err != nil {

--- a/filters/auth/grantlogout_test.go
+++ b/filters/auth/grantlogout_test.go
@@ -223,10 +223,7 @@ func TestGrantLogoutNoRevokeTokenURL(t *testing.T) {
 
 	var proxyUrl string
 	{
-		routes, err := eskip.Parse(`Path("/logout") -> grantLogout() -> redirectTo(302) -> <shunt>`)
-		if err != nil {
-			t.Fatal(err)
-		}
+		routes := eskip.MustParse(`Path("/logout") -> grantLogout() -> redirectTo(302) -> <shunt>`)
 
 		proxy, err := newAuthProxy(config, routes...)
 		if err != nil {

--- a/filters/builtin/decompress_test.go
+++ b/filters/builtin/decompress_test.go
@@ -5,12 +5,13 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"fmt"
-	"github.com/andybalholm/brotli"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/andybalholm/brotli"
 
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
@@ -34,11 +35,7 @@ func decompressingProxy(t *testing.T, backendURL string) *proxytest.TestProxy {
 	routes := `
 		* -> decompress() -> "%s"
 	`
-	r, err := eskip.Parse(fmt.Sprintf(routes, backendURL))
-	if err != nil {
-		t.Fatal(err)
-		return nil
-	}
+	r := eskip.MustParse(fmt.Sprintf(routes, backendURL))
 
 	fr := make(filters.Registry)
 	fr.Register(NewDecompress())

--- a/filters/builtin/inlinecontent_test.go
+++ b/filters/builtin/inlinecontent_test.go
@@ -103,11 +103,7 @@ func TestInlineContent(t *testing.T) {
 		expectedContentType: "application/json",
 	}} {
 		t.Run(test.title, func(t *testing.T) {
-			r, err := eskip.Parse(test.routes)
-			if err != nil {
-				t.Error(err)
-				return
-			}
+			r := eskip.MustParse(test.routes)
 
 			p := proxytest.New(MakeRegistry(), r...)
 			defer p.Close()

--- a/filters/builtin/inlinecontentifstatus_test.go
+++ b/filters/builtin/inlinecontentifstatus_test.go
@@ -135,11 +135,7 @@ func TestInlineContentIfStatus(t *testing.T) {
 		expectedContentType: "application/json",
 	}} {
 		t.Run(test.title, func(t *testing.T) {
-			r, err := eskip.Parse(test.routes)
-			if err != nil {
-				t.Error(err)
-				return
-			}
+			r := eskip.MustParse(test.routes)
 
 			p := proxytest.New(MakeRegistry(), r...)
 			defer p.Close()

--- a/filters/shedder/admission_test.go
+++ b/filters/shedder/admission_test.go
@@ -400,10 +400,7 @@ func TestAdmissionControlCleanupMultipleFilters(t *testing.T) {
 			preProcessor := spec.PreProcessor()
 			postProcessor := spec.PostProcessor()
 
-			r, err := eskip.Parse(fmt.Sprintf(ti.doc, backend1.URL))
-			if err != nil {
-				t.Fatalf("Failed to parse doc: %v", err)
-			}
+			r := eskip.MustParse(fmt.Sprintf(ti.doc, backend1.URL))
 
 			fr := make(filters.Registry)
 			fr.Register(fspec)

--- a/filters/tee/tee_test.go
+++ b/filters/tee/tee_test.go
@@ -144,7 +144,7 @@ func TestTeeEndToEndBody(t *testing.T) {
 
 	routeStr := fmt.Sprintf(`route1: * -> tee("%v") -> "%v";`, shadowUrl, originalUrl)
 
-	route, _ := eskip.Parse(routeStr)
+	route := eskip.MustParse(routeStr)
 	registry := make(filters.Registry)
 	registry.Register(NewTee())
 	p := proxytest.New(registry, route...)
@@ -247,7 +247,7 @@ func TestTeeHeaders(t *testing.T) {
 
 	routeStr := fmt.Sprintf(`route1: * -> tee("%v") -> "%v";`, shadowServer.URL, originalServer.URL)
 
-	route, _ := eskip.Parse(routeStr)
+	route := eskip.MustParse(routeStr)
 	registry := make(filters.Registry)
 	registry.Register(NewTee())
 	p := proxytest.New(registry, route...)

--- a/filters/tee/teeloopback_test.go
+++ b/filters/tee/teeloopback_test.go
@@ -44,7 +44,7 @@ func TestLoopbackAndMatchPredicate(t *testing.T) {
 	split := backendtest.NewBackendRecorder(listenFor)
 	shadow := backendtest.NewBackendRecorder(listenFor)
 
-	routes, _ := eskip.Parse(fmt.Sprintf(routeDoc, original.GetURL(), split.GetURL(), shadow.GetURL()))
+	routes := eskip.MustParse(fmt.Sprintf(routeDoc, original.GetURL(), split.GetURL(), shadow.GetURL()))
 	registry := make(filters.Registry)
 	registry.Register(NewTeeLoopback())
 	p := proxytest.WithRoutingOptions(registry, routing.Options{
@@ -83,7 +83,7 @@ func TestOriginalBackendServeEvenWhenShadowDoesNotReply(t *testing.T) {
 	}))
 	defer shadow.Close()
 
-	routes, _ := eskip.Parse(fmt.Sprintf(routeDoc, split.GetURL(), split.GetURL(), shadow.URL))
+	routes := eskip.MustParse(fmt.Sprintf(routeDoc, split.GetURL(), split.GetURL(), shadow.URL))
 	registry := make(filters.Registry)
 	registry.Register(NewTeeLoopback())
 	p := proxytest.WithParamsAndRoutingOptions(registry,
@@ -121,7 +121,7 @@ func TestOriginalBackendServeEvenWhenShadowIsDown(t *testing.T) {
 		shadow: Path("/foo") && Traffic(1) && Tee("A") -> "%v";
 	`
 	split := backendtest.NewBackendRecorder(listenFor)
-	routes, _ := eskip.Parse(fmt.Sprintf(routeDoc, split.GetURL(), split.GetURL(), "http://fakeurl"))
+	routes := eskip.MustParse(fmt.Sprintf(routeDoc, split.GetURL(), split.GetURL(), "http://fakeurl"))
 	registry := make(filters.Registry)
 	registry.Register(NewTeeLoopback())
 	p := proxytest.WithRoutingOptions(registry, routing.Options{
@@ -151,7 +151,7 @@ func TestInfiniteLoopback(t *testing.T) {
 	split := backendtest.NewBackendRecorder(listenFor)
 	shadow := backendtest.NewBackendRecorder(listenFor)
 
-	routes, _ := eskip.Parse(fmt.Sprintf(routeDoc, split.GetURL(), shadow.GetURL()))
+	routes := eskip.MustParse(fmt.Sprintf(routeDoc, split.GetURL(), shadow.GetURL()))
 	registry := make(filters.Registry)
 	registry.Register(NewTeeLoopback())
 	p := proxytest.WithRoutingOptions(registry, routing.Options{
@@ -182,10 +182,7 @@ func TestLoopbackWithClientIP(t *testing.T) {
 	shadow := backendtest.NewBackendRecorder(listenFor)
 
 	routeDoc := fmt.Sprintf(routeFmt, split.GetURL(), shadow.GetURL())
-	routes, err := eskip.Parse(routeDoc)
-	if err != nil {
-		t.Fatal(err)
-	}
+	routes := eskip.MustParse(routeDoc)
 
 	filterRegistry := make(filters.Registry)
 	filterRegistry.Register(NewTeeLoopback())

--- a/predicates/traffic/traffic_test.go
+++ b/predicates/traffic/traffic_test.go
@@ -178,11 +178,7 @@ func TestTrafficPredicateInRoutes(t *testing.T) {
 			epsilonFactor := 0.1
 			epsilon := float64(N) * epsilonFactor
 
-			r, err := eskip.Parse(tc.routes)
-			if err != nil {
-				t.Error(err)
-				return
-			}
+			r := eskip.MustParse(tc.routes)
 
 			p := proxytest.WithRoutingOptions(builtin.MakeRegistry(), routing.Options{
 				Predicates: []routing.PredicateSpec{

--- a/proxy/backendratelimit_test.go
+++ b/proxy/backendratelimit_test.go
@@ -94,10 +94,7 @@ func TestBackendRatelimitRoundRobin(t *testing.T) {
 	defer backends.close()
 
 	doc := fmt.Sprintf(`* -> backendRatelimit("testapi", %d, "%s") -> <roundRobin, %v>`, maxHits, timeWindow.String(), backends)
-	r, err := eskip.Parse(doc)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := eskip.MustParse(doc)
 
 	p := proxytest.WithParams(filterRegistry, proxy.Params{RateLimiters: ratelimitRegistry}, r...)
 	defer p.Close()
@@ -195,10 +192,7 @@ func TestBackendRatelimitScenarios(t *testing.T) {
 			backends := newCountingBackends(ti.backends)
 			defer backends.close()
 
-			r, err := eskip.Parse(strings.ReplaceAll(ti.routes, "$backends", backends.String()))
-			if err != nil {
-				t.Fatal(err)
-			}
+			r := eskip.MustParse(strings.ReplaceAll(ti.routes, "$backends", backends.String()))
 
 			p := proxytest.WithParams(filterRegistry, proxy.Params{RateLimiters: ratelimitRegistry}, r...)
 			defer p.Close()

--- a/proxy/fallbackgroup_test.go
+++ b/proxy/fallbackgroup_test.go
@@ -57,10 +57,7 @@ func TestFallbackGroupLB(t *testing.T) {
 		groupB_BE2.URL,
 	)
 
-	routes, err := eskip.Parse(routesDoc)
-	if err != nil {
-		t.Fatal(err)
-	}
+	routes := eskip.MustParse(routesDoc)
 
 	p := proxytest.New(builtin.MakeRegistry(), routes...)
 	defer p.Close()

--- a/proxy/lb_failingbackend_test.go
+++ b/proxy/lb_failingbackend_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/proxy/proxytest"
@@ -98,10 +97,7 @@ func setup() (*proxytest.TestProxy, []closer) {
 		groupD_BE2Failing.url,
 	)
 
-	routes, err := eskip.Parse(routesDoc)
-	if err != nil {
-		log.Fatal(err)
-	}
+	routes := eskip.MustParse(routesDoc)
 
 	p := proxytest.New(builtin.MakeRegistry(), routes...)
 

--- a/proxy/split_test.go
+++ b/proxy/split_test.go
@@ -31,10 +31,7 @@ func TestRequestURIClonedOnSplit(t *testing.T) {
 		shadow: Tee("test") -> dependentFilter() -> <shunt>
 	`
 
-	r, err := eskip.Parse(routes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := eskip.MustParse(routes)
 
 	df := make(dependentFilter)
 	fr := builtin.MakeRegistry()

--- a/routesrv/routesrv_test.go
+++ b/routesrv/routesrv_test.go
@@ -89,12 +89,7 @@ func parseEskipFixture(t *testing.T, fileName string) []*eskip.Route {
 	if err != nil {
 		t.Fatalf("failed to open eskip fixture %s: %v", fileName, err)
 	}
-	routes, err := eskip.Parse(string(eskipBytes))
-	if err != nil {
-		t.Fatalf("eskip fixture is not valid eskip %s: %v", fileName, err)
-	}
-
-	return routes
+	return eskip.MustParse(string(eskipBytes))
 }
 
 func getRoutes(rs *routesrv.RouteServer) *httptest.ResponseRecorder {

--- a/routing/host_test.go
+++ b/routing/host_test.go
@@ -56,10 +56,8 @@ func benchmarkPredicateHost(b *testing.B, predicateFmt string) {
 	var routes []*routing.Route
 	for i := 0; i < R; i++ {
 		p := strings.ReplaceAll(predicateFmt, "{i}", fmt.Sprintf("%d", i))
-		def, err := eskip.Parse(fmt.Sprintf(`r%d: %s -> <shunt>;`, i, p))
-		if err != nil {
-			b.Fatal(err)
-		}
+		def := eskip.MustParse(fmt.Sprintf(`r%d: %s -> <shunt>;`, i, p))
+
 		route, err := routing.ExportProcessRouteDef(pr, fr, def[0])
 		if err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
This is useful in tests to reduce boilerplate (similar to e.g. https://pkg.go.dev/regexp#MustCompile).

See also discussion https://github.com/golang/go/issues/54297

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>