### PR TITLE
fix: NewResponseController was added in Go1.20

### DIFF
--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.19'
+          go-version: '^1.20'
 
       - name: Login to Github Container Registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.19'
+          go-version: '^1.20'
       - run: go version
       - run: make deps
       - run: make check-fmt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.19'
+          go-version: '^1.20'
       - run: go version
       - run: make deps
       - run: make check-race
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.19'
+          go-version: '^1.20'
       - run: go version
       - run: make deps
       - run: make check-fmt

--- a/go.mod
+++ b/go.mod
@@ -172,4 +172,4 @@ require (
 	oras.land/oras-go/v2 v2.2.1 // indirect
 )
 
-go 1.19
+go 1.20


### PR DESCRIPTION
fix: https://pkg.go.dev/net/http#NewResponseController was added in Go1.20 so we should also tell dependencies that this is a requirement

Updates https://github.com/zalando/skipper/issues/2433