### PR TITLE
dataclients/kubernetes: add test for traffic split with custom route

### DIFF
--- a/dataclients/kubernetes/testdata/routegroups/traffic/issue2268-2.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/issue2268-2.eskip
@@ -1,0 +1,8 @@
+// Custom route kube_rg__ns__issue2268__all__0_1 has the same number of predicates as the kube_rg__ns__issue2268__all__1_0 route
+// which causes undefined behavior: a request with foo cookie might be routed to any of them.
+kube_rg__ns__issue2268__all__0_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Cookie("foo", "^") && Traffic(0.6) -> "http://42.0.0.1:8080";
+kube_rg__ns__issue2268__all__0_1: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Cookie("foo", "^")                 -> "http://42.0.0.2:8080";
+kube_rg__ns__issue2268__all__1_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Traffic(0.8)                       -> "http://42.0.0.3:8080";
+kube_rg__ns__issue2268__all__1_1: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/")                                       -> "http://42.0.0.4:8080";
+
+kube_rg____test_example_org__catchall__0_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic/issue2268-2.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/traffic/issue2268-2.yaml
@@ -15,24 +15,33 @@ spec:
       type: service
       serviceName: service-2
       servicePort: 8080
+    - name: service-3
+      type: service
+      serviceName: service-3
+      servicePort: 8080
+    - name: service-4
+      type: service
+      serviceName: service-4
+      servicePort: 8080
     - name: shunt
       type: shunt
   routes:
-    # custom route without traffic split to
+    # custom route with traffic split to
     # handle all requests with a foo cookie
     - pathSubtree: /
       predicates:
         - Cookie("foo", "^")
-      filters:
-        - status(500)
-      backends:
-        - backendName: shunt
-    # route with traffic split
-    - pathSubtree: /
       backends:
         - backendName: service-1
-          weight: 80
+          weight: 60
         - backendName: service-2
+          weight: 40
+    # route with traffic split and different backends
+    - pathSubtree: /
+      backends:
+        - backendName: service-3
+          weight: 80
+        - backendName: service-4
           weight: 20
 ---
 apiVersion: v1
@@ -62,6 +71,32 @@ spec:
   type: ClusterIP
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-3
+spec:
+  clusterIP: 1.2.3.6
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-4
+spec:
+  clusterIP: 1.2.3.7
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
 kind: Endpoints
 metadata:
   namespace: ns
@@ -82,6 +117,32 @@ metadata:
 subsets:
   - addresses:
       - ip: 42.0.0.2
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-3
+subsets:
+  - addresses:
+      - ip: 42.0.0.3
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-4
+subsets:
+  - addresses:
+      - ip: 42.0.0.4
     ports:
       - name: http
         port: 8080


### PR DESCRIPTION
This change adds test to demonstrate the problem with custom route with traffic split described in #2268

For https://github.com/zalando/skipper/issues/2268