### PR TITLE
Update packaging procedure for Windows binaries

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -74,8 +74,7 @@ pipeline:
         make build.package
 
         files=(-u sha256sum.txt)
-        for f in *.tar.gz; do files+=(-u "$f"); done
-        for f in *.zip; do files+=(-u "$f"); done
+        for f in *.tar.gz *.zip; do files+=(-u "$f"); done
         echo "create release page"
         tf=$(mktemp)
         echo -e "### Changes\n" >$tf

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -73,7 +73,9 @@ pipeline:
         echo "Creating release for tag: ${RELEASE_VERSION}"
         make build.package
 
-        files=(-u sha256sum.txt); for f in *.tar.gz; do files+=(-u "$f"); done
+        files=(-u sha256sum.txt)
+        for f in *.tar.gz; do files+=(-u "$f"); done
+        for f in *.zip; do files+=(-u "$f"); done
         echo "create release page"
         tf=$(mktemp)
         echo -e "### Changes\n" >$tf

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -133,11 +133,9 @@ build.package: build.linux build.darwin build.windows
 	tar --transform 's,^\.,skipper-$(VERSION)-darwin-arm64,' -C build/darwin/arm64 -czvf skipper-$(VERSION)-darwin-arm64.tar.gz .
 
 # Pack windows binaries as zip - use a temp directory to achieve same transform result as other archives
-	mkdir skipper-$(VERSION)-windows-amd64
-	for f in ./build/windows/amd64/*.exe; do cp "$$f" "skipper-$(VERSION)-windows-amd64"; done
+	cp -R build/windows/amd64/ skipper-$(VERSION)-windows-amd64
 	zip -r skipper-$(VERSION)-windows-amd64.zip skipper-$(VERSION)-windows-amd64
 	rm -rf skipper-$(VERSION)-windows-amd64
 
 # Generate checksums for all archives and save to file
-	for f in *.tar.gz; do sha256sum $$f >> sha256sum.txt; done
-	for f in *.zip; do sha256sum $$f >> sha256sum.txt; done
+	for f in *.tar.gz *.zip; do sha256sum $$f >> sha256sum.txt; done

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -138,4 +138,4 @@ build.package: build.linux build.darwin build.windows
 	rm -rf skipper-$(VERSION)-windows-amd64
 
 # Generate checksums for all archives and save to file
-	for f in *.tar.gz *.zip; do sha256sum $$f >> sha256sum.txt; done
+	sha256sum *.tar.gz *.zip > sha256sum.txt

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -120,13 +120,24 @@ build/windows/amd64/%:
 	GOOS=windows \
 	GOARCH=amd64 \
 	CGO_ENABLED=$(CGO_ENABLED) \
-	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o build/windows/amd64/$(notdir $@) ../cmd/$(notdir $@)/*.go
+	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o build/windows/amd64/$(notdir $@).exe ../cmd/$(notdir $@)/*.go
 
 build.package: build.linux build.darwin build.windows
+# Pack linux binaries as tar
 	tar --transform 's,^\.,skipper-$(VERSION)-linux-amd64,' -C build/linux/amd64 -czvf skipper-$(VERSION)-linux-amd64.tar.gz .
 	tar --transform 's,^\.,skipper-$(VERSION)-linux-arm64,' -C build/linux/arm64 -czvf skipper-$(VERSION)-linux-arm64.tar.gz .
 	tar --transform 's,^\.,skipper-$(VERSION)-linux-armv7,' -C build/linux/arm/v7 -czvf skipper-$(VERSION)-linux-armv7.tar.gz .
+
+# Pack darwin binaries as tar
 	tar --transform 's,^\.,skipper-$(VERSION)-darwin-amd64,' -C build/darwin/amd64 -czvf skipper-$(VERSION)-darwin-amd64.tar.gz .
 	tar --transform 's,^\.,skipper-$(VERSION)-darwin-arm64,' -C build/darwin/arm64 -czvf skipper-$(VERSION)-darwin-arm64.tar.gz .
-	tar --transform 's,^\.,skipper-$(VERSION)-windows-amd64,' -C build/windows/amd64 -czvf skipper-$(VERSION)-windows-amd64.tar.gz .
+
+# Pack windows binaries as zip - use a temp directory to achieve same transform result as other archives
+	mkdir skipper-$(VERSION)-windows-amd64
+	for f in ./build/windows/amd64/*.exe; do cp "$$f" "skipper-$(VERSION)-windows-amd64"; done
+	zip -r skipper-$(VERSION)-windows-amd64.zip skipper-$(VERSION)-windows-amd64
+	rm -rf skipper-$(VERSION)-windows-amd64
+
+# Generate checksums for all archives and save to file
 	for f in *.tar.gz; do sha256sum $$f >> sha256sum.txt; done
+	for f in *.zip; do sha256sum $$f >> sha256sum.txt; done


### PR DESCRIPTION
Fixes #2666

- The Windows binaries are now built as executables with the extension `.exe`
- The Windows binaries are now packed in a `zip` archive with the same directory structure as the `tar` archives for Linux and Darwin. The logic is overly complex due to the flattening function of the `zip` command not being as powerful as the one `tar` provides. If it is not a requirement to keep the directory structure inside the zip archive, the four lines for packaging the Windows binaries can be condensed to a single line. Let me know if this is desired please :smile: 

I am unable to verify if the changes to `delivery.yaml` are working as intended. 

Verification of archive structure:

``` shell
$ unzip skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64.zip -d tmp
Archive:  skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64.zip
   creating: tmp/skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64/
  inflating: tmp/skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64/routesrv.exe  
  inflating: tmp/skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64/eskip.exe  
  inflating: tmp/skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64/webhook.exe  
  inflating: tmp/skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64/skipper.exe
$ ls tmp/skipper-73a77c9d9cc6a339022aae12f0b61d7d26e61572-windows-amd64/
eskip.exe  routesrv.exe  skipper.exe  webhook.exe
```