### PR TITLE
packaging: fix Dockerfile to support dependabot updates

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3:latest@sha256:2924ef858efe1025d8f4094b1e3ee6f86db2d3e211052c06e0c8afb86643d46a
+ARG BASE_IMAGE=default
+FROM registry.opensource.zalan.do/library/alpine-3:latest@sha256:2924ef858efe1025d8f4094b1e3ee6f86db2d3e211052c06e0c8afb86643d46a AS default
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates


### PR DESCRIPTION
Dependabot does not update ARG instruction and updates only the first FROM instruction, see https://github.com/dependabot/dependabot-core/issues/2057
This change uses workaround described here https://github.com/dependabot/dependabot-core/issues/2057#issuecomment-1351660410