### PR TITLE
fix: terminate etcd process after running tests

### DIFF
--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -26,14 +26,14 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	defer func() {
-		err := etcdtest.Stop()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
+	exitCode := m.Run()
 
-	os.Exit(m.Run())
+	err = etcdtest.Stop()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(exitCode)
 }
 
 func checkInitial(d []*eskip.Route) bool {


### PR DESCRIPTION
After the etcd tests are done, etcd is not terminated.
Subsequent tests may therefore fail because an etcd process is still running and a new process of etcd can't start.
For example, if tests are run locally.

Executing os.Exit() terminates the program immediately; the deferred `etcdtest.Stop()` function is not executed [1].
The provided patch would terminate the etcd process in the end.

[1]\: https://pkg.go.dev/os#Exit