### PR TITLE
Introduce lockedSource type to avoid concurrent use of rand.Source

### DIFF
--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -70,19 +70,19 @@ func fadeIn(now time.Time, duration time.Duration, exponent float64, detected ti
 
 func shiftWeighted(rnd *rand.Rand, ctx *routing.LBContext, now time.Time) routing.LBEndpoint {
 	var sum float64
-	weightSums := make([]float64, 0, len(ctx.Route.LBEndpoints))
 	rt := ctx.Route
 	ep := ctx.Route.LBEndpoints
 	for _, epi := range ep {
 		wi := fadeIn(now, rt.LBFadeInDuration, rt.LBFadeInExponent, epi.Detected)
 		sum += wi
-		weightSums = append(weightSums, sum)
 	}
 
-	choice := ep[len(weightSums)-1]
+	choice := ep[len(ep)-1]
 	r := rnd.Float64() * sum
-	for i := range weightSums {
-		if weightSums[i] > r {
+	var upto float64
+	for i, epi := range ep {
+		upto += fadeIn(now, rt.LBFadeInDuration, rt.LBFadeInExponent, epi.Detected)
+		if upto > r {
 			choice = ep[i]
 			break
 		}

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -120,7 +120,7 @@ func withFadeIn(rnd *rand.Rand, ctx *routing.LBContext, choice int, algo routing
 	if rnd.Float64() < f {
 		return ep[choice]
 	}
-	notFadingIndexes := []int{}
+	notFadingIndexes := make([]int, 0, len(ep))
 	for i := 0; i < len(ep); i++ {
 		if _, fadingIn := fadeInState(now, ctx.Route.LBFadeInDuration, ep[i].Detected); !fadingIn {
 			notFadingIndexes = append(notFadingIndexes, i)

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -70,7 +70,7 @@ func fadeIn(now time.Time, duration time.Duration, exponent float64, detected ti
 
 func shiftWeighted(rnd *rand.Rand, ctx *routing.LBContext, now time.Time) routing.LBEndpoint {
 	var sum float64
-	weightSums := []float64{}
+	weightSums := make([]float64, 0, len(ctx.Route.LBEndpoints))
 	rt := ctx.Route
 	ep := ctx.Route.LBEndpoints
 	for _, epi := range ep {

--- a/loadbalancer/locked_source.go
+++ b/loadbalancer/locked_source.go
@@ -1,0 +1,28 @@
+package loadbalancer
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type lockedSource struct {
+	mu sync.Mutex
+	r  rand.Source
+}
+
+func newLockedSource() *lockedSource {
+	return &lockedSource{r: rand.NewSource(time.Now().UnixNano())}
+}
+
+func (s *lockedSource) Int63() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.r.Int63()
+}
+
+func (s *lockedSource) Seed(seed int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.r.Seed(seed)
+}

--- a/loadbalancer/locked_source_test.go
+++ b/loadbalancer/locked_source_test.go
@@ -1,0 +1,26 @@
+package loadbalancer
+
+import (
+	"sync"
+	"testing"
+)
+
+func loadTestLockedSource(s *lockedSource, n int) {
+	for i := 0; i < n; i++ {
+		s.Int63()
+	}
+}
+
+func TestLockedSourceForConcurrentUse(t *testing.T) {
+	s := newLockedSource()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			loadTestLockedSource(s, 100000)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
+ Introduced lockedSource type to avoid concurrent use of rand.Source
+ Added test calling lockedSource concurrently
+ Added benchmark for loadbalancer
+ Removed some unused fields from {random,roundRobin,consistentHash} structs
+ Preallocate slices
+ Do not use weightedSums slice

Updates https://github.com/zalando/skipper/issues/2346