### PR TITLE
update: github.com/rcrowley/go-metrics - codahale

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.15.1
-	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/redis/go-redis/v9 v9.0.5
 	github.com/sarslanhan/cronmask v0.0.0-20190709075623-766eca24d011
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
-github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
-github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
+github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -77,21 +77,22 @@ func TestHandlerCodaHaleAllMetricsRequest(t *testing.T) {
 	}
 	m := metrics.NewCodaHale(o)
 	mh := metrics.NewHandler(o, m)
+	m.IncCounter("TestHandlerCodaHaleAllMetricsRequest")
 
 	r, _ := http.NewRequest("GET", "/metrics", nil)
 	rw := httptest.NewRecorder()
 	mh.ServeHTTP(rw, r)
 
 	if rw.Code != http.StatusOK {
-		t.Error("Metrics endpoint should provide a valid response")
+		t.Fatalf("Metrics endpoint should provide a valid response, got: %d", rw.Code)
 	}
 
 	var data map[string]map[string]interface{}
 	if err := json.Unmarshal(rw.Body.Bytes(), &data); err != nil {
-		t.Error("Unable to unmarshal metrics response")
+		t.Fatalf("Unable to unmarshal metrics response: %v", err)
 	}
 
-	if _, ok := data["gauges"]["runtime.MemStats.NumGC"]; !ok {
+	if _, ok := data["counters"]["TestHandlerCodaHaleAllMetricsRequest"]; !ok {
 		t.Error("Metrics endpoint should've returned some runtime metrics in it")
 	}
 }
@@ -103,8 +104,9 @@ func TestHandlerCodaHaleSingleMetricsRequest(t *testing.T) {
 	}
 	m := metrics.NewCodaHale(o)
 	mh := metrics.NewHandler(o, m)
+	m.IncCounter("TestHandlerCodaHaleSingleMetricsRequest")
 
-	r, _ := http.NewRequest("GET", "/metrics/runtime.MemStats.NumGC", nil)
+	r, _ := http.NewRequest("GET", "/metrics/TestHandlerCodaHaleSingleMetricsRequest", nil)
 	rw := httptest.NewRecorder()
 	mh.ServeHTTP(rw, r)
 	if rw.Code != http.StatusOK {
@@ -120,7 +122,7 @@ func TestHandlerCodaHaleSingleMetricsRequest(t *testing.T) {
 		t.Error("Metrics endpoint for exact match should've returned exactly te requested item")
 	}
 
-	if _, ok := data["gauges"]["runtime.MemStats.NumGC"]; !ok {
+	if _, ok := data["counters"]["TestHandlerCodaHaleSingleMetricsRequest"]; !ok {
 		t.Error("Metrics endpoint should've returned some runtime metrics in it")
 	}
 }
@@ -133,8 +135,9 @@ func TestHandlerCodaHaleSingleMetricsRequestWhenUsingPrefix(t *testing.T) {
 	}
 	m := metrics.NewCodaHale(o)
 	mh := metrics.NewHandler(o, m)
+	m.IncCounter("TestHandlerCodaHaleSingleMetricsRequestWhenUsingPrefix")
 
-	r, _ := http.NewRequest("GET", "/metrics/zmon.runtime.MemStats.NumGC", nil)
+	r, _ := http.NewRequest("GET", "/metrics/zmon.TestHandlerCodaHaleSingleMetricsRequestWhenUsingPrefix", nil)
 	rw := httptest.NewRecorder()
 	mh.ServeHTTP(rw, r)
 	if rw.Code != http.StatusOK {
@@ -150,7 +153,7 @@ func TestHandlerCodaHaleSingleMetricsRequestWhenUsingPrefix(t *testing.T) {
 		t.Error("Metrics endpoint for exact match using prefix should've returned exactly te requested item")
 	}
 
-	if _, ok := data["gauges"]["zmon.runtime.MemStats.NumGC"]; !ok {
+	if _, ok := data["counters"]["zmon.TestHandlerCodaHaleSingleMetricsRequestWhenUsingPrefix"]; !ok {
 		t.Error("Metrics endpoint for exact match using prefix should've returned some runtime metrics in it")
 	}
 }
@@ -162,6 +165,7 @@ func TestHandlerCodaHaleMetricsRequestWithPattern(t *testing.T) {
 	}
 	m := metrics.NewCodaHale(o)
 	mh := metrics.NewHandler(o, m)
+	m.UpdateGauge("runtime.Num", 5.0)
 
 	r, _ := http.NewRequest("GET", "/metrics/runtime.Num", nil)
 	rw := httptest.NewRecorder()


### PR DESCRIPTION
update: github.com/rcrowley/go-metrics - codahale
test: fix metrics tests to use separate created metrics instead relying on implicitly defined runtime metrics, which are dropped by sync.Once package global in https://github.com/rcrowley/go-metrics/commit/615496d9b7277a58d61fdeb8f9a3d4185fcf1bb2