### PR TITLE
Return endpointregistry to the load balancer

### DIFF
--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -75,7 +75,7 @@ func shiftWeighted(rnd *rand.Rand, ctx *routing.LBContext, now time.Time) routin
 	rt := ctx.Route
 	ep := ctx.LBEndpoints
 	for _, epi := range ep {
-		wi := fadeIn(now, rt.LBFadeInDuration, rt.LBFadeInExponent, epi.Detected)
+		wi := fadeIn(now, rt.LBFadeInDuration, rt.LBFadeInExponent, epi.EndpointRegistryMetrics.DetectedTime())
 		sum += wi
 	}
 
@@ -83,7 +83,7 @@ func shiftWeighted(rnd *rand.Rand, ctx *routing.LBContext, now time.Time) routin
 	r := rnd.Float64() * sum
 	var upto float64
 	for i, epi := range ep {
-		upto += fadeIn(now, rt.LBFadeInDuration, rt.LBFadeInExponent, epi.Detected)
+		upto += fadeIn(now, rt.LBFadeInDuration, rt.LBFadeInExponent, epi.EndpointRegistryMetrics.DetectedTime())
 		if upto > r {
 			choice = ep[i]
 			break
@@ -116,7 +116,7 @@ func withFadeIn(rnd *rand.Rand, ctx *routing.LBContext, choice int, algo routing
 		now,
 		ctx.Route.LBFadeInDuration,
 		ctx.Route.LBFadeInExponent,
-		ctx.LBEndpoints[choice].Detected,
+		ctx.LBEndpoints[choice].EndpointRegistryMetrics.DetectedTime(),
 	)
 
 	if rnd.Float64() < f {
@@ -124,7 +124,7 @@ func withFadeIn(rnd *rand.Rand, ctx *routing.LBContext, choice int, algo routing
 	}
 	notFadingIndexes := make([]int, 0, len(ep))
 	for i := 0; i < len(ep); i++ {
-		if _, fadingIn := fadeInState(now, ctx.Route.LBFadeInDuration, ep[i].Detected); !fadingIn {
+		if _, fadingIn := fadeInState(now, ctx.Route.LBFadeInDuration, ep[i].EndpointRegistryMetrics.DetectedTime()); !fadingIn {
 			notFadingIndexes = append(notFadingIndexes, i)
 		}
 	}
@@ -263,7 +263,7 @@ func computeLoadAverage(ctx *routing.LBContext) float64 {
 	sum := 1.0 // add 1 to include the request that just arrived
 	endpoints := ctx.LBEndpoints
 	for _, v := range endpoints {
-		sum += float64(v.Metrics.GetInflightRequests())
+		sum += float64(v.EndpointRegistryMetrics.InflightRequests())
 	}
 	return sum / float64(len(endpoints))
 }
@@ -280,10 +280,10 @@ func (ch *consistentHash) boundedLoadSearch(key string, balanceFactor float64, c
 		if skipEndpoint(endpointIndex) {
 			continue
 		}
-		load := ctx.LBEndpoints[endpointIndex].Metrics.GetInflightRequests()
+		load := ctx.LBEndpoints[endpointIndex].EndpointRegistryMetrics.InflightRequests()
 		// We know there must be an endpoint whose load <= average load.
 		// Since targetLoad >= average load (balancerFactor >= 1), there must also be an endpoint with load <= targetLoad.
-		if load <= int(targetLoad) {
+		if float64(load) <= targetLoad {
 			break
 		}
 		ringIndex = (ringIndex + 1) % ch.Len()
@@ -375,7 +375,7 @@ func (p *powerOfRandomNChoices) Apply(ctx *routing.LBContext) routing.LBEndpoint
 // getScore returns negative value of inflightrequests count.
 func (p *powerOfRandomNChoices) getScore(e routing.LBEndpoint) int64 {
 	// endpoints with higher inflight request should have lower score
-	return -int64(e.Metrics.GetInflightRequests())
+	return -e.EndpointRegistryMetrics.InflightRequests()
 }
 
 type (

--- a/loadbalancer/fadein_test.go
+++ b/loadbalancer/fadein_test.go
@@ -67,10 +67,11 @@ func initializeEndpoints(endpointAges []time.Duration, fadeInDuration time.Durat
 
 	for i := range eps {
 		ctx.Route.LBEndpoints = append(ctx.Route.LBEndpoints, routing.LBEndpoint{
-			Host:     eps[i],
-			Detected: detectionTimes[i],
+			Host:                    eps[i],
+			Detected:                detectionTimes[i],
+			EndpointRegistryMetrics: ctx.Registry.GetMetrics(eps[i]),
 		})
-		ctx.Registry.GetMetrics(eps[i]).SetDetected(detectionTimes[i])
+		ctx.Route.LBEndpoints[i].EndpointRegistryMetrics.SetDetected(detectionTimes[i])
 	}
 	ctx.LBEndpoints = ctx.Route.LBEndpoints
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -848,6 +848,10 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 	if endpoint != nil {
 		endpoint.Metrics.IncInflightRequest()
 		defer endpoint.Metrics.DecInflightRequest()
+
+		entry := p.registry.GetMetrics(endpoint.Host)
+		entry.IncInflightRequest()
+		defer entry.DecInflightRequest()
 	}
 
 	if p.experimentalUpgrade && isUpgradeRequest(req) {

--- a/routing/endpointregistry.go
+++ b/routing/endpointregistry.go
@@ -86,13 +86,14 @@ func (r *EndpointRegistry) Do(routes []*Route) []*Route {
 
 	for _, route := range routes {
 		if route.BackendType == eskip.LBBackend {
-			for _, epi := range route.LBEndpoints {
-				metrics := r.GetMetrics(epi.Host)
-				if metrics.DetectedTime().IsZero() {
-					metrics.SetDetected(now)
+			for i := range route.LBEndpoints {
+				epi := &route.LBEndpoints[i]
+				epi.EndpointRegistryMetrics = r.GetMetrics(epi.Host)
+				if epi.EndpointRegistryMetrics.DetectedTime().IsZero() {
+					epi.EndpointRegistryMetrics.SetDetected(now)
 				}
 
-				metrics.SetLastSeen(now)
+				epi.EndpointRegistryMetrics.SetLastSeen(now)
 			}
 		}
 	}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -179,6 +179,11 @@ type LBEndpoint struct {
 	// Detected represents the time when skipper instances first detected a new LB endpoint. This detection
 	// time is used for the fade-in feature of the round-robin and random LB algorithms.
 	Detected time.Time
+
+	// There is ongoing effort to move all dynamic data about endpoints to the EndpointRegistry instead of the
+	// LBEndpoint struct. This will allow us to remove Metrics and Detected fields above and replace them with
+	// EndpointRegistryMetrics which has host-wide metrics instead of route-wide metrics.
+	EndpointRegistryMetrics Metrics
 }
 
 // LBAlgorithm implementations apply a load balancing algorithm


### PR DESCRIPTION
This PR is intended to return endpointregistry component in the hotpath back, however, without introducing lock contention.
At the moment I create this PR to have a test image to perform load tests.
