### PR TITLE
dataclients/kubernetes: fix logging

### DIFF
--- a/dataclients/kubernetes/ingress.go
+++ b/dataclients/kubernetes/ingress.go
@@ -362,7 +362,7 @@ func addHostTLSCert(ic *ingressContext, hosts []string, secretID *definitions.Re
 // convert logs if an invalid found, but proceeds with the valid ones.
 // Reporting failures in Ingress status is not possible, because
 // Ingress status field only supports IP and Hostname as string.
-func (ing *ingress) convert(state *clusterState, df defaultFilters, r *certregistry.CertRegistry, enableLogging bool) ([]*eskip.Route, error) {
+func (ing *ingress) convert(state *clusterState, df defaultFilters, r *certregistry.CertRegistry, loggingEnabled bool) ([]*eskip.Route, error) {
 	var ewIngInfo map[string][]string // r.Id -> {namespace, name}
 	if ing.kubernetesEnableEastWest {
 		ewIngInfo = make(map[string][]string)
@@ -371,7 +371,7 @@ func (ing *ingress) convert(state *clusterState, df defaultFilters, r *certregis
 	hostRoutes := make(map[string][]*eskip.Route)
 	redirect := createRedirectInfo(ing.provideHTTPSRedirect, ing.httpsRedirectCode)
 	for _, i := range state.ingressesV1 {
-		r, err := ing.ingressV1Route(i, redirect, state, hostRoutes, df, r, enableLogging)
+		r, err := ing.ingressV1Route(i, redirect, state, hostRoutes, df, r, loggingEnabled)
 		if err != nil {
 			return nil, err
 		}

--- a/dataclients/kubernetes/ingressv1.go
+++ b/dataclients/kubernetes/ingressv1.go
@@ -402,13 +402,13 @@ func (ing *ingress) ingressV1Route(
 	hostRoutes map[string][]*eskip.Route,
 	df defaultFilters,
 	r *certregistry.CertRegistry,
-	enableLogging bool,
+	loggingEnabled bool,
 ) (*eskip.Route, error) {
 	if i.Metadata == nil || i.Metadata.Namespace == "" || i.Metadata.Name == "" || i.Spec == nil {
 		log.Error("invalid ingress item: missing Metadata or Spec")
 		return nil, nil
 	}
-	logger := newLogger("Ingress", i.Metadata.Namespace, i.Metadata.Name, enableLogging)
+	logger := newLogger("Ingress", i.Metadata.Namespace, i.Metadata.Name, loggingEnabled)
 
 	redirect.initCurrent(i.Metadata)
 	ic := &ingressContext{

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -481,12 +481,12 @@ func splitHosts(hosts []string, domains []string) ([]string, []string) {
 	return internalHosts, externalHosts
 }
 
-func (r *routeGroups) convert(s *clusterState, df defaultFilters, enableLogging bool) ([]*eskip.Route, error) {
+func (r *routeGroups) convert(s *clusterState, df defaultFilters, loggingEnabled bool) ([]*eskip.Route, error) {
 	var rs []*eskip.Route
 	redirect := createRedirectInfo(r.options.ProvideHTTPSRedirect, r.options.HTTPSRedirectCode)
 
 	for _, rg := range s.routeGroups {
-		logger := newLogger("RouteGroup", rg.Metadata.Namespace, rg.Metadata.Name, enableLogging)
+		logger := newLogger("RouteGroup", rg.Metadata.Namespace, rg.Metadata.Name, loggingEnabled)
 
 		redirect.initCurrent(rg.Metadata)
 


### PR DESCRIPTION
Logging should be enabled after loggingInterval elapsed since it was last enabled (and not since last update).

Followup on https://github.com/zalando/skipper/pull/2427