### PR TITLE
dataclients/kubernetes: RouteGroup catchall interferes with Ingress

### DIFF
--- a/dataclients/kubernetes/mixed_test.go
+++ b/dataclients/kubernetes/mixed_test.go
@@ -1,0 +1,13 @@
+package kubernetes_test
+
+import (
+	"testing"
+
+	"github.com/zalando/skipper/dataclients/kubernetes/kubernetestest"
+)
+
+func TestMixedFixtures(t *testing.T) {
+	kubernetestest.FixturesToTest(t,
+		"testdata/mixed",
+	)
+}

--- a/dataclients/kubernetes/testdata/mixed/ingress-routegroup-catchall.eskip
+++ b/dataclients/kubernetes/testdata/mixed/ingress-routegroup-catchall.eskip
@@ -1,0 +1,11 @@
+kube_foo__qux__www_example_org____qux: Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
+    -> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_rg__default__qux_rg__all__0_0: HeaderRegexp("User-Agent", "^FooBar$") && Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$") && PathSubtree("/")
+    -> status(403)
+    -> inlineContent("Forbidden")
+    -> <shunt>;
+
+// The following catchall route for RouteGroup interferes with Ingress route
+// kube_rg____www_example_org__catchall__0_0: Host("^(www[.]example[.]org[.]?(:[0-9]+)?)$")
+//     -> <shunt>;

--- a/dataclients/kubernetes/testdata/mixed/ingress-routegroup-catchall.yaml
+++ b/dataclients/kubernetes/testdata/mixed/ingress-routegroup-catchall.yaml
@@ -1,0 +1,66 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  rules:
+    - host: www.example.org
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: qux
+                port:
+                  number: 80
+---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: qux-rg
+spec:
+  hosts:
+    - www.example.org
+  backends:
+    - name: shunt
+      type: shunt
+  routes:
+    - pathSubtree: /
+      predicates:
+        - HeaderRegexp("User-Agent", "^FooBar$")
+      filters:
+        - status(403)
+        - inlineContent("Forbidden")
+      backends:
+        - backendName: shunt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qux
+  namespace: foo
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: qux
+  namespace: foo
+subsets:
+  - addresses:
+      - ip: 10.2.9.103
+      - ip: 10.2.9.104
+    ports:
+      - port: 8080
+        protocol: TCP


### PR DESCRIPTION
Dataclient creates a catchall route for RouteGroup that interferes with an Ingress route and leads to sporadic 404 responses.

Dataclient should probably create catchall routes after processing all Ingresses and RouteGroups.

Alternatively we may consider disabling catchall routes completely since default response code when there is no route is 404. This should also reduce routing table size.