### PR TITLE
secrets: handle empty secrets

### DIFF
--- a/secrets/file.go
+++ b/secrets/file.go
@@ -20,6 +20,7 @@ const (
 var (
 	ErrWrongFileType    = errors.New("file type not supported")
 	ErrFailedToReadFile = errors.New("failed to read file")
+	errEmptyFile        = errors.New("empty file")
 )
 
 // SecretsProvider is a SecretsReader and can add secret sources that
@@ -81,7 +82,7 @@ func (sp *SecretPaths) Add(path string) error {
 	switch mode := fi.Mode(); {
 	// Kubernetes uses symlink to file
 	case mode.IsRegular() || mode&os.ModeSymlink != 0:
-		if _, err := os.ReadFile(path); err != nil {
+		if _, err := readSecretFile(path); err != nil {
 			return err
 		}
 	case mode.IsDir():
@@ -184,6 +185,9 @@ func readSecretFile(path string) ([]byte, error) {
 	}
 	if len(data) > 0 && data[len(data)-1] == 0xa {
 		data = data[:len(data)-1]
+	}
+	if len(data) == 0 {
+		return nil, errEmptyFile
 	}
 	return data, nil
 }

--- a/secrets/file_test.go
+++ b/secrets/file_test.go
@@ -235,6 +235,32 @@ func TestSecretPaths(t *testing.T) {
 
 		checkSecret(t, path, "created")
 	})
+
+	t.Run("errors on empty file", func(t *testing.T) {
+		path := t.TempDir() + "/foo"
+
+		writeFile(t, path, "")
+
+		assert.Error(t, sp.Add(path))
+	})
+
+	t.Run("removes empty file", func(t *testing.T) {
+		path := t.TempDir() + "/foo"
+
+		writeFile(t, path, "created")
+
+		require.NoError(t, sp.Add(path))
+
+		checkSecret(t, path, "created")
+
+		writeFile(t, path, "")
+
+		_, exists := sp.GetSecret(path)
+		assert.False(t, exists)
+
+		writeFile(t, path, "re-created")
+		checkSecret(t, path, "re-created")
+	})
 }
 
 func TestSecretPathsDoesNotRefreshAfterClose(t *testing.T) {


### PR DESCRIPTION
Logs error on add and treat empty file as removed on update.

In particular it errors instead of using empty value when secret path comes from process substitution
```
$ bin/routesrv -kubernetes-token-file=<(echo foobar)
ERRO[0000] Failed to read file /dev/fd/63: empty file
FATA[0000] failed to get secret /dev/fd/63
```

which is a symlink to a named pipe
```
$ ls -l <(echo foobar)
lr-x------ 1 jdoe jdoe 64 Sep 25 13:36 /dev/fd/63 -> 'pipe:[7925874]'
```