### PR TITLE
filters/auth: reduce allocations for tokeninfo scope and claims checks

### DIFF
--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -174,16 +174,3 @@ func all(left, right []string) bool {
 	}
 	return true
 }
-
-// intersect checks that one string in the left is also in the right
-func intersect(left, right []string) bool {
-	for _, l := range left {
-		for _, r := range right {
-			if l == r {
-				return true
-			}
-		}
-	}
-
-	return false
-}

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -329,12 +329,12 @@ func (f *tokenOidcFilter) validateAnyClaims(h map[string]interface{}) bool {
 		return false
 	}
 
-	keys := make([]string, 0, len(h))
-	for k := range h {
-		keys = append(keys, k)
+	for _, c := range f.claims {
+		if _, ok := h[c]; ok {
+			return true
+		}
 	}
-
-	return intersect(f.claims, keys)
+	return false
 }
 
 func (f *tokenOidcFilter) validateAllClaims(h map[string]interface{}) bool {
@@ -346,11 +346,12 @@ func (f *tokenOidcFilter) validateAllClaims(h map[string]interface{}) bool {
 		return false
 	}
 
-	keys := make([]string, 0, len(h))
-	for k := range h {
-		keys = append(keys, k)
+	for _, c := range f.claims {
+		if _, ok := h[c]; !ok {
+			return false
+		}
 	}
-	return all(f.claims, keys)
+	return true
 }
 
 type OauthState struct {

--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -271,16 +271,13 @@ func (f *tokeninfoFilter) validateAnyScopes(h map[string]interface{}) bool {
 	if !ok {
 		return false
 	}
-	var a []string
-	for i := range v {
-		s, ok := v[i].(string)
-		if !ok {
-			return false
-		}
-		a = append(a, s)
-	}
 
-	return intersect(f.scopes, a)
+	for _, scope := range f.scopes {
+		if contains(v, scope) {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *tokeninfoFilter) validateAllScopes(h map[string]interface{}) bool {
@@ -296,16 +293,13 @@ func (f *tokeninfoFilter) validateAllScopes(h map[string]interface{}) bool {
 	if !ok {
 		return false
 	}
-	var a []string
-	for i := range v {
-		s, ok := v[i].(string)
-		if !ok {
+
+	for _, scope := range f.scopes {
+		if !contains(v, scope) {
 			return false
 		}
-		a = append(a, s)
 	}
-
-	return all(f.scopes, a)
+	return true
 }
 
 func (f *tokeninfoFilter) validateAnyKV(h map[string]interface{}) bool {
@@ -334,6 +328,15 @@ func (f *tokeninfoFilter) validateAllKV(h map[string]interface{}) bool {
 		}
 	}
 	return true
+}
+
+func contains(vals []interface{}, s string) bool {
+	for _, v := range vals {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 // Request handles authentication based on the defined auth type.


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/filters/auth
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                                               │   HEAD~1    │                HEAD                 │
                                               │   sec/op    │   sec/op     vs base                │
OAuthTokeninfoRequest/oauthTokeninfoAllScope-8   422.5n ± 4%   246.2n ± 1%  -41.74% (p=0.000 n=10)
OAuthTokeninfoRequest/oauthTokeninfoAnyScope-8   413.5n ± 4%   251.5n ± 0%  -39.19% (p=0.000 n=10)
geomean                                          418.0n        248.8n       -40.48%

                                               │   HEAD~1   │                 HEAD                  │
                                               │    B/op    │   B/op    vs base                     │
OAuthTokeninfoRequest/oauthTokeninfoAllScope-8   112.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=10)
OAuthTokeninfoRequest/oauthTokeninfoAnyScope-8   112.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=10)
geomean                                          112.0                  ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                               │   HEAD~1   │                  HEAD                   │
                                               │ allocs/op  │ allocs/op   vs base                     │
OAuthTokeninfoRequest/oauthTokeninfoAllScope-8   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
OAuthTokeninfoRequest/oauthTokeninfoAnyScope-8   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                                          3.000                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```
