### PR TITLE
proxy: set zero content length for default response

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"bytes"
 	stdlibcontext "context"
 	"errors"
 	"io"
@@ -62,15 +61,15 @@ type noopFlushedResponseWriter struct {
 	ignoredHeader http.Header
 }
 
-func defaultBody() io.ReadCloser {
-	return io.NopCloser(&bytes.Buffer{})
+func noBody() io.ReadCloser {
+	return http.NoBody
 }
 
 func defaultResponse(r *http.Request) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusNotFound,
 		Header:     make(http.Header),
-		Body:       defaultBody(),
+		Body:       noBody(),
 		Request:    r,
 	}
 }
@@ -89,7 +88,7 @@ func cloneRequestMetadata(r *http.Request) *http.Request {
 		ProtoMinor:       r.ProtoMinor,
 		Header:           cloneHeader(r.Header),
 		Trailer:          cloneHeader(r.Trailer),
-		Body:             defaultBody(),
+		Body:             noBody(),
 		ContentLength:    r.ContentLength,
 		TransferEncoding: r.TransferEncoding,
 		Close:            r.Close,
@@ -109,7 +108,7 @@ func cloneResponseMetadata(r *http.Response) *http.Response {
 		ProtoMinor:       r.ProtoMinor,
 		Header:           cloneHeader(r.Header),
 		Trailer:          cloneHeader(r.Trailer),
-		Body:             defaultBody(),
+		Body:             noBody(),
 		ContentLength:    r.ContentLength,
 		TransferEncoding: r.TransferEncoding,
 		Close:            r.Close,
@@ -180,7 +179,7 @@ func (c *context) ensureDefaultResponse() {
 	}
 
 	if c.response.Body == nil {
-		c.response.Body = defaultBody()
+		c.response.Body = noBody()
 	}
 }
 
@@ -235,7 +234,7 @@ func (c *context) Serve(r *http.Response) {
 	}
 
 	if r.Body == nil {
-		r.Body = defaultBody()
+		r.Body = noBody()
 	}
 
 	c.servedWithResponse = true

--- a/proxy/defaultresponse_test.go
+++ b/proxy/defaultresponse_test.go
@@ -1,0 +1,26 @@
+package proxy_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/eskip"
+	"github.com/zalando/skipper/proxy/proxytest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultResponse(t *testing.T) {
+	p := proxytest.Config{
+		Routes: eskip.MustParse(`* -> <shunt>`),
+	}.Create()
+	defer p.Close()
+
+	rsp, body, err := p.Client().GetBody(p.URL)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusNotFound, rsp.StatusCode)
+	assert.Len(t, body, 0)
+	assert.Equal(t, "0", rsp.Header.Get("Content-Length"))
+}


### PR DESCRIPTION
Content-Length header prevents http.ResponseWriter from writing chunked response.

It turns out that reading empty chunked response is slow(er). In particular this change speeds up TrafficSegment tests that perform 10k requests to routes that send no body:
```
r50: Path("/test") && TrafficSegment(0.0, 0.5) -> status(200) -> <shunt>;
r30: Path("/test") && TrafficSegment(0.5, 0.8) -> status(201) -> <shunt>;
r20: Path("/test") && TrafficSegment(0.8, 1.0) -> status(202) -> <shunt>;
```

Test runtime before the change:
```
$ go test ./predicates/traffic/ -count=1 -run=TestTrafficSegment
ok      github.com/zalando/skipper/predicates/traffic   9.357s
```
and after:
```
ok      github.com/zalando/skipper/predicates/traffic   4.260s
```

Related #1562