### PR TITLE
fix: flakytest for all redistest based tests

### DIFF
--- a/filters/tee/tee_test.go
+++ b/filters/tee/tee_test.go
@@ -245,7 +245,6 @@ func TestTeeEndToEndBody2TeeRoutesAndClosing(t *testing.T) {
 	dc.Update(routeNoShadow, nil)
 	originalHandler.served = make(chan struct{})
 	shadowHandler.served = make(chan struct{})
-	defer close(shadowHandler.served)
 
 	// test shadow do not get anything
 	testingStr := "TESTEST"

--- a/net/redistest/redistest.go
+++ b/net/redistest/redistest.go
@@ -24,7 +24,7 @@ func NewTestRedisWithPassword(t testing.TB, password string) (address string, do
 	start := time.Now()
 
 	// first testcontainer start takes longer than subsequent
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
 
 	port, err := nat.NewPort("tcp", "6379")


### PR DESCRIPTION
Attempt to fix all kind of tests that depend on waiting for redis testcontainers.