### PR TITLE
dataclient/kubernetes: reduce amount of logs

### DIFF
--- a/dataclients/kubernetes/export_test.go
+++ b/dataclients/kubernetes/export_test.go
@@ -1,0 +1,7 @@
+package kubernetes
+
+import "time"
+
+func (c *Client) SetLoggingInterval(d time.Duration) {
+	c.loggingInterval = d
+}

--- a/dataclients/kubernetes/ingressv1.go
+++ b/dataclients/kubernetes/ingressv1.go
@@ -402,16 +402,14 @@ func (ing *ingress) ingressV1Route(
 	hostRoutes map[string][]*eskip.Route,
 	df defaultFilters,
 	r *certregistry.CertRegistry,
+	enableLogging bool,
 ) (*eskip.Route, error) {
 	if i.Metadata == nil || i.Metadata.Namespace == "" || i.Metadata.Name == "" || i.Spec == nil {
 		log.Error("invalid ingress item: missing Metadata or Spec")
 		return nil, nil
 	}
-	logger := log.WithFields(log.Fields{
-		"kind": "Ingress",
-		"ns":   i.Metadata.Namespace,
-		"name": i.Metadata.Name,
-	})
+	logger := newLogger("Ingress", i.Metadata.Namespace, i.Metadata.Name, enableLogging)
+
 	redirect.initCurrent(i.Metadata)
 	ic := &ingressContext{
 		state:               state,

--- a/dataclients/kubernetes/logger.go
+++ b/dataclients/kubernetes/logger.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import log "github.com/sirupsen/logrus"
+
+type logger struct {
+	logger *log.Entry
+}
+
+func newLogger(kind, namespace, name string, enabled bool) *logger {
+	if !enabled {
+		return nil
+	}
+	return &logger{log.WithFields(log.Fields{"kind": kind, "ns": namespace, "name": name})}
+}
+
+func (l *logger) Debugf(format string, args ...any) {
+	if l != nil {
+		l.logger.Debugf(format, args...)
+	}
+}
+
+func (l *logger) Infof(format string, args ...any) {
+	if l != nil {
+		l.logger.Infof(format, args...)
+	}
+}
+
+func (l *logger) Errorf(format string, args ...any) {
+	if l != nil {
+		l.logger.Errorf(format, args...)
+	}
+}

--- a/dataclients/kubernetes/logger_test.go
+++ b/dataclients/kubernetes/logger_test.go
@@ -1,0 +1,76 @@
+package kubernetes_test
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/dataclients/kubernetes"
+	"github.com/zalando/skipper/dataclients/kubernetes/kubernetestest"
+)
+
+func TestLogger(t *testing.T) {
+	manifest, err := os.Open("testdata/routegroups/convert/failing-filter.yaml")
+	require.NoError(t, err)
+	defer manifest.Close()
+
+	var out bytes.Buffer
+	log.SetOutput(&out)
+	defer log.SetOutput(os.Stderr)
+
+	countMessages := func() int {
+		return strings.Count(out.String(), "Error transforming external hosts")
+	}
+
+	a, err := kubernetestest.NewAPI(kubernetestest.TestAPIOptions{}, manifest)
+	require.NoError(t, err)
+
+	s := httptest.NewServer(a)
+	defer s.Close()
+
+	c, err := kubernetes.New(kubernetes.Options{KubernetesURL: s.URL})
+	require.NoError(t, err)
+	defer c.Close()
+
+	const testLoggingInterval = 1 * time.Second
+	c.SetLoggingInterval(testLoggingInterval)
+
+	_, err = c.LoadAll()
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countMessages(), "one message expected after initial load")
+
+	for i := 0; i < 10; i++ {
+		_, _, err := c.LoadUpdate()
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, countMessages(), "one message expected on subsequent updates before logging interval elapsed")
+	}
+
+	time.Sleep(2 * testLoggingInterval)
+
+	for i := 0; i < 10; i++ {
+		_, _, err := c.LoadUpdate()
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, countMessages(), "two messages expected on subsequent updates after logging interval elapsed")
+	}
+
+	oldLevel := log.GetLevel()
+	defer log.SetLevel(oldLevel)
+
+	log.SetLevel(log.DebugLevel)
+
+	for i := 0; i < 10; i++ {
+		_, _, err := c.LoadUpdate()
+		require.NoError(t, err)
+
+		assert.Equal(t, 3+i, countMessages(), "a new message expected for each subsequent update when log level is debug")
+	}
+}


### PR DESCRIPTION
Log Ingress/RouteGroup processing messages at most once per minute unless log level is debug.