### PR TITLE
queuelistener: fix testListener goroutine leak

### DIFF
--- a/queuelistener/listener_test.go
+++ b/queuelistener/listener_test.go
@@ -80,8 +80,13 @@ func (l *testListener) Accept() (net.Conn, error) {
 		select {
 		case l.conns <- c:
 		default:
-			// drop one if cannot store the latest
-			<-l.conns
+			// Drop one if cannot store the latest.
+			// The test might have received a connection in the meantime so do not block.
+			// Sending is safe as Accept is called from a single goroutine.
+			select {
+			case <-l.conns:
+			default:
+			}
 			l.conns <- c
 		}
 	}


### PR DESCRIPTION
Queuelistener continously calls Accept on the testListener which keeps a buffer of last accepted testConnections in the conns channel.

The test code races to receive from the same channel so Accept goroutine may occasionally block receiving from the empty channel which would be detected by goroutine leak detector introduced by the #2499.

The problem could be reproduced e.g. by running:
```
GODEBUG=tracebackancestors=10 go test ./queuelistener/ -run=TestTeardown/connections_accepted_from_the_wrapped_listener_closed_after_tear_down -count=1000

noleak: 1 active

goroutine 2655 [chan receive]:
github.com/zalando/skipper/queuelistener.(*testListener).Accept(0xc0000e7830)
...
```

This change avoids blocking Accept on potentially empty channel.