### PR TITLE
packaging: update Dockerfile

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,16 +1,20 @@
 ARG BASE_IMAGE=default
+ARG BUILD_FOLDER=build
+ARG TARGETPLATFORM
+
 FROM registry.opensource.zalan.do/library/alpine-3:latest AS default
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
-RUN apk --no-cache add ca-certificates && update-ca-certificates
-RUN mkdir -p /usr/bin
-ARG BUILD_FOLDER=build
-ARG TARGETPLATFORM
-ADD ${BUILD_FOLDER}/${TARGETPLATFORM}/skipper \
+
+RUN cat /etc/alpine-release \
+    && apk --no-cache add ca-certificates \
+    && update-ca-certificates
+
+COPY ${BUILD_FOLDER}/${TARGETPLATFORM}/skipper \
     ${BUILD_FOLDER}/${TARGETPLATFORM}/eskip \
     ${BUILD_FOLDER}/${TARGETPLATFORM}/webhook \
-    ${BUILD_FOLDER}/${TARGETPLATFORM}/routesrv /usr/bin/
-ENV PATH $PATH:/usr/bin
+    ${BUILD_FOLDER}/${TARGETPLATFORM}/routesrv \
+    /usr/bin/
 
 EXPOSE 9090 9911
 


### PR DESCRIPTION
* uses COPY instead of ADD following https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
* prints alpine release version during build
* removes redundant commands
* does not touch Dockerfile.arm64 and Dockerfile.armv7 - they are almost identical to Dockerfile and we may unify and use a single Dockerfile for all builds later.

Followup on #2546