### PR TITLE
Check the absence of inflight requests before removing endpoint from endpointregistry

### DIFF
--- a/routing/endpointregistry.go
+++ b/routing/endpointregistry.go
@@ -63,9 +63,11 @@ func (r *EndpointRegistry) Do(routes []*Route) []*Route {
 
 	for host, ts := range r.lastSeen {
 		if ts.Add(lastSeenTimeout).Before(now) {
-			delete(r.lastSeen, host)
 			r.mu.Lock()
-			delete(r.data, host)
+			if r.data[host].inflightRequests == 0 {
+				delete(r.lastSeen, host)
+				delete(r.data, host)
+			}
 			r.mu.Unlock()
 		}
 	}

--- a/routing/endpointregistry_test.go
+++ b/routing/endpointregistry_test.go
@@ -75,6 +75,7 @@ func TestDoRemovesOldEntries(t *testing.T) {
 
 	r.IncInflightRequest("endpoint1.test:80")
 	r.IncInflightRequest("endpoint2.test:80")
+	r.DecInflightRequest("endpoint2.test:80")
 
 	routing.SetNow(r, func() time.Time {
 		return beginTestTs.Add(routing.ExportLastSeenTimeout + time.Second)


### PR DESCRIPTION
This check is needed for endpoints with latency more than lastSeenTimeout. They should still be kept in endpointregistry even after this timeout until all pending DecInflightOperations are done.