### PR TITLE
packaging: use latest label in Dockerfile

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=default
-FROM registry.opensource.zalan.do/library/alpine-3@sha256:2213d4d74c39af5313b631cbde2630b4007755b280f0f6b98867f66103b76113 AS default
+FROM registry.opensource.zalan.do/library/alpine-3:latest AS default
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
 RUN apk --no-cache add ca-certificates && update-ca-certificates


### PR DESCRIPTION
Dependabot fails to update registry.opensource.zalan.do/library/alpine-3 base image hash, see https://github.com/dependabot/dependabot-core/issues/7387

This change removes image hash and re-introduces latest label. For multiarch and ghcr.io builds base image is specified via BASE_IMAGE build argument and also uses latest label.

Followup on #2546