### PR TITLE
routesrv: fix flaky TestESkipBytesHandlerWithOldLastModified

### DIFF
--- a/routesrv/eskipbytes.go
+++ b/routesrv/eskipbytes.go
@@ -27,6 +27,7 @@ type eskipBytes struct {
 	mu           sync.RWMutex
 
 	tracer ot.Tracer
+	now    func() time.Time
 }
 
 // formatAndSet takes a slice of routes and stores them eskip-formatted
@@ -42,7 +43,7 @@ func (e *eskipBytes) formatAndSet(routes []*eskip.Route) (_ int, initialized boo
 
 	updated = !bytes.Equal(e.data, data)
 	if updated {
-		e.lastModified = time.Now()
+		e.lastModified = e.now()
 		e.data = data
 		e.etag = fmt.Sprintf(`"%x"`, sha256.Sum256(e.data))
 		e.count = len(routes)

--- a/routesrv/export_test.go
+++ b/routesrv/export_test.go
@@ -1,0 +1,7 @@
+package routesrv
+
+import "time"
+
+func SetNow(rs *RouteServer, now func() time.Time) {
+	rs.poller.b.now = now
+}

--- a/routesrv/polling.go
+++ b/routesrv/polling.go
@@ -104,6 +104,7 @@ func (p *poller) poll(wg *sync.WaitGroup) {
 			}
 			if updated {
 				logger.Info(LogRoutesUpdated)
+				span.SetTag("routes.updated", true)
 				routesUpdated.SetToCurrentTime()
 			}
 			span.SetTag("routes.count", routesCount)

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -42,7 +42,7 @@ func New(opts skipper.Options) (*RouteServer, error) {
 		return nil, err
 	}
 
-	b := &eskipBytes{tracer: tracer}
+	b := &eskipBytes{tracer: tracer, now: time.Now}
 	bs := &eskipBytesStatus{b: b}
 	handler := http.NewServeMux()
 	handler.Handle("/health", bs)


### PR DESCRIPTION
* fix flaky test by mocking clock instead of using sleep.
* add tracing tag on route update

Follows up on #2526