### PR TITLE
fix: fifo() filter does not account for client timeouts

### DIFF
--- a/filters/scheduler/fifo.go
+++ b/filters/scheduler/fifo.go
@@ -151,3 +151,8 @@ func (f *fifoFilter) Response(ctx filters.FilterContext) {
 	pending[last]()
 	ctx.StateBag()[fifoKey] = pending[:last]
 }
+
+// HandleErrorResponse is to opt-in for filters to get called
+// Response(ctx) in case of errors via proxy. It has to return true to
+// opt-in.
+func (f *fifoFilter) HandleErrorResponse() bool { return true }

--- a/filters/scheduler/fifo_test.go
+++ b/filters/scheduler/fifo_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/flowid"
 	"github.com/zalando/skipper/metrics/metricstest"
 	"github.com/zalando/skipper/net/httptest"
 	"github.com/zalando/skipper/proxy"
@@ -500,5 +501,129 @@ func TestConstantRouteUpdatesFifo(t *testing.T) {
 				t.Fatalf("OK too low got<want: %d < %0.0f", countOK, want)
 			}
 		})
+	}
+}
+
+func TestFifoClientTimeout(t *testing.T) {
+	metrics := &metricstest.MockMetrics{}
+	reg := scheduler.RegistryWith(scheduler.Options{
+		Metrics:                metrics,
+		EnableRouteFIFOMetrics: true,
+	})
+	defer reg.Close()
+
+	fr := make(filters.Registry)
+	fr.Register(NewFifo())
+	fr.Register(flowid.New())
+
+	t.Logf("set backend timeout to 200ms")
+	backendTime := 200 * time.Millisecond
+	backend := stdlibhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/change-timeout" {
+			s := r.URL.Query().Get("d")
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("ERR"))
+				return
+			}
+			backendTime = d
+
+		} else {
+			time.Sleep(backendTime)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer backend.Close()
+
+	args := []interface{}{10, 300, "3s"}
+	doc := fmt.Sprintf(`
+r: * -> fifo(%v, %v, "%v") -> flowId() -> <loopback>;
+s: HeaderRegexp("X-Flow-Id", ".*") -> fifo(%v, %v, "%v") -> "%s";
+be: Path("/change-timeout") -> "%s";`, append(append(args, args...), backend.URL, backend.URL)...)
+
+	dc, err := testdataclient.NewDoc(doc)
+	if err != nil {
+		t.Fatalf("Failed to create testdataclient: %v", err)
+	}
+	defer dc.Close()
+
+	ro := routing.Options{
+		SignalFirstLoad: true,
+		FilterRegistry:  fr,
+		DataClients:     []routing.DataClient{dc},
+		PostProcessors:  []routing.PostProcessor{reg},
+	}
+	rt := routing.New(ro)
+	defer rt.Close()
+	<-rt.FirstLoad()
+
+	tracer := &testTracer{MockTracer: mocktracer.New()}
+	pr := proxy.WithParams(proxy.Params{
+		Routing:           rt,
+		OpenTracing:       &proxy.OpenTracingParams{Tracer: tracer},
+		AccessLogDisabled: true,
+	})
+	defer pr.Close()
+
+	ts := stdlibhttptest.NewServer(pr)
+	defer ts.Close()
+
+	reqURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse url %s: %v", ts.URL, err)
+	}
+
+	rsp, err := http.DefaultClient.Get(reqURL.String())
+	if err != nil {
+		t.Fatalf("Failed to get response from %s: %v", reqURL.String(), err)
+	}
+	rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Fatalf("Failed to get valid response from endpoint: %d", rsp.StatusCode)
+	}
+
+	// step1: slow backend leads to client timeouts
+	t.Log("step1: backend is slow, so we assume we get only 499 client timeout")
+	va := httptest.NewVegetaAttacker(reqURL.String(), 200, 100*time.Millisecond, 50*time.Millisecond)
+	va.Attack(io.Discard, 2*time.Second, "client timeout")
+	t.Logf("Success [0..1]: %0.2f", va.Success())
+	t.Logf("requests: %d", va.TotalRequests())
+	count500, ok := va.CountStatus(500)
+	t.Logf("500s: %d", count500)
+	count502, ok := va.CountStatus(502)
+	t.Logf("502s: %d", count502)
+	count503, ok := va.CountStatus(503)
+	t.Logf("503s: %d", count503)
+	count499, ok := va.CountStatus(0)
+	t.Logf("499s: %d", count499)
+	if !ok || va.TotalRequests() != uint64(count499) {
+		t.Fatalf("want a lot 499 client cancel but %d != %d", va.TotalRequests(), uint64(count499))
+	}
+
+	// step2: heal backend
+	t.Log("step2: set backend timeout to 2ms")
+	rsp, err = http.DefaultClient.Get(reqURL.String() + "/change-timeout?d=2ms")
+	if err != nil {
+		t.Fatalf("Failed to get response from %s: %v", reqURL.String()+"/change-timeout?d=2ms", err)
+	}
+	defer rsp.Body.Close()
+
+	// step3: healthy backend leads to 200 OK
+	t.Log("step3: after backend is fine again we assume we get only 200 OK")
+	va = httptest.NewVegetaAttacker(reqURL.String(), 200, 100*time.Millisecond, 50*time.Millisecond)
+	va.Attack(io.Discard, 2*time.Second, "client should not timeout")
+	total := va.TotalRequests()
+	t.Logf("Success [0..1]: %0.2f", va.Success())
+	t.Logf("requests: %d", total)
+	countOK, ok := va.CountStatus(http.StatusOK)
+	if !ok || uint64(countOK) != total {
+		t.Fatalf("want to OK: %d != %d", countOK, total)
+	}
+	count499, _ = va.CountStatus(0)
+	if count499 > 0 {
+		t.Fatalf("want no 499 client cancel but %d > 0", count499)
 	}
 }


### PR DESCRIPTION
fix: fifo() filter does not account for client timeouts leading to longer downtime than required