### PR TITLE
validation webhook: Initialize validator object in tests

### DIFF
--- a/cmd/webhook/admission/admission_test.go
+++ b/cmd/webhook/admission/admission_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/dataclients/kubernetes/definitions"
 )
 
 const (
@@ -136,7 +137,7 @@ func TestRouteGroupAdmitter(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 
 			w := httptest.NewRecorder()
-			rgAdm := &RouteGroupAdmitter{}
+			rgAdm := &RouteGroupAdmitter{RouteGroupValidator: &definitions.RouteGroupValidator{}}
 
 			h := Handler(rgAdm)
 			h(w, req)
@@ -200,7 +201,7 @@ func TestIngressAdmitter(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 
 			w := httptest.NewRecorder()
-			ingressAdm := &IngressAdmitter{}
+			ingressAdm := &IngressAdmitter{IngressValidator: &definitions.IngressV1Validator{}}
 
 			h := Handler(ingressAdm)
 			h(w, req)
@@ -217,8 +218,8 @@ func TestIngressAdmitter(t *testing.T) {
 }
 
 func TestMalformedRequests(t *testing.T) {
-	routeGroupHandler := Handler(&RouteGroupAdmitter{})
-	ingressHandler := Handler(&IngressAdmitter{})
+	routeGroupHandler := Handler(&RouteGroupAdmitter{RouteGroupValidator: &definitions.RouteGroupValidator{}})
+	ingressHandler := Handler(&IngressAdmitter{IngressValidator: &definitions.IngressV1Validator{}})
 
 	for _, tc := range []struct {
 		name           string


### PR DESCRIPTION
Test shouldn't be working without validator initialized or at least some of them, related to https://github.com/zalando/skipper/issues/1618.
