### PR TITLE
proxy/bakendtest: fix panic in test

### DIFF
--- a/proxy/backendtest/backendrecorder_test.go
+++ b/proxy/backendtest/backendrecorder_test.go
@@ -16,8 +16,10 @@ func TestServerShouldCloseWhenAllRequestsAreFulfilled(t *testing.T) {
 			resp, err := http.Get(recorder.GetURL() + "/" + strconv.Itoa(counter))
 			if err != nil {
 				t.Error(err)
+				return
 			}
-			_, _ = io.ReadAll(resp.Body)
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
 		}(i)
 	}
 	recorder.Done()


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x6a07a3]

goroutine 10 [running]:
github.com/zalando/skipper/proxy/backendtest.TestServerShouldCloseWhenAllRequestsAreFulfilled.func1(0x0?)
	/workspace/proxy/backendtest/backendrecorder_test.go:20 +0xc3
created by github.com/zalando/skipper/proxy/backendtest.TestServerShouldCloseWhenAllRequestsAreFulfilled in goroutine 6
	/workspace/proxy/backendtest/backendrecorder_test.go:15 +0x45
```