### PR TITLE
proxy: fix flaky TestSlowService

### DIFF
--- a/proxy/backendtimeout_test.go
+++ b/proxy/backendtimeout_test.go
@@ -20,7 +20,7 @@ func TestSlowService(t *testing.T) {
 		service.Close()
 	}()
 
-	doc := fmt.Sprintf(`* -> backendTimeout("1ms") -> "%s"`, service.URL)
+	doc := fmt.Sprintf(`* -> backendTimeout("10ms") -> "%s"`, service.URL)
 	tp, err := newTestProxy(doc, FlagsNone)
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +30,7 @@ func TestSlowService(t *testing.T) {
 	ps := httptest.NewServer(tp.proxy)
 	defer ps.Close()
 
-	rsp, err := http.Get(ps.URL)
+	rsp, err := ps.Client().Get(ps.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestFastService(t *testing.T) {
 	ps := httptest.NewServer(tp.proxy)
 	defer ps.Close()
 
-	rsp, err := http.Get(ps.URL)
+	rsp, err := ps.Client().Get(ps.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestBackendTimeoutInTheMiddleOfServiceResponse(t *testing.T) {
 	ps := httptest.NewServer(tp.proxy)
 	defer ps.Close()
 
-	rsp, err := http.Get(ps.URL)
+	rsp, err := ps.Client().Get(ps.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestRetryAndSlowService(t *testing.T) {
 	ps := httptest.NewServer(tp.proxy)
 	defer ps.Close()
 
-	rsp, err := http.Get(ps.URL)
+	rsp, err := ps.Client().Get(ps.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestRetryAndFastService(t *testing.T) {
 	ps := httptest.NewServer(tp.proxy)
 	defer ps.Close()
 
-	rsp, err := http.Get(ps.URL)
+	rsp, err := ps.Client().Get(ps.URL)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
backendTimeout("1ms") in TestSlowService may cancel context during
dialing which results in `i/o timeout` error and 502 response status
```
$ go test ./proxy -run=TestSlowService -count=10000 | grep -F 'FAIL:' -C1
...
time="2023-08-18T20:50:57+02:00" level=error msg="error while proxying after 1.295026ms, route  with backend network http://127.0.0.1:38613/, status code 502: dialing failed true: failed to do backend roundtrip to 127.0.0.1:38613: dial tcp 127.0.0.1:38613: i/o timeout, remote host: 127.0.0.1, request: \"GET / HTTP/1.1\", host: 127.0.0.1:36801, user agent: \"Go-http-client/1.1\""
--- FAIL: TestSlowService (0.00s)
    backendtimeout_test.go:40: expected 504, got: &{502 Bad Gateway 502 HTTP/1.1 1 1 map[Content-Length:[12] Content-Type:[text/plain; charset=utf-8] Date:[Fri, 18 Aug 2023 18:50:57 GMT] Server:[Skipper] X-Content-Type-Options:[nosniff]] 0xc00068e100 12 [] false false map[] 0xc000255600 <nil>}
```

Increase TestSlowService filter parameter to 10ms.
Also make requests using test proxy client.