### PR TITLE
dataclients/kubernetes: add token file flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -151,6 +151,7 @@ type Config struct {
 	KubernetesIngress                       bool                               `yaml:"kubernetes"`
 	KubernetesInCluster                     bool                               `yaml:"kubernetes-in-cluster"`
 	KubernetesURL                           string                             `yaml:"kubernetes-url"`
+	KubernetesTokenFile                     string                             `yaml:"kubernetes-token-file"`
 	KubernetesHealthcheck                   bool                               `yaml:"kubernetes-healthcheck"`
 	KubernetesHTTPSRedirect                 bool                               `yaml:"kubernetes-https-redirect"`
 	KubernetesHTTPSRedirectCode             int                                `yaml:"kubernetes-https-redirect-code"`
@@ -436,8 +437,9 @@ func NewConfig() *Config {
 
 	// Kubernetes:
 	flag.BoolVar(&cfg.KubernetesIngress, "kubernetes", false, "enables skipper to generate routes for ingress resources in kubernetes cluster. Enables -normalize-host")
-	flag.BoolVar(&cfg.KubernetesInCluster, "kubernetes-in-cluster", false, "specify if skipper is running inside kubernetes cluster")
-	flag.StringVar(&cfg.KubernetesURL, "kubernetes-url", "", "kubernetes API base URL for the ingress data client; requires kubectl proxy running; omit if kubernetes-in-cluster is set to true")
+	flag.BoolVar(&cfg.KubernetesInCluster, "kubernetes-in-cluster", false, "specify if skipper is running inside kubernetes cluster. It will automatically discover API server URL and service account token")
+	flag.StringVar(&cfg.KubernetesURL, "kubernetes-url", "", "kubernetes API server URL, ignored if kubernetes-in-cluster is set to true")
+	flag.StringVar(&cfg.KubernetesTokenFile, "kubernetes-token-file", "", "kubernetes token file path, ignored if kubernetes-in-cluster is set to true")
 	flag.BoolVar(&cfg.KubernetesHealthcheck, "kubernetes-healthcheck", true, "automatic healthcheck route for internal IPs with path /kube-system/healthz; valid only with kubernetes")
 	flag.BoolVar(&cfg.KubernetesHTTPSRedirect, "kubernetes-https-redirect", true, "automatic HTTP->HTTPS redirect route; valid only with kubernetes")
 	flag.IntVar(&cfg.KubernetesHTTPSRedirectCode, "kubernetes-https-redirect-code", 308, "overrides the default redirect code (308) when used together with -kubernetes-https-redirect")
@@ -779,6 +781,7 @@ func (c *Config) ToOptions() skipper.Options {
 		Kubernetes:                             c.KubernetesIngress,
 		KubernetesInCluster:                    c.KubernetesInCluster,
 		KubernetesURL:                          c.KubernetesURL,
+		KubernetesTokenFile:                    c.KubernetesTokenFile,
 		KubernetesHealthcheck:                  c.KubernetesHealthcheck,
 		KubernetesHTTPSRedirect:                c.KubernetesHTTPSRedirect,
 		KubernetesHTTPSRedirectCode:            c.KubernetesHTTPSRedirectCode,

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -86,6 +86,10 @@ type Options struct {
 	// environment variables.)
 	KubernetesURL string
 
+	// TokenFile configures path to the token file.
+	// Defaults to /var/run/secrets/kubernetes.io/serviceaccount/token when running in-cluster.
+	TokenFile string
+
 	// KubernetesNamespace is used to switch between finding ingresses in the cluster-scope or limit
 	// the ingresses to only those in the specified namespace. Defaults to "" which means monitor ingresses
 	// in the cluster-scope.

--- a/skipper.go
+++ b/skipper.go
@@ -166,6 +166,10 @@ type Options struct {
 	// skipper is not running in-cluster, the default API URL will be used.
 	KubernetesURL string
 
+	// KubernetesTokenFile configures path to the token file.
+	// Defaults to /var/run/secrets/kubernetes.io/serviceaccount/token when running in-cluster.
+	KubernetesTokenFile string
+
 	// KubernetesHealthcheck, when Kubernetes ingress is set, indicates
 	// whether an automatic healthcheck route should be generated. The
 	// generated route will report healthyness when the Kubernetes API
@@ -913,6 +917,7 @@ func (o *Options) KubernetesDataClientOptions() kubernetes.Options {
 		DefaultFiltersDir:                 o.DefaultFiltersDir,
 		KubernetesInCluster:               o.KubernetesInCluster,
 		KubernetesURL:                     o.KubernetesURL,
+		TokenFile:                         o.KubernetesTokenFile,
 		KubernetesNamespace:               o.KubernetesNamespace,
 		KubernetesEnableEastWest:          o.KubernetesEnableEastWest,
 		KubernetesEastWestDomain:          o.KubernetesEastWestDomain,


### PR DESCRIPTION
Add flag to supply token file when running outside of cluster.
This is useful to test skipper/routesrv outside of the cluster without using kubectl proxy.