### PR TITLE
fix: http.ResponseController is available since Go-1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.20
 
 replace github.com/go-redis/redis/v9 => github.com/szuecs/redis/v9 v9.0.0-beta.1.0.20220801200609-6f7f800107ba


### PR DESCRIPTION
fix: http.ResponseController is available since Go-1.20

see also: https://github.com/zalando/skipper/actions/runs/4940453717/jobs/8832346991#step:5:157