### PR TITLE
refactor: proxy error response

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1273,29 +1273,31 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		msgPrefix = "client canceled"
 		logFunc = p.log.Infof
 	}
-	req := ctx.Request()
-	remoteAddr := remoteHost(req)
-	uri := req.RequestURI
-	if i := strings.IndexRune(uri, '?'); i >= 0 {
-		uri = uri[:i]
+	if id != unknownRouteID {
+		req := ctx.Request()
+		remoteAddr := remoteHost(req)
+		uri := req.RequestURI
+		if i := strings.IndexRune(uri, '?'); i >= 0 {
+			uri = uri[:i]
+		}
+		logFunc(
+			`%s after %v, route %s with backend %s %s%s, status code %d: %v, remote host: %s, request: "%s %s %s", host: %s, user agent: "%s"`,
+			msgPrefix,
+			time.Since(ctx.startServe),
+			id,
+			backendType,
+			backend,
+			flowIdLog,
+			ctx.response.StatusCode,
+			err,
+			remoteAddr,
+			req.Method,
+			uri,
+			req.Proto,
+			req.Host,
+			req.UserAgent(),
+		)
 	}
-	logFunc(
-		`%s after %v, route %s with backend %s %s%s, status code %d: %v, remote host: %s, request: "%s %s %s", host: %s, user agent: "%s"`,
-		msgPrefix,
-		time.Since(ctx.startServe),
-		id,
-		backendType,
-		backend,
-		flowIdLog,
-		ctx.response.StatusCode,
-		err,
-		remoteAddr,
-		req.Method,
-		uri,
-		req.Proto,
-		req.Host,
-		req.UserAgent(),
-	)
 
 	copyHeader(ctx.responseWriter.Header(), ctx.response.Header)
 	ctx.responseWriter.WriteHeader(ctx.response.StatusCode)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1124,8 +1124,6 @@ func (p *Proxy) do(ctx *context) (err error) {
 		backendStart := time.Now()
 		rsp, perr := p.makeBackendRequest(ctx, backendContext)
 		if perr != nil {
-			p.makeErrorResponse(ctx, perr)
-
 			if done != nil {
 				done(false)
 			}
@@ -1145,13 +1143,14 @@ func (p *Proxy) do(ctx *context) (err error) {
 				rsp, perr2 = p.makeBackendRequest(ctx, backendContext)
 				if perr2 != nil {
 					p.log.Errorf("Failed to retry backend request: %v", perr2)
-					p.makeErrorResponse(ctx, perr2)
 					if perr2.code >= http.StatusInternalServerError {
 						p.metrics.MeasureBackend5xx(backendStart)
 					}
+					p.makeErrorResponse(ctx, perr2)
 					return perr2
 				}
 			} else {
+				p.makeErrorResponse(ctx, perr)
 				return perr
 			}
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1010,9 +1010,12 @@ func (p *Proxy) do(ctx *context) (err error) {
 			p.onPanicSometimes.Do(func() {
 				p.log.Errorf("stacktrace of panic caused by: %v:\n%s", r, stack())
 			})
-			println("panic recovery")
 
-			err = fmt.Errorf("panic caused by: %v", r)
+			perr := &proxyError{
+				err: fmt.Errorf("panic caused by: %v", r),
+			}
+			p.makeErrorResponse(ctx, perr)
+			err = perr
 		}
 	}()
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1297,7 +1297,9 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 		req.UserAgent(),
 	)
 
+	copyHeader(ctx.responseWriter.Header(), ctx.response.Header)
 	ctx.responseWriter.WriteHeader(ctx.response.StatusCode)
+	ctx.responseWriter.Flush()
 	_, _ = copyStream(ctx.responseWriter, ctx.response.Body)
 
 	p.metrics.MeasureServe(

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1020,7 +1020,7 @@ func (p *Proxy) do(ctx *context) (err error) {
 	}()
 
 	if ctx.executionCounter > p.maxLoops {
-		// TODO(sszuecs): think about setting status code to 465 (AWS redirect loop) or similar
+		// TODO(sszuecs): think about setting status code to 463 or 465 (check what AWS ALB sets for redirect loop) or similar
 		p.makeErrorResponse(ctx, &proxyError{err: errMaxLoopbacksReached})
 		return errMaxLoopbacksReached
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1010,6 +1010,7 @@ func (p *Proxy) do(ctx *context) (err error) {
 			p.onPanicSometimes.Do(func() {
 				p.log.Errorf("stacktrace of panic caused by: %v:\n%s", r, stack())
 			})
+			println("panic recovery")
 
 			err = fmt.Errorf("panic caused by: %v", r)
 		}
@@ -1086,6 +1087,8 @@ func (p *Proxy) do(ctx *context) (err error) {
 	} else if ctx.route.BackendType == eskip.LoopBackend {
 		loopCTX := ctx.clone()
 		if err := p.do(loopCTX); err != nil {
+			// in case of error we have to copy the response in this recursion unwinding
+			ctx.response = loopCTX.response
 			return err
 		}
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1999,7 +2000,7 @@ func TestAccessLogOnFailedRequest(t *testing.T) {
 
 	p, err := newTestProxy(fmt.Sprintf(`* -> "%s"`, s.URL), 0)
 	if err != nil {
-		t.Errorf("Failed to create test proxy: %v", err)
+		t.Fatalf("Failed to create test proxy: %v", err)
 		return
 	}
 	defer p.close()
@@ -2009,7 +2010,7 @@ func TestAccessLogOnFailedRequest(t *testing.T) {
 
 	rsp, err := http.Get(ps.URL)
 	if err != nil {
-		t.Errorf("Failed to GET: %v", err)
+		t.Fatalf("Failed to GET: %v", err)
 		return
 	}
 
@@ -2024,15 +2025,14 @@ func TestAccessLogOnFailedRequest(t *testing.T) {
 
 	proxyURL, err := url.Parse(ps.URL)
 	if err != nil {
-		t.Errorf("Failed to parse url: %v", err)
+		t.Fatalf("Failed to parse url: %v", err)
 		return
 	}
 
 	expected := fmt.Sprintf(`"GET / HTTP/1.1" %d %d "-" "Go-http-client/1.1"`, http.StatusBadGateway, len(http.StatusText(http.StatusBadGateway))+1)
 	if !strings.Contains(output, expected) || !strings.Contains(output, proxyURL.Host) {
 		t.Errorf("Failed to get accesslog '%v' '%v'", output, expected)
-		t.Logf("out: '%v'", output)
-		t.Logf("expect: '%v'", expected)
+		t.Logf("%s", cmp.Diff(output, expected))
 	}
 }
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1990,9 +1990,11 @@ func TestEnableAccessLogWithFilter(t *testing.T) {
 }
 
 func TestAccessLogOnFailedRequest(t *testing.T) {
-	var buf bytes.Buffer
+	buf := &LockedBuffer{
+		buf: &bytes.Buffer{},
+	}
 	logging.Init(logging.Options{
-		AccessLogOutput: &buf})
+		AccessLogOutput: buf})
 
 	s := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	s.Close()

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -10,6 +10,12 @@ type LockedBuffer struct {
 	buf *bytes.Buffer
 }
 
+func NewLockedBuffer() *LockedBuffer {
+	return &LockedBuffer{
+		buf: &bytes.Buffer{},
+	}
+}
+
 func (b *LockedBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -1,0 +1,23 @@
+package proxy
+
+import (
+	"bytes"
+	"sync"
+)
+
+type LockedBuffer struct {
+	mu  sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (b *LockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *LockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}


### PR DESCRIPTION
refactor: proxy error response to always have a response defined to simplify the logic

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>