### PR TITLE
fix: master build was broken because test was not removed

### DIFF
--- a/cmd/eskip/args_test.go
+++ b/cmd/eskip/args_test.go
@@ -78,11 +78,6 @@ func TestProcessArgs(t *testing.T) {
 		nil,
 		nil,
 	}, {
-		[]string{"-sort-predicates"},
-		false,
-		nil,
-		nil,
-	}, {
 
 		// etcd-urls
 		[]string{"-etcd-urls", "https://etcd1.example.org:4242,https://etcd2.example.org:4545", "-etcd-oauth-token", "example"},


### PR DESCRIPTION
fix: master build was broken since 15513a52119cda20e515a27d37d38bd57bd8dee4 because test was not removed