### PR TITLE
proxy: fix flaky TestAuditLogging

### DIFF
--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -161,7 +161,7 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	done := make(chan struct{}, 2)
 
 	if p.useAuditLog {
-		copyAsync("backend->request+audit", backendConn, io.MultiWriter(requestHijackedConn, p.auditLogOut), done)
+		copyAsync("backend->request+audit", backendConn, io.MultiWriter(p.auditLogOut, requestHijackedConn), done)
 	} else {
 		copyAsync("backend->request", backendConn, requestHijackedConn, done)
 	}

--- a/proxy/upgrade_test.go
+++ b/proxy/upgrade_test.go
@@ -344,10 +344,9 @@ func TestAuditLogging(t *testing.T) {
 		return func(t *testing.T) {
 			wss := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
 				if _, err := io.Copy(ws, ws); err != nil {
-					t.Fatal(err)
+					t.Error(err)
 				}
 			}))
-
 			defer wss.Close()
 
 			// only used as poor man's sync, the audit log in question goes stdout and stderr,


### PR DESCRIPTION
The TestAuditLogging could flake because it checks audit log after receiving response message from the connection which may happen before write to audit log by io.MultiWriter has finished.

It could be reproduced via:
```
go test ./proxy -run=TestAuditLogging -count=10000 -failfast
```

This change writes to auditLog before writing to the connection which also would show failed message in the audit log in case write to connection fails.

Fixes #2572