### PR TITLE
migrate publish coverage report from codecov.io to coveralls.io 

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -27,4 +27,11 @@ jobs:
       - run: make osv-scanner
       - run: make govulncheck
       - run: make capslock
-      - run: make publish-coverage
+      - run: make coverprofile
+      - name: Convert coverage to lcov
+        uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ clean: ## clean temporary files and directories
 	rm -rf .bin
 	rm -f _test_plugins/*.so
 	rm -f _test_plugins_fail/*.so
-	rm -f .coverprofile-all
+	rm -f .coverprofile-all coverage.out
 
 .PHONY: deps
 deps: ## install dependencies to run everything
@@ -169,6 +169,9 @@ check-fmt: $(SOURCES) ## check format code
 .PHONY: precommit
 precommit: fmt build vet staticcheck check-race shortcheck ## precommit hook
 
+coverprofile: $(SOURCES) $(TEST_PLUGINS)
+	go test -test.short -covermode atomic -coverprofile=coverage.out ./...
+
 .coverprofile-all: $(SOURCES) $(TEST_PLUGINS)
 	go test -test.short -coverprofile=.coverprofile-all ./...
 
@@ -179,8 +182,3 @@ cover: .coverprofile-all ## coverage test and show it in your browser
 .PHONY: show-cover
 show-cover: .coverprofile-all
 	go tool cover -html .coverprofile-all
-
-.PHONY: publish-coverage
-publish-coverage: .coverprofile-all
-	curl -s https://codecov.io/bash -o codecov
-	bash codecov -f .coverprofile-all


### PR DESCRIPTION
migrate publish coverage report from codecov.io to coveralls.io and use GH action to do the auth