### PR TITLE
filters/auth/grant: support client id and secret file placeholders

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -451,8 +451,10 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.Oauth2SecretFile, "oauth2-secret-file", "", "sets the filename with the encryption key for the authentication cookie and grant flow state stored in secrets registry")
 	flag.StringVar(&cfg.Oauth2ClientID, "oauth2-client-id", "", "sets the OAuth2 client id of the current service, used to exchange the access code")
 	flag.StringVar(&cfg.Oauth2ClientSecret, "oauth2-client-secret", "", "sets the OAuth2 client secret associated with the oauth2-client-id, used to exchange the access code")
-	flag.StringVar(&cfg.Oauth2ClientIDFile, "oauth2-client-id-file", "", "sets the path of the file containing the OAuth2 client id of the current service, used to exchange the access code")
-	flag.StringVar(&cfg.Oauth2ClientSecretFile, "oauth2-client-secret-file", "", "sets the path of the file containing the OAuth2 client secret associated with the oauth2-client-id, used to exchange the access code")
+	flag.StringVar(&cfg.Oauth2ClientIDFile, "oauth2-client-id-file", "", "sets the path of the file containing the OAuth2 client id of the current service, used to exchange the access code. "+
+		"File name may contain {host} placeholder which will be replaced by the request host")
+	flag.StringVar(&cfg.Oauth2ClientSecretFile, "oauth2-client-secret-file", "", "sets the path of the file containing the OAuth2 client secret associated with the oauth2-client-id, used to exchange the access code. "+
+		"File name may contain {host} placeholder which will be replaced by the request host")
 	flag.StringVar(&cfg.Oauth2CallbackPath, "oauth2-callback-path", "", "sets the path where the OAuth2 callback requests with the authorization code should be redirected to")
 	flag.DurationVar(&cfg.Oauth2TokeninfoTimeout, "oauth2-tokeninfo-timeout", 2*time.Second, "sets the default tokeninfo request timeout duration to 2000ms")
 	flag.IntVar(&cfg.Oauth2TokeninfoCacheSize, "oauth2-tokeninfo-cache-size", 0, "non-zero value enables tokeninfo cache and sets the maximum number of cached tokens")

--- a/secrets/file.go
+++ b/secrets/file.go
@@ -17,7 +17,6 @@ const (
 )
 
 var (
-	ErrAlreadyExists    = errors.New("secret already exists")
 	ErrWrongFileType    = errors.New("file type not supported")
 	ErrFailedToReadFile = errors.New("failed to read file")
 )
@@ -133,7 +132,7 @@ func (sp *SecretPaths) handleDir(p string) error {
 
 func (sp *SecretPaths) registerSecretFile(p string) error {
 	if _, ok := sp.GetSecret(p); ok {
-		return ErrAlreadyExists
+		return nil
 	}
 	dat, err := os.ReadFile(p)
 	if err != nil {

--- a/skipper.go
+++ b/skipper.go
@@ -759,10 +759,12 @@ type Options struct {
 
 	// OAuth2ClientIDFile, the path of the file containing the OAuth2 client id of
 	// the current service, used to exchange the access code.
+	// File name may contain {host} placeholder which will be replaced by the request host.
 	OAuth2ClientIDFile string
 
 	// OAuth2ClientSecretFile, the path of the file containing the secret associated
 	// with the ClientID, used to exchange the access code.
+	// File name may contain {host} placeholder which will be replaced by the request host.
 	OAuth2ClientSecretFile string
 
 	// OAuth2CallbackPath contains the path where the OAuth2 callback requests with the


### PR DESCRIPTION
This change enables `{host}` placeholder in the client id and secret filenames.

E.g. for the request to `foo.example.org` when flag values are `-oauth2-client-id-file=/var/run/secrets/{host}-client-id` and `-oauth2-client-secret-file=/var/run/secrets/{host}-client-secret` the client id and secret files would be `/var/run/secrets/foo.example.org-client-id` and `/var/run/secrets/foo.example.org-client-secret` respectively.