### PR TITLE
proxy/proxytest: add TLS support

### DIFF
--- a/proxy/proxytest/cert.go
+++ b/proxy/proxytest/cert.go
@@ -1,0 +1,80 @@
+// Generate a self-signed X.509 certificate for a TLS server.
+// Based on https://go.dev/src/crypto/tls/generate_cert.go
+package proxytest
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"time"
+)
+
+func NewCertificate(hosts ...string) tls.Certificate {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(1 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		panic(err)
+	}
+
+	template := x509.Certificate{
+		IsCA:         true,
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{Organization: []string{"Zalando SE"}},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		// ECDSA, ED25519 and RSA subject keys should have the DigitalSignature
+		// KeyUsage bits set in the x509.Certificate template
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		panic(err)
+	}
+
+	certPEM := new(bytes.Buffer)
+	if err := pem.Encode(certPEM, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		panic(err)
+	}
+
+	keyPEM := new(bytes.Buffer)
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := pem.Encode(keyPEM, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		panic(err)
+	}
+
+	cert, err := tls.X509KeyPair(certPEM.Bytes(), keyPEM.Bytes())
+	if err != nil {
+		panic(err)
+	}
+	return cert
+}

--- a/proxy/proxytest/proxytest_test.go
+++ b/proxy/proxytest/proxytest_test.go
@@ -1,0 +1,53 @@
+package proxytest_test
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/net/dnstest"
+	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/routing"
+)
+
+func TestHttps(t *testing.T) {
+	dnstest.LoopbackNames(t, "foo.skipper.test", "bar.skipper.test")
+
+	p := proxytest.Config{
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+		},
+		Routes: eskip.MustParse(`
+			any: * -> inlineContent("any host response") -> <shunt>;
+			foo: Host("^foo[.]skipper[.]test") -> inlineContent("foo.skipper.test response") -> <shunt>;
+			bar: Host("^bar[.]skipper[.]test") -> inlineContent("bar.skipper.test response") -> <shunt>;
+		`),
+		Certificates: []tls.Certificate{
+			proxytest.NewCertificate("127.0.0.1", "::1", "foo.skipper.test", "bar.skipper.test"),
+		},
+	}.Create()
+	defer p.Close()
+
+	client := p.Client()
+
+	get := func(url string) string {
+		t.Helper()
+		rsp, err := client.Get(url)
+		require.NoError(t, err)
+		defer rsp.Body.Close()
+
+		b, err := io.ReadAll(rsp.Body)
+		require.NoError(t, err)
+
+		return string(b)
+	}
+
+	assert.Equal(t, "any host response", get(p.URL))
+	assert.Equal(t, "foo.skipper.test response", get("https://"+net.JoinHostPort("foo.skipper.test", p.Port)))
+	assert.Equal(t, "bar.skipper.test response", get("https://"+net.JoinHostPort("bar.skipper.test", p.Port)))
+}


### PR DESCRIPTION
* introduces Config to simplify creation of test proxy
* adds helper to create certificate for given domains
* starts TLS server when certificate is present

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>