### PR TITLE
test: fix data race in upgrade header test

### DIFF
--- a/proxy/upgrade_test.go
+++ b/proxy/upgrade_test.go
@@ -340,7 +340,7 @@ func TestInvalidHTTPDialBackend(t *testing.T) {
 
 func TestAuditLogging(t *testing.T) {
 	message := strconv.Itoa(rand.Int())
-	test := func(enabled bool, check func(*testing.T, *bytes.Buffer, *bytes.Buffer)) func(t *testing.T) {
+	test := func(enabled bool, check func(*testing.T, string, string)) func(t *testing.T) {
 		return func(t *testing.T) {
 			wss := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
 				if _, err := io.Copy(ws, ws); err != nil {
@@ -412,18 +412,18 @@ func TestAuditLogging(t *testing.T) {
 				<-p.auditLogHook
 			}
 
-			check(t, sout, serr)
+			check(t, sout.String(), serr.String())
 		}
 	}
 
-	t.Run("off", test(false, func(t *testing.T, sout, serr *bytes.Buffer) {
-		if sout.Len() != 0 || serr.Len() != 0 {
-			t.Error("failed to disable audit log")
+	t.Run("off", test(false, func(t *testing.T, sout, serr string) {
+		if sout != "" || len(serr) != 0 {
+			t.Errorf("failed to disable audit log: %s", sout)
 		}
 	}))
 
-	t.Run("on", test(true, func(t *testing.T, sout, serr *bytes.Buffer) {
-		if !strings.Contains(sout.String(), message) || serr.Len() == 0 {
+	t.Run("on", test(true, func(t *testing.T, sout, serr string) {
+		if !strings.Contains(sout, message) || len(serr) == 0 {
 			t.Error("failed to enable audit log")
 		}
 	}))


### PR DESCRIPTION
test: fix data race in upgrade header test

```
--- FAIL: TestAuditLogging (0.00s)
    --- FAIL: TestAuditLogging/on (0.00s)
        upgrade_test.go:427: failed to enable audit log
==================
WARNING: DATA RACE
Write at 0x00c0004894a0 by goroutine 3828:
  bytes.(*Buffer).grow()
      /opt/hostedtoolcache/go/1.20.4/x64/src/bytes/buffer.go:128 +0x450
  bytes.(*Buffer).Write()
      /opt/hostedtoolcache/go/1.20.4/x64/src/bytes/buffer.go:170 +0xcd
  io.(*multiWriter).Write()
      /opt/hostedtoolcache/go/1.20.4/x64/src/io/multi.go:85 +0xc5
  io.copyBuffer()
      /opt/hostedtoolcache/go/1.20.4/x64/src/io/io.go:429 +0x2de
  io.Copy()
      /opt/hostedtoolcache/go/1.20.4/x64/src/io/io.go:386 +0x93
  github.com/zalando/skipper/proxy.copyAsync.func1()
      /home/runner/work/skipper/skipper/proxy/upgrade.go:218 +0x72

Previous read at 0x00c0004894a0 by goroutine 3812:
  bytes.(*Buffer).String()
      /opt/hostedtoolcache/go/1.20.4/x64/src/bytes/buffer.go:65 +0x85
  github.com/zalando/skipper/proxy.TestAuditLogging.func3()
      /home/runner/work/skipper/skipper/proxy/upgrade_test.go:426 +0x62
  github.com/zalando/skipper/proxy.TestAuditLogging.func1.1()
      /home/runner/work/skipper/skipper/proxy/upgrade_test.go:415 +0xdb1
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.4/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.4/x64/src/testing/testing.go:1629 +0x47
```