### PR TITLE
OPA: authorization based on request body

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -501,7 +501,7 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableOpenPolicyAgent, "enable-open-policy-agent", false, "enables Open Policy Agent filters")
 	flag.StringVar(&cfg.OpenPolicyAgentConfigTemplate, "open-policy-agent-config-template", "", "file containing a template for an Open Policy Agent configuration file that is interpolated for each OPA filter instance")
 	flag.StringVar(&cfg.OpenPolicyAgentEnvoyMetadata, "open-policy-agent-envoy-metadata", "", "JSON file containing meta-data passed as input for compatibility with Envoy policies in the format")
-	flag.DurationVar(&cfg.OpenPolicyAgentCleanerInterval, "open-policy-agent-cleaner-interval", openpolicyagent.DefaultCleanerInterval, "Duration in seconds to wait before cleaning up unused opa instances")
+	flag.DurationVar(&cfg.OpenPolicyAgentCleanerInterval, "open-policy-agent-cleaner-interval", openpolicyagent.DefaultCleanIdlePeriod, "Duration in seconds to wait before cleaning up unused opa instances")
 	flag.DurationVar(&cfg.OpenPolicyAgentStartupTimeout, "open-policy-agent-startup-timeout", openpolicyagent.DefaultOpaStartupTimeout, "Maximum duration in seconds to wait for the open policy agent to start up")
 	flag.Int64Var(&cfg.OpenPolicyAgentMaxRequestBodySize, "open-policy-agent-max-request-body-size", openpolicyagent.DefaultMaxRequestBodySize, "Maximum number of bytes from a http request body that are passed as input to the policy")
 	flag.Int64Var(&cfg.OpenPolicyAgentMaxMemoryBodyParsing, "open-policy-agent-max-memory-body-parsing", openpolicyagent.DefaultMaxMemoryBodyParsing, "Total number of bytes used to parse http request bodies across all requests. Once the limit is met, requests will be rejected.")

--- a/config/config.go
+++ b/config/config.go
@@ -278,11 +278,13 @@ type Config struct {
 	LuaModules *listFlag `yaml:"lua-modules"`
 	LuaSources *listFlag `yaml:"lua-sources"`
 
-	EnableOpenPolicyAgent          bool          `yaml:"enable-open-policy-agent"`
-	OpenPolicyAgentConfigTemplate  string        `yaml:"open-policy-agent-config-template"`
-	OpenPolicyAgentEnvoyMetadata   string        `yaml:"open-policy-agent-envoy-metadata"`
-	OpenPolicyAgentCleanerInterval time.Duration `yaml:"open-policy-agent-cleaner-interval"`
-	OpenPolicyAgentStartupTimeout  time.Duration `yaml:"open-policy-agent-startup-timeout"`
+	EnableOpenPolicyAgent               bool          `yaml:"enable-open-policy-agent"`
+	OpenPolicyAgentConfigTemplate       string        `yaml:"open-policy-agent-config-template"`
+	OpenPolicyAgentEnvoyMetadata        string        `yaml:"open-policy-agent-envoy-metadata"`
+	OpenPolicyAgentCleanerInterval      time.Duration `yaml:"open-policy-agent-cleaner-interval"`
+	OpenPolicyAgentStartupTimeout       time.Duration `yaml:"open-policy-agent-startup-timeout"`
+	OpenPolicyAgentMaxRequestBodySize   int64         `yaml:"open-policy-agent-max-request-body-size"`
+	OpenPolicyAgentMaxMemoryBodyParsing int64         `yaml:"open-policy-agent-max-memory-body-parsing"`
 }
 
 const (
@@ -501,6 +503,8 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.OpenPolicyAgentEnvoyMetadata, "open-policy-agent-envoy-metadata", "", "JSON file containing meta-data passed as input for compatibility with Envoy policies in the format")
 	flag.DurationVar(&cfg.OpenPolicyAgentCleanerInterval, "open-policy-agent-cleaner-interval", openpolicyagent.DefaultCleanerInterval, "Duration in seconds to wait before cleaning up unused opa instances")
 	flag.DurationVar(&cfg.OpenPolicyAgentStartupTimeout, "open-policy-agent-startup-timeout", openpolicyagent.DefaultOpaStartupTimeout, "Maximum duration in seconds to wait for the open policy agent to start up")
+	flag.Int64Var(&cfg.OpenPolicyAgentMaxRequestBodySize, "open-policy-agent-max-request-body-size", openpolicyagent.DefaultMaxRequestBodySize, "Maximum number of bytes from a http request body that are passed as input to the policy")
+	flag.Int64Var(&cfg.OpenPolicyAgentMaxMemoryBodyParsing, "open-policy-agent-max-memory-body-parsing", openpolicyagent.DefaultMaxMemoryBodyParsing, "Total number of bytes used to parse http request bodies across all requests. Once the limit is met, requests will be rejected.")
 
 	// TLS client certs
 	flag.StringVar(&cfg.ClientKeyFile, "client-tls-key", "", "TLS Key file for backend connections, multiple keys may be given comma separated - the order must match the certs")
@@ -901,11 +905,13 @@ func (c *Config) ToOptions() skipper.Options {
 		LuaModules: c.LuaModules.values,
 		LuaSources: c.LuaSources.values,
 
-		EnableOpenPolicyAgent:          c.EnableOpenPolicyAgent,
-		OpenPolicyAgentConfigTemplate:  c.OpenPolicyAgentConfigTemplate,
-		OpenPolicyAgentEnvoyMetadata:   c.OpenPolicyAgentEnvoyMetadata,
-		OpenPolicyAgentCleanerInterval: c.OpenPolicyAgentCleanerInterval,
-		OpenPolicyAgentStartupTimeout:  c.OpenPolicyAgentStartupTimeout,
+		EnableOpenPolicyAgent:               c.EnableOpenPolicyAgent,
+		OpenPolicyAgentConfigTemplate:       c.OpenPolicyAgentConfigTemplate,
+		OpenPolicyAgentEnvoyMetadata:        c.OpenPolicyAgentEnvoyMetadata,
+		OpenPolicyAgentCleanerInterval:      c.OpenPolicyAgentCleanerInterval,
+		OpenPolicyAgentStartupTimeout:       c.OpenPolicyAgentStartupTimeout,
+		OpenPolicyAgentMaxRequestBodySize:   c.OpenPolicyAgentMaxRequestBodySize,
+		OpenPolicyAgentMaxMemoryBodyParsing: c.OpenPolicyAgentMaxMemoryBodyParsing,
 	}
 	for _, rcci := range c.CloneRoute {
 		eskipClone := eskip.NewClone(rcci.Reg, rcci.Repl)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/zalando/skipper/filters/openpolicyagent"
 	"github.com/zalando/skipper/net"
 	"github.com/zalando/skipper/proxy"
 	"gopkg.in/yaml.v2"
@@ -160,8 +161,10 @@ func defaultConfig() *Config {
 		ValidateQueryLog:                        true,
 		LuaModules:                              commaListFlag(),
 		LuaSources:                              commaListFlag(),
-		OpenPolicyAgentCleanerInterval:          10 * time.Second,
+		OpenPolicyAgentCleanerInterval:          openpolicyagent.DefaultCleanIdlePeriod,
 		OpenPolicyAgentStartupTimeout:           30 * time.Second,
+		OpenPolicyAgentMaxRequestBodySize:       openpolicyagent.DefaultMaxRequestBodySize,
+		OpenPolicyAgentMaxMemoryBodyParsing:     openpolicyagent.DefaultMaxMemoryBodyParsing,
 	}
 }
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1879,6 +1879,20 @@ Headers both to the upstream and the downstream service can be manipulated the s
 
 This allows both to add and remove unwanted headers in allow/deny cases.
 
+#### opaAuthorizeRequestWithBody
+
+Requests can also be authorized based on the request body the same way that is supported with the [Open Policy Agent Envoy plugin](https://www.openpolicyagent.org/docs/latest/envoy-primer/#example-input), look for the input attribute `parsed_body` in the upstream documentation.
+
+This filter has the same parameters that the `opaAuthorizeRequest` filter has.
+
+A request's body is parsed up to a maximum size with a default of 1MB that can be configured via the `-open-policy-agent-max-request-body-size` command line argument. To avoid OOM errors due to too many concurrent authorized body requests, another flag `-open-policy-agent-max-memory-body-parsing` controls how much memory can be used across all requests with a default of 100MB. If in-flight requests that use body authorization exceed that limit, incoming requests that use the body will be rejected with an internal server error. The number of concurrent requests is 
+
+$$ n_{max-memory-body-parsing} \over min(avg(n_{request-content-length}), n_{max-request-body-size}) $$
+
+so if requests on average have 100KB and the maximum memory is set to 100MB, on average 1024 authorized requests can be processed concurrently. 
+
+The filter also honors the `skip-request-body-parse` of the corresponding [configuration](https://www.openpolicyagent.org/docs/latest/envoy-introduction/#configuration) that the OPA plugin uses. 
+
 #### opaServeResponse
 
 Always serves the response even if the policy allows the request and can customize the response completely. Can be used to re-implement legacy authorization services by already using data in Open Policy Agent but implementing an old REST API. This can also be useful to support Single Page Applications to return the calling users' permissions.
@@ -1921,6 +1935,20 @@ For this filter, the data flow looks like this independent of an allow/deny deci
              └──────────────────┘
 
 ```
+
+#### opaServeResponseWithReqBody
+
+If you want to serve requests directly from an Open Policy Agent policy that uses the request body, this can be done by using the `input.parsed_body` attribute the same way that is supported with the [Open Policy Agent Envoy plugin](https://www.openpolicyagent.org/docs/latest/envoy-primer/#example-input).
+
+This filter has the same parameters that the `opaServeResponse` filter has.
+
+A request's body is parsed up to a maximum size with a default of 1MB that can be configured via the `-open-policy-agent-max-request-body-size` command line argument. To avoid OOM errors due to too many concurrent authorized body requests, another flag `-open-policy-agent-max-memory-body-parsing` controls how much memory can be used across all requests with a default of 100MB. If  in-flight requests that use body authorization exceed that limit, incoming requests that use the body will be rejected with an internal server error. The number of concurrent requests is 
+
+$$ n_{max-memory-body-parsing} \over min(avg(n_{request-content-length}), n_{max-request-body-size}) $$
+
+so if requests on average have 100KB and the maximum memory is set to 100MB, on average 1024 authorized requests can be processed concurrently.
+
+The filter also honors the `skip-request-body-parse` of the corresponding [configuration](https://www.openpolicyagent.org/docs/latest/envoy-introduction/#configuration) that the OPA plugin uses. 
 
 ## Cookie Handling
 ### dropRequestCookie

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -348,7 +348,9 @@ const (
 	ConsistentHashKeyName                      = "consistentHashKey"
 	ConsistentHashBalanceFactorName            = "consistentHashBalanceFactor"
 	OpaAuthorizeRequestName                    = "opaAuthorizeRequest"
+	OpaAuthorizeRequestWithBodyName            = "opaAuthorizeRequestWithBody"
 	OpaServeResponseName                       = "opaServeResponse"
+	OpaServeResponseWithReqBodyName            = "opaServeResponseWithReqBody"
 	TLSName                                    = "tlsPassClientCertificates"
 
 	// Undocumented filters

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -41,7 +41,7 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 	}
 
 	logger := opa.manager.Logger().WithFields(map[string]interface{}{"decision-id": result.DecisionID})
-	input, err = envoyauth.RequestToInput(req, logger, nil, true)
+	input, err = envoyauth.RequestToInput(req, logger, nil, opa.EnvoyPluginConfig().SkipRequestBodyParse)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert request to input: %w", err)
 	}

--- a/filters/openpolicyagent/internal/envoy/envoyplugin.go
+++ b/filters/openpolicyagent/internal/envoy/envoyplugin.go
@@ -48,8 +48,10 @@ func (p *Plugin) Reconfigure(ctx context.Context, config interface{}) {
 
 // PluginConfig represents the plugin configuration.
 type PluginConfig struct {
-	Path        string `json:"path"`
-	DryRun      bool   `json:"dry-run"`
+	Path                 string `json:"path"`
+	DryRun               bool   `json:"dry-run"`
+	SkipRequestBodyParse bool   `json:"skip-request-body-parse"`
+
 	ParsedQuery ast.Body
 }
 

--- a/filters/openpolicyagent/internal/envoy/skipperadapter.go
+++ b/filters/openpolicyagent/internal/envoy/skipperadapter.go
@@ -8,7 +8,7 @@ import (
 	ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 )
 
-func AdaptToExtAuthRequest(req *http.Request, metadata *ext_authz_v3_core.Metadata, contextExtensions map[string]string) *ext_authz_v3.CheckRequest {
+func AdaptToExtAuthRequest(req *http.Request, metadata *ext_authz_v3_core.Metadata, contextExtensions map[string]string, rawBody []byte) *ext_authz_v3.CheckRequest {
 
 	headers := make(map[string]string, len(req.Header))
 	for h, vv := range req.Header {
@@ -25,6 +25,7 @@ func AdaptToExtAuthRequest(req *http.Request, metadata *ext_authz_v3_core.Metada
 					Method:  req.Method,
 					Path:    req.URL.Path,
 					Headers: headers,
+					RawBody: rawBody,
 				},
 			},
 			ContextExtensions: contextExtensions,

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -65,6 +65,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:             "Allow Matching Environment",
+			filterName:      "opaAuthorizeRequest",
 			bundleName:      "somebundle.tar.gz",
 			regoQuery:       "envoy/authz/allow_runtime_environment",
 			requestPath:     "/allow",

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	opasdktest "github.com/open-policy-agent/opa/sdk/test"
@@ -19,9 +20,14 @@ import (
 func TestAuthorizeRequestFilter(t *testing.T) {
 	for _, ti := range []struct {
 		msg               string
+		filterName        string
+		extraeskip        string
 		bundleName        string
 		regoQuery         string
 		requestPath       string
+		requestMethod     string
+		requestHeaders    http.Header
+		body              string
 		contextExtensions string
 		expectedBody      string
 		expectedHeaders   http.Header
@@ -31,9 +37,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 	}{
 		{
 			msg:               "Allow Requests",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow",
 			requestPath:       "/allow",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusOK,
 			expectedBody:      "Welcome!",
@@ -43,9 +51,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Allow Matching Context Extension",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow_context_extensions",
 			requestPath:       "/allow",
+			requestMethod:     "GET",
 			contextExtensions: "com.mycompany.myprop: myvalue",
 			expectedStatus:    http.StatusOK,
 			expectedBody:      "Welcome!",
@@ -66,9 +76,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Simple Forbidden",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow",
 			requestPath:       "/forbidden",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusForbidden,
 			expectedHeaders:   make(http.Header),
@@ -77,9 +89,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Allow With Structured Rules",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow_object",
 			requestPath:       "/allow/structured",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusOK,
 			expectedBody:      "Welcome!",
@@ -89,9 +103,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Forbidden With Body",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow_object",
 			requestPath:       "/forbidden",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusUnauthorized,
 			expectedHeaders:   map[string][]string{"X-Ext-Auth-Allow": {"no"}},
@@ -101,9 +117,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Misconfigured Rego Query",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/invalid_path",
 			requestPath:       "/allow",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusInternalServerError,
 			expectedBody:      "",
@@ -113,9 +131,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Wrong Query Data Type",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow_wrong_type",
 			requestPath:       "/allow",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusInternalServerError,
 			expectedBody:      "",
@@ -125,9 +145,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Wrong Query Data Type",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow_object_invalid_headers_to_remove",
 			requestPath:       "/allow",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusInternalServerError,
 			expectedBody:      "",
@@ -137,15 +159,92 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:               "Wrong Query Data Type",
+			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow_object_invalid_headers",
 			requestPath:       "/allow",
+			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusInternalServerError,
 			expectedBody:      "",
 			expectedHeaders:   make(http.Header),
 			backendHeaders:    make(http.Header),
 			removeHeaders:     make(http.Header),
+		},
+		{
+			msg:             "Allow With Body",
+			filterName:      "opaAuthorizeRequestWithBody",
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_body",
+			requestMethod:   "POST",
+			body:            `{ "target_id" : "123456" }`,
+			requestHeaders:  map[string][]string{"content-type": {"application/json"}},
+			requestPath:     "/allow_body",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "Welcome!",
+			expectedHeaders: make(http.Header),
+			backendHeaders:  make(http.Header),
+			removeHeaders:   make(http.Header),
+		},
+		{
+			msg:             "Forbidden With Body",
+			filterName:      "opaAuthorizeRequestWithBody",
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_body",
+			requestMethod:   "POST",
+			body:            `{ "target_id" : "wrong id" }`,
+			requestHeaders:  map[string][]string{"content-type": {"application/json"}},
+			requestPath:     "/allow_body",
+			expectedStatus:  http.StatusForbidden,
+			expectedBody:    "",
+			expectedHeaders: make(http.Header),
+			backendHeaders:  make(http.Header),
+			removeHeaders:   make(http.Header),
+		},
+		{
+			msg:             "GET against body protected endpoint",
+			filterName:      "opaAuthorizeRequestWithBody",
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_body",
+			requestMethod:   "GET",
+			requestHeaders:  map[string][]string{"content-type": {"application/json"}},
+			requestPath:     "/allow_body",
+			expectedStatus:  http.StatusForbidden,
+			expectedBody:    "",
+			expectedHeaders: make(http.Header),
+			backendHeaders:  make(http.Header),
+			removeHeaders:   make(http.Header),
+		},
+		{
+			msg:             "Broken Body",
+			filterName:      "opaAuthorizeRequestWithBody",
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_body",
+			requestMethod:   "POST",
+			body:            `{ "target_id" / "wrong id" }`,
+			requestHeaders:  map[string][]string{"content-type": {"application/json"}},
+			requestPath:     "/allow_body",
+			expectedStatus:  http.StatusBadRequest,
+			expectedBody:    "",
+			expectedHeaders: make(http.Header),
+			backendHeaders:  make(http.Header),
+			removeHeaders:   make(http.Header),
+		},
+		{
+			msg:             "Chained OPA filter with body",
+			filterName:      "opaAuthorizeRequestWithBody",
+			extraeskip:      `-> opaAuthorizeRequestWithBody("somebundle.tar.gz")`,
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_body",
+			requestMethod:   "POST",
+			body:            `{ "target_id" : "123456" }`,
+			requestHeaders:  map[string][]string{"content-type": {"application/json"}},
+			requestPath:     "/allow_body",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "Welcome!",
+			expectedHeaders: make(http.Header),
+			backendHeaders:  make(http.Header),
+			removeHeaders:   make(http.Header),
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
@@ -154,6 +253,12 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 				w.Write([]byte("Welcome!"))
 				assert.True(t, isHeadersPresent(t, ti.backendHeaders, r.Header), "Enriched request header is absent.")
 				assert.True(t, isHeadersAbsent(t, ti.removeHeaders, r.Header), "Unwanted HTTP Headers present.")
+
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assert.Equal(t, ti.body, string(body))
 			}))
 
 			opaControlPlane := opasdktest.MustNewServer(
@@ -211,6 +316,12 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 							"allowed": true,
 							"headers": "bogus string instead of object"
 						}
+
+						default allow_body = false
+
+						allow_body {
+							input.parsed_body.target_id == "123456"
+						}						
 					`,
 				}),
 			)
@@ -242,15 +353,27 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry()
 			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
 			fr.Register(ftSpec)
+			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+			fr.Register(ftSpec)
 
-			r := eskip.MustParse(fmt.Sprintf(`* -> opaAuthorizeRequest("%s", "%s") -> "%s"`, ti.bundleName, ti.contextExtensions, clientServer.URL))
+			r := eskip.MustParse(fmt.Sprintf(`* -> %s("%s", "%s") %s -> "%s"`, ti.filterName, ti.bundleName, ti.contextExtensions, ti.extraeskip, clientServer.URL))
 
 			proxy := proxytest.New(fr, r...)
 
-			req, err := http.NewRequest("GET", proxy.URL+ti.requestPath, nil)
+			var bodyReader io.Reader
+			if ti.body != "" {
+				bodyReader = strings.NewReader(ti.body)
+			}
+
+			req, err := http.NewRequest(ti.requestMethod, proxy.URL+ti.requestPath, bodyReader)
 			for name, values := range ti.removeHeaders {
 				for _, value := range values {
 					req.Header.Add(name, value) //adding the headers to validate removal.
+				}
+			}
+			for name, values := range ti.requestHeaders {
+				for _, value := range values {
+					req.Header.Add(name, value)
 				}
 			}
 

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -74,6 +74,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:             "Allow With opa.runtime execution",
+			filterName:      "opaServeResponse",
 			bundleName:      "somebundle.tar.gz",
 			regoQuery:       "envoy/authz/allow_object",
 			requestPath:     "allow/production",
@@ -83,6 +84,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		},
 		{
 			msg:             "Deny With opa.runtime execution",
+			filterName:      "opaServeResponse",
 			bundleName:      "somebundle.tar.gz",
 			regoQuery:       "envoy/authz/allow_object",
 			requestPath:     "allow/test",

--- a/filters/openpolicyagent/response.go
+++ b/filters/openpolicyagent/response.go
@@ -16,6 +16,10 @@ func (opa *OpenPolicyAgentInstance) ServeInvalidDecisionError(fc filters.FilterC
 }
 
 func (opa *OpenPolicyAgentInstance) HandleInvalidDecisionError(fc filters.FilterContext, span opentracing.Span, result *envoyauth.EvalResult, err error, serve bool) {
+	opa.HandleEvaluationError(fc, span, result, err, serve, http.StatusInternalServerError)
+}
+
+func (opa *OpenPolicyAgentInstance) HandleEvaluationError(fc filters.FilterContext, span opentracing.Span, result *envoyauth.EvalResult, err error, serve bool, status int) {
 	fc.Metrics().IncCounter(opa.MetricsKey("decision.err"))
 	span.SetTag("error", true)
 
@@ -39,12 +43,12 @@ func (opa *OpenPolicyAgentInstance) HandleInvalidDecisionError(fc filters.Filter
 
 		opa.Logger().WithFields(map[string]interface{}{
 			"err": err,
-		}).Info("Rejecting request because of an invalid decision")
+		}).Info("Rejecting request because of an error")
 	}
 
 	if serve {
 		resp := http.Response{}
-		resp.StatusCode = http.StatusInternalServerError
+		resp.StatusCode = status
 
 		fc.Serve(&resp)
 	}


### PR DESCRIPTION
This PR adds the ability to use the request's body in authorisation decisions with Open Policy Agent. 

It supports the OPA Envoy plugin behaviour and only parses the body up to a configurable maximum size and otherwise tees the request body. This is to avoid parsing large bodies and create memory and performance issues inside Skipper. 

Disabling body parsing can be configured via the Open Policy Agent configuration file. It supports the same content types that the upstream OPA plugin supports: `application/json` and `multipart/form-data`. 

To make negative impact on latency or memory consumption measurable, two new filter names are introduced that capture the intent to use the body. The implementation is also smart in the sense that it will check if the policy actually uses the body on from the input object before inspecting the body stream. 