### PR TITLE
filters/diag: speedup latency filter tests

### DIFF
--- a/filters/diag/diag.go
+++ b/filters/diag/diag.go
@@ -105,6 +105,7 @@ type jitter struct {
 	mean  time.Duration
 	delta time.Duration
 	typ   distribution
+	sleep func(time.Duration)
 }
 
 var randomChars = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
@@ -619,6 +620,7 @@ func (j *jitter) CreateFilter(args []interface{}) (filters.Filter, error) {
 		typ:   j.typ,
 		mean:  mean,
 		delta: delta,
+		sleep: time.Sleep,
 	}, nil
 }
 
@@ -635,7 +637,7 @@ func (j *jitter) Request(filters.FilterContext) {
 		return
 	}
 	f := r * float64(j.delta)
-	time.Sleep(j.mean + time.Duration(int64(f)))
+	j.sleep(j.mean + time.Duration(int64(f)))
 }
 
 func (j *jitter) Response(filters.FilterContext) {
@@ -651,5 +653,5 @@ func (j *jitter) Response(filters.FilterContext) {
 		return
 	}
 	f := r * float64(j.delta)
-	time.Sleep(j.mean + time.Duration(int64(f)))
+	j.sleep(j.mean + time.Duration(int64(f)))
 }

--- a/filters/diag/diag_test.go
+++ b/filters/diag/diag_test.go
@@ -798,12 +798,12 @@ func TestRequestLatency(t *testing.T) {
 			}
 
 			N := 1000
-			res := make([]time.Duration, N)
+
+			res := make([]time.Duration, 0, N)
+			SetSleep(f, func(d time.Duration) { res = append(res, d) })
+
 			for i := 0; i < N; i++ {
-				start := time.Now()
 				f.Request(nil)
-				d := time.Since(start)
-				res[i] = d
 			}
 
 			sort.Slice(res, func(i, j int) bool {
@@ -877,12 +877,12 @@ func TestResponseLatency(t *testing.T) {
 			}
 
 			N := 1000
-			res := make([]time.Duration, N)
+
+			res := make([]time.Duration, 0, N)
+			SetSleep(f, func(d time.Duration) { res = append(res, d) })
+
 			for i := 0; i < N; i++ {
-				start := time.Now()
 				f.Response(nil)
-				d := time.Since(start)
-				res[i] = d
 			}
 
 			sort.Slice(res, func(i, j int) bool {

--- a/filters/diag/export_test.go
+++ b/filters/diag/export_test.go
@@ -11,6 +11,8 @@ func SetSleep(f filters.Filter, sleep func(time.Duration)) {
 	switch f := f.(type) {
 	case *histFilter:
 		f.sleep = sleep
+	case *jitter:
+		f.sleep = sleep
 	default:
 		panic(fmt.Sprintf("unsupported filter type: %T", f))
 	}


### PR DESCRIPTION
Use mocked sleep (similar to #2432) to speedup latency filters tests.

Before:
```
$ go test ./filters/diag/ -v -run='TestRequestLatency|TestResponseLatency' | grep PASS
--- PASS: TestRequestLatency (21.06s)
    --- PASS: TestRequestLatency/test_uniform_latency (10.54s)
    --- PASS: TestRequestLatency/test_normal_latency (10.52s)
--- PASS: TestResponseLatency (21.40s)
    --- PASS: TestResponseLatency/test_response_uniform_latency (10.60s)
    --- PASS: TestResponseLatency/test_response_normal_latency (10.79s)
PASS
```

After:
```
$ go test ./filters/diag/ -v -run='TestRequestLatency|TestResponseLatency' | grep PASS
--- PASS: TestRequestLatency (0.00s)
    --- PASS: TestRequestLatency/test_uniform_latency (0.00s)
    --- PASS: TestRequestLatency/test_normal_latency (0.00s)
--- PASS: TestResponseLatency (0.00s)
    --- PASS: TestResponseLatency/test_response_uniform_latency (0.00s)
    --- PASS: TestResponseLatency/test_response_normal_latency (0.00s)
PASS
```