### PR TITLE
fix: apiUsageMonitoring to be able to observe client timeout

### DIFF
--- a/filters/apiusagemonitoring/filter.go
+++ b/filters/apiusagemonitoring/filter.go
@@ -46,6 +46,11 @@ type apiUsageMonitoringStateBag struct {
 	begin time.Time
 }
 
+// HandleErrorResponse is to opt-in for filters to get called
+// Response(ctx) in case of errors via proxy. It has to return true to
+// opt-in.
+func (f *apiUsageMonitoringFilter) HandleErrorResponse() bool { return true }
+
 func (f *apiUsageMonitoringFilter) Request(c filters.FilterContext) {
 	u := *c.Request().URL
 	c.StateBag()[stateBagKey] = apiUsageMonitoringStateBag{


### PR DESCRIPTION
fix: apiUsageMonitoring to be able to observe client timeout error case and record 499 status codes

fix this: https://github.com/zalando/skipper/issues/1238#issuecomment-727878056