### PR TITLE
fix: use pinned dependencies for docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry.opensource.zalan.do/library/alpine-3:latest
-LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
+FROM registry.opensource.zalan.do/library/alpine-3:latest@sha256:2924ef858efe1025d8f4094b1e3ee6f86db2d3e211052c06e0c8afb86643d46a
+LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 
 ADD skipper /usr/bin/
 

--- a/fastcgiserver/Dockerfile
+++ b/fastcgiserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.3-fpm-alpine3.11
+FROM php:7.4.3-fpm-alpine3.11@sha256:a748390f2d9f006a0bed261f751656ea49c8f040f664038fe7a47bab44f61212
 
 RUN echo $'[www] \n\
 user = www-data \n\

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3:latest
+ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3:latest@sha256:2924ef858efe1025d8f4094b1e3ee6f86db2d3e211052c06e0c8afb86643d46a
 FROM ${BASE_IMAGE}
-LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
+LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 RUN mkdir -p /usr/bin
 ARG BUILD_FOLDER=build

--- a/packaging/Dockerfile.alpine
+++ b/packaging/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:alpine@sha256:913de96707b0460bcfdfe422796bb6e559fc300f6c53286777805a9a3010a5ea
 
 ENV CGO_ENABLED 1
 ENV GOOS linux

--- a/packaging/Dockerfile.arm64
+++ b/packaging/Dockerfile.arm64
@@ -1,5 +1,5 @@
-FROM --platform=linux/arm64 alpine:3
-LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
+FROM --platform=linux/arm64 alpine:3@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126
+LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 ADD build/linux/arm64/skipper \
     build/linux/arm64/eskip \

--- a/packaging/Dockerfile.armv7
+++ b/packaging/Dockerfile.armv7
@@ -1,5 +1,5 @@
-FROM --platform=linux/arm/v7 alpine:3
-LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
+FROM --platform=linux/arm/v7 alpine:3@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126
+LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 ADD build/linux/arm/v7/skipper \
     build/linux/arm/v7/eskip \


### PR DESCRIPTION
fix: use pinned dependencies for docker  base images, which can be detected and updated by dependabot