### PR TITLE
feature: filter fifoWithBody

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2819,6 +2819,31 @@ Example:
 fifo(100, 150, "10s")
 ```
 
+### fifoWithBody
+
+This Filter is similar to the [lifo](#lifo) filter in regards to
+parameters and status codes.
+Performance considerations are similar to [fifo](#fifo).
+
+The difference between fifo and fifoWithBody is that fifo will decrement
+the concurrency as soon as the backend sent response headers and
+fifoWithBody will decrement the concurrency if the response body was
+served. Normally both are very similar, but if you have a fully async
+component that serves multiple website fragments, this would decrement
+concurrency too early.
+
+Parameters:
+
+* MaxConcurrency specifies how many goroutines are allowed to work on this queue (int)
+* MaxQueueSize sets the queue size (int)
+* Timeout sets the timeout to get request scheduled (time)
+
+Example:
+
+```
+fifoWithBody(100, 150, "10s")
+```
+
 ### lifo
 
 This Filter changes skipper to handle the route with a bounded last in

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -216,6 +216,7 @@ func Filters() []filters.Spec {
 		auth.NewForwardToken(),
 		auth.NewForwardTokenField(),
 		scheduler.NewFifo(),
+		scheduler.NewFifoWithBody(),
 		scheduler.NewLIFO(),
 		scheduler.NewLIFOGroup(),
 		rfc.NewPath(),

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -35,6 +35,9 @@ const (
 
 	// BackendRatelimit is the key used in the state bag to configure backend ratelimit in proxy
 	BackendRatelimit = "backend:ratelimit"
+
+	// FifoWithBody
+	FifoWithBody = "fifo:body:func"
 )
 
 // FilterContext object providing state and information that is unique to a request.
@@ -327,6 +330,7 @@ const (
 	SetDynamicBackendUrl                       = "setDynamicBackendUrl"
 	ApiUsageMonitoringName                     = "apiUsageMonitoring"
 	FifoName                                   = "fifo"
+	FifoWithBodyName                           = "fifoWithBody"
 	LifoName                                   = "lifo"
 	LifoGroupName                              = "lifoGroup"
 	RfcPathName                                = "rfcPath"

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -35,9 +35,6 @@ const (
 
 	// BackendRatelimit is the key used in the state bag to configure backend ratelimit in proxy
 	BackendRatelimit = "backend:ratelimit"
-
-	// FifoWithBody
-	FifoWithBody = "fifo:body:func"
 )
 
 // FilterContext object providing state and information that is unique to a request.

--- a/filters/scheduler/fifo_test.go
+++ b/filters/scheduler/fifo_test.go
@@ -403,8 +403,8 @@ func TestFifo(t *testing.T) {
 			wantOkRate:  1.0,
 		},
 		{
-			name:          "fifoWithbody simple ok",
-			filter:        `fifoWithbody(3, 5, "1s")`,
+			name:          "fifoWithBody simple ok",
+			filter:        `fifoWithBody(3, 5, "1s")`,
 			freq:          20,
 			per:           100 * time.Millisecond,
 			backendTime:   1 * time.Millisecond,
@@ -421,8 +421,8 @@ func TestFifo(t *testing.T) {
 			wantOkRate:    0,
 		},
 		{
-			name:          "fifoWithbody simple client canceled",
-			filter:        `fifoWithbody(3, 5, "1s")`,
+			name:          "fifoWithBody simple client canceled",
+			filter:        `fifoWithBody(3, 5, "1s")`,
 			freq:          20,
 			per:           100 * time.Millisecond,
 			backendTime:   1 * time.Millisecond,
@@ -439,8 +439,8 @@ func TestFifo(t *testing.T) {
 			wantOkRate:    0.005,
 		},
 		{
-			name:          "fifoWithbody with reaching max concurrency and queue timeouts",
-			filter:        `fifoWithbody(3, 5, "10ms")`,
+			name:          "fifoWithBody with reaching max concurrency and queue timeouts",
+			filter:        `fifoWithBody(3, 5, "10ms")`,
 			freq:          20,
 			per:           10 * time.Millisecond,
 			backendTime:   11 * time.Millisecond,

--- a/filters/scheduler/fifo_test.go
+++ b/filters/scheduler/fifo_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	stdlibhttptest "net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,7 +20,29 @@ import (
 	"github.com/zalando/skipper/scheduler"
 )
 
-func TestFifoCreateFilter(t *testing.T) {
+func TestCreateFifoName(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		filterFunc func() filters.Spec
+	}{
+		{
+			name:       filters.FifoName,
+			filterFunc: NewFifo,
+		},
+		{
+			name:       filters.FifoWithBodyName,
+			filterFunc: NewFifoWithBody,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.filterFunc().Name() != tt.name {
+				t.Fatalf("got %q, want %q", tt.filterFunc().Name(), tt.name)
+			}
+		})
+	}
+}
+
+func TestCreateFifoFilter(t *testing.T) {
 	for _, tt := range []struct {
 		name         string
 		args         []interface{}
@@ -57,6 +80,33 @@ func TestFifoCreateFilter(t *testing.T) {
 				MaxQueueSize:   5,
 				Timeout:        1 * time.Second,
 			},
+		},
+		{
+			name: "fifo negative value arg1",
+			args: []interface{}{
+				-3,
+				5,
+				"1s",
+			},
+			wantParseErr: true,
+		},
+		{
+			name: "fifo negative value arg2",
+			args: []interface{}{
+				3,
+				-5,
+				"1s",
+			},
+			wantParseErr: true,
+		},
+		{
+			name: "fifo too small value arg3",
+			args: []interface{}{
+				3,
+				5,
+				"1ns",
+			},
+			wantParseErr: true,
 		},
 		{
 			name: "fifo wrong type arg1",
@@ -106,43 +156,160 @@ func TestFifoCreateFilter(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := &fifoSpec{}
-			ff, err := spec.CreateFilter(tt.args)
-			if err != nil && !tt.wantParseErr {
-				t.Fatalf("Failed to parse filter: %v", err)
+			for _, f := range []func() filters.Spec{NewFifo, NewFifoWithBody} {
+				spec := f()
+				ff, err := spec.CreateFilter(tt.args)
+				if err != nil && !tt.wantParseErr {
+					t.Fatalf("Failed to parse filter: %v", err)
+				}
+				if err == nil && tt.wantParseErr {
+					t.Fatal("Failed to get wanted error on create filter")
+				}
+
+				if _, ok := ff.(*fifoFilter); !ok && err == nil {
+					t.Fatal("Failed to convert filter to *fifoFilter")
+				}
 			}
-			if err == nil && tt.wantParseErr {
-				t.Fatal("Failed to get wanted error on create filter")
+		})
+	}
+}
+
+func TestFifoWithBody(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		args         []interface{}
+		backendTime  time.Duration
+		responseSize int
+	}{
+		{
+			name:         "fifoWithBody 1024",
+			args:         []interface{}{1, 0, "1s"},
+			backendTime:  10 * time.Millisecond,
+			responseSize: 1024,
+		},
+		{
+			name:         "fifoWithBody 100MB",
+			args:         []interface{}{1, 0, "20ms"},
+			backendTime:  10 * time.Millisecond,
+			responseSize: 100 * 1000 * 1024,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+			backend := stdlibhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				// sleep here to test the difference between streaming response and not
+				time.Sleep(tt.backendTime)
+				// TODO: maybe better to do slow body streaming?
+				w.Write([]byte(strings.Repeat("A", tt.responseSize)))
+			}))
+			defer backend.Close()
+
+			// proxy
+			metrics := &metricstest.MockMetrics{}
+			reg := scheduler.RegistryWith(scheduler.Options{
+				Metrics:                metrics,
+				EnableRouteFIFOMetrics: true,
+			})
+			defer reg.Close()
+			fr := make(filters.Registry)
+			fr.Register(NewFifoWithBody())
+			args := append(tt.args, backend.URL)
+			doc := fmt.Sprintf(`r: * -> fifoWithBody(%v, %v, "%v") -> "%s"`, args...)
+			t.Logf("%s", doc)
+			dc, err := testdataclient.NewDoc(doc)
+			if err != nil {
+				t.Fatalf("Failed to create testdataclient: %v", err)
 			}
-			if tt.wantParseErr {
-				return
+			defer dc.Close()
+			ro := routing.Options{
+				SignalFirstLoad: true,
+				FilterRegistry:  fr,
+				DataClients:     []routing.DataClient{dc},
+				PostProcessors:  []routing.PostProcessor{reg},
+			}
+			rt := routing.New(ro)
+			defer rt.Close()
+			<-rt.FirstLoad()
+			tracer := &testTracer{MockTracer: mocktracer.New()}
+			pr := proxy.WithParams(proxy.Params{
+				Routing:     rt,
+				OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
+			})
+			defer pr.Close()
+			ts := stdlibhttptest.NewServer(pr)
+			defer ts.Close()
+
+			// simple test
+			rsp, err := ts.Client().Get(ts.URL)
+			if err != nil {
+				t.Fatalf("Failed to get response from %s: %v", ts.URL, err)
+			}
+			defer rsp.Body.Close()
+			if rsp.StatusCode != http.StatusOK {
+				t.Fatalf("Failed to get valid response from endpoint: %d", rsp.StatusCode)
+			}
+			b, err := io.ReadAll(rsp.Body)
+			if err != nil {
+				t.Fatalf("Failed to read response body from: %v", err)
+			}
+			if len(b) != tt.responseSize {
+				t.Fatalf("Failed to read the size, got: %v, want: %v", len(b), tt.responseSize)
 			}
 
-			f, ok := ff.(*fifoFilter)
-			if !ok {
-				t.Fatal("Failed to convert filter to *fifoFilter")
+			// the streaming test
+			rspCH := make(chan *http.Response)
+			errCH := make(chan error)
+			waithCH := make(chan struct{})
+			go func() {
+				rsp, err := ts.Client().Get(ts.URL)
+				waithCH <- struct{}{}
+				if err != nil {
+					errCH <- err
+				} else {
+					rspCH <- rsp
+				}
+			}()
+
+			<-waithCH
+			rsp, err = ts.Client().Get(ts.URL)
+			if err != nil {
+				t.Fatalf("Failed to do 2nd request: %v", err)
+			} else {
+				b, err := io.ReadAll(rsp.Body)
+				if err != nil {
+					t.Fatalf("Failed 2nd request to read body: %v", err)
+				}
+				if len(b) != tt.responseSize {
+					t.Fatalf("Failed 2nd request to get response size: %d, want: %d", len(b), tt.responseSize)
+				}
+			}
+			select {
+			case err := <-errCH:
+				t.Fatalf("Failed to do request: %v", err)
+			case rsp := <-rspCH:
+				b, err := io.ReadAll(rsp.Body)
+				if err != nil {
+					t.Fatalf("Failed to read body: %v", err)
+				}
+				if len(b) != tt.responseSize {
+					t.Fatalf("Failed to get response size: %d, want: %d", len(b), tt.responseSize)
+				}
 			}
 
-			// validate config
-			config := f.Config()
-			if config != tt.wantConfig {
-				t.Fatalf("Failed to get Config, got: %v, want: %v", config, tt.wantConfig)
-			}
-			if f.queue != f.GetQueue() {
-				t.Fatal("Failed to get expected queue")
-			}
 		})
 	}
 }
 
 func TestFifo(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		filter      string
-		freq        int
-		per         time.Duration
-		backendTime time.Duration
-		wantOkRate  float64
+		name          string
+		filter        string
+		freq          int
+		per           time.Duration
+		backendTime   time.Duration
+		clientTimeout time.Duration
+		wantOkRate    float64
 	}{
 		{
 			name:        "fifo simple ok",
@@ -153,28 +320,52 @@ func TestFifo(t *testing.T) {
 			wantOkRate:  1.0,
 		},
 		{
-			name:        "fifo with reaching max concurrency and queue timeouts",
-			filter:      `fifo(3, 5, "10ms")`,
-			freq:        200,
-			per:         100 * time.Millisecond,
-			backendTime: 10 * time.Millisecond,
-			wantOkRate:  0.1,
+			name:          "fifoWithbody simple ok",
+			filter:        `fifoWithbody(3, 5, "1s")`,
+			freq:          20,
+			per:           100 * time.Millisecond,
+			backendTime:   1 * time.Millisecond,
+			clientTimeout: time.Second,
+			wantOkRate:    1.0,
 		},
 		{
-			name:        "fifo with reaching max concurrency and queue full",
-			filter:      `fifo(3, 5, "250ms")`,
-			freq:        200,
-			per:         100 * time.Millisecond,
-			backendTime: 100 * time.Millisecond,
-			wantOkRate:  0.0008,
+			name:          "fifo with reaching max concurrency and queue timeouts",
+			filter:        `fifo(3, 5, "10ms")`,
+			freq:          200,
+			per:           100 * time.Millisecond,
+			backendTime:   10 * time.Millisecond,
+			clientTimeout: time.Second,
+			wantOkRate:    0.1,
+		},
+		{
+			name:          "fifoWithbody with reaching max concurrency and queue timeouts",
+			filter:        `fifoWithbody(3, 5, "10ms")`,
+			freq:          200,
+			per:           100 * time.Millisecond,
+			backendTime:   10 * time.Millisecond,
+			clientTimeout: time.Second,
+			wantOkRate:    0.1,
+		},
+		{
+			name:          "fifo with reaching max concurrency and queue full",
+			filter:        `fifo(1, 1, "250ms")`,
+			freq:          200,
+			per:           100 * time.Millisecond,
+			backendTime:   100 * time.Millisecond,
+			clientTimeout: time.Second,
+			wantOkRate:    0.0008,
+		},
+		{
+			name:          "fifoWithBody with reaching max concurrency and queue full",
+			filter:        `fifoWithBody(1, 1, "250ms")`,
+			freq:          200,
+			per:           100 * time.Millisecond,
+			backendTime:   100 * time.Millisecond,
+			clientTimeout: time.Second,
+			wantOkRate:    0.0008,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fs := NewFifo()
-			if fs.Name() != filters.FifoName {
-				t.Fatalf("Failed to get name got %s want %s", fs.Name(), filters.FifoName)
-			}
-
 			metrics := &metricstest.MockMetrics{}
 			reg := scheduler.RegistryWith(scheduler.Options{
 				Metrics:                metrics,
@@ -183,7 +374,8 @@ func TestFifo(t *testing.T) {
 			defer reg.Close()
 
 			fr := make(filters.Registry)
-			fr.Register(fs)
+			fr.Register(NewFifo())
+			fr.Register(NewFifoWithBody())
 
 			backend := stdlibhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				time.Sleep(tt.backendTime)
@@ -235,9 +427,7 @@ func TestFifo(t *testing.T) {
 				t.Fatalf("Failed to get valid response from endpoint: %d", rsp.StatusCode)
 			}
 
-			const clientTimeout = 1 * time.Second
-
-			va := httptest.NewVegetaAttacker(ts.URL, tt.freq, tt.per, clientTimeout)
+			va := httptest.NewVegetaAttacker(ts.URL, tt.freq, tt.per, tt.clientTimeout)
 			va.Attack(io.Discard, 1*time.Second, tt.name)
 
 			t.Logf("Success [0..1]: %0.2f", va.Success())
@@ -266,30 +456,36 @@ func TestFifo(t *testing.T) {
 
 func TestFifoConstantRouteUpdates(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		filter      string
-		freq        int
-		per         time.Duration
-		updateRate  time.Duration
-		backendTime time.Duration
-		wantOkRate  float64
+		name          string
+		filter        string
+		freq          int
+		per           time.Duration
+		updateRate    time.Duration
+		backendTime   time.Duration
+		clientTimeout time.Duration
+		wantOkRate    float64
 	}{
 		{
-			name:        "fifo simple ok",
-			filter:      `fifo(3, 5, "1s")`,
-			freq:        20,
-			per:         100 * time.Millisecond,
-			updateRate:  25 * time.Millisecond,
-			backendTime: 1 * time.Millisecond,
-			wantOkRate:  1.0,
+			name:          "fifo simple ok",
+			filter:        `fifo(3, 5, "1s")`,
+			freq:          20,
+			per:           100 * time.Millisecond,
+			updateRate:    25 * time.Millisecond,
+			backendTime:   1 * time.Millisecond,
+			clientTimeout: time.Second,
+			wantOkRate:    1.0,
+		}, {
+			name:          "fifoWithBody simple ok",
+			filter:        `fifoWithBody(3, 5, "1s")`,
+			freq:          20,
+			per:           100 * time.Millisecond,
+			updateRate:    25 * time.Millisecond,
+			backendTime:   1 * time.Millisecond,
+			clientTimeout: time.Second,
+			wantOkRate:    1.0,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fs := NewFifo()
-			if fs.Name() != filters.FifoName {
-				t.Fatalf("Failed to get name got %s want %s", fs.Name(), filters.FifoName)
-			}
-
 			metrics := &metricstest.MockMetrics{}
 			reg := scheduler.RegistryWith(scheduler.Options{
 				Metrics:                metrics,
@@ -298,7 +494,8 @@ func TestFifoConstantRouteUpdates(t *testing.T) {
 			defer reg.Close()
 
 			fr := make(filters.Registry)
-			fr.Register(fs)
+			fr.Register(NewFifo())
+			fr.Register(NewFifoWithBody())
 
 			backend := stdlibhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				time.Sleep(tt.backendTime)
@@ -312,7 +509,6 @@ func TestFifoConstantRouteUpdates(t *testing.T) {
 			}
 
 			doc := fmt.Sprintf(`aroute: * -> %s -> "%s"`, tt.filter, backend.URL)
-
 			dc, err := testdataclient.NewDoc(doc)
 			if err != nil {
 				t.Fatalf("Failed to create testdataclient: %v", err)
@@ -351,7 +547,7 @@ func TestFifoConstantRouteUpdates(t *testing.T) {
 
 			// run dataclient updates
 			quit := make(chan struct{})
-			newDoc := fmt.Sprintf(`aroute: * -> fifo(100, 200, "250ms") -> "%s"`, backend.URL)
+			newDoc := fmt.Sprintf(`aroute: * -> %s -> "%s"`, tt.filter, backend.URL)
 			go func(q chan<- struct{}, updateRate time.Duration, doc1, doc2 string) {
 				i := 0
 				for {
@@ -371,9 +567,7 @@ func TestFifoConstantRouteUpdates(t *testing.T) {
 
 			}(quit, tt.updateRate, doc, newDoc)
 
-			const clientTimeout = 1 * time.Second
-
-			va := httptest.NewVegetaAttacker(ts.URL, tt.freq, tt.per, clientTimeout)
+			va := httptest.NewVegetaAttacker(ts.URL, tt.freq, tt.per, tt.clientTimeout)
 			va.Attack(io.Discard, 1*time.Second, tt.name)
 			quit <- struct{}{}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1460,6 +1460,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ctx.Logger().Errorf("Failed to set write deadline: %v", e)
 		}
 	}
+	if sbf, ok := ctx.StateBag()[filters.FifoWithBody]; ok {
+		if f, ok := sbf.(func()); ok {
+			defer f()
+		}
+	}
 
 	if err != nil {
 		p.errorResponse(ctx, err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1454,22 +1454,28 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := p.do(ctx)
 
+	// writeTimeout() filter
 	if d, ok := ctx.StateBag()[filters.WriteTimeout].(time.Duration); ok {
 		e := ctx.ResponseController().SetWriteDeadline(time.Now().Add(d))
 		if e != nil {
 			ctx.Logger().Errorf("Failed to set write deadline: %v", e)
 		}
 	}
-	if sbf, ok := ctx.StateBag()[filters.FifoWithBody]; ok {
-		if f, ok := sbf.(func()); ok {
-			defer f()
-		}
-	}
 
+	// stream response body to client
 	if err != nil {
 		p.errorResponse(ctx, err)
 	} else {
 		p.serveResponse(ctx)
+	}
+
+	// fifoWtihBody() filter
+	if sbf, ok := ctx.StateBag()[filters.FifoWithBodyName]; ok {
+		if fs, ok := sbf.([]func()); ok {
+			for i := len(fs) - 1; i >= 0; i-- {
+				fs[i]()
+			}
+		}
 	}
 
 	if ctx.cancelBackendContext != nil {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -155,6 +155,20 @@ func (fq *fifoQueue) wait(ctx context.Context) (func(), error) {
 	cnt := fq.counter
 	fq.mu.RUnlock()
 
+	// check request context expired
+	// https://github.com/golang/go/issues/63615
+	if err := ctx.Err(); err != nil {
+		switch err {
+		case context.DeadlineExceeded:
+			return nil, ErrQueueTimeout
+		case context.Canceled:
+			return nil, ErrClientCanceled
+		default:
+			// does not exist yet in Go stdlib as of Go1.18.4
+			return nil, err
+		}
+	}
+
 	// handle queue
 	all := cnt.Add(1)
 	// queue full?
@@ -178,6 +192,18 @@ func (fq *fifoQueue) wait(ctx context.Context) (func(), error) {
 		default:
 			// does not exist yet in Go stdlib as of Go1.18.4
 			return nil, err
+		}
+	} else {
+		// semaphore will not fail on Acquire when context timed out, nor when it's canceled.
+		// see also: https://github.com/golang/go/issues/63615
+		// The behavior can change as in the proposed change, so the code path on error would apply.
+		// If the proposed change was merge this code path below can likely be cleaned up.
+		select {
+		case <-c.Done():
+			// We timed out in Acquire, so it never increased semaphore by one
+			cnt.Add(-1)
+			return nil, ErrQueueTimeout
+		default:
 		}
 	}
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -193,18 +193,6 @@ func (fq *fifoQueue) wait(ctx context.Context) (func(), error) {
 			// does not exist yet in Go stdlib as of Go1.18.4
 			return nil, err
 		}
-	} else {
-		// semaphore will not fail on Acquire when context timed out, nor when it's canceled.
-		// see also: https://github.com/golang/go/issues/63615
-		// The behavior can change as in the proposed change, so the code path on error would apply.
-		// If the proposed change was merge this code path below can likely be cleaned up.
-		select {
-		case <-c.Done():
-			// We timed out in Acquire, so it never increased semaphore by one
-			cnt.Add(-1)
-			return nil, ErrQueueTimeout
-		default:
-		}
 	}
 
 	return func() {


### PR DESCRIPTION
feature: filter fifoWithBody that works similar to fifo(), but release deferred until body streaming to client was finished

fix: https://github.com/zalando/skipper/issues/2579
fix: we did not check context canceled before, see also https://github.com/golang/go/issues/63615