### PR TITLE
dataclients/kubernetes: fix Ingress backend weights for more than two services

### DIFF
--- a/dataclients/kubernetes/testdata/ingressV1/traffic/no-weights.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/no-weights.eskip
@@ -1,0 +1,20 @@
+kube_namespace1__ingress1__test1_example_org____service1v1: Host("^(test1[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.25) && True() && True() -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+kube_namespace1__ingress1__test1_example_org____service1v2: Host("^(test1[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.3333333333333333) && True() -> <roundRobin, "http://42.0.1.4:8080", "http://42.0.1.5:8080">;
+kube_namespace1__ingress1__test1_example_org____service1v3: Host("^(test1[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.5) -> <roundRobin, "http://42.0.1.6:8080", "http://42.0.1.7:8080">;
+kube_namespace1__ingress1__test1_example_org____service1v4: Host("^(test1[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://42.0.1.8:8080", "http://42.0.1.9:8080">;
+
+kube_namespace1__ingress2__test2_example_org____service1v1: Host("^(test2[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.3333333333333333) && True() && True() -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+kube_namespace1__ingress2__test2_example_org____service1v3: Host("^(test2[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.5) -> <roundRobin, "http://42.0.1.6:8080", "http://42.0.1.7:8080">;
+kube_namespace1__ingress2__test2_example_org____service1v4: Host("^(test2[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://42.0.1.8:8080", "http://42.0.1.9:8080">;
+
+kube_namespace1__ingress3__test3_example_org____service1v1: Host("^(test3[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.3333333333333333) && True() && True() -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+kube_namespace1__ingress3__test3_example_org____service1v3: Host("^(test3[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.5) -> <roundRobin, "http://42.0.1.6:8080", "http://42.0.1.7:8080">;
+kube_namespace1__ingress3__test3_example_org____service1v4: Host("^(test3[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://42.0.1.8:8080", "http://42.0.1.9:8080">;
+
+kube_namespace1__ingress4__test4_example_org____service1v1: Host("^(test4[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.5) && True() && True() -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+kube_namespace1__ingress4__test4_example_org____service1v4: Host("^(test4[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://42.0.1.8:8080", "http://42.0.1.9:8080">;
+
+kube_namespace1__ingress5__test5_example_org____service1v1: Host("^(test5[.]example[.]org[.]?(:[0-9]+)?)$") && Traffic(0.5) && True() && True() -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
+kube_namespace1__ingress5__test5_example_org____service1v4: Host("^(test5[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://42.0.1.8:8080", "http://42.0.1.9:8080">;
+
+kube_namespace1__ingress6__test6_example_org____service1v1: Host("^(test6[.]example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/no-weights.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/no-weights.yaml
@@ -1,0 +1,333 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress1
+  # backend weights are not specified
+spec:
+  rules:
+    - host: test1.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress2
+  annotations:
+    # explicit zero weight
+    zalando.org/backend-weights: '{"service1v1": 1, "service1v2": 0, "service1v3": 1, "service1v4": 1}'
+spec:
+  rules:
+    - host: test2.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress3
+  annotations:
+    # missing weight (implicit zero)
+    zalando.org/backend-weights: '{"service1v1": 1, "service1v3": 1, "service1v4": 1}'
+spec:
+  rules:
+    - host: test3.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress4
+  annotations:
+    # two missing weights (implicit zero)
+    zalando.org/backend-weights: '{"service1v1": 1, "service1v4": 1}'
+spec:
+  rules:
+    - host: test4.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress5
+  annotations:
+    # one missing and one explicit zero weights
+    zalando.org/backend-weights: '{"service1v1": 1, "service1v2": 0, "service1v4": 1}'
+spec:
+  rules:
+    - host: test5.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: namespace1
+  name: ingress6
+  annotations:
+    # three missing weights
+    zalando.org/backend-weights: '{"service1v1": 1}'
+spec:
+  rules:
+    - host: test6.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v1
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v2
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v3
+                port:
+                  name: port1
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: service1v4
+                port:
+                  name: port1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v3
+spec:
+  clusterIP: 1.2.3.6
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: namespace1
+  name: service1v4
+spec:
+  clusterIP: 1.2.3.7
+  ports:
+    - name: port1
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v1
+subsets:
+  - addresses:
+      - ip: 42.0.1.2
+      - ip: 42.0.1.3
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v2
+subsets:
+  - addresses:
+      - ip: 42.0.1.4
+      - ip: 42.0.1.5
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v3
+subsets:
+  - addresses:
+      - ip: 42.0.1.6
+      - ip: 42.0.1.7
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: namespace1
+  name: service1v4
+subsets:
+  - addresses:
+      - ip: 42.0.1.8
+      - ip: 42.0.1.9
+    ports:
+      - name: port1
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/three-backends-with-one-zero-weight.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/three-backends-with-one-zero-weight.eskip
@@ -4,7 +4,8 @@ kube_namespace1__ingress1______:
 
 kube_namespace1__ingress1__test_example_org____service1v1:
   Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") &&
-  Traffic(0.3)
+  Traffic(0.3) &&
+  True()
   -> <roundRobin, "http://42.0.1.2:8080", "http://42.0.1.3:8080">;
 
 kube_namespace1__ingress1__test_example_org____service1v2:


### PR DESCRIPTION
When there are more than two backend services and no weights are specified, dataclient should add correct number of `True()` predicates to adjust route weights.

Example:
```
rN: Path("/foo") && Traffic(...) && True() && True() ... True() -> ...
...
r3: Path("/foo") && Traffic(...) && True() && True() -> ...
r2: Path("/foo") && Traffic(...) && True() -> ...
r1: Path("/foo") && Traffic(...) -> ...
r0: Path("/foo") -> ...
```