### PR TITLE
eskip: sort built-in predicates

### DIFF
--- a/cmd/eskip/args.go
+++ b/cmd/eskip/args.go
@@ -39,7 +39,6 @@ const (
 	appendFiltersFlag  = "append"
 	appendFileFlag     = "append-file"
 	prettyFlag         = "pretty"
-	sortPredicatesFlag = "sort-predicates"
 	indentStrFlag      = "indent"
 	jsonFlag           = "json"
 
@@ -76,7 +75,6 @@ var (
 	appendFiltersArg  string
 	appendFileArg     string
 	pretty            bool
-	sortPredicates    bool
 	indentStr         string
 	printJson         bool
 )
@@ -112,7 +110,6 @@ func initFlags() {
 	flags.StringVar(&appendFileArg, appendFileFlag, "", appendFileUsage)
 
 	flags.BoolVar(&pretty, prettyFlag, false, prettyUsage)
-	flags.BoolVar(&sortPredicates, sortPredicatesFlag, false, sortPredicateUsage)
 	flags.StringVar(&indentStr, indentStrFlag, "  ", indentStrUsage)
 	flags.BoolVar(&printJson, jsonFlag, false, jsonUsage)
 }

--- a/cmd/eskip/doc.go
+++ b/cmd/eskip/doc.go
@@ -83,7 +83,6 @@ const (
 	appendFiltersUsage  = "append filters to each patched route"
 	appendFileUsage     = "append filters from a file to each patched route"
 	prettyUsage         = "prints routes in a more readable format"
-	sortPredicateUsage  = "sort routes predicates"
 	indentStrUsage      = "indent string used in pretty printing. Must match regexp \\s"
 	jsonUsage           = "prints routes as JSON"
 

--- a/cmd/eskip/load.go
+++ b/cmd/eskip/load.go
@@ -142,8 +142,7 @@ func printCmd(a cmdArgs) error {
 			}
 		}
 
-		eskip.Fprint(stdout, eskip.PrettyPrintInfo{Pretty: pretty, IndentStr: indentStr, SortPredicates: sortPredicates}, lr.routes...)
-
+		eskip.Fprint(stdout, eskip.PrettyPrintInfo{Pretty: pretty, IndentStr: indentStr}, lr.routes...)
 	}
 
 	if len(lr.parseErrors) > 0 {

--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -829,3 +829,65 @@ func BenchmarkParsePredicates(b *testing.B) {
 		_, _ = ParsePredicates(doc)
 	}
 }
+
+var stringSink string
+
+func BenchmarkRouteString(b *testing.B) {
+	doc := `
+		Method("GET") &&
+		Path("/foo") &&
+		Host(/foo/) &&
+		Host(/bar/) &&
+		Host(/baz/) &&
+		PathRegexp(/C/) &&
+		PathRegexp(/B/) &&
+		PathRegexp(/A/) &&
+		Header("Foo", "Bar") &&
+		Header("Bar", "Baz") &&
+		Header("Qux", "Bar") &&
+		HeaderRegexp("B", /3/) &&
+		HeaderRegexp("B", /2/) &&
+		HeaderRegexp("A", /1/) &&
+		Foo("bar", "baz") &&
+		True() -> <shunt>`
+
+	rr, err := Parse(doc)
+	if err != nil {
+		b.Fatal(err)
+	}
+	r := rr[0]
+	var s string
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s = r.String()
+	}
+	stringSink = s
+}
+
+func BenchmarkRouteStringNoRepeatedPredicates(b *testing.B) {
+	doc := `
+		Method("GET") &&
+		Path("/foo") &&
+		Host(/foo/) &&
+		PathRegexp(/A/) &&
+		Header("Foo", "Bar") &&
+		HeaderRegexp("A", /1/) &&
+		Foo("bar", "baz") &&
+		True() -> <shunt>`
+
+	rr, err := Parse(doc)
+	if err != nil {
+		b.Fatal(err)
+	}
+	r := rr[0]
+	var s string
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s = r.String()
+	}
+	stringSink = s
+}


### PR DESCRIPTION
PRs #2202 and #2208 added SortPredicates flag to PrettyPrintInfo
and -sort-predicates flag to eskip tool which enables sorting
of built-in and regular predicates.

Header and HeaderRegexp built-in predicates are represented as maps
internally therefore sorting is necessary to obtain stable
eskip serialization of a route.

This was planned to be used in routesrv which serves routes in eskip
format and supports HTTP caching via ETag.

Regular predicates are evaluated in ordered and short-circuit manner
which makes it possible to put "cheap" predicates before "expensive".
Sorting regular predicates therefore breaks short-circuit evaluation.

With the above in mind it makes sense to sort built-in Header and
HeaderRegexp predicates unconditionally and leave regular predicates intact.

This change:

* sorts built-in Header and HeaderRegexp predicates unconditionally in-place
  using string representation to reduce allocations
* does not sort regular predicates
* removes SortPredicates flag from PrettyPrintInfo
* removes -sort-predicates from eskip

Benchmark results to demonstrate the cost of sorting:
```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/eskip
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                                  │ /tmp/BenchmarkRouteString.old │   /tmp/BenchmarkRouteString.new    │
                                  │            sec/op             │   sec/op     vs base               │
RouteString-8                                         13.70µ ± 2%   14.07µ ± 2%  +2.74% (p=0.009 n=10)
RouteStringNoRepeatedPredicates-8                     7.083µ ± 3%   7.102µ ± 1%       ~ (p=0.079 n=10)
geomean                                               9.850µ        9.997µ       +1.50%

                                  │ /tmp/BenchmarkRouteString.old │     /tmp/BenchmarkRouteString.new     │
                                  │             B/op              │     B/op      vs base                 │
RouteString-8                                        2.430Ki ± 0%   2.477Ki ± 0%  +1.93% (p=0.000 n=10)
RouteStringNoRepeatedPredicates-8                    1.211Ki ± 0%   1.211Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                              1.715Ki        1.732Ki       +0.96%
¹ all samples are equal

                                  │ /tmp/BenchmarkRouteString.old │    /tmp/BenchmarkRouteString.new    │
                                  │           allocs/op           │ allocs/op   vs base                 │
RouteString-8                                          94.00 ± 0%   96.00 ± 0%  +2.13% (p=0.000 n=10)
RouteStringNoRepeatedPredicates-8                      53.00 ± 0%   53.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                70.58        71.33       +1.06%
¹ all samples are equal
```

Note that sorting only happens when there are several Header or HeaderRegexp predicates in the route.
Extra allocations should go away in the future thanks to golang/go#61180

Followup on #2208
Updates #2519