### PR TITLE
fix: GH actions run an outdated Go version

### DIFF
--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -28,7 +28,8 @@ jobs:
       - uses: actions/setup-go@bfd2fb341f32be7281829126376a12a780ca79fc
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.20'
+          go-version: '^1.21'
+          check-latest: true
 
       - name: Login to Github Container Registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/setup-go@bfd2fb341f32be7281829126376a12a780ca79fc
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.20'
+          go-version: '^1.21'
+          check-latest: true
       - run: go version
       - run: make deps
       - run: make check-fmt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,8 @@ jobs:
       - uses: actions/setup-go@bfd2fb341f32be7281829126376a12a780ca79fc
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.20'
+          go-version: '^1.21'
+          check-latest: true
       - run: go version
       - run: make deps
       - run: make check-race
@@ -34,7 +35,8 @@ jobs:
       - uses: actions/setup-go@bfd2fb341f32be7281829126376a12a780ca79fc
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.20'
+          go-version: '^1.21'
+          check-latest: true
       - run: go version
       - run: make deps
       - run: make check-fmt


### PR DESCRIPTION
fix: GH actions run an outdated Go version, trying to fix as stated in https://github.com/actions/setup-go/tree/main#check-latest-version