### PR TITLE
build: use CDP runtime to build docs

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -101,19 +101,18 @@ pipeline:
 - id: docs
   depends_on: [build]
   type: script
-  overlay: ci/python
+  vm_config:
+    type: linux
+    image: cdp-runtime/mkdocs-v9
+    size: small
   commands:
   - desc: install deps
     cmd: |
-      pip3 install mkdocs mkdocs-material markdown-include
+      pipx inject mkdocs-material markdown-include
   - desc: build docs
     cmd: |
-      mkdocs build --strict
-      shopt -s extglob  # needed to use !(pr)
-      if [ "$CDP_PULL_REQUEST_NUMBER" ]; then
-        mkdir -p site/pr/#{CDP_PULL_REQUEST_NUMBER}
-        mv site/!(pr) site/pr/#{CDP_PULL_REQUEST_NUMBER}
-      fi
+      build-docs
+
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
         echo "Please update the docs with: mkdocs gh-deploy"
       fi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,6 @@ markdown_extensions:
     generic: true
 
 extra_javascript:
-  - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 


### PR DESCRIPTION
Use CDP runtime instead of deprecated overlay to build doc site.

Tested locally via:
```
docker run -it -p 8000:8000 --rm -v $PWD:/workspace pierone.stups.zalan.do/cdp-runtime/mkdocs-v9 sh -c 'pipx inject mkdocs-material markdown-include && serve-docs'
```