### PR TITLE
dataclients/kubernetes: use fixtures to test Ingress backend weights

### DIFF
--- a/dataclients/kubernetes/ingress_test.go
+++ b/dataclients/kubernetes/ingress_test.go
@@ -16,5 +16,6 @@ func TestIngressV1Fixtures(t *testing.T) {
 		"testdata/ingressV1/service-ports",
 		"testdata/ingressV1/external-name",
 		"testdata/ingressV1/tls",
+		"testdata/ingressV1/traffic",
 	)
 }

--- a/dataclients/kubernetes/path_test.go
+++ b/dataclients/kubernetes/path_test.go
@@ -80,7 +80,7 @@ func TestPathMatchingModes(t *testing.T) {
 
 	setIngressWithPath := func(p string, annotations ...string) {
 		i := testIngress(
-			"namespace1", "ingress1", "service1", "", "", "", "", "", "", map[string]string{}, definitions.BackendPortV1{Number: 8080}, 1.0,
+			"namespace1", "ingress1", "service1", "", "", "", "", "", "", map[string]string{}, definitions.BackendPortV1{Number: 8080},
 			testRule("www.example.org", testPathRule(p, "service1", definitions.BackendPortV1{Number: 8080})),
 		)
 
@@ -345,12 +345,12 @@ func TestIngressSpecificMode(t *testing.T) {
 	defer api.Close()
 
 	ingressWithDefault := testIngress(
-		"namespace1", "ingress1", "service1", "", "", "", "", "", "", map[string]string{}, definitions.BackendPortV1{Number: 8080}, 1.0,
+		"namespace1", "ingress1", "service1", "", "", "", "", "", "", map[string]string{}, definitions.BackendPortV1{Number: 8080},
 		testRule("www.example.org", testPathRule("^/foo", "service1", definitions.BackendPortV1{Number: 8080})),
 	)
 
 	ingressWithCustom := testIngress(
-		"namespace1", "ingress1", "service1", "", "", "", "", "", "", map[string]string{}, definitions.BackendPortV1{Number: 8080}, 1.0,
+		"namespace1", "ingress1", "service1", "", "", "", "", "", "", map[string]string{}, definitions.BackendPortV1{Number: 8080},
 		testRule("www.example.org", testPathRule("/bar", "service1", definitions.BackendPortV1{Number: 8080})),
 	)
 	ingressWithCustom.Metadata.Annotations[pathModeAnnotationKey] = pathPrefixString

--- a/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.default-filters/bar.foo
+++ b/dataclients/kubernetes/testdata/ingress/ingress-data/ing-with-prule-wrong-ing-port.default-filters/bar.foo
@@ -1,1 +1,0 @@
-setResponseHeader("default", "filter")

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/1-2-3-4.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/1-2-3-4.eskip
@@ -1,0 +1,25 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v1:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.1) &&
+  True() &&
+  True()
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v2:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.2222222222222222) &&
+  True()
+  -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v3:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.42857142857142855)
+  -> <roundRobin, "http://42.0.1.6:8080", "http://42.0.1.7:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v4:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$")
+  -> <roundRobin, "http://42.0.1.8:8080", "http://42.0.1.9:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/1-2-3-4.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/1-2-3-4.yaml
@@ -1,0 +1,149 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  annotations:
+    zalando.org/backend-weights: '{"service1v1": 1, "service1v2": 2, "service1v3": 3, "service1v4": 4}'
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v3
+spec:
+  clusterIP: 1.2.3.6
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v4
+spec:
+  clusterIP: 1.2.3.7
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v3
+subsets:
+  - addresses:
+      - ip: 42.0.1.6
+      - ip: 42.0.1.7
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v4
+subsets:
+  - addresses:
+      - ip: 42.0.1.8
+      - ip: 42.0.1.9
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/20-60-20.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/20-60-20.eskip
@@ -1,0 +1,18 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v1:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.2) &&
+  True()
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v2:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.75)
+  -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v3:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$")
+  -> <roundRobin, "http://42.0.1.6:8080", "http://42.0.1.7:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/20-60-20.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/20-60-20.yaml
@@ -1,0 +1,117 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  annotations:
+    # if all backends has a weight, all should get relative weight
+    zalando.org/backend-weights: '{"service1v1": 20, "service1v2": 60, "service1v3": 20}'
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v3
+spec:
+  clusterIP: 1.2.3.6
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v3
+subsets:
+  - addresses:
+      - ip: 42.0.1.6
+      - ip: 42.0.1.7
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/25-45-3-27.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/25-45-3-27.eskip
@@ -1,0 +1,25 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v1:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.25) &&
+  True() &&
+  True()
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v2:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.6) &&
+  True()
+  -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v3:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.1)
+  -> <roundRobin, "http://42.0.1.6:8080", "http://42.0.1.7:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v4:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$")
+  -> <roundRobin, "http://42.0.1.8:8080", "http://42.0.1.9:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/25-45-3-27.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/25-45-3-27.yaml
@@ -1,0 +1,150 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  annotations:
+    # if 4 backends have weights, all should get relative weight
+    zalando.org/backend-weights: '{"service1v1": 25, "service1v2": 45, "service1v3": 3, "service1v4": 27}'
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v3
+spec:
+  clusterIP: 1.2.3.6
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v4
+spec:
+  clusterIP: 1.2.3.7
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v3
+subsets:
+  - addresses:
+      - ip: 42.0.1.6
+      - ip: 42.0.1.7
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v4
+subsets:
+  - addresses:
+      - ip: 42.0.1.8
+      - ip: 42.0.1.9
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/60-140.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/60-140.eskip
@@ -1,0 +1,12 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v1:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.3)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v2:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$")
+  -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/60-140.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/60-140.yaml
@@ -1,0 +1,84 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  annotations:
+    # weights are relative and should always sum to 1.0.
+    zalando.org/backend-weights: '{"service1v1": 60, "service1v2": 140}'
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/three-backends-with-one-zero-weight.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/three-backends-with-one-zero-weight.eskip
@@ -1,0 +1,12 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v1:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.3)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v2:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$")
+  -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/three-backends-with-one-zero-weight.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/three-backends-with-one-zero-weight.yaml
@@ -1,0 +1,117 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  annotations:
+    # if two of three backends has a weight, only two should get traffic
+    zalando.org/backend-weights: '{"service1v1": 30, "service1v2": 70}'
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v3
+spec:
+  clusterIP: 1.2.3.6
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v3
+subsets:
+  - addresses:
+      - ip: 42.0.1.6
+      - ip: 42.0.1.7
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-no-weights.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-no-weights.eskip
@@ -1,0 +1,12 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v1:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
+  Traffic(0.5)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v2:
+  Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$")
+  -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-no-weights.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-no-weights.yaml
@@ -1,0 +1,82 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  # if two backends doesn't have any weight, they get equal amount of traffic.
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-with-one-zero-weight.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-with-one-zero-weight.eskip
@@ -1,0 +1,7 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org____service1v1:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-with-one-zero-weight.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/two-backends-with-one-zero-weight.yaml
@@ -1,0 +1,84 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  annotations:
+    # if only one backend has a weight, only one backend should get 100% traffic
+    zalando.org/backend-weights: '{"service1v1": 30}'
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/with-path-30-70.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/with-path-30-70.eskip
@@ -1,0 +1,18 @@
+kube_namespace1__ingress1______:
+  *
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org___test1__service1v1:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/) &&
+  PathRegexp(/^(\/test1)/) &&
+  Traffic(0.3)
+  -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+
+kube_namespace1__ingress1__test_example_org___test1__service1v2:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/) &&
+  PathRegexp(/^(\/test1)/)
+  -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;
+
+kube___catchall__test_example_org____:
+  Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
+  -> <shunt>;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/with-path-30-70.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/with-path-30-70.yaml
@@ -1,0 +1,85 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  annotations:
+    zalando.org/backend-weights: '{"service1v1": 30, "service1v2": 70}'
+spec:
+  defaultBackend:
+    service:
+      name: service1v1
+      port:
+        name: port1
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - path: "/test1"
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - path: "/test1"
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP


### PR DESCRIPTION
This change converts tests of computeBackendWeightsV1 into equivalent Ingress fixtures which should simplify refactoring of the weight calculation algorithm.

For https://github.com/zalando/skipper/issues/2268