### PR TITLE
add Tracer to skipper options (overrides OpenTracing)

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -667,9 +667,9 @@ type Options struct {
 	// for a route when it's available (e.g. for RouteGroups)
 	OpenTracingBackendNameTag bool
 
-	// Tracer allows pre-created tracer to be passed on to skipper. Providing the tracer
-	// overrides options provided under OpenTracing property.
-	Tracer ot.Tracer
+	// OpenTracingTracer allows pre-created tracer to be passed on to skipper. Providing the
+	// tracer instance overrides options provided under OpenTracing property.
+	OpenTracingTracer ot.Tracer
 
 	// PluginDir defines the directory to load plugins from, DEPRECATED, use PluginDirs
 	PluginDir string
@@ -1149,9 +1149,9 @@ func (o *Options) tlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 	return config, nil
 }
 
-func (o *Options) tracerInstance() (ot.Tracer, error) {
-	if o.Tracer != nil {
-		return o.Tracer, nil
+func (o *Options) openTracingTracerInstance() (ot.Tracer, error) {
+	if o.OpenTracingTracer != nil {
+		return o.OpenTracingTracer, nil
 	}
 
 	if len(o.OpenTracing) > 0 {
@@ -1493,7 +1493,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	o.PluginDirs = append(o.PluginDirs, o.PluginDir)
 
-	tracer, err := o.tracerInstance()
+	tracer, err := o.openTracingTracerInstance()
 	if err != nil {
 		return err
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -1159,9 +1159,12 @@ func (o *Options) tracerInstance() (ot.Tracer, error) {
 	} else {
 		// always have a tracer available, so filter authors can rely on the
 		// existence of a tracer
-		tracer, _ := tracing.LoadTracingPlugin(o.PluginDirs, []string{"noop"})
-		if tracer == nil {
-			return ot.NoopTracer{}, nil
+		tracer, err := tracing.LoadTracingPlugin(o.PluginDirs, []string{"noop"})
+		if err != nil {
+			return nil, err
+		} else if tracer == nil {
+			// LoadTracingPlugin unfortunately may return nil tracer
+			return nil, fmt.Errorf("failed to load tracing plugin from %v", o.PluginDirs)
 		}
 		return tracer, nil
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -1159,7 +1159,11 @@ func (o *Options) tracerInstance() (ot.Tracer, error) {
 	} else {
 		// always have a tracer available, so filter authors can rely on the
 		// existence of a tracer
-		return tracing.LoadTracingPlugin(o.PluginDirs, []string{"noop"})
+		tracer, _ := tracing.LoadTracingPlugin(o.PluginDirs, []string{"noop"})
+		if tracer == nil {
+			return ot.NoopTracer{}, nil
+		}
+		return tracer, nil
 	}
 }
 

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -111,7 +111,6 @@ func TestOptionsFilterRegistry(t *testing.T) {
 
 func TestOptionsTracerInstanceOverridesOpenTracing(t *testing.T) {
 	tracer := &tracingtest.Tracer{}
-	// run skipper proxy that we want to test
 	o := Options{
 		Tracer:      tracer,
 		OpenTracing: []string{"noop"},
@@ -119,11 +118,10 @@ func TestOptionsTracerInstanceOverridesOpenTracing(t *testing.T) {
 
 	tr, err := o.tracerInstance()
 	assert.Nil(t, err)
-	assert.NotNil(t, tr)
+	assert.Same(t, tr, tracer)
 }
 
 func TestOptionsTracerInstanceFallbacksToOpenTracingWhenTracerIsNil(t *testing.T) {
-	// run skipper proxy that we want to test
 	o := Options{
 		OpenTracing: []string{"noop"},
 	}

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -117,7 +117,7 @@ func TestOptionsTracerInstanceOverridesOpenTracing(t *testing.T) {
 	}
 
 	tr, err := o.tracerInstance()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Same(t, tr, tracer)
 }
 
@@ -127,7 +127,7 @@ func TestOptionsTracerInstanceFallbacksToOpenTracingWhenTracerIsNil(t *testing.T
 	}
 
 	tr, err := o.tracerInstance()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, tr)
 }
 

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -131,12 +131,12 @@ func TestOptionsTracerInstanceFallbacksToOpenTracingWhenTracerIsNil(t *testing.T
 	assert.NotNil(t, tr)
 }
 
-func TestOptionsDefaultTracer(t *testing.T) {
+func TestOptionsTracerInstanceReturnsErrorWhenNoTracerConfigIsSpecified(t *testing.T) {
 	o := Options{}
 
 	tr, err := o.tracerInstance()
-	assert.NoError(t, err)
-	assert.NotNil(t, tr)
+	assert.Error(t, err)
+	assert.Nil(t, tr)
 }
 
 func TestOptionsTLSConfig(t *testing.T) {

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -118,13 +118,21 @@ func TestOptionsTracerInstanceOverridesOpenTracing(t *testing.T) {
 
 	tr, err := o.tracerInstance()
 	assert.NoError(t, err)
-	assert.Same(t, tr, tracer)
+	assert.Same(t, tracer, tr)
 }
 
 func TestOptionsTracerInstanceFallbacksToOpenTracingWhenTracerIsNil(t *testing.T) {
 	o := Options{
 		OpenTracing: []string{"noop"},
 	}
+
+	tr, err := o.tracerInstance()
+	assert.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestOptionsDefaultTracer(t *testing.T) {
+	o := Options{}
 
 	tr, err := o.tracerInstance()
 	assert.NoError(t, err)

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -109,32 +109,32 @@ func TestOptionsFilterRegistry(t *testing.T) {
 	assert.NotContains(t, fr, filters.BearerInjectorName)
 }
 
-func TestOptionsTracerInstanceOverridesOpenTracing(t *testing.T) {
+func TestOptionsOpenTracingTracerInstanceOverridesOpenTracing(t *testing.T) {
 	tracer := &tracingtest.Tracer{}
 	o := Options{
-		Tracer:      tracer,
-		OpenTracing: []string{"noop"},
+		OpenTracingTracer: tracer,
+		OpenTracing:       []string{"noop"},
 	}
 
-	tr, err := o.tracerInstance()
+	tr, err := o.openTracingTracerInstance()
 	assert.NoError(t, err)
 	assert.Same(t, tracer, tr)
 }
 
-func TestOptionsTracerInstanceFallbacksToOpenTracingWhenTracerIsNil(t *testing.T) {
+func TestOptionsOpenTracingTracerInstanceFallbacksToOpenTracingWhenTracerIsNil(t *testing.T) {
 	o := Options{
 		OpenTracing: []string{"noop"},
 	}
 
-	tr, err := o.tracerInstance()
+	tr, err := o.openTracingTracerInstance()
 	assert.NoError(t, err)
 	assert.NotNil(t, tr)
 }
 
-func TestOptionsTracerInstanceReturnsErrorWhenNoTracerConfigIsSpecified(t *testing.T) {
+func TestOptionsOpenTracingTracerInstanceReturnsErrorWhenNoTracerConfigIsSpecified(t *testing.T) {
 	o := Options{}
 
-	tr, err := o.tracerInstance()
+	tr, err := o.openTracingTracerInstance()
 	assert.Error(t, err)
 	assert.Nil(t, tr)
 }

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -568,8 +568,7 @@ func TestTracerInstanceTakesPrecedenceOverTracingOptions(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	span, _ := tracer.FindSpan("ingress")
-	assert.NotNil(t, span)
+	assert.NotNil(t, tracer.RecordedSpans)
 
 	sigs <- syscall.SIGTERM
 }


### PR DESCRIPTION
This PR enables applications that extends skipper to pre-initialize `Tracer` instance and feed it directly to Skipper overriding `OpenTracing`. The need for this arises due to the inherent behaviour of skipper making the `Tracer` available only via request context. Thus preventing the extending application to reuse the tracer instance.