### PR TITLE
add option to set request timeout for request

### DIFF
--- a/net/httpclient_test.go
+++ b/net/httpclient_test.go
@@ -247,11 +247,16 @@ func TestTransport(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:        "context deadline error should occur when the request is timedout",
-			bearerToken: string(testToken),
-			req:         httptest.NewRequest("GET", "http://example.com/", nil),
-			wantErr:     true,
-			reqTimeout:  10 * time.Millisecond,
+			name:       "context deadline error should occur when the request is timedout",
+			req:        httptest.NewRequest("GET", "http://example.com/", nil),
+			wantErr:    true,
+			reqTimeout: 10 * time.Millisecond,
+		},
+		{
+			name:       "no context deadline error should occur when the request is processed within the requested timeout",
+			req:        httptest.NewRequest("GET", "http://example.com/", nil),
+			wantErr:    false,
+			reqTimeout: 5 * time.Millisecond,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -260,7 +265,7 @@ func TestTransport(t *testing.T) {
 					t.Errorf("wrong request method got: %s, want: %s", r.Method, tt.req.Method)
 				}
 
-				if tt.reqTimeout != 0 {
+				if tt.reqTimeout != 0 && tt.wantErr {
 					time.Sleep(tt.reqTimeout + 10*time.Millisecond)
 				}
 


### PR DESCRIPTION
The current package has timeouts specific to each stage of an http request E.g: `ResponseHeaderTimeout` `TLSHandshakeTimeout`. This PR adds an option to set a timeout that would be applicable to the whole request.