### PR TITLE
dataclients/kubernetes: improve logging

### DIFF
--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ep-port.log
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-prule-wrong-ep-port.log
@@ -1,1 +1,1 @@
-convertPathRuleV1: Failed to get service foo, bar, baz
+level=error msg="Failed to get service bar, baz" kind=Ingress name=qux ns=foo

--- a/dataclients/kubernetes/testdata/ingressV1/tls/tls-invalid-secret.log
+++ b/dataclients/kubernetes/testdata/ingressV1/tls/tls-invalid-secret.log
@@ -1,1 +1,1 @@
-.*level=error msg="secret must contain tls.crt and tls.key in data field"
+level=error msg="Failed to generate TLS certificate from secret: secret must contain tls.crt and tls.key in data field" kind=Ingress name=myapp-ingress ns=default

--- a/dataclients/kubernetes/testdata/ingressV1/tls/tls-invalid-tls.log
+++ b/dataclients/kubernetes/testdata/ingressV1/tls/tls-invalid-tls.log
@@ -1,1 +1,1 @@
-.*level=error msg="failed to decode tls.crt from secret myapp-secret"
+level=error msg="Failed to generate TLS certificate from secret: failed to decode tls.crt from secret myapp-secret"

--- a/dataclients/kubernetes/testdata/ingressV1/tls/tls-missing-host.log
+++ b/dataclients/kubernetes/testdata/ingressV1/tls/tls-missing-host.log
@@ -1,1 +1,1 @@
-.*level=info msg="no matching tls hosts found for ingress myapp-ingress"
+level=info msg="No matching tls hosts found" kind=Ingress name=myapp-ingress ns=default

--- a/dataclients/kubernetes/testdata/ingressV1/tls/tls-missing-secret.log
+++ b/dataclients/kubernetes/testdata/ingressV1/tls/tls-missing-secret.log
@@ -1,1 +1,1 @@
-.*level=error msg="failed to find secret myapp-secret in namespace default"
+level=error msg="Failed to find secret myapp-secret in namespace default" kind=Ingress name=myapp-ingress ns=default

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-filter.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-filter.log
@@ -1,3 +1,3 @@
-[[]routegroup[]]
-[[]eskip[]]
-filter
+\[eskip\] filter
+parse failed
+kind=RouteGroup name=myapp ns=foo

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-filter.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-filter.yaml
@@ -1,6 +1,7 @@
 apiVersion: zalando.org/v1
 kind: RouteGroup
 metadata:
+  namespace: foo
   name: myapp
 spec:
   hosts:
@@ -19,6 +20,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: foo
   name: myapp
 spec:
   ports:
@@ -32,6 +34,7 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
+  namespace: foo
   name: myapp
 subsets:
 - addresses:

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-predicate.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-predicate.log
@@ -1,3 +1,3 @@
-[[]routegroup[]]
-[[]eskip[]]
-predicate
+\[eskip\] predicate
+parse failed
+kind=RouteGroup name=myapp ns=foo

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-predicate.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-predicate.yaml
@@ -1,6 +1,7 @@
 apiVersion: zalando.org/v1
 kind: RouteGroup
 metadata:
+  namespace: foo
   name: myapp
 spec:
   hosts:
@@ -19,6 +20,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: foo
   name: myapp
 spec:
   ports:
@@ -32,6 +34,7 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
+  namespace: foo
   name: myapp
 subsets:
 - addresses:

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.eskip
@@ -1,4 +1,4 @@
-kube_rg__default__myapp__all__0_0:
+kube_rg__foo__myapp__all__0_0:
 	Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app")
 	-> <roundRobin, "http://10.2.4.8:80", "http://10.2.4.16:80">;
 

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.log
@@ -1,1 +1,2 @@
-[[]routegroup[]] error transforming
+Error transforming external hosts: service not found: foo/non-existent
+kind=RouteGroup name=myapp-no-service ns=foo

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.yaml
@@ -1,6 +1,7 @@
 apiVersion: zalando.org/v1
 kind: RouteGroup
 metadata:
+  namespace: foo
   name: myapp
 spec:
   hosts:
@@ -18,6 +19,7 @@ spec:
 apiVersion: zalando.org/v1
 kind: RouteGroup
 metadata:
+  namespace: foo
   name: myapp-no-service
 spec:
   hosts:
@@ -35,6 +37,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: foo
   name: myapp
 spec:
   ports:
@@ -48,6 +51,7 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
+  namespace: foo
   name: myapp
 subsets:
 - addresses:

--- a/dataclients/kubernetes/testdata/routegroups/convert/invalid-backend-implicit-route.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/invalid-backend-implicit-route.log
@@ -1,2 +1,2 @@
-[[]routegroup[]]
 not supported service type
+kind=RouteGroup name=myapp

--- a/dataclients/kubernetes/testdata/routegroups/convert/missing-service.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/missing-service.log
@@ -1,2 +1,2 @@
-[[]routegroup[]]
+kind=RouteGroup name=myapp
 service not found

--- a/dataclients/kubernetes/testdata/routegroups/convert/no-catchall-for-failed-route-group.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/no-catchall-for-failed-route-group.log
@@ -1,3 +1,2 @@
-[[]routegroup[]]
-[[]eskip[]]
+kind=RouteGroup name=myapp
 syntax error

--- a/dataclients/kubernetes/testdata/routegroups/convert/service-not-cluster-ip-type.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/service-not-cluster-ip-type.log
@@ -1,2 +1,2 @@
-[[]routegroup[]]
+kind=RouteGroup name=myapp
 not supported service type

--- a/dataclients/kubernetes/testdata/routegroups/convert/single-failing-route-makes-the-group-fail.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/single-failing-route-makes-the-group-fail.log
@@ -1,3 +1,3 @@
-[routegroup]
-error transforming
-[[]eskip[]] predicate
+Error transforming
+\[eskip\] predicate
+kind=RouteGroup name=failing

--- a/dataclients/kubernetes/testdata/routegroups/convert/target-port-not-found.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/target-port-not-found.log
@@ -1,2 +1,2 @@
-[[]routegroup[]]
+kind=RouteGroup name=myapp
 target port not found

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-explicit-route.log
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-explicit-route.log
@@ -1,3 +1,2 @@
-[[]routegroup[]]
-[[]eskip[]]
-error while applying default filters
+Failed to retrieve default filters: error while applying default filters for route group and service: default/myapp myapp
+kind=RouteGroup name=myapp

--- a/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-implicit-route.log
+++ b/dataclients/kubernetes/testdata/routegroups/default-filters/invalid-filters-implicit-route.log
@@ -1,3 +1,2 @@
-[[]routegroup[]]
-[[]eskip[]]
-error while applying default filters
+Failed to retrieve default filters: error while applying default filters for route group and service: default/myapp myapp
+kind=RouteGroup name=myapp

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
@@ -1,3 +1,2 @@
-[[]routegroup[]]
-error transforming internal hosts for default/myapp: service not found:
-default/myapp.
+Error transforming internal hosts: service not found: default/myapp
+kind=RouteGroup name=myapp

--- a/dataclients/kubernetes/testdata/routegroups/with-ingress/failing-ingress-item.log
+++ b/dataclients/kubernetes/testdata/routegroups/with-ingress/failing-ingress-item.log
@@ -1,1 +1,2 @@
-convertPathRuleV1: Failed to get service
+Failed to get service myappv1, 80
+kind=Ingress name=myappv1 ns=default


### PR DESCRIPTION
Ingress context has a logger that logs related ingress name and namespace.

This change:

* adds kind, name and namespace logger fields
* adds logger to RouteGroup context
* uses context loggers instead of global where applicable
* removes `convertPathRuleV1: ` prefix and makes all log messages start from capital letter