### PR TITLE
filters/auth/grant: use request.Host and https scheme in original and redirect urls

### DIFF
--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -103,7 +103,7 @@ type OAuthConfig struct {
 	// MaxIdleConnectionsPerHost used for tokeninfo, access-token and refresh-token endpoint.
 	MaxIdleConnectionsPerHost int
 
-	// Tracer used for tokeninfo , access-token and refresh-token endpoint.
+	// Tracer used for tokeninfo, access-token and refresh-token endpoint.
 	Tracer opentracing.Tracer
 }
 
@@ -286,24 +286,15 @@ func (c *OAuthConfig) GetClientSecret() string {
 func (c *OAuthConfig) RedirectURLs(req *http.Request) (redirect, original string) {
 	u := *req.URL
 
-	if fp := req.Header.Get("X-Forwarded-Proto"); fp != "" {
-		u.Scheme = fp
-	} else if req.TLS != nil {
-		u.Scheme = "https"
-	} else {
-		u.Scheme = "http"
-	}
-
-	if fh := req.Header.Get("X-Forwarded-Host"); fh != "" {
-		u.Host = fh
-	} else {
-		u.Host = req.Host
-	}
+	u.Scheme = "https"
+	u.Host = req.Host
 
 	original = u.String()
 
 	u.Path = c.CallbackPath
 	u.RawQuery = ""
+
 	redirect = u.String()
+
 	return
 }


### PR DESCRIPTION
Token cookie domain has Secure attibute and its domain is derived from the request.Host value. This change uses request.Host to build original and redirect url and enforces https scheme for consistency. It also refactors tests to use https.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>