### PR TITLE
predicates/traffic: add TrafficSegment min equals max tests

### DIFF
--- a/predicates/traffic/segment.go
+++ b/predicates/traffic/segment.go
@@ -73,5 +73,6 @@ func (*segmentSpec) Weight() int {
 
 func (p *segmentPredicate) Match(req *http.Request) bool {
 	r := routing.FromContext(req.Context(), randomValue, rand.Float64)
+	// min == max defines a never-matching interval and always yields false
 	return p.min <= r && r < p.max
 }

--- a/predicates/traffic/segment_test.go
+++ b/predicates/traffic/segment_test.go
@@ -89,16 +89,21 @@ func TestTrafficSegmentMatch(t *testing.T) {
 }
 
 func TestTrafficSegmentMinEqualsMax(t *testing.T) {
-	pp := eskip.MustParsePredicates(`TrafficSegment(0.5, 0.5)`)
-	require.Len(t, pp, 1)
+	for _, minMax := range []float64{
+		0.0,
+		1.0 / 10.0, // can not be represented exactly as float64
+		0.5,
+		2.0 / 3.0, // can not be represented exactly as float64
+		1.0,
+	} {
+		t.Run(fmt.Sprintf("minMax=%v", minMax), func(t *testing.T) {
+			spec := traffic.NewSegment()
+			p, err := spec.Create([]any{minMax, minMax})
+			require.NoError(t, err)
 
-	spec := traffic.NewSegment()
-	p, err := spec.Create(pp[0].Args)
-	require.NoError(t, err)
-
-	assert.False(t, p.Match(requestWithR(0.0)))
-	assert.False(t, p.Match(requestWithR(0.5)))
-	assert.False(t, p.Match(requestWithR(1.0)))
+			assert.False(t, p.Match(requestWithR(minMax)))
+		})
+	}
 }
 
 func TestTrafficSegmentSpec(t *testing.T) {


### PR DESCRIPTION
* use test request with exactly the same random value as min and max arguments
* add tests for common edge cases

For #2268