### PR TITLE
predicates: add TrafficSegment predicate

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -716,6 +716,32 @@ catalog:
     "https://catalog";
 ```
 
+## TrafficSegment
+
+TrafficSegment predicate requires two number arguments $min$ and $max$
+from an interval $[0, 1]$ (from zero included to one included) and $min <= max$.
+
+Let $r$ be one-per-request uniform random number value from $[0, 1)$.
+TrafficSegment matches if $r$ belongs to an interval from $[min, max)$.
+Upper interval boundary $max$ is excluded to simplify definition of
+adjacent intervals - the upper boundary of the first interval
+then equals lower boundary of the next and so on, e.g. $[0, 0.25)$ and $[0.25, 1)$.
+
+This predicate has weight of -1 and therefore does not affect route weight.
+
+Parameters:
+
+* min (decimal) from an interval [0, 1]
+* max (decimal) from an interval [0, 1], min <= max
+
+Example of routes splitting traffic in 50%+30%+20% proportion:
+
+```
+r50: Path("/test") && TrafficSegment(0.0, 0.5) -> <shunt>;
+r30: Path("/test") && TrafficSegment(0.5, 0.8) -> <shunt>;
+r20: Path("/test") && TrafficSegment(0.8, 1.0) -> <shunt>;
+```
+
 ## ContentLengthBetween
 
 The ContentLengthBetween predicate matches a route when a request content length header value is between min and max provided values.

--- a/eskip/eskip.go
+++ b/eskip/eskip.go
@@ -665,6 +665,16 @@ func MustParse(code string) []*Route {
 	return r
 }
 
+// MustParsePredicates parses a set of predicates (combined by '&&') into
+// a list of parsed predicate definitions and panics in case of error
+func MustParsePredicates(s string) []*Predicate {
+	p, err := ParsePredicates(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
 func partialParse(f string, partialToRoute func(string) string) (*parsedRoute, error) {
 	rs, err := parse(partialToRoute(f))
 	if err != nil {

--- a/predicates/predicates.go
+++ b/predicates/predicates.go
@@ -44,5 +44,6 @@ const (
 	ClientIPName              = "ClientIP"
 	TeeName                   = "Tee"
 	TrafficName               = "Traffic"
+	TrafficSegmentName        = "TrafficSegment"
 	ContentLengthBetweenName  = "ContentLengthBetween"
 )

--- a/predicates/traffic/export_test.go
+++ b/predicates/traffic/export_test.go
@@ -1,0 +1,3 @@
+package traffic
+
+var ExportRandomValue = randomValue

--- a/predicates/traffic/segment.go
+++ b/predicates/traffic/segment.go
@@ -1,0 +1,77 @@
+package traffic
+
+import (
+	"math/rand"
+	"net/http"
+
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/routing"
+)
+
+type (
+	segmentSpec      struct{}
+	segmentPredicate struct{ min, max float64 }
+)
+
+type contextKey struct{}
+
+var randomValue contextKey
+
+// NewSegment creates a new traffic segment predicate specification
+func NewSegment() routing.WeightedPredicateSpec {
+	return &segmentSpec{}
+}
+
+func (*segmentSpec) Name() string {
+	return predicates.TrafficSegmentName
+}
+
+// Create new predicate instance with two number arguments _min_ and _max_
+// from an interval [0, 1] (from zero included to one included) and _min_ <= _max_.
+//
+// Let _r_ be one-per-request uniform random number value from [0, 1).
+// This predicate matches if _r_ belongs to an interval from [_min_, _max_).
+// Upper interval boundary _max_ is excluded to simplify definition of
+// adjacent intervals - the upper boundary of the first interval
+// then equals lower boundary of the next and so on, e.g. [0, 0.25) and [0.25, 1).
+//
+// This predicate has weight of -1 and therefore does not affect route weight.
+//
+// Example of routes splitting traffic in 50%+30%+20% proportion:
+//
+//	r50: Path("/test") && TrafficSegment(0.0, 0.5) -> <shunt>;
+//	r30: Path("/test") && TrafficSegment(0.5, 0.8) -> <shunt>;
+//	r20: Path("/test") && TrafficSegment(0.8, 1.0) -> <shunt>;
+func (*segmentSpec) Create(args []any) (routing.Predicate, error) {
+	if len(args) != 2 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	p, ok := &segmentPredicate{}, false
+
+	if p.min, ok = args[0].(float64); !ok || p.min < 0 || p.min > 1 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	if p.max, ok = args[1].(float64); !ok || p.max < 0 || p.max > 1 {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	// min == max defines a never-matching interval, e.g. "owl interval" [0,0)
+	if p.min > p.max {
+		return nil, predicates.ErrInvalidPredicateParameters
+	}
+
+	return p, nil
+}
+
+// Weight returns -1.
+// By returning -1 this predicate does not affect route weight.
+func (*segmentSpec) Weight() int {
+	return -1
+}
+
+func (p *segmentPredicate) Match(req *http.Request) bool {
+	r := routing.FromContext(req.Context(), randomValue, rand.Float64)
+	return p.min <= r && r < p.max
+}

--- a/predicates/traffic/segment_test.go
+++ b/predicates/traffic/segment_test.go
@@ -1,0 +1,203 @@
+package traffic_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/predicates"
+	"github.com/zalando/skipper/predicates/primitive"
+	"github.com/zalando/skipper/predicates/tee"
+	"github.com/zalando/skipper/predicates/traffic"
+	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/routing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrafficSegmentInvalidCreateArguments(t *testing.T) {
+	spec := traffic.NewSegment()
+
+	for _, def := range []string{
+		`TrafficSegment()`,
+		`TrafficSegment(1)`,
+		`TrafficSegment(1, 0)`,
+		`TrafficSegment(0, 1.1)`,
+		`TrafficSegment(1, 2)`,
+		`TrafficSegment(0, "1")`,
+		`TrafficSegment("0", 1)`,
+	} {
+		t.Run(def, func(t *testing.T) {
+			pp := eskip.MustParsePredicates(def)
+			require.Len(t, pp, 1)
+
+			_, err := spec.Create(pp[0].Args)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func requestWithR(r float64) *http.Request {
+	req := &http.Request{}
+	req = req.WithContext(routing.NewContext(req.Context()))
+
+	_ = routing.FromContext(req.Context(), traffic.ExportRandomValue, func() float64 { return r })
+	return req
+}
+
+func getN(t *testing.T, client *proxytest.TestClient, url string, n int) map[int]int {
+	codes := make(map[int]int)
+	for i := 0; i < n; i++ {
+		rsp, err := client.Get(url)
+		require.NoError(t, err)
+		rsp.Body.Close()
+
+		codes[rsp.StatusCode]++
+	}
+	return codes
+}
+
+func TestTrafficSegmentMatch(t *testing.T) {
+	pp := eskip.MustParsePredicates(`TrafficSegment(0, 0.5)`)
+	require.Len(t, pp, 1)
+
+	spec := traffic.NewSegment()
+	p, err := spec.Create(pp[0].Args)
+	require.NoError(t, err)
+
+	assert.True(t, p.Match(requestWithR(0.0)))
+	assert.True(t, p.Match(requestWithR(0.1)))
+	assert.True(t, p.Match(requestWithR(0.49)))
+
+	assert.False(t, p.Match(requestWithR(0.5))) // upper interval boundary is excluded
+	assert.False(t, p.Match(requestWithR(0.6)))
+	assert.False(t, p.Match(requestWithR(1.0)))
+}
+
+func TestTrafficSegmentMinEqualsMax(t *testing.T) {
+	pp := eskip.MustParsePredicates(`TrafficSegment(0.5, 0.5)`)
+	require.Len(t, pp, 1)
+
+	spec := traffic.NewSegment()
+	p, err := spec.Create(pp[0].Args)
+	require.NoError(t, err)
+
+	assert.False(t, p.Match(requestWithR(0.0)))
+	assert.False(t, p.Match(requestWithR(0.5)))
+	assert.False(t, p.Match(requestWithR(1.0)))
+}
+
+func TestTrafficSegmentSpec(t *testing.T) {
+	spec := traffic.NewSegment()
+
+	assert.Equal(t, predicates.TrafficSegmentName, spec.Name())
+	assert.Equal(t, -1, spec.Weight())
+}
+
+func TestTrafficSegmentSplit(t *testing.T) {
+	p := proxytest.Config{
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+			Predicates: []routing.PredicateSpec{
+				traffic.NewSegment(),
+			},
+		},
+		Routes: eskip.MustParse(`
+			r50: Path("/test") && TrafficSegment(0.0, 0.5) -> status(200) -> <shunt>;
+			r30: Path("/test") && TrafficSegment(0.5, 0.8) -> status(201) -> <shunt>;
+			r20: Path("/test") && TrafficSegment(0.8, 1.0) -> status(202) -> <shunt>;
+		`),
+	}.Create()
+	defer p.Close()
+
+	const (
+		N     = 1_000
+		delta = 0.05 * N
+	)
+
+	codes := getN(t, p.Client(), p.URL+"/test", N)
+
+	t.Logf("Response codes: %v", codes)
+
+	assert.InDelta(t, N*0.5, codes[200], delta)
+	assert.InDelta(t, N*0.3, codes[201], delta)
+	assert.InDelta(t, N*0.2, codes[202], delta)
+}
+
+func TestTrafficSegmentTeeLoopback(t *testing.T) {
+	var loopRequests int32
+	loopBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&loopRequests, 1)
+	}))
+	defer loopBackend.Close()
+
+	p := proxytest.Config{
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+			Predicates: []routing.PredicateSpec{
+				traffic.NewSegment(),
+				tee.New(),
+				primitive.NewTrue(),
+			},
+		},
+		Routes: eskip.MustParse(fmt.Sprintf(`
+			r0: * -> status(200) -> <shunt>;
+			r1: Path("/test") && TrafficSegment(0.0, 0.5) -> teeLoopback("a-loop") -> status(201) -> <shunt>;
+			r2: Path("/test") && Tee("a-loop") && True() -> "%s";
+		`, loopBackend.URL)),
+	}.Create()
+	defer p.Close()
+
+	const (
+		N     = 1_000
+		delta = 0.05 * N
+	)
+
+	codes := getN(t, p.Client(), p.URL+"/test", N)
+
+	// wait for loopback requests to complete
+	time.Sleep(100 * time.Millisecond)
+
+	t.Logf("Response codes: %v, loopRequests: %d", codes, loopRequests)
+
+	assert.InDelta(t, N*0.5, codes[200], delta)
+	assert.InDelta(t, N*0.5, codes[201], delta)
+	assert.Equal(t, codes[201], int(loopRequests))
+}
+
+func TestTrafficSegmentLoopbackBackend(t *testing.T) {
+	p := proxytest.Config{
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+			Predicates: []routing.PredicateSpec{
+				traffic.NewSegment(),
+				tee.New(),
+				primitive.NewTrue(),
+			},
+		},
+		Routes: eskip.MustParse(`
+			r0: * -> status(200) -> <shunt>;
+			r1: Path("/test") && TrafficSegment(0.0, 0.5) -> setPath("a-loop") -> <loopback>;
+			r2: Path("/a-loop") -> status(201) -> <shunt>;
+		`),
+	}.Create()
+	defer p.Close()
+
+	const (
+		N     = 1_000
+		delta = 0.05 * N
+	)
+
+	codes := getN(t, p.Client(), p.URL+"/test", N)
+
+	t.Logf("Response codes: %v", codes)
+
+	assert.InDelta(t, N*0.5, codes[200], delta)
+	assert.InDelta(t, N*0.5, codes[201], delta)
+}

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -289,6 +289,7 @@ func (c *context) Split() (filters.FilterContext, error) {
 	}
 	serverSpan := opentracing.SpanFromContext(originalRequest.Context())
 	cr = cr.WithContext(opentracing.ContextWithSpan(cr.Context(), serverSpan))
+	cr = cr.WithContext(routing.NewContext(cr.Context()))
 	originalRequest.Body = body
 	cc.request = cr
 	return cc, nil

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1442,6 +1442,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		setTag(span, HTTPRemoteIPTag, stripPort(r.RemoteAddr))
 	p.setCommonSpanInfo(r.URL, r, span)
 	r = r.WithContext(ot.ContextWithSpan(r.Context(), span))
+	r = r.WithContext(routing.NewContext(r.Context()))
 
 	ctx = newContext(lw, r, p)
 	ctx.startServe = time.Now()

--- a/routing/context.go
+++ b/routing/context.go
@@ -1,0 +1,34 @@
+package routing
+
+import (
+	"context"
+	"sync"
+)
+
+type contextKey struct{}
+
+var routingContextKey contextKey
+
+// NewContext returns a new context with associated routing context.
+// It does nothing and returns ctx if it already has associated routing context.
+func NewContext(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(routingContextKey).(*sync.Map); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, routingContextKey, &sync.Map{})
+}
+
+// FromContext returns value from the routing context stored in ctx.
+// It returns value associated with the key or stores result of the defaultValue call.
+// defaultValue may be called multiple times but only one result will be used as a default value.
+func FromContext[K comparable, V any](ctx context.Context, key K, defaultValue func() V) V {
+	m, _ := ctx.Value(routingContextKey).(*sync.Map)
+
+	// https://github.com/golang/go/issues/44159#issuecomment-780774977
+	val, ok := m.Load(key)
+	if !ok {
+		val = defaultValue()
+		val, _ = m.LoadOrStore(key, val)
+	}
+	return val.(V)
+}

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -130,11 +130,10 @@ func TestProcessRouteDefErrors(t *testing.T) {
 }
 
 func TestProcessRouteDefWeight(t *testing.T) {
-
-	wps := weightedPredicateSpec{}
-
-	cpm := make(map[string]routing.PredicateSpec)
-	cpm[wps.Name()] = wps
+	cpm := map[string]routing.PredicateSpec{
+		"WeightedPredicate10":      weightedPredicateSpec{name: "WeightedPredicate10", weight: 10},
+		"WeightedPredicateMinus10": weightedPredicateSpec{name: "WeightedPredicateMinus10", weight: -10},
+	}
 
 	for _, ti := range []struct {
 		route  string
@@ -155,6 +154,15 @@ func TestProcessRouteDefWeight(t *testing.T) {
 		}, {
 			`WeightedPredicate10() && Weight(20) -> <shunt>`,
 			30,
+		}, {
+			`WeightedPredicateMinus10() -> <shunt>`,
+			-10,
+		}, {
+			`WeightedPredicateMinus10() && Weight(10) -> <shunt>`,
+			0,
+		}, {
+			`WeightedPredicateMinus10() && Weight(20) -> <shunt>`,
+			10,
 		},
 	} {
 		func() {
@@ -290,7 +298,10 @@ func TestLogging(t *testing.T) {
 	})
 }
 
-type weightedPredicateSpec struct{}
+type weightedPredicateSpec struct {
+	name   string
+	weight int
+}
 type weightedPredicate struct{}
 
 func (w weightedPredicate) Match(request *http.Request) bool {
@@ -298,7 +309,7 @@ func (w weightedPredicate) Match(request *http.Request) bool {
 }
 
 func (w weightedPredicateSpec) Name() string {
-	return "WeightedPredicate10"
+	return w.name
 }
 
 func (w weightedPredicateSpec) Create([]interface{}) (routing.Predicate, error) {
@@ -306,5 +317,5 @@ func (w weightedPredicateSpec) Create([]interface{}) (routing.Predicate, error) 
 }
 
 func (w weightedPredicateSpec) Weight() int {
-	return 10
+	return w.weight
 }

--- a/skipper.go
+++ b/skipper.go
@@ -1784,6 +1784,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		cookie.New(),
 		query.New(),
 		traffic.New(),
+		traffic.NewSegment(),
 		primitive.NewTrue(),
 		primitive.NewFalse(),
 		primitive.NewShutdown(),


### PR DESCRIPTION
This change adds routing context to pass information between multiple predicates and uses it to implement new TrafficSegment predicate.

For https://github.com/zalando/skipper/issues/2268