### PR TITLE
dataclients/kubernetes: reject RouteGroups with duplicate backend references

### DIFF
--- a/dataclients/kubernetes/definitions/testdata/validation/duplicate-default-backend.log
+++ b/dataclients/kubernetes/definitions/testdata/validation/duplicate-default-backend.log
@@ -1,0 +1,1 @@
+duplicate backend reference: app

--- a/dataclients/kubernetes/definitions/testdata/validation/duplicate-default-backend.yaml
+++ b/dataclients/kubernetes/definitions/testdata/validation/duplicate-default-backend.yaml
@@ -1,0 +1,15 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: test-route-group-duplicate-default-backends
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: app
+      type: service
+      serviceName: app-svc
+      servicePort: 80
+  defaultBackends:
+    - backendName: app
+    - backendName: app

--- a/dataclients/kubernetes/definitions/testdata/validation/route-with-duplicate-backend-reference.log
+++ b/dataclients/kubernetes/definitions/testdata/validation/route-with-duplicate-backend-reference.log
@@ -1,0 +1,1 @@
+duplicate backend reference: app

--- a/dataclients/kubernetes/definitions/testdata/validation/route-with-duplicate-backend-reference.yaml
+++ b/dataclients/kubernetes/definitions/testdata/validation/route-with-duplicate-backend-reference.yaml
@@ -1,0 +1,19 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: test-route-group-duplicate-backends
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: app
+      type: service
+      serviceName: app-svc
+      servicePort: 80
+  defaultBackends:
+    - backendName: app
+  routes:
+    - path: /
+      backends:
+        - backendName: app
+        - backendName: app


### PR DESCRIPTION
For https://github.com/zalando/skipper/issues/2268