### PR TITLE
gosec: fix G601 rule

### DIFF
--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -34,7 +34,8 @@ var invalidRouteExpression = errors.New("one or more invalid route expressions")
 // parse errors if any.
 func mapRouteInfo(allInfo []*eskip.RouteInfo) loadResult {
 	lr := loadResult{make([]*eskip.Route, len(allInfo)), make(map[string]error)}
-	for i, info := range allInfo {
+	for i := range allInfo {
+		info := allInfo[i]
 		lr.routes[i] = &info.Route
 		if info.ParseError != nil {
 			lr.parseErrors[info.Id] = info.ParseError

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -371,7 +371,8 @@ func parseRoutes(data map[string]string) []*eskip.RouteInfo {
 // parsing failed.
 func infoToRoutesLogged(info []*eskip.RouteInfo) []*eskip.Route {
 	var routes []*eskip.Route
-	for _, ri := range info {
+	for i := range info {
+		ri := info[i]
 		if ri.ParseError == nil {
 			routes = append(routes, &ri.Route)
 		} else {

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -197,7 +197,8 @@ func (s *apiUsageMonitoringSpec) parseJsonConfiguration(args []interface{}) []*a
 
 func (s *apiUsageMonitoringSpec) buildUnknownPathInfo(paths []*pathInfo) *pathInfo {
 	var applicationId *string
-	for _, path := range paths {
+	for i := range paths {
+		path := paths[i]
 		if applicationId != nil && *applicationId != path.ApplicationId {
 			return s.unknownPath
 		}

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -577,7 +577,8 @@ func receiveRouteMatcher(o Options, out chan<- *routeTable, quit <-chan struct{}
 				invalidRouteIds[err.ID] = struct{}{}
 			}
 
-			for _, r := range routes {
+			for i := range routes {
+				r := routes[i]
 				if _, found := invalidRouteIds[r.Id]; found {
 					invalidRoutes = append(invalidRoutes, &r.Route)
 				} else {


### PR DESCRIPTION
gosec started to produce false positives
"G601 (CWE-118): Implicit memory aliasing in for loop." for slices of struct pointers, see https://github.com/securego/gosec/issues/966

This changes fixes G601 rule wwarnings instead of muting it.