### PR TITLE
routesrv: check config parse error

### DIFF
--- a/cmd/routesrv/main.go
+++ b/cmd/routesrv/main.go
@@ -8,10 +8,12 @@ import (
 
 func main() {
 	cfg := config.NewConfig()
-	cfg.Parse()
+	if err := cfg.Parse(); err != nil {
+		log.Fatalf("Error processing config: %s", err)
+	}
+
 	log.SetLevel(cfg.ApplicationLogLevel)
-	err := routesrv.Run(cfg.ToOptions())
-	if err != nil {
+	if err := routesrv.Run(cfg.ToOptions()); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Fail startup on invalid config.