### PR TITLE
dataclients/kubernetes: add TrafficSegment-based backend traffic calculator

### DIFF
--- a/dataclients/kubernetes/ingress.go
+++ b/dataclients/kubernetes/ingress.go
@@ -58,6 +58,7 @@ type ingress struct {
 	kubernetesEnableEastWest bool
 	provideHTTPSRedirect     bool
 	forceKubernetesService   bool
+	backendTrafficAlgorithm  string
 }
 
 var nonWord = regexp.MustCompile(`\W`)
@@ -79,6 +80,7 @@ func newIngress(o Options) *ingress {
 		eastWestRangePredicates:  o.KubernetesEastWestRangePredicates,
 		allowedExternalNames:     o.AllowedExternalNames,
 		forceKubernetesService:   o.ForceKubernetesService,
+		backendTrafficAlgorithm:  o.BackendTrafficAlgorithm,
 	}
 }
 

--- a/dataclients/kubernetes/ingressv1.go
+++ b/dataclients/kubernetes/ingressv1.go
@@ -422,7 +422,7 @@ func (ing *ingress) ingressV1Route(
 		hostRoutes:          hostRoutes,
 		defaultFilters:      df,
 		certificateRegistry: r,
-		calculateTraffic:    GetBackendTrafficCalculator[*weightedIngressBackend]("traffic-predicate"),
+		calculateTraffic:    GetBackendTrafficCalculator[*weightedIngressBackend](ing.backendTrafficAlgorithm),
 	}
 
 	var route *eskip.Route

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -215,6 +215,9 @@ type Options struct {
 	// ForceKubernetesService overrides the default Skipper functionality to route traffic using
 	// Kubernetes Endpoint, instead using Kubernetes Services.
 	ForceKubernetesService bool
+
+	// BackendTrafficAlgorithm specifies the algorithm to calculate the backend traffic.
+	BackendTrafficAlgorithm string
 }
 
 // Client is a Skipper DataClient implementation used to create routes based on Kubernetes Ingress settings.

--- a/dataclients/kubernetes/kubernetestest/fixtures.go
+++ b/dataclients/kubernetes/kubernetestest/fixtures.go
@@ -48,6 +48,7 @@ type kubeOptionsParser struct {
 	ServicesLabels           map[string]string  `yaml:"kubernetes-services-label-selector"`
 	EndpointsLabels          map[string]string  `yaml:"kubernetes-endpoints-label-selector"`
 	ForceKubernetesService   bool               `yaml:"force-kubernetes-service"`
+	BackendTrafficAlgorithm  string             `yaml:"backend-traffic-algorithm"`
 }
 
 func baseNoExt(n string) string {
@@ -232,6 +233,7 @@ func testFixture(t *testing.T, f fixtureSet) {
 		o.ServicesLabelSelectors = kop.ServicesLabels
 		o.EndpointsLabelSelectors = kop.EndpointsLabels
 		o.ForceKubernetesService = kop.ForceKubernetesService
+		o.BackendTrafficAlgorithm = kop.BackendTrafficAlgorithm
 
 		aen, err := compileRegexps(kop.AllowedExternalNames)
 		if err != nil {

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -530,7 +530,7 @@ func (r *routeGroups) convert(s *clusterState, df defaultFilters) ([]*eskip.Rout
 				backendNameTracingTag: r.options.BackendNameTracingTag,
 				internal:              false,
 				allowedExternalNames:  r.options.AllowedExternalNames,
-				calculateTraffic:      GetBackendTrafficCalculator[*definitions.BackendReference]("traffic-predicate"),
+				calculateTraffic:      GetBackendTrafficCalculator[*definitions.BackendReference](r.options.BackendTrafficAlgorithm),
 			}
 
 			ri, err := transformRouteGroup(ctx)
@@ -567,7 +567,7 @@ func (r *routeGroups) convert(s *clusterState, df defaultFilters) ([]*eskip.Rout
 				backendNameTracingTag: r.options.BackendNameTracingTag,
 				internal:              true,
 				allowedExternalNames:  r.options.AllowedExternalNames,
-				calculateTraffic:      GetBackendTrafficCalculator[*definitions.BackendReference]("traffic-predicate"),
+				calculateTraffic:      GetBackendTrafficCalculator[*definitions.BackendReference](r.options.BackendTrafficAlgorithm),
 			}
 
 			internalRi, err := transformRouteGroup(internalCtx)

--- a/dataclients/kubernetes/routegroups_test.go
+++ b/dataclients/kubernetes/routegroups_test.go
@@ -22,6 +22,10 @@ func TestRouteGroupTraffic(t *testing.T) {
 	kubernetestest.FixturesToTest(t, "testdata/routegroups/traffic")
 }
 
+func TestRouteGroupTrafficSegment(t *testing.T) {
+	kubernetestest.FixturesToTest(t, "testdata/routegroups/traffic-segment")
+}
+
 func TestRouteGroupEastWest(t *testing.T) {
 	kubernetestest.FixturesToTest(t, "testdata/routegroups/east-west")
 }

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/0-1-2.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/0-1-2.eskip
@@ -1,0 +1,4 @@
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
+kube_rg__default__app__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0, 0) -> "https://b1.example.org";
+kube_rg__default__app__all__0_1: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0, 0.3333333333333333) -> "https://b2.example.org";
+kube_rg__default__app__all__0_2: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0.3333333333333333, 1) -> "https://b3.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/0-1-2.kube
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/0-1-2.kube
@@ -1,0 +1,1 @@
+backend-traffic-algorithm: traffic-segment-predicate

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/0-1-2.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/0-1-2.yaml
@@ -1,0 +1,26 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: app
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: b1
+      type: network
+      address: https://b1.example.org
+    - name: b2
+      type: network
+      address: https://b2.example.org
+    - name: b3
+      type: network
+      address: https://b3.example.org
+  routes:
+    - path: /app
+      backends:
+        - backendName: b1
+          weight: 0
+        - backendName: b2
+          weight: 1
+        - backendName: b3
+          weight: 2

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/20-30-50.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/20-30-50.eskip
@@ -1,0 +1,4 @@
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
+kube_rg__default__app__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0, 0.2) -> "https://b1.example.org";
+kube_rg__default__app__all__0_1: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0.2, 0.5) -> "https://b2.example.org";
+kube_rg__default__app__all__0_2: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0.5, 1) -> "https://b3.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/20-30-50.kube
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/20-30-50.kube
@@ -1,0 +1,1 @@
+backend-traffic-algorithm: traffic-segment-predicate

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/20-30-50.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/20-30-50.yaml
@@ -1,0 +1,26 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: app
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: b1
+      type: network
+      address: https://b1.example.org
+    - name: b2
+      type: network
+      address: https://b2.example.org
+    - name: b3
+      type: network
+      address: https://b3.example.org
+  routes:
+    - path: /app
+      backends:
+        - backendName: b1
+          weight: 20
+        - backendName: b2
+          weight: 30
+        - backendName: b3
+          weight: 50

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/issue2268.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/issue2268.eskip
@@ -1,0 +1,7 @@
+// Custom route with cookie predicate has a higher weight than other routes because
+// TrafficSegment predicate does not affect final route weight.
+kube_rg__ns__issue2268__all__0_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && Cookie("foo", "^")     -> status(500) -> <shunt>;
+kube_rg__ns__issue2268__all__1_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && TrafficSegment(0, 0.8) -> "http://42.0.0.1:8080";
+kube_rg__ns__issue2268__all__1_1: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/") && TrafficSegment(0.8, 1) -> "http://42.0.0.2:8080";
+
+kube_rg____test_example_org__catchall__0_0: Host("^(test[.]example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/issue2268.kube
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/issue2268.kube
@@ -1,0 +1,1 @@
+backend-traffic-algorithm: traffic-segment-predicate

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/issue2268.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/issue2268.yaml
@@ -1,0 +1,87 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  namespace: ns
+  name: issue2268
+spec:
+  hosts:
+    - test.example.org
+  backends:
+    - name: service-1
+      type: service
+      serviceName: service-1
+      servicePort: 8080
+    - name: service-2
+      type: service
+      serviceName: service-2
+      servicePort: 8080
+    - name: shunt
+      type: shunt
+  routes:
+    # custom route
+    - pathSubtree: /
+      predicates:
+        - Cookie("foo", "^")
+      filters:
+        - status(500)
+      backends:
+        - backendName: shunt
+    # service route
+    - pathSubtree: /
+      backends:
+        - backendName: service-1
+          weight: 80
+        - backendName: service-2
+          weight: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-1
+spec:
+  clusterIP: 1.2.3.4
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: ns
+  name: service-2
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-1
+subsets:
+  - addresses:
+      - ip: 42.0.0.1
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: ns
+  name: service-2
+subsets:
+  - addresses:
+      - ip: 42.0.0.2
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/no-weights.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/no-weights.eskip
@@ -1,0 +1,4 @@
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
+kube_rg__default__app__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0, 0.3333333333333333) -> "https://b1.example.org";
+kube_rg__default__app__all__0_1: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0.3333333333333333, 0.6666666666666666) -> "https://b2.example.org";
+kube_rg__default__app__all__0_2: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") && TrafficSegment(0.6666666666666666, 1) -> "https://b3.example.org";

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/no-weights.kube
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/no-weights.kube
@@ -1,0 +1,1 @@
+backend-traffic-algorithm: traffic-segment-predicate

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/no-weights.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/no-weights.yaml
@@ -1,0 +1,23 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: app
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: b1
+      type: network
+      address: https://b1.example.org
+    - name: b2
+      type: network
+      address: https://b2.example.org
+    - name: b3
+      type: network
+      address: https://b3.example.org
+  routes:
+    - path: /app
+      backends:
+        - backendName: b1
+        - backendName: b2
+        - backendName: b3

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/one-backend.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/one-backend.eskip
@@ -1,0 +1,2 @@
+kube_rg__default__app__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app") -> "https://b1.example.org";
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/one-backend.kube
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/one-backend.kube
@@ -1,0 +1,1 @@
+backend-traffic-algorithm: traffic-segment-predicate

--- a/dataclients/kubernetes/testdata/routegroups/traffic-segment/one-backend.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/traffic-segment/one-backend.yaml
@@ -1,0 +1,15 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: app
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: b1
+      type: network
+      address: https://b1.example.org
+  routes:
+    - path: /app
+      backends:
+        - backendName: b1

--- a/dataclients/kubernetes/traffic.go
+++ b/dataclients/kubernetes/traffic.go
@@ -15,8 +15,12 @@ type backendTraffic interface {
 
 // GetBackendTrafficCalculator returns a function that calculates backendTraffic for each backend using specified algorithm
 func GetBackendTrafficCalculator[T definitions.WeightedBackend](algorithm string) func(b []T) map[string]backendTraffic {
-	// WIP: only traffic predicate calculator is supported for now
-	return trafficPredicateCalculator[T]
+	switch algorithm {
+	case "traffic-segment-predicate":
+		return trafficSegmentPredicateCalculator[T]
+	default:
+		return trafficPredicateCalculator[T]
+	}
 }
 
 // trafficPredicate implements backendTraffic using Traffic() and True() predicates

--- a/dataclients/kubernetes/traffic_segment.go
+++ b/dataclients/kubernetes/traffic_segment.go
@@ -1,0 +1,65 @@
+package kubernetes
+
+import (
+	"github.com/zalando/skipper/dataclients/kubernetes/definitions"
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/predicates"
+)
+
+type trafficSegmentPredicate struct {
+	min, max float64
+}
+
+func trafficSegmentPredicateCalculator[T definitions.WeightedBackend](b []T) map[string]backendTraffic {
+	bt := make(map[string]backendTraffic, len(b))
+
+	sum := 0.0
+	for _, bi := range b {
+		if _, ok := bt[bi.GetName()].(*trafficSegmentPredicate); ok {
+			// ignore duplicate backends
+			continue
+		}
+
+		p := &trafficSegmentPredicate{}
+		bt[bi.GetName()] = p
+
+		p.min = sum
+		sum += bi.GetWeight()
+		p.max = sum
+	}
+
+	if sum == 0 {
+		// evenly split traffic between backends
+		// range over b instead of bt for stable order
+		for _, bi := range b {
+			p := bt[bi.GetName()].(*trafficSegmentPredicate)
+			p.min = sum
+			sum += 1
+			p.max = sum
+		}
+	}
+
+	// normalize segments
+	for _, v := range bt {
+		p := v.(*trafficSegmentPredicate)
+
+		p.min /= sum
+
+		// last segment always ends up with p.max equal to one because
+		// dividing a finite non-zero value by itself always produces one,
+		// see https://stackoverflow.com/questions/63439390/does-ieee-754-float-division-or-subtraction-by-itself-always-result-in-the-same
+		p.max /= sum
+	}
+	return bt
+}
+
+func (ts *trafficSegmentPredicate) allowed() bool {
+	return ts.min != ts.max
+}
+
+func (ts *trafficSegmentPredicate) apply(r *eskip.Route) {
+	if ts.min == 0 && ts.max == 1 {
+		return
+	}
+	r.Predicates = appendPredicate(r.Predicates, predicates.TrafficSegmentName, ts.min, ts.max)
+}


### PR DESCRIPTION
* adds backend traffic split algorithm implementation based on TrafficSegment predicate
* adds BackendTrafficAlgorithm k8s dataclient option (for now only available in tests)
* adds basic test suite for the implementation

This is part 1 of N in series of changes.

For #2268