### PR TITLE
fix: flakytest for all redistest based tests

### DIFF
--- a/filters/tee/tee_test.go
+++ b/filters/tee/tee_test.go
@@ -245,7 +245,6 @@ func TestTeeEndToEndBody2TeeRoutesAndClosing(t *testing.T) {
 	dc.Update(routeNoShadow, nil)
 	originalHandler.served = make(chan struct{})
 	shadowHandler.served = make(chan struct{})
-	defer close(shadowHandler.served)
 
 	// test shadow do not get anything
 	testingStr := "TESTEST"

--- a/net/redistest/redistest.go
+++ b/net/redistest/redistest.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/redis/go-redis/v9"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -23,15 +24,23 @@ func NewTestRedisWithPassword(t testing.TB, password string) (address string, do
 	start := time.Now()
 
 	// first testcontainer start takes longer than subsequent
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
+
+	port, err := nat.NewPort("tcp", "6379")
+	if err != nil {
+		t.Fatalf("Failed to get new nat port: %v", err)
+	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "redis:6-alpine",
 			Cmd:          args,
 			ExposedPorts: []string{"6379/tcp"},
-			WaitingFor:   wait.ForLog("* Ready to accept connections"),
+			WaitingFor: wait.ForAll(
+				wait.ForLog("* Ready to accept connections"),
+				wait.NewHostPortStrategy(port),
+			),
 		},
 		Started: true,
 	})


### PR DESCRIPTION
fix: flakytest for all redistest based tests
fix: flakytest increase timeout for starting container
fix: flakytest defer close(channel) is leading to double close