### PR TITLE
optimize: change max from 1GB to 4GB to accept tcp conns

### DIFF
--- a/queuelistener/listener_test.go
+++ b/queuelistener/listener_test.go
@@ -685,7 +685,7 @@ func TestOptions(t *testing.T) {
 		defer got.Close()
 		l := got.(*listener)
 
-		if l.maxConcurrency != o.MaxConcurrency || l.maxQueueSize != o.MaxQueueSize {
+		if l.maxConcurrency != int64(o.MaxConcurrency) || l.maxQueueSize != int64(o.MaxQueueSize) {
 			t.Errorf("Failed to overwrite calculated settings: %d != %d || %d != %d", l.maxConcurrency, o.MaxConcurrency, l.maxQueueSize, o.MaxQueueSize)
 		}
 	})
@@ -703,11 +703,11 @@ func TestOptions(t *testing.T) {
 		defer got.Close()
 		l := got.(*listener)
 
-		if o.MaxConcurrency != 0 && l.maxConcurrency == o.MaxConcurrency {
+		if o.MaxConcurrency != 0 && l.maxConcurrency == int64(o.MaxConcurrency) {
 			t.Errorf("Failed to use calculate maxConcurrency settings: %d == %d", l.maxConcurrency, o.MaxConcurrency)
 		}
-		if l.maxConcurrency != o.MemoryLimitBytes/o.ConnectionBytes {
-			t.Errorf("Calculated is not: %d != %d", l.maxConcurrency, o.MemoryLimitBytes/o.ConnectionBytes)
+		if l.maxConcurrency != o.MemoryLimitBytes/int64(o.ConnectionBytes) {
+			t.Errorf("Calculated is not: %d != %d", l.maxConcurrency, o.MemoryLimitBytes/int64(o.ConnectionBytes))
 		}
 	})
 	t.Run("when max queue size is not set, it is calculated from max concurrency", func(t *testing.T) {
@@ -722,13 +722,13 @@ func TestOptions(t *testing.T) {
 		defer got.Close()
 		l := got.(*listener)
 
-		if o.MaxQueueSize != 0 && l.maxQueueSize == o.MaxQueueSize {
+		if o.MaxQueueSize != 0 && l.maxQueueSize == int64(o.MaxQueueSize) {
 			t.Errorf("Failed to use calculated maxQueueSize setting: %d == %d", l.maxConcurrency, o.MaxConcurrency)
 		}
 		if l.maxQueueSize == 0 || l.maxQueueSize > maxCalculatedQueueSize {
 			t.Errorf("Calculated maxQueueSize not in bounds: %d", l.maxQueueSize)
 		}
-		if l.maxQueueSize != 10*o.MaxConcurrency {
+		if l.maxQueueSize != 10*int64(o.MaxConcurrency) {
 			t.Errorf("Calculated maxQueueSize is wrong: %d != %d", l.maxQueueSize, 10*o.MaxConcurrency)
 		}
 	})
@@ -1094,7 +1094,7 @@ func TestMonitoring(t *testing.T) {
 func TestListen(t *testing.T) {
 	for _, tt := range []struct {
 		name             string
-		memoryLimit      int
+		memoryLimit      int64
 		bytesPerRequest  int
 		network, address string
 		wantErr          bool
@@ -1184,7 +1184,7 @@ func TestListen(t *testing.T) {
 func TestQueue1(t *testing.T) {
 	for _, tt := range []struct {
 		name            string
-		memoryLimit     int
+		memoryLimit     int64
 		bytesPerRequest int
 		allow           int
 	}{

--- a/queuelistener/ring.go
+++ b/queuelistener/ring.go
@@ -8,7 +8,7 @@ type ring struct {
 	size        int
 }
 
-func newRing(maxSize int) *ring {
+func newRing(maxSize int64) *ring {
 	return &ring{connections: make([]net.Conn, maxSize)}
 }
 

--- a/skipper.go
+++ b/skipper.go
@@ -1137,7 +1137,7 @@ func listen(o *Options, address string, mtr metrics.Metrics) (net.Listener, erro
 		return net.Listen("tcp", address)
 	}
 
-	var memoryLimit int
+	var memoryLimit int64
 	if o.MaxTCPListenerConcurrency <= 0 {
 		// cgroup v1: https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
 		// cgroup v2: https://www.kernel.org/doc/Documentation/cgroup-v2.txt
@@ -1156,7 +1156,7 @@ func listen(o *Options, address string, mtr metrics.Metrics) (net.Listener, erro
 		}
 		if err == nil {
 			memoryLimitString := strings.TrimSpace(string(memoryLimitBytes))
-			memoryLimit, err = strconv.Atoi(memoryLimitString)
+			memoryLimit, err = strconv.ParseInt(memoryLimitString, 10, 64)
 			if err != nil {
 				log.Errorf("Failed to convert memory limits, fallback to defaults: %v", err)
 			}

--- a/skipper.go
+++ b/skipper.go
@@ -1161,9 +1161,9 @@ func listen(o *Options, address string, mtr metrics.Metrics) (net.Listener, erro
 				log.Errorf("Failed to convert memory limits, fallback to defaults: %v", err)
 			}
 
-			// 1GB, temporarily, as a tested magic number until a better mechanism is in place:
-			if memoryLimit > 1<<30 {
-				memoryLimit = 1 << 30
+			// 4GB, temporarily, as a tested magic number until a better mechanism is in place:
+			if memoryLimit > 1<<32 {
+				memoryLimit = 1 << 32
 			}
 		}
 	}


### PR DESCRIPTION
optimize: change max from 1GB to 4GB to accept tcp connections in the tcp listener
otherwise we throttle performance for large nodes