### PR TITLE
Print percentiles in benchmark 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/abbot/go-http-auth v0.4.0
 	github.com/andybalholm/brotli v1.1.0
 	github.com/aryszka/jobqueue v0.0.3
+	github.com/benburkert/pbench v0.0.0-20160623210926-4ec5821845ef
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cjoudrey/gluahttp v0.0.0-20201111170219-25003d9adfa9
@@ -94,6 +95,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJ
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/aryszka/jobqueue v0.0.3 h1:O5YbgzQCjRomudwnDTY5BrHUNJhvPHQHq7GfGpE+ybs=
 github.com/aryszka/jobqueue v0.0.3/go.mod h1:SdxqI6HZ4E1Lss94tey5OfjcAu3bdCDWS1AQzzIN4m4=
+github.com/benburkert/pbench v0.0.0-20160623210926-4ec5821845ef h1:+7ZJvJGiV4hUBdjhEDhfGdjBCOmhVi0YQ5n+6g/ei+k=
+github.com/benburkert/pbench v0.0.0-20160623210926-4ec5821845ef/go.mod h1:hrhDSsc41bBqGejYXbvMh6qexfcC2vXjodP5gufwWyI=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -151,6 +153,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424 h1:Vh7rylVZRZCj6W41lRlP17xPk4Nq260H4Xo/DDYmEZk=
+github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424/go.mod h1:vmp8DIyckQMXOPl0AQVHt+7n5h7Gb7hS6CUydiV8QeA=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
This is needed to improve the performance impact of this component.

```
rzavodskikh@ZALANDO-39125:~/skipper$ for i in {1..20}; do go test -benchmem -run=^$ -bench ^BenchmarkGetInflightRequests$ github.com/zalando/skipper/routing |& tee -a output; done
rzavodskikh@ZALANDO-39125:~/skipper$ benchstat output  | grep P99
GetInflightRequests/1_goroutines/P99-16       2.094µ ±  9%
GetInflightRequests/2_goroutines/P99-16       2.079µ ±  6%
GetInflightRequests/3_goroutines/P99-16       2.084µ ±  8%
GetInflightRequests/4_goroutines/P99-16       2.074µ ± 11%
GetInflightRequests/5_goroutines/P99-16       2.033µ ±  9%
GetInflightRequests/6_goroutines/P99-16       1.688µ ± 51%
GetInflightRequests/7_goroutines/P99-16       1.653µ ± 37%
GetInflightRequests/8_goroutines/P99-16       1.833µ ± 62%
GetInflightRequests/12_goroutines/P99-16      941.0n ± 61%
GetInflightRequests/16_goroutines/P99-16      1.182µ ± 71%
GetInflightRequests/24_goroutines/P99-16      782.0n ± 59%
GetInflightRequests/32_goroutines/P99-16      2.024µ ± 38%
GetInflightRequests/48_goroutines/P99-16      1.954µ ± 61%
GetInflightRequests/64_goroutines/P99-16      2.024µ ± 12%
GetInflightRequests/128_goroutines/P99-16     2.054µ ±  8%
GetInflightRequests/256_goroutines/P99-16     1.934µ ±  3%
GetInflightRequests/512_goroutines/P99-16     1.914µ ±  7%
GetInflightRequests/768_goroutines/P99-16     2.044µ ±  8%
GetInflightRequests/1024_goroutines/P99-16    2.043µ ±  7%
GetInflightRequests/1536_goroutines/P99-16    2.144µ ±  7%
GetInflightRequests/2048_goroutines/P99-16    2.104µ ±  6%
GetInflightRequests/4096_goroutines/P99-16    2.525µ ± 37%
GetInflightRequests/8192_goroutines/P99-16    2.385µ ± 23%
GetInflightRequests/16384_goroutines/P99-16   1.263µ ± 52%
GetInflightRequests/32768_goroutines/P99-16   301.0n ± 70%
rzavodskikh@ZALANDO-39125:~/skipper$ 
```