### PR TITLE
metrics: add IncCounter benchmark

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -223,10 +223,27 @@ func BenchmarkMeasureSinceCodaHale(b *testing.B) {
 	benchmarkMeasureSince(b, m)
 }
 
+func BenchmarkIncCounterPrometheus(b *testing.B) {
+	m := metrics.NewMetrics(metrics.Options{Format: metrics.PrometheusKind})
+	benchmarkIncCounter(b, m)
+}
+
+func BenchmarkIncCounterCodaHale(b *testing.B) {
+	m := metrics.NewMetrics(metrics.Options{Format: metrics.CodaHaleKind})
+	benchmarkIncCounter(b, m)
+}
+
 func benchmarkMeasureSince(b *testing.B, m metrics.Metrics) {
 	start := time.Now()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m.MeasureSince("a.metrics.key", start)
+		m.MeasureSince("MeasureSince", start)
+	}
+}
+
+func benchmarkIncCounter(b *testing.B, m metrics.Metrics) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.IncCounter("IncCounter")
 	}
 }


### PR DESCRIPTION
Benchmark stats for the #2374 change:
```
$ go test ./metrics -run=NONE -bench=Benchmark -count=10 -benchmem > /tmp/no-go.txt
$ git checkout 0872c3269812f787655ecff6a921b5ce0fad9d1c
$ go test ./metrics -run=NONE -bench=Benchmark -count=10 -benchmem > /tmp/with-go.txt
$ benchstat /tmp/with-go.txt /tmp/no-go.txt
name                      old time/op    new time/op    delta
MeasureSincePrometheus-8     370ns ± 1%     368ns ± 0%    -0.61%  (p=0.000 n=9+9)
MeasureSinceCodaHale-8       629ns ± 6%     335ns ± 1%   -46.77%  (p=0.000 n=9+9)
IncCounterPrometheus-8       276ns ± 5%     252ns ± 1%    -8.88%  (p=0.000 n=10+10)
IncCounterCodaHale-8         375ns ±11%      60ns ± 1%   -84.03%  (p=0.000 n=10+9)

name                      old alloc/op   new alloc/op   delta
MeasureSincePrometheus-8     32.0B ± 0%     32.0B ± 0%      ~     (all equal)
MeasureSinceCodaHale-8       73.7B ±42%      0.0B       -100.00%  (p=0.000 n=10+10)
IncCounterPrometheus-8       32.0B ± 0%     32.0B ± 0%      ~     (all equal)
IncCounterCodaHale-8         32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
MeasureSincePrometheus-8      2.00 ± 0%      2.00 ± 0%      ~     (all equal)
MeasureSinceCodaHale-8        1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
IncCounterPrometheus-8        2.00 ± 0%      2.00 ± 0%      ~     (all equal)
IncCounterCodaHale-8          1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```