### PR TITLE
Temporary skip tests using net/redistest

### DIFF
--- a/net/redistest/redistest.go
+++ b/net/redistest/redistest.go
@@ -15,6 +15,11 @@ func NewTestRedis(t testing.TB) (address string, done func()) {
 }
 
 func NewTestRedisWithPassword(t testing.TB, password string) (address string, done func()) {
+
+	if fixDeadline, _ := time.Parse("2006-01-02", "2023-08-01"); time.Now().Before(fixDeadline) {
+		t.Skip("https://github.com/testcontainers/testcontainers-go/issues/1359")
+	}
+
 	var args []string
 	if password != "" {
 		args = append(args, "--requirepass", password)


### PR DESCRIPTION
Redis testcontainer fails to start due to https://github.com/testcontainers/testcontainers-go/issues/1359 caused by https://github.com/golang/go/issues/61076 and we can not pin cdp-runtime/go to a working patch version before 1.20.6