### PR TITLE
packaging: use latest label

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,16 +1,20 @@
 ARG BASE_IMAGE=default
-FROM registry.opensource.zalan.do/library/alpine-3@sha256:2213d4d74c39af5313b631cbde2630b4007755b280f0f6b98867f66103b76113 AS default
-FROM ${BASE_IMAGE}
-LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
-RUN apk --no-cache add ca-certificates && update-ca-certificates
-RUN mkdir -p /usr/bin
 ARG BUILD_FOLDER=build
 ARG TARGETPLATFORM
-ADD ${BUILD_FOLDER}/${TARGETPLATFORM}/skipper \
+
+FROM registry.opensource.zalan.do/library/alpine-3:latest AS default
+FROM ${BASE_IMAGE}
+LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
+
+RUN cat /etc/alpine-release \
+    && apk --no-cache add ca-certificates \
+    && update-ca-certificates
+
+COPY ${BUILD_FOLDER}/${TARGETPLATFORM}/skipper \
     ${BUILD_FOLDER}/${TARGETPLATFORM}/eskip \
     ${BUILD_FOLDER}/${TARGETPLATFORM}/webhook \
-    ${BUILD_FOLDER}/${TARGETPLATFORM}/routesrv /usr/bin/
-ENV PATH $PATH:/usr/bin
+    ${BUILD_FOLDER}/${TARGETPLATFORM}/routesrv \
+    /usr/bin/
 
 EXPOSE 9090 9911
 


### PR DESCRIPTION
Dependabot fails to update registry.opensource.zalan.do/library/alpine-3 base image hash, see https://github.com/dependabot/dependabot-core/issues/7387

This change
* removes image hash and re-introduces latest label. For multiarch and ghcr.io builds base image is specified via BASE_IMAGE build argument and also uses latest label.
* uses COPY instead of ADD following https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
* prints alpine release version during build
* removes redundant commands
* does not touch Dockerfile.arm64 and Dockerfile.armv7 - they are almost identical to Dockerfile and we may unify and use a single Dockerfile for all builds later.

Followup on #2546