### PR TITLE
skipper: do not log nil error after shutdown

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -44,5 +44,7 @@ func main() {
 	}
 
 	log.SetLevel(cfg.ApplicationLogLevel)
-	log.Fatal(skipper.Run(cfg.ToOptions()))
+	if err := skipper.Run(cfg.ToOptions()); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
This disables `level=fatal msg="<nil>"` message after succesfull shutdown.