### PR TITLE
packaging: remove base image tag

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=default
-FROM registry.opensource.zalan.do/library/alpine-3:latest@sha256:2213d4d74c39af5313b631cbde2630b4007755b280f0f6b98867f66103b76113 AS default
+FROM registry.opensource.zalan.do/library/alpine-3@sha256:2213d4d74c39af5313b631cbde2630b4007755b280f0f6b98867f66103b76113 AS default
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates

--- a/packaging/Dockerfile.arm64
+++ b/packaging/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 alpine:3@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a
+FROM --platform=linux/arm64 alpine@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 ADD build/linux/arm64/skipper \

--- a/packaging/Dockerfile.armv7
+++ b/packaging/Dockerfile.armv7
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm/v7 alpine:3@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a
+FROM --platform=linux/arm/v7 alpine@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 ADD build/linux/arm/v7/skipper \


### PR DESCRIPTION
When hash is specified the tag is ignored, see https://github.com/moby/moby/issues/37866

The tag apparently confused dependabot and prevents it from updating the image:
```
updater | 2023/08/29 00:21:53 INFO <job_714994438> Checking if library/alpine-3 latest needs updating
updater | 2023/08/29 00:21:53 INFO <job_714994438> Latest version is latest
  proxy | 2023/08/29 00:21:53 [018] HEAD https://registry.opensource.zalan.do:443/v2/library/alpine-3/manifests/latest
  proxy | 2023/08/29 00:21:53 [018] 200 https://registry.opensource.zalan.do:443/v2/library/alpine-3/manifests/latest
updater | 2023/08/29 00:21:53 INFO <job_714994438> Pull request already exists for library/alpine-3 with latest version latest
```