### PR TITLE
feature: lua config to selective enable inline,file,none

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -301,6 +301,7 @@ func NewConfig() *Config {
 	cfg.ForwardedHeadersExcludeCIDRList = commaListFlag()
 	cfg.CompressEncodings = commaListFlag("gzip", "deflate", "br")
 	cfg.LuaModules = commaListFlag()
+	cfg.LuaSources = commaListFlag()
 	cfg.Oauth2GrantTokeninfoKeys = commaListFlag()
 
 	flag := flag.NewFlagSet("", flag.ExitOnError)

--- a/config/config.go
+++ b/config/config.go
@@ -269,7 +269,7 @@ type Config struct {
 	ClusterRatelimitMaxGroupShards int `yaml:"cluster-ratelimit-max-group-shards"`
 
 	LuaModules *listFlag `yaml:"lua-modules"`
-	LuaSources string    `yaml:"lua-sources"`
+	LuaSources *listFlag `yaml:"lua-sources"`
 }
 
 const (
@@ -540,7 +540,7 @@ func NewConfig() *Config {
 	flag.IntVar(&cfg.ClusterRatelimitMaxGroupShards, "cluster-ratelimit-max-group-shards", 1, "sets the maximum number of group shards for the clusterRatelimit filter")
 
 	flag.Var(cfg.LuaModules, "lua-modules", "comma separated list of lua filter modules. Use <module>.<symbol> to selectively enable module symbols, for example: package,base._G,base.print,json")
-	flag.StringVar(&cfg.LuaSources, "lua-sources", "", `comma separated list of lua input types for the lua() filter. Valid sources <""|"file"|"inline"|"file,inline"|"none">. Use "file" to only allow lua file references in lua filter. Default "" is the same as "file,inline". Use "none" to disable lua filters.`)
+	flag.Var(cfg.LuaSources, "lua-sources", `comma separated list of lua input types for the lua() filter. Valid sources "", "file", "inline", "file,inline" and "none". Use "file" to only allow lua file references in lua filter. Default "" is the same as "file","inline". Use "none" to disable lua filters.`)
 
 	cfg.flags = flag
 	return cfg
@@ -915,7 +915,7 @@ func (c *Config) ToOptions() skipper.Options {
 		ClusterRatelimitMaxGroupShards: c.ClusterRatelimitMaxGroupShards,
 
 		LuaModules: c.LuaModules.values,
-		LuaSources: c.LuaSources,
+		LuaSources: c.LuaSources.values,
 	}
 	for _, rcci := range c.CloneRoute {
 		eskipClone := eskip.NewClone(rcci.Reg, rcci.Repl)

--- a/config/config.go
+++ b/config/config.go
@@ -540,7 +540,7 @@ func NewConfig() *Config {
 	flag.IntVar(&cfg.ClusterRatelimitMaxGroupShards, "cluster-ratelimit-max-group-shards", 1, "sets the maximum number of group shards for the clusterRatelimit filter")
 
 	flag.Var(cfg.LuaModules, "lua-modules", "comma separated list of lua filter modules. Use <module>.<symbol> to selectively enable module symbols, for example: package,base._G,base.print,json")
-	flag.StringVar(&cfg.LuaSources, "lua-sources", "", `comma separated list of lua input types for the lua() filter. Valid sources <""|"file"|"inline"|"file,inline"|"none">. Use "file" to only allow lua file references in lua filter. It defaults to "", that allows is the same as "file,inline". "none" disable lua filters.`)
+	flag.StringVar(&cfg.LuaSources, "lua-sources", "", `comma separated list of lua input types for the lua() filter. Valid sources <""|"file"|"inline"|"file,inline"|"none">. Use "file" to only allow lua file references in lua filter. Default "" is the same as "file,inline". Use "none" to disable lua filters.`)
 
 	cfg.flags = flag
 	return cfg

--- a/config/config.go
+++ b/config/config.go
@@ -269,6 +269,7 @@ type Config struct {
 	ClusterRatelimitMaxGroupShards int `yaml:"cluster-ratelimit-max-group-shards"`
 
 	LuaModules *listFlag `yaml:"lua-modules"`
+	LuaSources string    `yaml:"lua-sources"`
 }
 
 const (
@@ -539,6 +540,7 @@ func NewConfig() *Config {
 	flag.IntVar(&cfg.ClusterRatelimitMaxGroupShards, "cluster-ratelimit-max-group-shards", 1, "sets the maximum number of group shards for the clusterRatelimit filter")
 
 	flag.Var(cfg.LuaModules, "lua-modules", "comma separated list of lua filter modules. Use <module>.<symbol> to selectively enable module symbols, for example: package,base._G,base.print,json")
+	flag.StringVar(&cfg.LuaSources, "lua-sources", "", `comma separated list of lua input types for the lua() filter. Valid sources <""|"file"|"inline"|"file,inline"|"none">. Use "file" to only allow lua file references in lua filter. It defaults to "", that allows is the same as "file,inline". "none" disable lua filters.`)
 
 	cfg.flags = flag
 	return cfg
@@ -913,6 +915,7 @@ func (c *Config) ToOptions() skipper.Options {
 		ClusterRatelimitMaxGroupShards: c.ClusterRatelimitMaxGroupShards,
 
 		LuaModules: c.LuaModules.values,
+		LuaSources: c.LuaSources,
 	}
 	for _, rcci := range c.CloneRoute {
 		eskipClone := eskip.NewClone(rcci.Reg, rcci.Repl)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -157,6 +157,7 @@ func defaultConfig() *Config {
 		ValidateQuery:                           true,
 		ValidateQueryLog:                        true,
 		LuaModules:                              commaListFlag(),
+		LuaSources:                              commaListFlag(),
 	}
 }
 

--- a/script/script.go
+++ b/script/script.go
@@ -32,7 +32,7 @@ var (
 	// requests, but only this number is cached.
 	MaxPoolSize int = 10
 
-	errLuaSourcesDisabled = errors.New("Lua Sources are disabled")
+	errLuaSourcesDisabled = errors.New("lua Sources are disabled")
 )
 
 type LuaOptions struct {

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -65,6 +65,7 @@ func TestScript(t *testing.T) {
 		expectedOutgoingHost   string
 		expectedURL            string
 		expectedStatus         int
+		expectedError          error
 	}{
 		{
 			name: "state bag",
@@ -296,6 +297,10 @@ func TestScript(t *testing.T) {
 		},
 		{
 			name: "iterate request cookies",
+			opts: LuaOptions{
+				// use non-existing module
+				Modules: []string{"none"},
+			},
 			context: testContext{
 				requestHeader: map[string]string{"Cookie": "PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1; csrftoken=repeat"},
 				script: `function request(ctx, params)
@@ -314,6 +319,7 @@ func TestScript(t *testing.T) {
 			opts: LuaOptions{
 				// use non-existing module
 				Modules: []string{"none"},
+				Sources: []string{"inline"},
 			},
 			context: testContext{
 				script: `
@@ -324,53 +330,83 @@ func TestScript(t *testing.T) {
 			},
 			expectedRequestHeader: map[string]string{"X-Message": "still usable without modules"},
 		},
+		{
+			name: "disable all sources and try to reference inline script",
+			opts: LuaOptions{
+				Sources: []string{"none"},
+			},
+			context: testContext{
+				script: `
+					function request(ctx, params)
+						ctx.request.header["X-Message"] = "still usable without modules"
+					end
+				`,
+			},
+			expectedError: errLuaSourcesDisabled,
+		},
+		{
+			name: "disable all sources and try to reference file source",
+			opts: LuaOptions{
+				Sources: []string{"none"},
+			},
+			context: testContext{
+				script: "foo.lua",
+			},
+			expectedError: errLuaSourcesDisabled,
+		},
 	} {
-		log.Println("Running", test.name, "test")
-
-		fc, err := runFilter(test.opts, &test.context)
-		if err != nil {
-			t.Errorf("failed to run filter: %v", err)
-		}
-
-		exp := len(test.expectedRequestHeader)
-		if exp > 0 && exp != len(fc.Request().Header) {
-			t.Errorf("[%s] request header mismatch: expected %v, got: %v", test.name, test.expectedRequestHeader, fc.Request().Header)
-		}
-		for k, v := range test.expectedRequestHeader {
-			if fc.Request().Header.Get(k) != v {
-				t.Errorf("[%s] %s request header: expected %s, got: %s", test.name, k, v, fc.Request().Header.Get(k))
+		t.Run(test.name, func(t *testing.T) {
+			fc, err := runFilter(test.opts, &test.context)
+			if err != nil && test.expectedError == nil {
+				t.Fatalf("Failed to run filter: %v", err)
+			} else if test.expectedError != nil {
+				if err == test.expectedError {
+					// ok, error as expected
+					return
+				}
+				t.Fatalf("Should fail to create filter: expected: %v, got: %v", test.expectedError, err)
 			}
-		}
 
-		exp = len(test.expectedResponseHeader)
-		if exp > 0 && exp != len(fc.Response().Header) {
-			t.Errorf("[%s] response header mismatch: expected %v, got: %v", test.name, test.expectedResponseHeader, fc.Response().Header)
-		}
-		for k, v := range test.expectedResponseHeader {
-			if fc.Response().Header.Get(k) != v {
-				t.Errorf("[%s] %s response header: expected %s, got: %s", test.name, k, v, fc.Response().Header.Get(k))
+			exp := len(test.expectedRequestHeader)
+			if exp > 0 && exp != len(fc.Request().Header) {
+				t.Errorf("[%s] request header mismatch: expected %v, got: %v", test.name, test.expectedRequestHeader, fc.Request().Header)
 			}
-		}
-
-		if len(fc.StateBag()) != len(test.expectedStateBag) {
-			t.Errorf("[%s] state bag mismatch: expected %v, got: %v", test.name, test.expectedStateBag, fc.StateBag())
-		}
-		for k, v := range test.expectedStateBag {
-			bv, ok := fc.StateBag()[k]
-			if !ok || v != bv {
-				t.Errorf("[%s] %s state bag: expected %s, got: %s", test.name, k, v, bv)
+			for k, v := range test.expectedRequestHeader {
+				if fc.Request().Header.Get(k) != v {
+					t.Errorf("[%s] %s request header: expected %s, got: %s", test.name, k, v, fc.Request().Header.Get(k))
+				}
 			}
-		}
 
-		if test.expectedOutgoingHost != "" && fc.OutgoingHost() != test.expectedOutgoingHost {
-			t.Errorf("[%s] outgoing host: expected %s, got: %s", test.name, test.expectedOutgoingHost, fc.OutgoingHost())
-		}
-		if test.expectedURL != "" && fc.Request().URL.String() != test.expectedURL {
-			t.Errorf("[%s] request path: expected %s, got: %v", test.name, test.expectedURL, fc.Request().URL)
-		}
-		if test.expectedStatus != 0 && test.expectedStatus != fc.Response().StatusCode {
-			t.Errorf("[%s] response status: expected %d, got: %d", test.name, test.expectedStatus, fc.Response().StatusCode)
-		}
+			exp = len(test.expectedResponseHeader)
+			if exp > 0 && exp != len(fc.Response().Header) {
+				t.Errorf("[%s] response header mismatch: expected %v, got: %v", test.name, test.expectedResponseHeader, fc.Response().Header)
+			}
+			for k, v := range test.expectedResponseHeader {
+				if fc.Response().Header.Get(k) != v {
+					t.Errorf("[%s] %s response header: expected %s, got: %s", test.name, k, v, fc.Response().Header.Get(k))
+				}
+			}
+
+			if len(fc.StateBag()) != len(test.expectedStateBag) {
+				t.Errorf("[%s] state bag mismatch: expected %v, got: %v", test.name, test.expectedStateBag, fc.StateBag())
+			}
+			for k, v := range test.expectedStateBag {
+				bv, ok := fc.StateBag()[k]
+				if !ok || v != bv {
+					t.Errorf("[%s] %s state bag: expected %s, got: %s", test.name, k, v, bv)
+				}
+			}
+
+			if test.expectedOutgoingHost != "" && fc.OutgoingHost() != test.expectedOutgoingHost {
+				t.Errorf("[%s] outgoing host: expected %s, got: %s", test.name, test.expectedOutgoingHost, fc.OutgoingHost())
+			}
+			if test.expectedURL != "" && fc.Request().URL.String() != test.expectedURL {
+				t.Errorf("[%s] request path: expected %s, got: %v", test.name, test.expectedURL, fc.Request().URL)
+			}
+			if test.expectedStatus != 0 && test.expectedStatus != fc.Response().StatusCode {
+				t.Errorf("[%s] response status: expected %d, got: %d", test.name, test.expectedStatus, fc.Response().StatusCode)
+			}
+		})
 	}
 }
 

--- a/skipper.go
+++ b/skipper.go
@@ -880,9 +880,10 @@ type Options struct {
 	LuaModules []string
 
 	// LuaSources that are allowed as input sources. Valid sources
-	// are "", "file", "inline", "file,inline". Empty string will
-	// disable the use of lua filters.
-	LuaSources string
+	// are "", "file", "inline", "file","inline". Empty list
+	// defaults to "file","inline" and "none" disables lua
+	// filters.
+	LuaSources []string
 
 	testOptions
 }
@@ -1715,11 +1716,10 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		o.CustomFilters = append(o.CustomFilters, compress)
 	}
 
-	if len(o.LuaModules) > 0 && len(o.LuaSources) > 0 {
-		luaSources := strings.Split(o.LuaSources, ",")
+	if len(o.LuaModules) > 0 {
 		lua, err := script.NewLuaScriptWithOptions(script.LuaOptions{
 			Modules: o.LuaModules,
-			Sources: luaSources,
+			Sources: o.LuaSources,
 		})
 		if err != nil {
 			log.Errorf("Failed to create lua filter: %v.", err)

--- a/skipper.go
+++ b/skipper.go
@@ -879,6 +879,11 @@ type Options struct {
 	// for example: package,base._G,base.print,json
 	LuaModules []string
 
+	// LuaSources that are allowed as input sources. Valid sources
+	// are "", "file", "inline", "file,inline". Empty string will
+	// disable the use of lua filters.
+	LuaSources string
+
 	testOptions
 }
 
@@ -1710,8 +1715,12 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		o.CustomFilters = append(o.CustomFilters, compress)
 	}
 
-	if len(o.LuaModules) > 0 {
-		lua, err := script.NewLuaScriptWithOptions(script.LuaOptions{Modules: o.LuaModules})
+	if len(o.LuaModules) > 0 && len(o.LuaSources) > 0 {
+		luaSources := strings.Split(o.LuaSources, ",")
+		lua, err := script.NewLuaScriptWithOptions(script.LuaOptions{
+			Modules: o.LuaModules,
+			Sources: luaSources,
+		})
 		if err != nil {
 			log.Errorf("Failed to create lua filter: %v.", err)
 			return err

--- a/skipper.go
+++ b/skipper.go
@@ -873,6 +873,10 @@ type Options struct {
 	// KubernetesEnableTLS enables kubernetes to use resources to terminate tls
 	KubernetesEnableTLS bool
 
+	// LuaModules that are allowed to be used.
+	//
+	// Use <module>.<symbol> to selectively enable module symbols,
+	// for example: package,base._G,base.print,json
 	LuaModules []string
 
 	testOptions

--- a/skipper.go
+++ b/skipper.go
@@ -1716,17 +1716,15 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		o.CustomFilters = append(o.CustomFilters, compress)
 	}
 
-	if len(o.LuaModules) > 0 {
-		lua, err := script.NewLuaScriptWithOptions(script.LuaOptions{
-			Modules: o.LuaModules,
-			Sources: o.LuaSources,
-		})
-		if err != nil {
-			log.Errorf("Failed to create lua filter: %v.", err)
-			return err
-		}
-		o.CustomFilters = append(o.CustomFilters, lua)
+	lua, err := script.NewLuaScriptWithOptions(script.LuaOptions{
+		Modules: o.LuaModules,
+		Sources: o.LuaSources,
+	})
+	if err != nil {
+		log.Errorf("Failed to create lua filter: %v.", err)
+		return err
 	}
+	o.CustomFilters = append(o.CustomFilters, lua)
 
 	// create routing
 	// create the proxy instance


### PR DESCRIPTION
feature that fixes https://github.com/zalando/skipper/issues/2262

config option -lua-sources allows to set:
- `-lua-sources=none` to disable lua sources
- `-lua-sources=file` to only allow file sources
- `-lua-sources=inline` to only allow inline scripts
- `-lua-sources=inline -lua-sources=file` to allow both, which is also the default as before.