### PR TITLE
zappr config to enforce mandatory PR labels

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -6,4 +6,15 @@ approvals:
       from:
         orgs:
           - "zalando"
+# mandatory pull request labels
+pull-request:
+  labels:
+    additional: true
+    oneOf:
+      - architectural
+      - major
+      - minor
+      - bugfix
+      - documentation
+      - dependencies
 X-Zalando-Team: "teapot"


### PR DESCRIPTION
Introduce zappr config to enforce mandatory PR labels

see also https://github.com/zalando-incubator/kubernetes-on-aws/pull/6600