### PR TITLE
filters/ratelimit: apply ratelimitFailClosed regardless of the position in the route

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1721,7 +1721,7 @@ As of now there is no negative/deny rule possible. The first matching path is ev
 
 ### Open Policy Agent
 
-To get started with [Open Policy Agent](https://www.openpolicyagent.org/), also have a look at the [tutorial](../tutorials/auth.md#open-policy-agent). This section is only a reference for the implemented filters. 
+To get started with [Open Policy Agent](https://www.openpolicyagent.org/), also have a look at the [tutorial](../tutorials/auth.md#open-policy-agent). This section is only a reference for the implemented filters.
 
 #### opaAuthorizeRequest
 
@@ -1796,7 +1796,7 @@ The difference is that if the decision in (3) is equivalent to false, the respon
 
 Headers both to the upstream and the downstream service can be manipulated the same way this works for [Envoy external authorization](https://www.openpolicyagent.org/docs/latest/envoy-primer/#example-policy-with-additional-controls)
 
-This allows both to add and remove unwanted headers in allow/deny cases. 
+This allows both to add and remove unwanted headers in allow/deny cases.
 
 #### opaServeResponse
 
@@ -1821,7 +1821,7 @@ For this filter, the data flow looks like this independent of an allow/deny deci
 
 ```ascii
              ┌──────────────────┐
- (1) Request │     Skipper      │ 
+ (1) Request │     Skipper      │
 ─────────────┤                  ├
              │                  │
  (4) Response│   (2)│   ▲ (3)   │
@@ -2255,8 +2255,9 @@ Path("/expensive") -> clusterLeakyBucketRatelimit("user-${request.cookie.Authori
 
 ### ratelimitFailClosed
 
-This filter changes the failure mode for rate limit filters. If the
-filter is present, infrastructure issues will lead to rate limit.
+This filter changes the failure mode for all rate limit filters of the route.
+By default rate limit filters fail open on infrastructure errors (e.g. when redis is down) and allow requests.
+When this filter is present on the route, rate limit filters will fail closed in case of infrastructure errors and deny requests.
 
 Examples:
 ```
@@ -2264,7 +2265,7 @@ fail_open: * -> clusterRatelimit("g",10, "1s")
 fail_closed: * -> ratelimitFailClosed() -> clusterRatelimit("g", 10, "1s")
 ```
 
-In case `clusterRatelimit` could not reach the swarm (f.e. redis):
+In case `clusterRatelimit` could not reach the swarm (e.g. redis):
 
 * Route `fail_open` will allow the request
 * Route `fail_closed` will deny the request
@@ -3015,7 +3016,7 @@ tracingTag("http.flow_id", "${request.header.X-Flow-Id}")
 
 ### tracingTagFromResponse
 
-This filter works just like [tracingTag](#tracingTag), but is applied after the request was processed. In particular, [template placeholders](#template-placeholders) referencing the response can be used in the parameters. 
+This filter works just like [tracingTag](#tracingTag), but is applied after the request was processed. In particular, [template placeholders](#template-placeholders) referencing the response can be used in the parameters.
 
 ### tracingSpanName
 

--- a/filters/ratelimit/fail_closed_test.go
+++ b/filters/ratelimit/fail_closed_test.go
@@ -3,11 +3,9 @@ package ratelimit_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/zalando/skipper/eskip"
-	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/builtin"
 	fratelimit "github.com/zalando/skipper/filters/ratelimit"
 	snet "github.com/zalando/skipper/net"
@@ -19,68 +17,64 @@ import (
 
 func TestFailureMode(t *testing.T) {
 	for _, tt := range []struct {
-		name                string
-		ratelimitFilterName string
-		failClosed          bool
-		wantLimit           bool
-		limitStatusCode     int
+		name            string
+		filters         string
+		wantLimit       bool
+		limitStatusCode int
 	}{
 		{
-			name:                "test clusterRatelimit fail open",
-			ratelimitFilterName: "clusterRatelimit",
-			wantLimit:           false,
-			limitStatusCode:     http.StatusTooManyRequests,
+			name:            "test clusterRatelimit fail open",
+			filters:         `clusterRatelimit("t", 1, "1s")`,
+			wantLimit:       false,
+			limitStatusCode: http.StatusTooManyRequests,
 		},
 		{
-			name:                "test clusterRatelimit fail closed",
-			ratelimitFilterName: "clusterRatelimit",
-			failClosed:          true,
-			wantLimit:           true,
-			limitStatusCode:     http.StatusTooManyRequests,
+			name:            "test clusterRatelimit fail closed",
+			filters:         `ratelimitFailClosed() -> clusterRatelimit("t", 1, "1s")`,
+			wantLimit:       true,
+			limitStatusCode: http.StatusTooManyRequests,
 		},
 		{
-			name:                "test clusterClientRatelimit fail open",
-			ratelimitFilterName: "clusterClientRatelimit",
-			wantLimit:           false,
-			limitStatusCode:     http.StatusTooManyRequests,
+			name:            "test clusterClientRatelimit fail open",
+			filters:         `clusterClientRatelimit("t", 1, "1s", "X-Test")`,
+			wantLimit:       false,
+			limitStatusCode: http.StatusTooManyRequests,
 		},
 		{
-			name:                "test clusterClientRatelimit fail closed",
-			ratelimitFilterName: "clusterClientRatelimit",
-			failClosed:          true,
-			wantLimit:           true,
-			limitStatusCode:     http.StatusTooManyRequests,
+			name:            "test clusterClientRatelimit fail closed",
+			filters:         `ratelimitFailClosed() -> clusterClientRatelimit("t", 1, "1s", "X-Test")`,
+			wantLimit:       true,
+			limitStatusCode: http.StatusTooManyRequests,
 		},
 		{
-			name:                "test backendRatelimit fail open",
-			ratelimitFilterName: "backendRatelimit",
-			wantLimit:           false,
-			limitStatusCode:     http.StatusServiceUnavailable,
+			name:            "test backendRatelimit fail open",
+			filters:         `backendRatelimit("t", 1, "1s")`,
+			wantLimit:       false,
+			limitStatusCode: http.StatusServiceUnavailable,
 		},
 		{
-			name:                "test backendRatelimit fail closed",
-			ratelimitFilterName: "backendRatelimit",
-			failClosed:          true,
-			wantLimit:           true,
-			limitStatusCode:     http.StatusServiceUnavailable,
+			name:            "test backendRatelimit fail closed",
+			filters:         `ratelimitFailClosed() -> backendRatelimit("t", 1, "1s")`,
+			wantLimit:       true,
+			limitStatusCode: http.StatusServiceUnavailable,
 		},
 		{
-			name:                "test clusterLeakyBucketRatelimit fail open",
-			ratelimitFilterName: "clusterLeakyBucketRatelimit",
-			wantLimit:           false,
-			limitStatusCode:     http.StatusTooManyRequests,
+			name:            "test clusterLeakyBucketRatelimit fail open",
+			filters:         `clusterLeakyBucketRatelimit("t", 1, "1s")`,
+			wantLimit:       false,
+			limitStatusCode: http.StatusTooManyRequests,
 		},
 		{
-			name:                "test clusterLeakyBucketRatelimit fail closed",
-			ratelimitFilterName: "clusterLeakyBucketRatelimit",
-			failClosed:          true,
-			wantLimit:           true,
-			limitStatusCode:     http.StatusTooManyRequests,
-		}} {
+			name:            "test clusterLeakyBucketRatelimit fail closed",
+			filters:         `ratelimitFailClosed() -> clusterLeakyBucketRatelimit("t", 1, "1s", 10, 1)`,
+			wantLimit:       true,
+			limitStatusCode: http.StatusTooManyRequests,
+		},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			fr := builtin.MakeRegistry()
 
-			reg := ratelimit.NewSwarmRegistry(nil, &snet.RedisOptions{Addrs: []string{"127.0.0.2:6379"}}, ratelimit.Settings{})
+			reg := ratelimit.NewSwarmRegistry(nil, &snet.RedisOptions{Addrs: []string{"fails.test:6379"}}, ratelimit.Settings{})
 			defer reg.Close()
 
 			provider := fratelimit.NewRatelimitProvider(reg)
@@ -96,19 +90,9 @@ func TestFailureMode(t *testing.T) {
 			}))
 			defer backend.Close()
 
-			args := []interface{}{"t", 1, "1s"}
-			switch tt.ratelimitFilterName {
-			case filters.ClusterLeakyBucketRatelimitName:
-				args = append(args, 10, 1)
-			case filters.ClusterClientRatelimitName:
-				args = append(args, "X-Test")
-			}
-
-			r := &eskip.Route{Filters: []*eskip.Filter{
-				{Name: tt.ratelimitFilterName, Args: args}}, Backend: backend.URL}
-			if tt.failClosed {
-				r.Filters = append([]*eskip.Filter{{Name: fratelimit.NewFailClosed().Name()}},
-					r.Filters...)
+			r := &eskip.Route{
+				Filters: eskip.MustParseFilters(tt.filters),
+				Backend: backend.URL,
 			}
 
 			proxy := proxytest.WithParamsAndRoutingOptions(
@@ -123,22 +107,16 @@ func TestFailureMode(t *testing.T) {
 				}, r)
 			defer proxy.Close()
 
-			reqURL, err := url.Parse(proxy.URL)
-			if err != nil {
-				t.Fatalf("Failed to parse url %s: %v", proxy.URL, err)
-			}
-			req, err := http.NewRequest("GET", reqURL.String(), nil)
+			req, err := http.NewRequest("GET", proxy.URL, nil)
 			if err != nil {
 				t.Fatal(err)
-				return
 			}
 			req.Header.Set("X-Test", "foo")
 
-			rsp, err := http.DefaultClient.Do(req)
+			rsp, err := proxy.Client().Do(req)
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			defer rsp.Body.Close()
 
 			limited := rsp.StatusCode == tt.limitStatusCode
@@ -149,5 +127,4 @@ func TestFailureMode(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/filters/ratelimit/fail_closed_test.go
+++ b/filters/ratelimit/fail_closed_test.go
@@ -70,6 +70,12 @@ func TestFailureMode(t *testing.T) {
 			wantLimit:       true,
 			limitStatusCode: http.StatusTooManyRequests,
 		},
+		{
+			name:            "test ratelimitFailClosed applies when placed after ratelimit filter",
+			filters:         `clusterRatelimit("t", 1, "1s") -> ratelimitFailClosed()`,
+			wantLimit:       true,
+			limitStatusCode: http.StatusTooManyRequests,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			fr := builtin.MakeRegistry()


### PR DESCRIPTION
ratelimitFailClosed is a route-wide configuration filter so it should apply to all ratelimit filters regardless of its position. 

PR consists of two commits: first refactors tests to simplify and allow routes with multiple filters and second makes ratelimitFailClosed apply regardless of the position in the route.