### PR TITLE
fix: endpointslices should not consider Serving condition

### DIFF
--- a/dataclients/kubernetes/endpointslices.go
+++ b/dataclients/kubernetes/endpointslices.go
@@ -153,5 +153,6 @@ func (ep *EndpointSliceEndpoints) isReady() bool {
 		return false
 	}
 	// defaults to ready, see also https://github.com/kubernetes/kubernetes/blob/91aca10d5984313c1c5858979d4946ff9446615f/pkg/proxy/endpointslicecache.go#L137C39-L139
-	return ep.Conditions.Ready == nil || *ep.Conditions.Ready || ep.Conditions.Serving == nil || *ep.Conditions.Serving
+	// we ignore serving because of https://github.com/zalando/skipper/issues/2684
+	return ep.Conditions.Ready == nil || *ep.Conditions.Ready
 }

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/lb-target-multi-multiple-endpointslices-conditions-all-serving.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/lb-target-multi-multiple-endpointslices-conditions-all-serving.eskip
@@ -1,13 +1,13 @@
 // default backend, target 1:
 kube_namespace1__ingress1______:
   *
-  -> <roundRobin, "http://42.0.1.1:8080", "http://42.0.1.2:8080", "http://42.0.1.3:8080", "http://42.0.1.4:8080">;
+  -> <roundRobin, "http://42.0.1.1:8080", "http://42.0.1.4:8080">;
 
 // path rule, target 1:
 kube_namespace1__ingress1__test_example_org___test1__service1:
   Host(/^(test[.]example[.]org[.]?(:[0-9]+)?)$/)
   && PathRegexp(/^(\/test1)/)
-  -> <roundRobin, "http://42.0.1.1:8080", "http://42.0.1.2:8080", "http://42.0.1.3:8080", "http://42.0.1.4:8080">;
+  -> <roundRobin, "http://42.0.1.1:8080", "http://42.0.1.4:8080">;
 
 // catch all:
 kube___catchall__test_example_org____:

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/lb-target-multi-multiple-endpointslices-conditions-all-serving.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/lb-target-multi-multiple-endpointslices-conditions-all-serving.yaml
@@ -85,6 +85,17 @@ endpoints:
       serving: true
       terminating: false
     zone: my-zone-2
+  - addresses:
+    - 42.0.1.5
+    conditions:
+      ready: false
+      serving: true
+    zone: my-zone-1
+  - addresses:
+    - 42.0.1.6
+    conditions:
+      ready: false
+    zone: my-zone-3
 ports:
   - name: port1
     port: 8080


### PR DESCRIPTION
see also https://github.com/zalando/skipper/issues/2684

added: test case for `ready: false` and `nil` cases