### PR TITLE
doc: makefile self documented similar to kubernetes project does it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,23 @@ TEST_PLUGINS       = _test_plugins/filter_noop.so \
 		     _test_plugins/multitype_noop.so \
 		     _test_plugins_fail/fail.so
 
+
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
 default: build
 
-lib: $(SOURCES)
+lib: $(SOURCES) ## build skipper library
 	go build $(PACKAGES)
 
 bindir:
 	mkdir -p bin
 
-skipper: $(SOURCES) bindir
+skipper: $(SOURCES) bindir ## build skipper binary
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o bin/skipper ./cmd/skipper/*.go
 
-eskip: $(SOURCES) bindir
+eskip: $(SOURCES) bindir ## build eskip binary
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o bin/eskip ./cmd/eskip/*.go
 
 webhook: $(SOURCES) bindir
@@ -36,34 +41,34 @@ ifeq (LIMIT_FDS, 256)
 	ulimit -n 1024
 endif
 
-build: $(SOURCES) lib skipper eskip webhook routesrv
+build: $(SOURCES) lib skipper eskip webhook routesrv ## build libe and all binaries
 
-build.linux.static:
+build.linux.static: ## build static linux binary for amd64
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/skipper -ldflags "-extldflags=-static -X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 
-build.linux.arm64:
+build.linux.arm64: ## build linux binary for arm64
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o bin/skipper -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 
-build.linux.armv7:
+build.linux.armv7: ## build linux binary for arm7
 	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -o bin/skipper -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 
 build.linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/skipper -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 
-build.darwin.arm64:
+build.darwin.arm64: ## build osx binary for arm64
 	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o bin/skipper -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 
-build.darwin:
+build.darwin: ## build osx binary for amd64
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o bin/skipper -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 
-build.windows:
+build.windows: ## build windows binary for amd64
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o bin/skipper -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 
-install: $(SOURCES)
+install: $(SOURCES) ## install skipper and eskip binaries into your system
 	go install -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/skipper
 	go install -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" ./cmd/eskip
 
-check: build check-plugins
+check: build check-plugins ## run all tests
 	# go test $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -71,7 +76,7 @@ check: build check-plugins
 	#
 	for p in $(PACKAGES); do go test $$p || break; done
 
-shortcheck: build check-plugins fixlimits
+shortcheck: build check-plugins fixlimits  ## run all short tests
 	# go test -test.short -run ^Test $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -79,7 +84,7 @@ shortcheck: build check-plugins fixlimits
 	#
 	for p in $(PACKAGES); do go test -test.short -run ^Test $$p || break -1; done
 
-cicheck: build check-plugins
+cicheck: build check-plugins ## run all short and redis tests
 	# go test -test.short -run ^Test $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -87,7 +92,7 @@ cicheck: build check-plugins
 	#
 	for p in $(PACKAGES); do go test -tags=redis -test.short -run ^Test $$p || break -1; done
 
-check-race: build
+check-race: build ## run all tests with race checker
 	# go test -race -test.short -run ^Test $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -104,7 +109,7 @@ _test_plugins/%.so: _test_plugins/%.go
 _test_plugins_fail/%.so: _test_plugins_fail/%.go
 	go build -buildmode=plugin -o $@ $<
 
-bench: build $(TEST_PLUGINS)
+bench: build $(TEST_PLUGINS) ## run all benchmark tests
 	# go test -bench . $(PACKAGES)
 	#
 	# due to vendoring and how go test ./... is not the same as go test ./a/... ./b/...
@@ -112,26 +117,26 @@ bench: build $(TEST_PLUGINS)
 	#
 	for p in $(PACKAGES); do go test -bench . $$p; done
 
-fuzz:
+fuzz: ## run all fuzz tests
 	for p in $(PACKAGES); do go test -run=NONE -fuzz=Fuzz -fuzztime 30s $$p; done
 
-lint: build staticcheck
+lint: build staticcheck ## run all linters
 
-clean:
+clean: ## clean temorary files and driectories
 	go clean -i -cache -testcache
 	rm -rf .coverprofile-all .cover
 	rm -f ./_test_plugins/*.so
 	rm -f ./_test_plugins_fail/*.so
 	rm -rf .bin
 
-deps:
+deps: ## install dependencies to run everything
 	go env
 	./etcd/install.sh $(TEST_ETCD_VERSION)
 	@go install honnef.co/go/tools/cmd/staticcheck@latest
 	@go install github.com/securego/gosec/v2/cmd/gosec@latest
 	@go install golang.org/x/vuln/cmd/govulncheck@latest
 
-vet: $(SOURCES)
+vet: $(SOURCES) ## run Go vet
 	go vet $(PACKAGES)
 
 # TODO(sszuecs) review disabling these checks, f.e.:
@@ -141,7 +146,7 @@ vet: $(SOURCES)
 # -ST1020 too many wrong comments on exported functions to fix right away
 # -ST1021 too many wrong comments on exported functions to fix right away
 # -ST1022 too many wrong comments on exported functions to fix right away
-staticcheck: $(SOURCES)
+staticcheck: $(SOURCES) ## run staticcheck
 	staticcheck -checks "all,-ST1000,-ST1003,-ST1012,-ST1020,-ST1021" $(PACKAGES)
 
 # TODO(sszuecs) review disabling these checks, f.e.:
@@ -153,16 +158,16 @@ staticcheck: $(SOURCES)
 gosec: $(SOURCES)
 	gosec -quiet -exclude="G101,G104,G304,G307,G402" ./...
 
-govulncheck: $(SOURCES)
+govulncheck: $(SOURCES) ## run govulncheck
 	govulncheck ./...
 
-fmt: $(SOURCES)
+fmt: $(SOURCES) ## format code
 	@gofmt -w -s $(SOURCES)
 
-check-fmt: $(SOURCES)
+check-fmt: $(SOURCES) ## check format code
 	@if [ "$$(gofmt -s -d $(SOURCES))" != "" ]; then false; else true; fi
 
-precommit: fmt build vet staticcheck check-race shortcheck
+precommit: fmt build vet staticcheck check-race shortcheck ## precommit hook
 
 .coverprofile-all: $(SOURCES) $(TEST_PLUGINS)
 	# go list -f \
@@ -180,7 +185,7 @@ precommit: fmt build vet staticcheck check-race shortcheck
 	go install github.com/modocache/gover@latest
 	gover . .coverprofile-all
 
-cover: .coverprofile-all
+cover: .coverprofile-all ## coverage test and show it in your browser
 	go tool cover -func .coverprofile-all
 
 show-cover: .coverprofile-all


### PR DESCRIPTION
doc: makefile self documented similar to kubernetes project does it

https://github.com/kubernetes-sigs/kubebuilder/blob/d0a1806c1d25c70777004271a4b773b490de3bcd/Makefile#L43-L44

```
% make help

Usage:
  make <target>
  help             Display this help
  lib              build skipper library
  skipper          build skipper binary
  eskip            build eskip binary
  build            build libe and all binaries
  install          install skipper and eskip binaries into your system
  check            run all tests
  shortcheck       run all short tests
  cicheck          run all short and redis tests
  check-race       run all tests with race checker
  bench            run all benchmark tests
  fuzz             run all fuzz tests
  lint             run all linters
  clean            clean temorary files and driectories
  deps             install dependencies to run everything
  vet              run Go vet
  staticcheck      run staticcheck
  govulncheck      run govulncheck
  fmt              format code
  check-fmt        check format code
  precommit        precommit hook
  cover            coverage test and show it in your browser
```