### PR TITLE
adding Prometheus metric for Routes health

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -1940,6 +1940,8 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	ro.PreProcessors = append(ro.PreProcessors, admissionControlSpec.PreProcessor())
 
+	ro.Metrics = mtr
+
 	routing := routing.New(ro)
 	defer routing.Close()
 


### PR DESCRIPTION
ref: https://github.com/zalando/skipper/issues/2595

adding Prometheus metrics for Routes health of `routes-total` and `routes-last-update` gauges that will allow to defines alerts if Skipper instances drift.