### PR TITLE
Conditional rate limiting

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2011,12 +2011,16 @@ Parameters:
 
 * number of allowed requests per time period (int)
 * time period for requests being counted (time.Duration)
-* optional parameter to set the same client by header, in case the provided string contains `,`, it will combine all these headers (string)
+* optional parameter to set the same client by header, in case the provided string contains `,`, it will combine all these headers (string).
+  Header names can be prefixed by symbols '!', indicating that the rate limit applies only if this header exists in the request, and '~',
+  indicating that the rate limit applies only if this header is missing. In both cases, it is possible to provide a value for
+  fine-grained control in the form `!HeaderName=Value`.
 
 ```
 clientRatelimit(3, "1m")
 clientRatelimit(3, "1m", "Authorization")
 clientRatelimit(3, "1m", "X-Foo,Authorization,X-Bar")
+clientRatelimit(3, "1m", "X-Foo,Authorization,!X-Bar=foo")
 ```
 
 See also the [ratelimit docs](https://godoc.org/github.com/zalando/skipper/ratelimit).
@@ -2059,12 +2063,16 @@ Parameters:
 * rate limit group (string)
 * number of allowed requests per time period (int)
 * time period for requests being counted (time.Duration)
-* optional parameter to set the same client by header, in case the provided string contains `,`, it will combine all these headers (string)
+* optional parameter to set the same client by header, in case the provided string contains `,`, it will combine all these headers (string).
+  Header names can be prefixed by symbols '!', indicating that the rate limit applies only if this header exists in the request, and '~',
+  indicating that the rate limit applies only if this header is missing. In both cases, it is possible to provide a value for
+  fine-grained control in the form `!HeaderName=Value`
 
 ```
 clusterClientRatelimit("groupA", 10, "1h")
 clusterClientRatelimit("groupA", 10, "1h", "Authorization")
 clusterClientRatelimit("groupA", 10, "1h", "X-Forwarded-For,Authorization,User-Agent")
+clusterClientRatelimit("groupA", 10, "1h", "X-Forwarded-For,Authorization,User-Agent,!X-Foo=bar")
 ```
 
 See also the [ratelimit docs](https://godoc.org/github.com/zalando/skipper/ratelimit).

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -469,9 +469,9 @@ func (f *filter) Request(ctx filters.FilterContext) {
 		return
 	}
 
-	s := f.settings.Lookuper.Lookup(ctx.Request())
-	if s == "" {
-		ctx.Logger().Debugf("Lookuper found no data in request for settings: %s and request: %v", f.settings, ctx.Request())
+	s, ok := f.settings.Lookuper.Lookup(ctx.Request())
+	if !ok {
+		ctx.Logger().Debugf("Lookup unsuccessful for settings: %s and request: %v", f.settings, ctx.Request())
 		return
 	}
 

--- a/filters/ratelimit/ratelimit.go
+++ b/filters/ratelimit/ratelimit.go
@@ -329,6 +329,26 @@ func clusterClientRatelimitFilter(args []interface{}) (*filter, error) {
 }
 
 func getLookuper(s string) ratelimit.Lookuper {
+	if strings.HasPrefix(s, "!") || strings.HasPrefix(s, "~") {
+
+		key, value, valueExists := strings.Cut(s[1:], "=")
+		headerName := http.CanonicalHeaderKey(key)
+
+		if s[0] == '!' && valueExists {
+			return ratelimit.NewHeaderWithValueMustExistLookuper(headerName, value)
+		}
+		if s[0] == '!' {
+			return ratelimit.NewHeaderMustExistLookuper(headerName)
+		}
+
+		if s[0] == '~' && valueExists {
+			return ratelimit.NewHeaderWithValueMustNotExistLookuper(headerName, value)
+		}
+		if s[0] == '~' {
+			return ratelimit.NewHeaderMustNotExistLookuper(headerName)
+		}
+	}
+
 	headerName := http.CanonicalHeaderKey(s)
 	if headerName == "X-Forwarded-For" {
 		return ratelimit.NewXForwardedForLookuper()

--- a/filters/ratelimit/ratelimit_test.go
+++ b/filters/ratelimit/ratelimit_test.go
@@ -441,7 +441,7 @@ type lookuper struct {
 	s string
 }
 
-func (l *lookuper) Lookup(*http.Request) string { return l.s }
+func (l *lookuper) Lookup(*http.Request) (string, bool) { return l.s, true }
 
 func TestLookuperNoData(t *testing.T) {
 	f := &filter{settings: ratelimit.Settings{Lookuper: &lookuper{""}}, provider: &noLimit{}}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -221,6 +221,84 @@ func (h HeaderLookuper) String() string {
 	return "HeaderLookuper"
 }
 
+// TODO Docs
+type HeaderMustExistLookuper struct {
+	key string
+}
+
+func NewHeaderMustExistLookuper(k string) HeaderMustExistLookuper {
+	return HeaderMustExistLookuper{key: k}
+}
+
+func (h HeaderMustExistLookuper) Lookup(req *http.Request) (string, bool) {
+	val := req.Header.Get(h.key)
+	return val, val != ""
+}
+
+func (h HeaderMustExistLookuper) String() string {
+	return "HeaderMustExistLookuper"
+}
+
+type HeaderWithValueMustExistLookuper struct {
+	key string
+	val string
+}
+
+func NewHeaderWithValueMustExistLookuper(k string, v string) HeaderWithValueMustExistLookuper {
+	return HeaderWithValueMustExistLookuper{key: k, val: v}
+}
+
+func (h HeaderWithValueMustExistLookuper) Lookup(req *http.Request) (string, bool) {
+	for _, v := range req.Header.Values(h.key) {
+		if v == h.val {
+			return v, true
+		}
+	}
+	return "", false
+}
+func (h HeaderWithValueMustExistLookuper) String() string {
+	return "HeaderWithValueMustExistLookuper"
+}
+
+type HeaderMustNotExistLookuper struct {
+	key string
+}
+
+func NewHeaderMustNotExistLookuper(k string) HeaderMustNotExistLookuper {
+	return HeaderMustNotExistLookuper{key: k}
+}
+
+func (h HeaderMustNotExistLookuper) Lookup(req *http.Request) (string, bool) {
+	return "", req.Header.Get(h.key) == ""
+}
+
+func (h HeaderMustNotExistLookuper) String() string {
+	return "HeaderMustNotExistLookuper"
+}
+
+type HeaderWithValueMustNotExistLookuper struct {
+	key   string
+	value string
+}
+
+func NewHeaderWithValueMustNotExistLookuper(k string, v string) HeaderWithValueMustNotExistLookuper {
+	return HeaderWithValueMustNotExistLookuper{key: k, value: v}
+}
+
+func (h HeaderWithValueMustNotExistLookuper) Lookup(req *http.Request) (string, bool) {
+	for _, v := range req.Header.Values(h.key) {
+		if v == h.value {
+			return "", false
+		}
+	}
+
+	return "", true
+}
+
+func (h HeaderWithValueMustNotExistLookuper) String() string {
+	return "HeaderWithValueMustNotExistLookuper"
+}
+
 // Lookupers is a slice of Lookuper, required to get a hashable member
 // in the TupleLookuper.
 type Lookupers []Lookuper

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -221,15 +221,18 @@ func (h HeaderLookuper) String() string {
 	return "HeaderLookuper"
 }
 
-// TODO Docs
+// HeaderMustExistLookuper implements Lookuper interface and will select a bucket
+// by a header only if it exists in request.
 type HeaderMustExistLookuper struct {
 	key string
 }
 
+// NewHeaderMustExistLookuper returns HeaderMustExistLookuper configured to lookup header named k
 func NewHeaderMustExistLookuper(k string) HeaderMustExistLookuper {
 	return HeaderMustExistLookuper{key: k}
 }
 
+// Lookup returns the content of the header and true if it exists, otherwise false.
 func (h HeaderMustExistLookuper) Lookup(req *http.Request) (string, bool) {
 	val := req.Header.Get(h.key)
 	return val, val != ""
@@ -239,15 +242,19 @@ func (h HeaderMustExistLookuper) String() string {
 	return "HeaderMustExistLookuper"
 }
 
+// HeaderWithValueMustExistLookuper implements Lookuper interface and will select a bucket
+// by a header only if it exists in request with a specific value.
 type HeaderWithValueMustExistLookuper struct {
 	key string
 	val string
 }
 
+// NewHeaderWithValueMustExistLookuper returns HeaderWithValueMustExistLookuper configured to lookup header named k with value v
 func NewHeaderWithValueMustExistLookuper(k string, v string) HeaderWithValueMustExistLookuper {
 	return HeaderWithValueMustExistLookuper{key: k, val: v}
 }
 
+// Lookup returns the content of the header and true if it exists with the specified value, otherwise false.
 func (h HeaderWithValueMustExistLookuper) Lookup(req *http.Request) (string, bool) {
 	for _, v := range req.Header.Values(h.key) {
 		if v == h.val {
@@ -260,14 +267,18 @@ func (h HeaderWithValueMustExistLookuper) String() string {
 	return "HeaderWithValueMustExistLookuper"
 }
 
+// HeaderMustNotExistLookuper implements Lookuper interface and will select a bucket
+// by a header only if it does not exist in request.
 type HeaderMustNotExistLookuper struct {
 	key string
 }
 
+// NewHeaderMustNotExistLookuper returns HeaderMustNotExistLookuper configured to lookup header named k
 func NewHeaderMustNotExistLookuper(k string) HeaderMustNotExistLookuper {
 	return HeaderMustNotExistLookuper{key: k}
 }
 
+// Lookup returns an empty string  ad true if the header does not exist, otherwise false.
 func (h HeaderMustNotExistLookuper) Lookup(req *http.Request) (string, bool) {
 	return "", req.Header.Get(h.key) == ""
 }
@@ -276,15 +287,19 @@ func (h HeaderMustNotExistLookuper) String() string {
 	return "HeaderMustNotExistLookuper"
 }
 
+// HeaderWithValueMustNotExistLookuper implements Lookuper interface and will select a bucket
+// by a header only if it does not exist in request with a specific value.
 type HeaderWithValueMustNotExistLookuper struct {
 	key   string
 	value string
 }
 
+// NewHeaderWithValueMustNotExistLookuper returns HeaderWithValueMustNotExistLookuper configured to lookup header named k with value v
 func NewHeaderWithValueMustNotExistLookuper(k string, v string) HeaderWithValueMustNotExistLookuper {
 	return HeaderWithValueMustNotExistLookuper{key: k, value: v}
 }
 
+// Lookup returns an empty string and true if the header does not exist with the specified value, otherwise false.
 func (h HeaderWithValueMustNotExistLookuper) Lookup(req *http.Request) (string, bool) {
 	for _, v := range req.Header.Values(h.key) {
 		if v == h.value {

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -230,7 +230,7 @@ func TestHeaderMustExistLookuper(t *testing.T) {
 		if lookupResult != "bar" {
 			t.Errorf("Failed to lookup request")
 		}
-	  if !ok {
+		if !ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
@@ -242,8 +242,8 @@ func TestHeaderMustExistLookuper(t *testing.T) {
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-		
-	  if ok {
+
+		if ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
@@ -262,7 +262,7 @@ func TestHeaderMustNotExistLookuper(t *testing.T) {
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-	  if ok {
+		if ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
@@ -274,13 +274,12 @@ func TestHeaderMustNotExistLookuper(t *testing.T) {
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-		
-	  if !ok {
+
+		if !ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
 }
-
 
 func TestHeaderWithValueMustExistLookuper(t *testing.T) {
 	req, err := http.NewRequest("GET", "/foo", nil)
@@ -295,7 +294,7 @@ func TestHeaderWithValueMustExistLookuper(t *testing.T) {
 		if lookupResult != "bar" {
 			t.Errorf("Failed to lookup request")
 		}
-	  if !ok {
+		if !ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
@@ -307,19 +306,19 @@ func TestHeaderWithValueMustExistLookuper(t *testing.T) {
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-	  if ok {
+		if ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
-	
+
 	t.Run("header with value must exist lookuper missing header", func(t *testing.T) {
 		xLookuper := NewHeaderWithValueMustExistLookuper("x-bruh", "bar")
 		lookupResult, ok := xLookuper.Lookup(req)
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-		
-	  if ok {
+
+		if ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
@@ -338,7 +337,7 @@ func TestHeaderWithValueMustNotExistLookuper(t *testing.T) {
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-	  if ok {
+		if ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
@@ -350,24 +349,23 @@ func TestHeaderWithValueMustNotExistLookuper(t *testing.T) {
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-	  if !ok {
+		if !ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
-	
+
 	t.Run("header with value must not exist lookuper missing header", func(t *testing.T) {
 		xLookuper := NewHeaderWithValueMustNotExistLookuper("x-bruh", "bar")
 		lookupResult, ok := xLookuper.Lookup(req)
 		if lookupResult != "" {
 			t.Errorf("Failed to lookup request")
 		}
-		
-	  if !ok {
+
+		if !ok {
 			t.Errorf("Failed to lookup request")
 		}
 	})
 }
-
 
 type falsyLookuper struct{}
 

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -217,6 +217,158 @@ func TestHeaderLookuper(t *testing.T) {
 	})
 }
 
+func TestHeaderMustExistLookuper(t *testing.T) {
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Errorf("Could not create request: %v", err)
+	}
+
+	t.Run("header must exist lookuper x header", func(t *testing.T) {
+		req.Header.Add("x-blah", "bar")
+		xLookuper := NewHeaderMustExistLookuper("x-bLAh")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "bar" {
+			t.Errorf("Failed to lookup request")
+		}
+	  if !ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+
+	t.Run("header must exist lookuper missing header", func(t *testing.T) {
+		xLookuper := NewHeaderMustExistLookuper("x-bruh")
+		lookupResult, ok := xLookuper.Lookup(req)
+
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+		
+	  if ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+}
+
+func TestHeaderMustNotExistLookuper(t *testing.T) {
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Errorf("Could not create request: %v", err)
+	}
+
+	t.Run("header must not exist lookuper x header", func(t *testing.T) {
+		req.Header.Add("x-blah", "bar")
+		xLookuper := NewHeaderMustNotExistLookuper("x-bLAh")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+	  if ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+
+	t.Run("header must not exist lookuper missing header", func(t *testing.T) {
+		xLookuper := NewHeaderMustNotExistLookuper("x-bruh")
+		lookupResult, ok := xLookuper.Lookup(req)
+
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+		
+	  if !ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+}
+
+
+func TestHeaderWithValueMustExistLookuper(t *testing.T) {
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Errorf("Could not create request: %v", err)
+	}
+
+	t.Run("header with value must exist lookuper x header", func(t *testing.T) {
+		req.Header.Add("x-blah", "bar")
+		xLookuper := NewHeaderWithValueMustExistLookuper("x-bLAh", "bar")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "bar" {
+			t.Errorf("Failed to lookup request")
+		}
+	  if !ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+
+	t.Run("header with value must exist lookuper x header with wrong value", func(t *testing.T) {
+		req.Header.Add("x-blah", "bar")
+		xLookuper := NewHeaderWithValueMustExistLookuper("x-bLAh", "foo")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+	  if ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+	
+	t.Run("header with value must exist lookuper missing header", func(t *testing.T) {
+		xLookuper := NewHeaderWithValueMustExistLookuper("x-bruh", "bar")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+		
+	  if ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+}
+
+func TestHeaderWithValueMustNotExistLookuper(t *testing.T) {
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Errorf("Could not create request: %v", err)
+	}
+
+	t.Run("header with value must not exist lookuper x header", func(t *testing.T) {
+		req.Header.Add("x-blah", "bar")
+		xLookuper := NewHeaderWithValueMustNotExistLookuper("x-bLAh", "bar")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+	  if ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+
+	t.Run("header with value must not exist lookuper x header with wrong value", func(t *testing.T) {
+		req.Header.Add("x-blah", "bar")
+		xLookuper := NewHeaderWithValueMustNotExistLookuper("x-bLAh", "foo")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+	  if !ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+	
+	t.Run("header with value must not exist lookuper missing header", func(t *testing.T) {
+		xLookuper := NewHeaderWithValueMustNotExistLookuper("x-bruh", "bar")
+		lookupResult, ok := xLookuper.Lookup(req)
+		if lookupResult != "" {
+			t.Errorf("Failed to lookup request")
+		}
+		
+	  if !ok {
+			t.Errorf("Failed to lookup request")
+		}
+	})
+}
+
+
 type falsyLookuper struct{}
 
 func (*falsyLookuper) Lookup(r *http.Request) (string, bool) {


### PR DESCRIPTION
This PR adds ability for the conditional rate limiting.
This extension allows you to rate limit clients based on existence or absence of certain headers (with or without specified values) without affecting the clients who do not fit the conditions.
##### An example:
```
-> clusterClientRatelimit("A", 30, "10s", "!X-Customer")
-> clusterClientRatelimit("B", 10, "10s", "~X-Customer,True-Client-IP")
```
The first ratelimit will be applied only to customers with the existing `X-Customer` header, the second one to the customers with the missing `X-Customer` header.
##### Syntax:
- If a header is prepended with `!`, the rate limiter will be applied only if this header exists in the request.

- If a header is prepended with `!` **and** also has a value separated by `=`, the rate limiter will be applied only if this header exists in the request and has this exact value.

- If a header  is prepended with `~`, the rate limiter will be applied only if this header does not exist in the request.

- If a header is prepended with `~` **and** also has a value separated by `=`, the rate limiter will be applied only if this header with this exact value does not exist in the request.
