### PR TITLE
cmd/webhook: refactor error handling

### DIFF
--- a/cmd/webhook/admission/definitions.go
+++ b/cmd/webhook/admission/definitions.go
@@ -43,6 +43,7 @@ type admissionRequest struct {
 	Name        string               `json:"name,omitempty"`
 	Namespace   string               `json:"namespace,omitempty"`
 	Operation   string               `json:"operation"`
+	UserInfo    userInfo             `json:"userInfo"`
 	Object      json.RawMessage      `json:"object,omitempty"`
 }
 
@@ -54,4 +55,8 @@ type admissionResponse struct {
 
 type status struct {
 	Message string `json:"message,omitempty"`
+}
+
+type userInfo struct {
+	Username string `json:"username,omitempty"`
 }

--- a/cmd/webhook/admission/ingress.go
+++ b/cmd/webhook/admission/ingress.go
@@ -15,16 +15,17 @@ func (iga *IngressAdmitter) name() string {
 }
 
 func (iga *IngressAdmitter) admit(req *admissionRequest) (*admissionResponse, error) {
-
-	ingressItem := definitions.IngressV1Item{}
-	err := json.Unmarshal(req.Object, &ingressItem)
-	if err != nil {
+	var ingressItem definitions.IngressV1Item
+	if err := json.Unmarshal(req.Object, &ingressItem); err != nil {
 		return nil, err
 	}
 
-	err = iga.IngressValidator.Validate(&ingressItem)
-	if err != nil {
-		return nil, err
+	if err := iga.IngressValidator.Validate(&ingressItem); err != nil {
+		return &admissionResponse{
+			UID:     req.UID,
+			Allowed: false,
+			Result:  &status{Message: err.Error()},
+		}, nil
 	}
 
 	return &admissionResponse{

--- a/cmd/webhook/admission/routegroup.go
+++ b/cmd/webhook/admission/routegroup.go
@@ -15,16 +15,17 @@ func (rga *RouteGroupAdmitter) name() string {
 }
 
 func (rga *RouteGroupAdmitter) admit(req *admissionRequest) (*admissionResponse, error) {
-
-	rgItem := definitions.RouteGroupItem{}
-	err := json.Unmarshal(req.Object, &rgItem)
-	if err != nil {
+	var rgItem definitions.RouteGroupItem
+	if err := json.Unmarshal(req.Object, &rgItem); err != nil {
 		return nil, err
 	}
 
-	err = rga.RouteGroupValidator.Validate(&rgItem)
-	if err != nil {
-		return nil, err
+	if err := rga.RouteGroupValidator.Validate(&rgItem); err != nil {
+		return &admissionResponse{
+			UID:     req.UID,
+			Allowed: false,
+			Result:  &status{Message: err.Error()},
+		}, nil
 	}
 
 	return &admissionResponse{


### PR DESCRIPTION
* return admission response with Allowed=false in case of validation errors
* fix approved and rejected request metrics
* add tests for malformed requests
- [x] requires https://github.com/zalando/skipper/pull/2522