### PR TITLE
feature: add TTL support for routes in etcd

### DIFF
--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -441,7 +441,7 @@ func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
 		}
 
 		id := path.Base(response.Node.Key)
-		if response.Action == "delete" {
+		if response.Action == "delete" || response.Action == "expire" {
 			deletes[id] = true
 			delete(updates, id)
 		} else {

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/etcd/etcdtest"
@@ -307,6 +308,53 @@ func TestReceiveInsert(t *testing.T) {
 
 	if len(ds) != 0 {
 		t.Error("unexpected delete")
+	}
+}
+
+func TestReceiveExpire(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	if err := etcdtest.DeleteAll(); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	c, err := New(Options{etcdtest.Urls, "/skippertest", 0, false, "", "", ""})
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	_, err = c.LoadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Will expire after a TTL of 1 second
+	etcdtest.PutDataToTTL("/skippertest", "pdp", `Path("/pdp") -> "https://expire.example.org"`, 1)
+
+	// Wait until the route is expired with a timeout of 5 seconds
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			t.Error("Timeout: route should expire after 1 second but did not expire within 5 seconds")
+			return
+		default:
+			rs, es, err := c.LoadUpdate()
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+
+			if checkDeleted(es, "pdp") {
+				if len(rs) != 0 {
+					t.Fatal("unexpected upsert")
+				}
+				return
+			}
+		}
 	}
 }
 

--- a/etcd/etcdtest/mocketcd.go
+++ b/etcd/etcdtest/mocketcd.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -169,8 +170,16 @@ func PutData(key, data string) error {
 
 // Saves a route in etcd with the specified prefix.
 func PutDataTo(prefix, key, data string) error {
+	return PutDataToTTL(prefix, key, data, 0)
+}
+
+// Saves a route with TTL in etcd with the specified prefix.
+func PutDataToTTL(prefix, key, data string, ttl int) error {
 	v := make(url.Values)
 	v.Add("value", data)
+	if ttl > 0 {
+		v.Add("ttl", strconv.Itoa(ttl))
+	}
 	req, err := http.NewRequest("PUT",
 		Urls[0]+"/v2/keys/skippertest/routes/"+key,
 		bytes.NewBufferString(v.Encode()))


### PR DESCRIPTION
Since we process a very large number of routes, we want to automatically clean up deprecated and thus expired routes.
Therefore, we use the TTL of etcd to automatically expire and remove old routes stored in etcd.

Currently routes with expired TTL are removed from etcd but stay active in Skipper until a restart of Skipper is performed.
Expiring routes from etcd provoke a parsing error when `LoadUpdate()` is executed.

This patch would allow Skipper to support both the already supported etcd `delete` action and additionally the `expire` action to ensure that routes are removed.

The tests are extended accordingly to verify the correct behavior of expiring routes.
`TestReceiveExpire` adds a route with the minimum TTL of 1 second. This route must expire and be removed.