### PR TITLE
Introduce endpointregistry component

### DIFF
--- a/filters/fadein/fadein.go
+++ b/filters/fadein/fadein.go
@@ -201,7 +201,6 @@ func NewPostProcessor() routing.PostProcessor {
 }
 
 func (p *postProcessor) Do(r []*routing.Route) []*routing.Route {
-	const configErrFmt = "Error while processing endpoint fade-in settings: %s, %s, %v."
 	now := time.Now()
 
 	for _, ri := range r {
@@ -229,13 +228,7 @@ func (p *postProcessor) Do(r []*routing.Route) []*routing.Route {
 		for i := range ri.LBEndpoints {
 			ep := &ri.LBEndpoints[i]
 
-			s, h, err := normalizeSchemeHost(ep.Scheme, ep.Host)
-			if err != nil {
-				log.Errorf(configErrFmt, ep.Scheme, ep.Host, err)
-				continue
-			}
-
-			key := endpointKey(s, h)
+			key := endpointKey(ep.Scheme, ep.Host)
 			detected := p.detected[key].when
 			if detected.IsZero() || endpointsCreated[key].After(detected) {
 				detected = now

--- a/filters/fadein/fadein_test.go
+++ b/filters/fadein/fadein_test.go
@@ -265,8 +265,8 @@ func TestPostProcessor(t *testing.T) {
 
 		rt, _ := createRouting(t, routes)
 		r := route(rt, "/")
-		if r == nil || len(r.LBEndpoints) == 0 || !r.LBEndpoints[0].Detected.IsZero() {
-			t.Fatal("failed to ignore invalid LB endpoint")
+		if r != nil {
+			t.Fatal("created invalid LB endpoint")
 		}
 	})
 

--- a/routing/endpointregistry.go
+++ b/routing/endpointregistry.go
@@ -1,0 +1,103 @@
+package routing
+
+import (
+	"sync"
+	"time"
+)
+
+// Metrics describe the data about endpoint that could be
+// used to perform better load balancing, fadeIn, etc.
+type Metrics interface {
+	DetectedTime() time.Time
+	InflightRequests() int64
+}
+
+type entry struct {
+	detected         time.Time
+	inflightRequests int64
+}
+
+var _ Metrics = &entry{}
+
+func (e *entry) DetectedTime() time.Time {
+	return e.detected
+}
+
+func (e *entry) InflightRequests() int64 {
+	return e.inflightRequests
+}
+
+type EndpointRegistry struct {
+	mu sync.Mutex
+
+	data map[string]*entry
+}
+
+var _ PostProcessor = &EndpointRegistry{}
+
+type RegistryOptions struct {
+}
+
+func (r *EndpointRegistry) Do(routes []*Route) []*Route {
+	for _, route := range routes {
+		for _, epi := range route.LBEndpoints {
+			metrics := r.GetMetrics(epi.Host)
+			if metrics.DetectedTime().IsZero() {
+				r.SetDetectedTime(epi.Host, time.Now())
+			}
+		}
+	}
+	return routes
+}
+
+func NewEndpointRegistry(o RegistryOptions) *EndpointRegistry {
+	return &EndpointRegistry{data: map[string]*entry{}}
+}
+
+func (r *EndpointRegistry) GetMetrics(key string) Metrics {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e := r.getOrInitEntryLocked(key)
+	copy := &entry{}
+	*copy = *e
+	return copy
+}
+
+func (r *EndpointRegistry) SetDetectedTime(key string, detected time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e := r.getOrInitEntryLocked(key)
+	e.detected = detected
+}
+
+func (r *EndpointRegistry) IncInflightRequest(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e := r.getOrInitEntryLocked(key)
+	e.inflightRequests++
+}
+
+func (r *EndpointRegistry) DecInflightRequest(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e := r.getOrInitEntryLocked(key)
+	e.inflightRequests--
+}
+
+// getOrInitEntryLocked returns pointer to endpoint registry entry
+// which contains the information about endpoint representing the
+// following key. r.mu must be held while calling this function and
+// using of the entry returned. In general, key represents the "host:port"
+// string
+func (r *EndpointRegistry) getOrInitEntryLocked(key string) *entry {
+	e, ok := r.data[key]
+	if !ok {
+		e = &entry{}
+		r.data[key] = e
+	}
+	return e
+}

--- a/routing/endpointregistry_test.go
+++ b/routing/endpointregistry_test.go
@@ -1,0 +1,149 @@
+package routing
+
+import (
+	"fmt"
+	"runtime/metrics"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyRegistry(t *testing.T) {
+	r := NewEndpointRegistry(RegistryOptions{})
+	m := r.GetMetrics("some key")
+
+	assert.Equal(t, time.Time{}, m.DetectedTime())
+	assert.Equal(t, int64(0), m.InflightRequests())
+}
+
+func TestSetAndGet(t *testing.T) {
+	r := NewEndpointRegistry(RegistryOptions{})
+
+	mBefore := r.GetMetrics("some key")
+	r.IncInflightRequest("some key")
+	mAfter := r.GetMetrics("some key")
+
+	assert.Equal(t, int64(0), mBefore.InflightRequests())
+	assert.Equal(t, int64(1), mAfter.InflightRequests())
+
+	ts, _ := time.Parse(time.DateOnly, "2023-08-29")
+	mBefore = r.GetMetrics("some key")
+	r.SetDetectedTime("some key", ts)
+	mAfter = r.GetMetrics("some key")
+
+	assert.Equal(t, time.Time{}, mBefore.DetectedTime())
+	assert.Equal(t, ts, mAfter.DetectedTime())
+}
+
+func TestSetAndGetAnotherKey(t *testing.T) {
+	r := NewEndpointRegistry(RegistryOptions{})
+
+	r.IncInflightRequest("some key")
+	mToChange := r.GetMetrics("some key")
+	mConst := r.GetMetrics("another key")
+
+	assert.Equal(t, int64(0), mConst.InflightRequests())
+	assert.Equal(t, int64(1), mToChange.InflightRequests())
+}
+
+func printTotalMutexWaitTime(b *testing.B) {
+	// Name of the metric we want to read.
+	const myMetric = "/sync/mutex/wait/total:seconds"
+
+	// Create a sample for the metric.
+	sample := make([]metrics.Sample, 1)
+	sample[0].Name = myMetric
+
+	// Sample the metric.
+	metrics.Read(sample)
+
+	// Check if the metric is actually supported.
+	// If it's not, the resulting value will always have
+	// kind KindBad.
+	if sample[0].Value.Kind() == metrics.KindBad {
+		panic(fmt.Sprintf("metric %q no longer supported", myMetric))
+	}
+
+	// Handle the result.
+	//
+	// It's OK to assume a particular Kind for a metric;
+	// they're guaranteed not to change.
+	mutexWaitTime := sample[0].Value.Float64()
+	b.Logf("total mutex waiting time since the beginning of benchmark: %f\n", mutexWaitTime)
+}
+
+func benchmarkIncInflightRequests(b *testing.B, name string, goroutines int) {
+	const key string = "some key"
+	const mapSize int = 10000
+
+	b.Run(name, func(b *testing.B) {
+		r := NewEndpointRegistry(RegistryOptions{})
+		for i := 1; i < mapSize; i++ {
+			r.IncInflightRequest(fmt.Sprintf("foo-%d", i))
+		}
+		r.IncInflightRequest(key)
+		r.IncInflightRequest(key)
+
+		wg := sync.WaitGroup{}
+		b.ResetTimer()
+		for i := 0; i < goroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for n := 0; n < b.N/goroutines; n++ {
+					r.IncInflightRequest(key)
+				}
+			}()
+		}
+		wg.Wait()
+
+		printTotalMutexWaitTime(b)
+	})
+}
+
+func BenchmarkIncInflightRequests(b *testing.B) {
+	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096}
+	for _, goroutines := range goroutinesNums {
+		benchmarkIncInflightRequests(b, fmt.Sprintf("%d goroutines", goroutines), goroutines)
+	}
+}
+
+func benchmarkGetInflightRequests(b *testing.B, name string, goroutines int) {
+	const key string = "some key"
+	const mapSize int = 10000
+
+	b.Run(name, func(b *testing.B) {
+		r := NewEndpointRegistry(RegistryOptions{})
+		for i := 1; i < mapSize; i++ {
+			r.IncInflightRequest(fmt.Sprintf("foo-%d", i))
+		}
+		r.IncInflightRequest(key)
+		r.IncInflightRequest(key)
+
+		var dummy int64
+		wg := sync.WaitGroup{}
+		b.ResetTimer()
+		for i := 0; i < goroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for n := 0; n < b.N/goroutines; n++ {
+					dummy = r.GetMetrics(key).InflightRequests()
+				}
+			}()
+		}
+		dummy++
+		wg.Wait()
+
+		printTotalMutexWaitTime(b)
+	})
+}
+
+func BenchmarkGetInflightRequests(b *testing.B) {
+	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096}
+	for _, goroutines := range goroutinesNums {
+		benchmarkGetInflightRequests(b, fmt.Sprintf("%d goroutines", goroutines), goroutines)
+	}
+}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -185,9 +185,10 @@ type LBAlgorithm interface {
 // LBContext is used to pass data to the load balancer to decide based
 // on that data which endpoint to call from the backends
 type LBContext struct {
-	Request *http.Request
-	Route   *Route
-	Params  map[string]interface{}
+	Request  *http.Request
+	Route    *Route
+	Params   map[string]interface{}
+	Registry *EndpointRegistry
 }
 
 // NewLBContext is used to create a new LBContext, to pass data to the

--- a/skipper.go
+++ b/skipper.go
@@ -1875,6 +1875,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	defer schedulerRegistry.Close()
 
 	// create a routing engine
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 	ro := routing.Options{
 		FilterRegistry:  o.filterRegistry(),
 		MatchingOptions: mo,
@@ -1885,6 +1886,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		SuppressLogs:    o.SuppressRouteUpdateLogs,
 		PostProcessors: []routing.PostProcessor{
 			loadbalancer.NewAlgorithmProvider(),
+			endpointRegistry,
 			schedulerRegistry,
 			builtin.NewRouteCreationMetrics(mtr),
 			fadein.NewPostProcessor(),
@@ -1939,6 +1941,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	proxyFlags := proxy.Flags(o.ProxyOptions) | o.ProxyFlags
 	proxyParams := proxy.Params{
 		Routing:                    routing,
+		EndpointRegistry:           endpointRegistry,
 		Flags:                      proxyFlags,
 		PriorityRoutes:             o.PriorityRoutes,
 		IdleConnectionsPerHost:     o.IdleConnectionsPerHost,


### PR DESCRIPTION
This component is needed to create an easy way for loadbalancer, fadein, etc. to find out required information about endpoints to increase readability of those parts and enable us to provide new features there, for example, passive health checks for endpoints.