### PR TITLE
filters/tracing: improve stateBagToTag 

### DIFF
--- a/filters/tracing/statebagtotag_test.go
+++ b/filters/tracing/statebagtotag_test.go
@@ -59,13 +59,18 @@ func TestStateBagToTag_CreateFilter(t *testing.T) {
 			args: []interface{}{""},
 			err:  filters.ErrInvalidFilterParameters,
 		},
+		{
+			msg:  "too many args",
+			args: []interface{}{"foo", "bar", "baz"},
+			err:  filters.ErrInvalidFilterParameters,
+		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
 			f, err := NewStateBagToTag().CreateFilter(ti.args)
 
 			assert.Equal(t, ti.err, err)
 			if err == nil {
-				ff := f.(stateBagToTagFilter)
+				ff := f.(*stateBagToTagFilter)
 
 				assert.Equal(t, ti.stateBag, ff.stateBagItemName)
 				assert.Equal(t, ti.tag, ff.tagName)


### PR DESCRIPTION
* reduce allocations when tag value is string
* check statebag value first to bail out early if it is absent
* restrict max number of arguments to two

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/filters/tracing
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                            │   HEAD~1    │                HEAD                 │
                            │   sec/op    │   sec/op     vs base                │
StateBagToTag_StringValue-8   313.1n ± 2%   124.3n ± 1%  -60.29% (p=0.000 n=10)

                            │   HEAD~1   │                HEAD                │
                            │    B/op    │   B/op     vs base                 │
StateBagToTag_StringValue-8   19.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                            │   HEAD~1   │                HEAD                 │
                            │ allocs/op  │ allocs/op   vs base                 │
StateBagToTag_StringValue-8   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

For https://github.com/zalando-incubator/kubernetes-on-aws/pull/6604