### PR TITLE
fix: openssf card scan told to remove top level permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,7 @@
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
 name: "CodeQL"
+permissions: {}
 
 on:
   push:
@@ -49,7 +50,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,7 @@
-name: docs-ci 
-on: 
+name: docs-ci
+permissions: {}
+
+on:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -1,4 +1,6 @@
 name: gh-package-deploy
+permissions: {}
+
 on:
   push:
     tags:
@@ -20,22 +22,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      
+
       - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
           go-version: '^1.19'
-      
+
       - name: Login to Github Container Registry
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435
         id: get-latest-tag
-      
+
       - name: Build Skipper Packages
         run: |
           cd packaging

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,4 +1,7 @@
 name: master
+
+permissions: {}
+
 on:
   push:
     branches:


### PR DESCRIPTION
fix: openssf card scan told to remove top level permissions, as every job has a set of permissions we should be able to drop top-level permissions to 0