### PR TITLE
filters/auth: allow insecure grant flow

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -198,6 +198,7 @@ type Config struct {
 	Oauth2GrantTokeninfoKeys          *listFlag     `yaml:"oauth2-grant-tokeninfo-keys"`
 	Oauth2TokenCookieName             string        `yaml:"oauth2-token-cookie-name"`
 	Oauth2TokenCookieRemoveSubdomains int           `yaml:"oauth2-token-cookie-remove-subdomains"`
+	Oauth2GrantInsecure               bool          `yaml:"oauth2-grant-insecure"`
 	WebhookTimeout                    time.Duration `yaml:"webhook-timeout"`
 	OidcSecretsFile                   string        `yaml:"oidc-secrets-file"`
 	OIDCCookieValidity                time.Duration `yaml:"oidc-cookie-validity"`
@@ -475,6 +476,7 @@ func NewConfig() *Config {
 	flag.Var(cfg.Oauth2GrantTokeninfoKeys, "oauth2-grant-tokeninfo-keys", "non-empty comma separated list configures keys to preserve in OAuth2 Grant Flow tokeninfo")
 	flag.StringVar(&cfg.Oauth2TokenCookieName, "oauth2-token-cookie-name", "oauth2-grant", "sets the name of the cookie where the encrypted token is stored")
 	flag.IntVar(&cfg.Oauth2TokenCookieRemoveSubdomains, "oauth2-token-cookie-remove-subdomains", 1, "sets the number of subdomains to remove from the callback request hostname to obtain token cookie domain")
+	flag.BoolVar(&cfg.Oauth2GrantInsecure, "oauth2-grant-insecure", false, "omits Secure attribute of the token cookie and uses http scheme for callback url")
 	flag.DurationVar(&cfg.WebhookTimeout, "webhook-timeout", 2*time.Second, "sets the webhook request timeout duration")
 	flag.StringVar(&cfg.OidcSecretsFile, "oidc-secrets-file", "", "file storing the encryption key of the OID Connect token. Enables OIDC filters")
 	flag.DurationVar(&cfg.OIDCCookieValidity, "oidc-cookie-validity", time.Hour, "sets the cookie expiry time to +1h for OIDC filters, in case no 'exp' claim is found in the JWT token")
@@ -818,6 +820,7 @@ func (c *Config) ToOptions() skipper.Options {
 		OAuth2GrantTokeninfoKeys:          c.Oauth2GrantTokeninfoKeys.values,
 		OAuth2TokenCookieName:             c.Oauth2TokenCookieName,
 		OAuth2TokenCookieRemoveSubdomains: c.Oauth2TokenCookieRemoveSubdomains,
+		OAuth2GrantInsecure:               c.Oauth2GrantInsecure,
 		WebhookTimeout:                    c.WebhookTimeout,
 		OIDCSecretsFile:                   c.OidcSecretsFile,
 		OIDCCookieValidity:                c.OIDCCookieValidity,

--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -110,6 +110,9 @@ type OAuthConfig struct {
 	// Init converts default nil to 1.
 	TokenCookieRemoveSubdomains *int
 
+	// Insecure omits Secure attribute of the token cookie and uses http scheme for callback url.
+	Insecure bool
+
 	// ConnectionTimeout used for tokeninfo, access-token and refresh-token endpoint.
 	ConnectionTimeout time.Duration
 
@@ -341,7 +344,12 @@ func (c *OAuthConfig) GetAuthURLParameters(redirectURI string) []oauth2.AuthCode
 func (c *OAuthConfig) RedirectURLs(req *http.Request) (redirect, original string) {
 	u := *req.URL
 
-	u.Scheme = "https"
+	if c.Insecure {
+		u.Scheme = "http"
+	} else {
+		u.Scheme = "https"
+	}
+
 	u.Host = req.Host
 
 	original = u.String()

--- a/filters/auth/grantcookie.go
+++ b/filters/auth/grantcookie.go
@@ -91,7 +91,7 @@ func createDeleteCookie(config *OAuthConfig, host string) *http.Cookie {
 		Path:     "/",
 		Domain:   extractDomainFromHost(host, *config.TokenCookieRemoveSubdomains),
 		MaxAge:   -1,
-		Secure:   true,
+		Secure:   !config.Insecure,
 		HttpOnly: true,
 	}
 }
@@ -133,7 +133,7 @@ func createCookie(config *OAuthConfig, host string, t *oauth2.Token) (*http.Cook
 		Path:     "/",
 		Domain:   domain,
 		Expires:  t.Expiry.Add(time.Hour * 24 * 30),
-		Secure:   true,
+		Secure:   !config.Insecure,
 		HttpOnly: true,
 	}, nil
 }

--- a/skipper.go
+++ b/skipper.go
@@ -800,6 +800,9 @@ type Options struct {
 	// the callback request hostname to obtain token cookie domain.
 	OAuth2TokenCookieRemoveSubdomains int
 
+	// OAuth2GrantInsecure omits Secure attribute of the token cookie and uses http scheme for callback url.
+	OAuth2GrantInsecure bool
+
 	// CompressEncodings, if not empty replace default compression encodings
 	CompressEncodings []string
 
@@ -1724,6 +1727,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		oauthConfig.GrantTokeninfoKeys = o.OAuth2GrantTokeninfoKeys
 		oauthConfig.TokenCookieName = o.OAuth2TokenCookieName
 		oauthConfig.TokenCookieRemoveSubdomains = &o.OAuth2TokenCookieRemoveSubdomains
+		oauthConfig.Insecure = o.OAuth2GrantInsecure
 		oauthConfig.ConnectionTimeout = o.OAuthTokeninfoTimeout
 		oauthConfig.MaxIdleConnectionsPerHost = o.IdleConnectionsPerHost
 		oauthConfig.Tracer = tracer


### PR DESCRIPTION
Add a flag to allow insecure grant flow:
* issue token cookie without secure attribute
* use http schem for callback url