### PR TITLE
Ingress docs: localRateLimit → clientRateLimit

### DIFF
--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -404,8 +404,8 @@ route as defined in eskip:
 
 ```
 zalando.org/skipper-routes: |
-  routename1: Path("/") -> localRatelimit(2, "1h") -> inlineContent("A") -> status(200) -> <shunt>;
-  routename2: Path("/foo") -> localRatelimit(5, "1h") -> inlineContent("B") -> status(200) -> <shunt>;
+  routename1: Path("/") -> clientRatelimit(2, "1h") -> inlineContent("A") -> status(200) -> <shunt>;
+  routename2: Path("/foo") -> clientRatelimit(5, "1h") -> inlineContent("B") -> status(200) -> <shunt>;
 ```
 
 Make sure the `;` semicolon is used to terminate the routes, if you
@@ -680,7 +680,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    zalando.org/skipper-filter: localRatelimit(20, "1h")
+    zalando.org/skipper-filter: clientRatelimit(20, "1h")
   name: app
 spec:
   rules:
@@ -705,7 +705,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    zalando.org/skipper-filter: localRatelimit(20, "1h", "auth")
+    zalando.org/skipper-filter: clientRatelimit(20, "1h", "auth")
   name: app
 spec:
   rules:
@@ -1121,7 +1121,7 @@ kind: Ingress
 metadata:
   annotations:
     zalando.org/skipper-predicate: Cookie("flavor", /^B$/) && Source("1.2.3.0/24", "195.168.0.0/17")
-    zalando.org/skipper-filter: localRatelimit(50, "10m") -> requestCookie("test-session", "abc")
+    zalando.org/skipper-filter: clientRatelimit(50, "10m") -> requestCookie("test-session", "abc")
   name: app
 spec:
   rules:

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1802,7 +1802,7 @@ Can be used as [egress](egress.md) feature.
 
 ## Rate Limit
 
-### ~~localRatelimit~~
+### <del>localRatelimit</del>
 
 **DEPRECATED** use [clientRatelimit](#clientratelimit) with the same
   settings instead.
@@ -2171,7 +2171,7 @@ See [the scripts page](scripts.md)
 
 
 ## Logs
-### ~~accessLogDisabled~~
+### <del>accessLogDisabled</del>
 
 **Deprecated:** use [disableAccessLog](#disableaccesslog) or [enableAccessLog](#enableaccesslog)
 


### PR DESCRIPTION
According to the filter reference, localRateLimit is deprecated and replaced by clientRateLimit.
This fixes this.

In addition, I noticed that in [the rendered docs page](https://opensource.zalando.com/skipper/reference/filters/#rate-limit) the `~~` is not rendered as a strike-through. The second commit tries to fix that (by using `<del>` directly).
I didn't try generating the documentation (as I didn't find an description on how to do this locally).