### PR TITLE
Added LBEndpoint field in routing.LBContext struct

### DIFF
--- a/loadbalancer/fadein_test.go
+++ b/loadbalancer/fadein_test.go
@@ -72,6 +72,7 @@ func initializeEndpoints(endpointAges []time.Duration, fadeInDuration time.Durat
 		})
 		ctx.Registry.SetDetectedTime(eps[i], detectionTimes[i])
 	}
+	ctx.LBEndpoints = ctx.Route.LBEndpoints
 
 	return ctx, eps
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -490,7 +490,7 @@ func mapRequest(ctx *context, requestContext stdlibcontext.Context, removeHopHea
 		setRequestURLFromRequest(u, r)
 		setRequestURLForDynamicBackend(u, stateBag)
 	case eskip.LBBackend:
-		endpoint = setRequestURLForLoadBalancedBackend(u, rt, &routing.LBContext{Request: r, Route: rt, Params: stateBag, Registry: registry})
+		endpoint = setRequestURLForLoadBalancedBackend(u, rt, &routing.LBContext{Request: r, Route: rt, LBEndpoints: rt.LBEndpoints, Params: stateBag, Registry: registry})
 	default:
 		u.Scheme = rt.Scheme
 		u.Host = rt.Host

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -190,10 +190,11 @@ type LBAlgorithm interface {
 // LBContext is used to pass data to the load balancer to decide based
 // on that data which endpoint to call from the backends
 type LBContext struct {
-	Request  *http.Request
-	Route    *Route
-	Params   map[string]interface{}
-	Registry *EndpointRegistry
+	Request     *http.Request
+	Route       *Route
+	LBEndpoints []LBEndpoint
+	Params      map[string]interface{}
+	Registry    *EndpointRegistry
 }
 
 // NewLBContext is used to create a new LBContext, to pass data to the


### PR DESCRIPTION
The routing.Route field of routing.LBContext struct will be eventually removed because loadbalancer in general does not require the full information about route, only about endpoints to balance load between.

You can think about this PR as preliminary one for the https://github.com/zalando/skipper/pull/2634