### PR TITLE
Eskip check fails on empty URL on network backend.

### DIFF
--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -103,7 +103,24 @@ func checkCmd(a cmdArgs) error {
 		return err
 	}
 
+	err = checkEmptyBackends(routes)
+
+	if err != nil {
+		return err
+	}
+
 	return checkRepeatedRouteIds(routes)
+}
+
+func checkEmptyBackends(routes []*eskip.Route) error {
+
+	for _, route := range routes {
+		if route.BackendType == eskip.NetworkBackend && route.Backend == "" {
+			return errors.New("Route has empty backend: " + route.Id)
+		}
+	}
+
+	return nil
 }
 
 // command executed for print.

--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -93,7 +93,7 @@ func checkRepeatedRouteIds(routes []*eskip.Route) error {
 func checkEmptyBackends(routes []*eskip.Route) error {
 	for _, route := range routes {
 		if route.BackendType == eskip.NetworkBackend && route.Backend == "" {
-			return fmt.Errorf("route %s has empty backend", route.Id)
+			return fmt.Errorf("route has empty backend: %s", route.Id)
 		}
 	}
 

--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -83,7 +83,7 @@ func checkRepeatedRouteIds(routes []*eskip.Route) error {
 	ids := map[string]bool{}
 	for _, route := range routes {
 		if ids[route.Id] {
-			return errors.New("Repeating route with id " + route.Id)
+			return fmt.Errorf("repeating route with id %s", route.Id)
 		}
 		ids[route.Id] = true
 	}

--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -90,6 +90,16 @@ func checkRepeatedRouteIds(routes []*eskip.Route) error {
 	return nil
 }
 
+func checkEmptyBackends(routes []*eskip.Route) error {
+	for _, route := range routes {
+		if route.BackendType == eskip.NetworkBackend && route.Backend == "" {
+			return fmt.Errorf("route %s has empty backend", route.Id)
+		}
+	}
+
+	return nil
+}
+
 // load and parse routes, ignore parse errors.
 func loadRoutesUnchecked(in *medium) []*eskip.Route {
 	lr, _ := loadRoutes(in)
@@ -104,23 +114,11 @@ func checkCmd(a cmdArgs) error {
 	}
 
 	err = checkEmptyBackends(routes)
-
 	if err != nil {
 		return err
 	}
 
 	return checkRepeatedRouteIds(routes)
-}
-
-func checkEmptyBackends(routes []*eskip.Route) error {
-
-	for _, route := range routes {
-		if route.BackendType == eskip.NetworkBackend && route.Backend == "" {
-			return errors.New("Route has empty backend: " + route.Id)
-		}
-	}
-
-	return nil
 }
 
 // command executed for print.

--- a/cmd/eskip/load_test.go
+++ b/cmd/eskip/load_test.go
@@ -144,11 +144,10 @@ func TestCheckRepeatingRouteIds(t *testing.T) {
 
 func TestCheckEmptyBackend(t *testing.T) {
 	const name = "testFile"
-	expectedError := errors.New("route empty has empty backend")
 
 	err := withFile(name, `foo: Method("POST") -> "https://www.example1.org";empty: Method("POST") -> "";`, func(_ *os.File) {
 		err := checkCmd(cmdArgs{in: &medium{typ: file, path: name}})
-		if err == nil || !errors.Is(err, expectedError) {
+		if err == nil || err.Error() != "route has empty backend: empty" {
 			t.Error("Expected an error for empty backend")
 		}
 	})

--- a/cmd/eskip/load_test.go
+++ b/cmd/eskip/load_test.go
@@ -144,9 +144,11 @@ func TestCheckRepeatingRouteIds(t *testing.T) {
 
 func TestCheckEmptyBackend(t *testing.T) {
 	const name = "testFile"
+	expectedError := errors.New("route empty has empty backend")
+
 	err := withFile(name, `foo: Method("POST") -> "https://www.example1.org";empty: Method("POST") -> "";`, func(_ *os.File) {
 		err := checkCmd(cmdArgs{in: &medium{typ: file, path: name}})
-		if err == nil {
+		if err == nil || !errors.Is(err, expectedError) {
 			t.Error("Expected an error for empty backend")
 		}
 	})

--- a/cmd/eskip/load_test.go
+++ b/cmd/eskip/load_test.go
@@ -142,6 +142,20 @@ func TestCheckRepeatingRouteIds(t *testing.T) {
 	}
 }
 
+func TestCheckEmptyBackend(t *testing.T) {
+	const name = "testFile"
+	err := withFile(name, `foo: Method("POST") -> "https://www.example1.org";empty: Method("POST") -> "";`, func(_ *os.File) {
+		err := checkCmd(cmdArgs{in: &medium{typ: file, path: name}})
+		if err == nil {
+			t.Error("Expected an error for empty backend")
+		}
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestCheckEtcdInvalid(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
This change to `eskip check` validates no routes have empty backend. 

"empty url" error falls between the "_pure syntactical_" checks that `eskip check` runs at validation time and the "_route-specific setup-dependant_" checks that skipper does at runtime (making sure, for example, that all predicates / filters exist, etc).

While this is not a fatal error, and loading the skip files in skipper works (only the specific route gets discarded), we think having this validation in `eskip check` is a better approach, because this is an error that is known in advance (no URL can be empty) and we could not find a reason we'd ever want to, on purpose, push a non-working route to production.


 Fixes #2523