### PR TITLE
validator: use ingress validator with dataclient

### DIFF
--- a/dataclients/kubernetes/ingress.go
+++ b/dataclients/kubernetes/ingress.go
@@ -255,15 +255,11 @@ func annotationPredicate(m *definitions.Metadata) string {
 }
 
 // parse routes annotation
-func extraRoutes(m *definitions.Metadata, logger *logger) []*eskip.Route {
+func extraRoutes(m *definitions.Metadata) []*eskip.Route {
 	var extraRoutes []*eskip.Route
 	annotationRoutes := m.Annotations[definitions.IngressRoutesAnnotation]
 	if annotationRoutes != "" {
-		var err error
-		extraRoutes, err = eskip.Parse(annotationRoutes)
-		if err != nil {
-			logger.Errorf("Failed to parse routes from %s, skipping: %v", definitions.IngressRoutesAnnotation, err)
-		}
+		extraRoutes, _ = eskip.Parse(annotationRoutes) // We ignore the error here because it should be handled by the validator object
 	}
 	return extraRoutes
 }

--- a/dataclients/kubernetes/ingressv1.go
+++ b/dataclients/kubernetes/ingressv1.go
@@ -432,7 +432,7 @@ func (ing *ingress) ingressV1Route(
 		logger:              logger,
 		annotationFilters:   annotationFilter(i.Metadata, logger),
 		annotationPredicate: annotationPredicate(i.Metadata),
-		extraRoutes:         extraRoutes(i.Metadata, logger),
+		extraRoutes:         extraRoutes(i.Metadata),
 		backendWeights:      backendWeights(i.Metadata, logger),
 		pathMode:            pathMode(i.Metadata, ing.pathMode, logger),
 		redirect:            redirect,

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-invalid-routes-annotation-missing-header-argument.log
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-invalid-routes-annotation-missing-header-argument.log
@@ -1,0 +1,1 @@
+\[ingress\] invalid \\\"zalando\.org\/skipper-routes\\\" annotation: invalid predicate count arg

--- a/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-invalid-routes-annotation-missing-header-argument.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/ingress-data/ing-with-invalid-routes-annotation-missing-header-argument.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: foo
+  name: qux
+  annotations:
+    zalando.org/skipper-routes: |
+      r1: Header("test") -> status(200) -> "http://foo.test"
+spec:
+  defaultBackend:
+    service:
+      name: bar
+      port:
+        number: 1234
+  rules:
+  - host: www.example.org
+    http:
+      paths:
+      - path: "/"
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: bar
+            port:
+              name: baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: foo
+  name: bar
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: baz
+    port: 8181
+    protocol: TCP
+    targetPort: 8080
+  - name: qux
+    port: 1234
+    protocol: TCP
+    targetPort: 2134
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  namespace: foo
+  name: bar
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: baz
+    port: 8080
+    protocol: TCP
+  - name: qux
+    port: 2134
+    protocol: TCP


### PR DESCRIPTION
Relates to https://github.com/zalando/skipper/issues/1618

IngressValidator was introduced in https://github.com/zalando/skipper/pull/2493 while we still validate inside skipper with some functions that will only drop the annotation but Ingress will still pass and work for example https://github.com/zalando/skipper/blob/master/dataclients/kubernetes/ingress.go#L257C1-L269C2 which will drop the annotation only if parsing fail.

This PR should fix this and at least drop the Ingress resource if validation for skipper annotations fail.