### PR TITLE
Get rid of kingpin

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"net/http"
 	"os"
 	"os/signal"
@@ -11,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/cmd/webhook/admission"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (
@@ -27,17 +27,16 @@ type config struct {
 }
 
 func (c *config) parse() {
-	kingpin.Flag("debug", "Enable debug logging").BoolVar(&c.debug)
-	kingpin.Flag("tls-cert-file", "File containing the certificate for HTTPS").Envar("CERT_FILE").StringVar(&c.certFile)
-	kingpin.Flag("tls-key-file", "File containing the private key for HTTPS").Envar("KEY_FILE").StringVar(&c.keyFile)
-	kingpin.Flag("address", "The address to listen on").Default(defaultHTTPSAddress).StringVar(&c.address)
+	flag.BoolVar(&c.debug, "debug", false, "Enable debug logging")
+	flag.StringVar(&c.certFile, "tls-cert-file", os.Getenv("CERT_FILE"), "File containing the certificate for HTTPS")
+	flag.StringVar(&c.keyFile, "tls-key-file", os.Getenv("KEY_FILE"), "File containing the private key for HTTPS")
+	flag.StringVar(&c.address, "address", defaultHTTPSAddress, "The address to listen on")
+	flag.Parse()
 
-	kingpin.Parse()
-
-	if (c.certFile != "" || c.keyFile != "") && !(c.certFile != "" && c.keyFile != "") {
-		log.Fatal("Config parse error: both of TLS cert & key must be provided or neither (for testing )")
-		return
-	}
+	// if (c.certFile != "" || c.keyFile != "") && !(c.certFile != "" && c.keyFile != "") {
+	// 	log.Fatal("Config parse error: both of TLS cert & key must be provided or neither (for testing )")
+	// 	return
+	// }
 
 	// support non-HTTPS for local testing
 	if (c.certFile == "" && c.keyFile == "") && c.address == defaultHTTPSAddress {

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -33,10 +33,10 @@ func (c *config) parse() {
 	flag.StringVar(&c.address, "address", defaultHTTPSAddress, "The address to listen on")
 	flag.Parse()
 
-	// if (c.certFile != "" || c.keyFile != "") && !(c.certFile != "" && c.keyFile != "") {
-	// 	log.Fatal("Config parse error: both of TLS cert & key must be provided or neither (for testing )")
-	// 	return
-	// }
+	if (c.certFile != "" || c.keyFile != "") && !(c.certFile != "" && c.keyFile != "") {
+		log.Fatal("Config parse error: both of TLS cert & key must be provided or neither (for testing )")
+		return
+	}
 
 	// support non-HTTPS for local testing
 	if (c.certFile == "" && c.keyFile == "") && c.address == defaultHTTPSAddress {

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.9.0
 	golang.org/x/time v0.3.0
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v2 v2.4.0
 	layeh.com/gopher-json v0.0.0-20201124131017-552bb3c4c3bf
@@ -60,8 +59,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,6 @@ github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/b
 github.com/abbot/go-http-auth v0.4.0 h1:QjmvZ5gSC7jm3Zg54DqWE/T5m1t2AfDu6QlXJT0EVT0=
 github.com/abbot/go-http-auth v0.4.0/go.mod h1:Cz6ARTIzApMJDzh5bRMSUou6UMSp0IEXg9km/ci7TJM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -725,8 +721,6 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Kingpin is only used in webhook admission, it makes sense to remove it and use flag package like we do everywhere.

This will stay in draft mode sense we don't have a test case for webhook admission flags, so another PR will be created to test the flags first, then we will follow up on this.