### PR TITLE
allow tagFilter to use response data

### DIFF
--- a/filters/tracing/tag.go
+++ b/filters/tracing/tag.go
@@ -45,6 +45,14 @@ func (s tagSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 }
 
 func (f tagFilter) Request(ctx filters.FilterContext) {
+	tagSpan(f, ctx)
+}
+
+func (f tagFilter) Response(ctx filters.FilterContext) {
+	tagSpan(f, ctx)
+}
+
+func tagSpan(f tagFilter, ctx filters.FilterContext) {
 	req := ctx.Request()
 	span := opentracing.SpanFromContext(req.Context())
 	if span == nil {
@@ -55,5 +63,3 @@ func (f tagFilter) Request(ctx filters.FilterContext) {
 		span.SetTag(f.tagName, v)
 	}
 }
-
-func (f tagFilter) Response(filters.FilterContext) {}

--- a/filters/tracing/tag_test.go
+++ b/filters/tracing/tag_test.go
@@ -66,7 +66,7 @@ func TestTracingTag(t *testing.T) {
 		},
 		"test_value",
 	}, {
-		"tag from header",
+		"tag from request header",
 		"${request.header.X-Flow-Id}",
 		&filtertest.Context{
 			FRequest: &http.Request{
@@ -76,6 +76,18 @@ func TestTracingTag(t *testing.T) {
 			},
 		},
 		"foo",
+	}, {
+		"tag from response header",
+		"${response.header.X-Fallback}",
+		&filtertest.Context{
+			FRequest: &http.Request{},
+			FResponse: &http.Response{
+				Header: http.Header{
+					"X-Fallback": []string{"true"},
+				},
+			},
+		},
+		"true",
 	}, {
 		"tag from missing header",
 		"${request.header.missing}",


### PR DESCRIPTION
This change allows to use response data when tagging the Skipper span using the `tracingTag` filter.

The use case for this is that users might want to consider an operation as failed even if it technically succeeds, e.g. because fallbacks were used. With this change, a response header can be sent, e.g. `"X-Fallback": "true"`, and then the filter `tracingTag("error", "${response.header.X-Fallback}")` would result in the span being marked as error.

Another use cases could be that metrics should be captured by use case, but the use case is not apparent from the request and instead only defined by the result of the request processing.