### PR TITLE
proxy: add uncompressed response counter

### DIFF
--- a/filters/auth/grant_test.go
+++ b/filters/auth/grant_test.go
@@ -183,7 +183,7 @@ func newGrantTestConfig(tokeninfoURL, providerURL string) *auth.OAuthConfig {
 	}
 }
 
-func newAuthProxy(t *testing.T, config *auth.OAuthConfig, routes []*eskip.Route, hosts ...string) (*proxytest.TestProxy, *http.Client) {
+func newAuthProxy(t *testing.T, config *auth.OAuthConfig, routes []*eskip.Route, hosts ...string) (*proxytest.TestProxy, *proxytest.TestClient) {
 	err := config.Init()
 	if err != nil {
 		t.Fatal(err)
@@ -235,7 +235,7 @@ func newAuthProxy(t *testing.T, config *auth.OAuthConfig, routes []*eskip.Route,
 	return proxy, client
 }
 
-func newSimpleGrantAuthProxy(t *testing.T, config *auth.OAuthConfig, hosts ...string) (*proxytest.TestProxy, *http.Client) {
+func newSimpleGrantAuthProxy(t *testing.T, config *auth.OAuthConfig, hosts ...string) (*proxytest.TestProxy, *proxytest.TestClient) {
 	return newAuthProxy(t, config, []*eskip.Route{{
 		Filters: []*eskip.Filter{
 			{Name: filters.OAuthGrantName},
@@ -320,7 +320,7 @@ func checkCookie(t *testing.T, rsp *http.Response, expectedDomain string) {
 	}
 }
 
-func grantQueryWithCookie(t *testing.T, client *http.Client, url string, cookies ...*http.Cookie) *http.Response {
+func grantQueryWithCookie(t *testing.T, client *proxytest.TestClient, url string, cookies ...*http.Cookie) *http.Response {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/filters/auth/grantclaimsquery_test.go
+++ b/filters/auth/grantclaimsquery_test.go
@@ -17,7 +17,7 @@ func TestGrantClaimsQuery(t *testing.T) {
 	tokeninfo := newGrantTestTokeninfo(testToken, "{\"scope\":[\"match\"], \"uid\":\"foo\"}")
 	defer tokeninfo.Close()
 
-	newAuthProxyForQuery := func(t *testing.T, config *auth.OAuthConfig, query string) (*proxytest.TestProxy, *http.Client) {
+	newAuthProxyForQuery := func(t *testing.T, config *auth.OAuthConfig, query string) (*proxytest.TestProxy, *proxytest.TestClient) {
 		return newAuthProxy(t, config, []*eskip.Route{{
 			Filters: []*eskip.Filter{
 				{Name: filters.OAuthGrantName},

--- a/metrics/metricstest/metricsmock.go
+++ b/metrics/metricstest/metricsmock.go
@@ -108,60 +108,60 @@ func (m *MockMetrics) IncFloatCounterBy(key string, value float64) {
 	})
 }
 
-func (*MockMetrics) MeasureRouteLookup(start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureRouteLookup(start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureFilterRequest(filterName string, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureFilterRequest(filterName string, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureAllFiltersRequest(routeId string, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureAllFiltersRequest(routeId string, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureBackend(routeId string, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureBackend(routeId string, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureBackendHost(routeBackendHost string, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureBackendHost(routeBackendHost string, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureFilterResponse(filterName string, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureFilterResponse(filterName string, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureAllFiltersResponse(routeId string, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureAllFiltersResponse(routeId string, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureResponse(code int, method string, routeId string, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureResponse(code int, method string, routeId string, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureServe(routeId, host, method string, code int, start time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureServe(routeId, host, method string, code int, start time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) IncRoutingFailures() {
-	panic("implement me")
+func (m *MockMetrics) IncRoutingFailures() {
+	// implement me
 }
 
-func (*MockMetrics) IncErrorsBackend(routeId string) {
-	panic("implement me")
+func (m *MockMetrics) IncErrorsBackend(routeId string) {
+	// implement me
 }
 
-func (*MockMetrics) MeasureBackend5xx(t time.Time) {
-	panic("implement me")
+func (m *MockMetrics) MeasureBackend5xx(t time.Time) {
+	// implement me
 }
 
-func (*MockMetrics) IncErrorsStreaming(routeId string) {
-	panic("implement me")
+func (m *MockMetrics) IncErrorsStreaming(routeId string) {
+	// implement me
 }
 
-func (*MockMetrics) RegisterHandler(path string, handler *http.ServeMux) {
-	panic("implement me")
+func (m *MockMetrics) RegisterHandler(path string, handler *http.ServeMux) {
+	// implement me
 }
 
 func (m *MockMetrics) UpdateGauge(key string, value float64) {

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -1,0 +1,65 @@
+package proxy_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/metrics"
+	"github.com/zalando/skipper/metrics/metricstest"
+	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/routing"
+	"github.com/zalando/skipper/routing/testdataclient"
+)
+
+func TestMetricsUncompressed(t *testing.T) {
+	dm := metrics.Default
+	t.Cleanup(func() { metrics.Default = dm })
+
+	m := &metricstest.MockMetrics{}
+	metrics.Default = m
+
+	// will update routes after proxy address is known
+	dc := testdataclient.New(nil)
+	defer dc.Close()
+
+	p := proxytest.Config{
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+			DataClients:    []routing.DataClient{dc},
+		},
+	}.Create()
+	defer p.Close()
+
+	err := dc.UpdateDoc(fmt.Sprintf(`
+		test: Path("/test") -> setPath("/backend") -> "%s";
+		backend: Path("/backend") && Header("Accept-Encoding", "gzip") -> compress() -> inlineContent("backend response") -> <shunt>;
+	`, p.URL), nil)
+	require.NoError(t, err)
+
+	// wait for route update
+	time.Sleep(10 * time.Millisecond)
+
+	client := p.Client()
+	client.Transport.(*http.Transport).DisableCompression = true
+
+	const N = 10
+
+	for i := 0; i < N; i++ {
+		rsp, body, err := client.GetBody(p.URL + "/test")
+		require.NoError(t, err)
+
+		require.Equal(t, 200, rsp.StatusCode)
+		require.Equal(t, []byte("backend response"), body)
+	}
+
+	m.WithCounters(func(counters map[string]int64) {
+		assert.Equal(t, counters["incoming.HTTP/1.1"], int64(2*N))
+		assert.Equal(t, counters["outgoing.HTTP/1.1"], int64(N))
+		assert.Equal(t, counters["experimental.uncompressed"], int64(N))
+	})
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -915,6 +915,9 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 		return nil, &proxyError{err: fmt.Errorf("unexpected error from Go stdlib net/http package during roundtrip: %w", err)}
 	}
 	p.tracing.setTag(ctx.proxySpan, HTTPStatusCodeTag, uint16(response.StatusCode))
+	if response.Uncompressed {
+		p.metrics.IncCounter("experimental.uncompressed")
+	}
 	return response, nil
 }
 


### PR DESCRIPTION
* Adds previously missing tests for proxy metrics
* Adds GetBody helper to the proxytest client

For https://github.com/zalando/skipper/issues/2307