### PR TITLE
build: simplify go commands

### DIFF
--- a/cmd/eskip/args_test.go
+++ b/cmd/eskip/args_test.go
@@ -81,7 +81,7 @@ func TestProcessArgs(t *testing.T) {
 		[]string{"-sort-predicates"},
 		false,
 		nil,
-		[]*medium{{typ: inline, eskip: `PathRegexp("^/") && Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") -> "https://www.example.org"`}},
+		nil,
 	}, {
 
 		// etcd-urls

--- a/cmd/eskip/write_test.go
+++ b/cmd/eskip/write_test.go
@@ -37,13 +37,6 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	defer func() {
-		err := etcdtest.Stop()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
 	urls, err := stringsToUrls(etcdtest.Urls...)
 	if err != nil {
 		log.Fatal(err)
@@ -51,7 +44,14 @@ func TestMain(m *testing.M) {
 
 	testEtcdUrls = urls
 
-	os.Exit(m.Run())
+	exitCode := m.Run()
+
+	err = etcdtest.Stop()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(exitCode)
 }
 
 func TestUpsertLoadFail(t *testing.T) {

--- a/net/redistest/redistest.go
+++ b/net/redistest/redistest.go
@@ -39,7 +39,7 @@ func NewTestRedisWithPassword(t testing.TB, password string) (address string, do
 		t.Fatalf("Failed to start redis server: %v", err)
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	address, err = container.Endpoint(ctx, "")
@@ -56,7 +56,7 @@ func NewTestRedisWithPassword(t testing.TB, password string) (address string, do
 	done = func() {
 		t.Logf("Stopping redis server at %s", address)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		if err := container.Terminate(ctx); err != nil {

--- a/script/options_test.go
+++ b/script/options_test.go
@@ -121,6 +121,7 @@ func ExampleLuaOptions_enableModules() {
 	// table
 	// table.insert
 	// table.sort
+	// package.config
 	// package.cpath
 	// package.loaded
 	// package.loaders


### PR DESCRIPTION
Use ./... instead of loop over packages.

Originally loop over packages was added by #359 that introduced glide package manager. This manager fetches dependencies into vendor/ subdirectory (see https://glide.readthedocs.io/en/latest/getting-started/) and apparently loop over packages was necessary back then. glide usage was removed by #764

The change now also runs testable examples.

Also:
* increases redis testcontainer ping and shutdown timeouts after observed CI failures
* fixes cmd/eskip etcd shutdown similar to #2359
* fixes cmd/eskip test introduced by #2202
* fixes lua example
* removed bench target as it makes little sense
* .coverprofile-all can not be simplified yet due to https://github.com/golang/go/issues/45361