### PR TITLE
eskip: improve lexer performance

### DIFF
--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func checkItems(t *testing.T, message string, l, lenExpected int, checkItem func(int) bool) bool {
+	t.Helper()
 	if l != lenExpected {
 		t.Error(message, "length", l, lenExpected)
 		return false
@@ -25,6 +26,7 @@ func checkItems(t *testing.T, message string, l, lenExpected int, checkItem func
 }
 
 func checkFilters(t *testing.T, message string, fs, fsExp []*Filter) bool {
+	t.Helper()
 	return checkItems(t, "filters "+message,
 		len(fs),
 		len(fsExp),
@@ -823,7 +825,18 @@ func TestFilterString(t *testing.T) {
 }
 
 func BenchmarkParsePredicates(b *testing.B) {
-	doc := `Foo("bar", "baz")`
+	doc := `FooBarBazKeyValues(
+		"https://example.org/foo0", "foobarbaz0",
+		"https://example.org/foo1", "foobarbaz1",
+		"https://example.org/foo2", "foobarbaz2",
+		"https://example.org/foo3", "foobarbaz3",
+		"https://example.org/foo4", "foobarbaz4",
+		"https://example.org/foo5", "foobarbaz5",
+		"https://example.org/foo6", "foobarbaz6",
+		"https://example.org/foo7", "foobarbaz7",
+		"https://example.org/foo8", "foobarbaz8",
+		"https://example.org/foo9", "foobarbaz9")`
+
 	_, err := ParsePredicates(doc)
 	if err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
* do not use fmt.Sprintf in ParseFilters and ParsePredicates
* avoid allocations for fixed tokens
* optimize scanWhile loop
* add scanEscaped fast path
* optimize scanRegexp and scanEscaped using strings.Builder
* optimize scanWhitespace
* optimize selectScanner using switch

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/eskip
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                  │   HEAD~1    │                HEAD                 │
                  │   sec/op    │   sec/op     vs base                │
ParsePredicates-8   29.88µ ± 3%   11.33µ ± 2%  -62.09% (p=0.000 n=10)

                  │    HEAD~1    │                 HEAD                 │
                  │     B/op     │     B/op      vs base                │
ParsePredicates-8   4.863Ki ± 0%   2.008Ki ± 0%  -58.71% (p=0.000 n=10)

                  │   HEAD~1    │                HEAD                │
                  │  allocs/op  │ allocs/op   vs base                │
ParsePredicates-8   198.00 ± 0%   33.00 ± 0%  -83.33% (p=0.000 n=10)
```
