### PR TITLE
dataclients/kubernetes: refactor Ingress and RouteGroup backend weight calculation

### DIFF
--- a/dataclients/kubernetes/definitions/definitions.go
+++ b/dataclients/kubernetes/definitions/definitions.go
@@ -38,3 +38,8 @@ func namespaceString(ns string) string {
 
 	return ns
 }
+
+type WeightedBackend interface {
+	GetName() string
+	GetWeight() float64
+}

--- a/dataclients/kubernetes/definitions/ingressv1.go
+++ b/dataclients/kubernetes/definitions/ingressv1.go
@@ -30,11 +30,6 @@ type IngressV1Spec struct {
 type BackendV1 struct {
 	Service Service `json:"service,omitempty"` // can be nil, because of TypedLocalObjectReference
 	// Resource TypedLocalObjectReference is not supported https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#typedlocalobjectreference-v1-core
-
-	// Traffic field used for custom traffic weights, but not part of the ingress spec.
-	Traffic float64
-	// number of True predicates to add to support multi color traffic switching
-	NoopCount int
 }
 
 // Service https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#ingressservicebackend-v1-networking-k8s-io

--- a/dataclients/kubernetes/definitions/routegroups.go
+++ b/dataclients/kubernetes/definitions/routegroups.go
@@ -130,6 +130,11 @@ type BackendReference struct {
 
 type BackendReferences []*BackendReference
 
+var _ WeightedBackend = &BackendReference{}
+
+func (br *BackendReference) GetName() string    { return br.BackendName }
+func (br *BackendReference) GetWeight() float64 { return float64(br.Weight) }
+
 type RouteSpec struct {
 	// Path specifies Path predicate, only one of Path or PathSubtree is allowed
 	Path string `json:"path,omitempty"`

--- a/dataclients/kubernetes/traffic.go
+++ b/dataclients/kubernetes/traffic.go
@@ -1,0 +1,122 @@
+package kubernetes
+
+import (
+	"github.com/zalando/skipper/dataclients/kubernetes/definitions"
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/predicates"
+)
+
+// backendTraffic specifies whether a given backend is allowed to receive any traffic and
+// modifies route to receive the desired traffic portion
+type backendTraffic interface {
+	allowed() bool
+	apply(*eskip.Route)
+}
+
+// GetBackendTrafficCalculator returns a function that calculates backendTraffic for each backend using specified algorithm
+func GetBackendTrafficCalculator[T definitions.WeightedBackend](algorithm string) func(b []T) map[string]backendTraffic {
+	// WIP: only traffic predicate calculator is supported for now
+	return trafficPredicateCalculator[T]
+}
+
+// trafficPredicate implements backendTraffic using Traffic() and True() predicates
+type trafficPredicate struct {
+	value   float64
+	balance int
+}
+
+var _ backendTraffic = &trafficPredicate{}
+
+// trafficPredicateCalculator calculates argument for the Traffic() predicate and
+// the number of True() predicates to be added to the routes based on the weights of the backends.
+//
+// The Traffic() argument is calculated based on the following rules:
+//
+//   - if no weight is defined for a backend it will get weight 0.
+//   - if no weights are specified for all backends of a path, then traffic will
+//     be distributed equally.
+//
+// Each Traffic() argument is relative to the number of remaining backends,
+// e.g. if the weight is specified as:
+//
+//	backend-1: 0.1
+//	backend-2: 0.2
+//	backend-3: 0.3
+//	backend-4: 0.4
+//
+// then Traffic() predicate arguments will be:
+//
+//	backend-1: Traffic(0.1)   == 0.1 / (0.1 + 0.2 + 0.3 + 0.4)
+//	backend-2: Traffic(0.222) == 0.2 / (0.2 + 0.3 + 0.4)
+//	backend-3: Traffic(0.428) == 0.3 / (0.3 + 0.4)
+//	backend-4: Traffic(1.0)   == 0.4 / (0.4)
+//
+// The weight of the backend routes will be adjusted by a number of True() predicates
+// equal to the number of remaining backends minus one, e.g. for the above example:
+//
+//	backend-1: Traffic(0.1)   && True() && True() -> ...
+//	backend-2: Traffic(0.222) && True() -> ...
+//	backend-3: Traffic(0.428) -> ...
+//	backend-4: Traffic(1.0)   -> ...
+//
+// Traffic(1.0) is handled in a special way, see trafficPredicate.apply().
+func trafficPredicateCalculator[T definitions.WeightedBackend](b []T) map[string]backendTraffic {
+	sum := 0.0
+	weights := make([]float64, len(b))
+	for i, bi := range b {
+		w := bi.GetWeight()
+		weights[i] = w
+		sum += w
+	}
+
+	if sum == 0 {
+		sum = float64(len(weights))
+		for i := range weights {
+			weights[i] = 1
+		}
+	}
+
+	var lastWithWeight int
+	for i, w := range weights {
+		if w > 0 {
+			lastWithWeight = i
+		}
+	}
+
+	bt := make(map[string]backendTraffic)
+
+	for i, bi := range b {
+		ct := &trafficPredicate{}
+		bt[bi.GetName()] = ct
+		switch {
+		case i == lastWithWeight:
+			ct.value = 1
+		case weights[i] == 0:
+			ct.value = 0
+		default:
+			ct.value = weights[i] / sum
+		}
+
+		sum -= weights[i]
+		ct.balance = len(b) - i - 2
+	}
+
+	return bt
+}
+
+func (tp *trafficPredicate) allowed() bool {
+	return tp.value > 0
+}
+
+// apply adds Traffic() and True() predicates to the route.
+// For the value of 1.0 no predicates will be added.
+func (tp *trafficPredicate) apply(r *eskip.Route) {
+	if tp.value == 1.0 {
+		return
+	}
+
+	r.Predicates = appendPredicate(r.Predicates, predicates.TrafficName, tp.value)
+	for i := 0; i < tp.balance; i++ {
+		r.Predicates = appendPredicate(r.Predicates, predicates.TrueName)
+	}
+}


### PR DESCRIPTION
* use the same algorithm to calculate arguments for Traffic() predicate for both Ingress and RouteGroup
* add GetBackendTrafficCalculator factory method to support alternative implementations

For #2268