### PR TITLE
dataclients/kubernetes: add tests for traffic split with custom route

### DIFF
--- a/dataclients/kubernetes/testdata/ingressV1/traffic/issue2268.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/issue2268.eskip
@@ -1,0 +1,5 @@
+// Custom route has the same number of predicates as the service_1 route
+// which causes undefined behavior: a request with foo cookie might be routed to any of them.
+kube_ns__issue2268_custom_0__test_example_org_____: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Cookie("foo", "^") -> status(500) -> <shunt>;
+kube_ns__issue2268__test_example_org_____service_1: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Traffic(0.8)       -> "http://42.0.0.1:8080";
+kube_ns__issue2268__test_example_org_____service_2: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/")                       -> "http://42.0.0.2:8080";

--- a/dataclients/kubernetes/testdata/ingressV1/traffic/issue2268.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/traffic/issue2268.yaml
@@ -1,0 +1,81 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: ns
+  name: issue2268
+  annotations:
+    zalando.org/backend-weights: |
+      {"service-1": 80, "service-2": 20}
+    zalando.org/skipper-routes: |
+      custom: Cookie("foo", "^") -> status(500) -> <shunt>;
+spec:
+  rules:
+    - host: test.example.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: service-1
+                port:
+                  name: http
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: service-2
+                port:
+                  name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-1
+subsets:
+  - addresses:
+      - ip: 42.0.0.1
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-2
+subsets:
+  - addresses:
+      - ip: 42.0.0.2
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/traffic/issue2268.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/issue2268.eskip
@@ -1,0 +1,7 @@
+// Custom route kube_rg__ns__issue2268__all__0_0 has the same number of predicates as the kube_rg__ns__issue2268__all__1_0 route
+// which causes undefined behavior: a request with foo cookie might be routed to any of them.
+kube_rg__ns__issue2268__all__0_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Cookie("foo", "^") -> status(500) -> <shunt>;
+kube_rg__ns__issue2268__all__1_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Traffic(0.8)       -> "http://42.0.0.1:8080";
+kube_rg__ns__issue2268__all__1_1: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/")                       -> "http://42.0.0.2:8080";
+
+kube_rg____test_example_org__catchall__0_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/issue2268.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/issue2268.yaml
@@ -1,0 +1,87 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  namespace: ns
+  name: issue2268
+spec:
+  hosts:
+    - test.example.org
+  backends:
+    - name: service-1
+      type: service
+      serviceName: service-1
+      servicePort: 8080
+    - name: service-2
+      type: service
+      serviceName: service-2
+      servicePort: 8080
+    - name: shunt
+      type: shunt
+  routes:
+    # custom route
+    - pathSubtree: /
+      predicates:
+        - Cookie("foo", "^")
+      filters:
+        - status(500)
+      backends:
+        - backendName: shunt
+    # service route
+    - pathSubtree: /
+      backends:
+        - backendName: service-1
+          weight: 80
+        - backendName: service-2
+          weight: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-1
+subsets:
+  - addresses:
+      - ip: 42.0.0.1
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-2
+subsets:
+  - addresses:
+      - ip: 42.0.0.2
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP


### PR DESCRIPTION
This change adds tests to demonstrate the problem described in #2268

For https://github.com/zalando/skipper/issues/2268