### PR TITLE
proxy: speedup TestBackendRatelimitScenarios

### DIFF
--- a/proxy/backendratelimit_test.go
+++ b/proxy/backendratelimit_test.go
@@ -109,6 +109,12 @@ func TestBackendRatelimitRoundRobin(t *testing.T) {
 }
 
 func TestBackendRatelimitScenarios(t *testing.T) {
+	// Use shared instance for all tests.
+	// If this test flakes because of backend IP reuse between test cases,
+	// implement database cleanup, see https://redis.io/commands/flushdb/.
+	redisAddr, done := redistest.NewTestRedis(t)
+	defer done()
+
 	for _, ti := range []struct {
 		name             string
 		routes           string
@@ -179,9 +185,6 @@ func TestBackendRatelimitScenarios(t *testing.T) {
 		t.Run(ti.name, func(t *testing.T) {
 			filterRegistry := builtin.MakeRegistry()
 			filterRegistry.Register(ratelimitfilters.NewBackendRatelimit())
-
-			redisAddr, done := redistest.NewTestRedis(t)
-			defer done()
 
 			ratelimitRegistry := ratelimit.NewSwarmRegistry(nil, &snet.RedisOptions{Addrs: []string{redisAddr}})
 			defer ratelimitRegistry.Close()


### PR DESCRIPTION
Reuse redis instance for multiple tests.

Before
```
$ go test ./proxy -short -count=1 -run=TestBackendRatelimitScenarios
ok      github.com/zalando/skipper/proxy        9.700s
```

After:
```
ok      github.com/zalando/skipper/proxy        2.510s
```