### PR TITLE
packaging: update base image version

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=default
-FROM registry.opensource.zalan.do/library/alpine-3:latest@sha256:ac3a6db04df95d849533ced3ce5cb697dc042e53613866e27066cc471ed63070 AS default
+FROM registry.opensource.zalan.do/library/alpine-3:latest@sha256:2213d4d74c39af5313b631cbde2630b4007755b280f0f6b98867f66103b76113 AS default
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates


### PR DESCRIPTION
```
~$ docker pull registry.opensource.zalan.do/library/alpine-3:latest
latest: Pulling from library/alpine-3
Digest: sha256:2213d4d74c39af5313b631cbde2630b4007755b280f0f6b98867f66103b76113
Status: Image is up to date for registry.opensource.zalan.do/library/alpine-3:latest
registry.opensource.zalan.do/library/alpine-3:latest
```

Related to #2536