### PR TITLE
Use sync.Map in the endpointregistry

### DIFF
--- a/filters/fadein/fadein_test.go
+++ b/filters/fadein/fadein_test.go
@@ -198,7 +198,7 @@ func TestPostProcessor(t *testing.T) {
 			PostProcessors: []routing.PostProcessor{
 				loadbalancer.NewAlgorithmProvider(),
 				endpointRegistry,
-				NewPostProcessor(),
+				NewPostProcessor(PostProcessorOptions{EndpointRegistry: endpointRegistry}),
 			},
 			SignalFirstLoad: true,
 		})
@@ -431,7 +431,7 @@ func TestPostProcessor(t *testing.T) {
 				if !ep.Detected.After(firstDetected) {
 					t.Fatal("Failed to reset detection time.")
 				}
-				if endpointRegistry.GetMetrics(ep.Host).DetectedTime().After(firstDetected) {
+				if !endpointRegistry.GetMetrics(ep.Host).DetectedTime().After(firstDetected) {
 					t.Fatal("Failed to reset detection time.")
 				}
 

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -419,7 +419,7 @@ func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 			t.Errorf("Expected in-flight requests for each endpoint to be less than %d. In-flight request counts: %d, %d, %d", limit, ifr0, ifr1, ifr2)
 		}
 		ep.Metrics.IncInflightRequest()
-		ctx.Registry.IncInflightRequest(ep.Host)
+		ctx.Registry.GetMetrics(ep.Host).IncInflightRequest()
 	}
 }
 
@@ -441,7 +441,7 @@ func TestConsistentHashKeyDistribution(t *testing.T) {
 func addInflightRequests(registry *routing.EndpointRegistry, endpoint routing.LBEndpoint, count int) {
 	for i := 0; i < count; i++ {
 		endpoint.Metrics.IncInflightRequest()
-		registry.IncInflightRequest(endpoint.Host)
+		registry.GetMetrics(endpoint.Host).IncInflightRequest()
 	}
 }
 

--- a/loadbalancer/fadein_test.go
+++ b/loadbalancer/fadein_test.go
@@ -70,7 +70,7 @@ func initializeEndpoints(endpointAges []time.Duration, fadeInDuration time.Durat
 			Host:     eps[i],
 			Detected: detectionTimes[i],
 		})
-		ctx.Registry.SetDetectedTime(eps[i], detectionTimes[i])
+		ctx.Registry.GetMetrics(eps[i]).SetDetected(detectionTimes[i])
 	}
 	ctx.LBEndpoints = ctx.Route.LBEndpoints
 
@@ -332,7 +332,7 @@ func benchmarkFadeIn(
 				Host:     eps[i],
 				Detected: detectionTimes[i],
 			})
-			registry.SetDetectedTime(eps[i], detectionTimes[i])
+			registry.GetMetrics(eps[i]).SetDetected(detectionTimes[i])
 		}
 
 		var wg sync.WaitGroup

--- a/proxy/fadeintesting_test.go
+++ b/proxy/fadeintesting_test.go
@@ -270,7 +270,7 @@ func (p *fadeInProxy) addInstances(n int) {
 			DataClients:    []routing.DataClient{client},
 			PostProcessors: []routing.PostProcessor{
 				loadbalancer.NewAlgorithmProvider(),
-				fadein.NewPostProcessor(),
+				fadein.NewPostProcessor(fadein.PostProcessorOptions{}),
 			},
 		})
 

--- a/skipper.go
+++ b/skipper.go
@@ -1908,7 +1908,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			endpointRegistry,
 			schedulerRegistry,
 			builtin.NewRouteCreationMetrics(mtr),
-			fadein.NewPostProcessor(),
+			fadein.NewPostProcessor(fadein.PostProcessorOptions{EndpointRegistry: endpointRegistry}),
 			admissionControlSpec.PostProcessor(),
 		},
 		SignalFirstLoad: o.WaitFirstRouteLoad,


### PR DESCRIPTION
This PR is intended to make endpointregistry component lock-free
+ use sync.Map to get entries by key
+ convert all entry fields to atomics
+ make GetMetrics method return the entry instead of copy to decrease complexity in general and number of calls to sync.Map's Load in particular

The benchmark results show that it could be slow to call `GetMetrics` too much, but if the user will find a way to reuse its return value, the performance will be much better both than current master and new version:
```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/routing
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
                                       │   master.txt   │     endpointregistrySyncMap.txt     │
                                       │     sec/op     │   sec/op     vs base                │
GetInflightRequests/1_goroutines-16      163.900n ±  7%   6.977n ± 2%  -95.74% (p=0.000 n=15)
GetInflightRequests/2_goroutines-16      202.100n ±  3%   3.792n ± 3%  -98.12% (p=0.000 n=15)
GetInflightRequests/3_goroutines-16      232.500n ±  8%   2.966n ± 4%  -98.72% (p=0.000 n=15)
GetInflightRequests/4_goroutines-16      252.500n ± 13%   2.572n ± 3%  -98.98% (p=0.000 n=15)
GetInflightRequests/5_goroutines-16      253.500n ±  8%   2.484n ± 4%  -99.02% (p=0.000 n=15)
GetInflightRequests/6_goroutines-16      251.900n ± 12%   2.148n ± 4%  -99.15% (p=0.000 n=15)
GetInflightRequests/7_goroutines-16      277.900n ± 10%   2.061n ± 4%  -99.26% (p=0.000 n=15)
GetInflightRequests/8_goroutines-16      268.800n ± 13%   1.834n ± 5%  -99.32% (p=0.000 n=15)
GetInflightRequests/12_goroutines-16     297.600n ± 22%   2.077n ± 3%  -99.30% (p=0.000 n=15)
GetInflightRequests/16_goroutines-16     270.100n ±  8%   2.578n ± 3%  -99.05% (p=0.000 n=15)
GetInflightRequests/24_goroutines-16     270.800n ± 14%   2.588n ± 2%  -99.04% (p=0.000 n=15)
GetInflightRequests/32_goroutines-16     279.400n ± 13%   2.593n ± 1%  -99.07% (p=0.000 n=15)
GetInflightRequests/48_goroutines-16     280.200n ± 10%   2.591n ± 1%  -99.08% (p=0.000 n=15)
GetInflightRequests/64_goroutines-16     298.500n ± 10%   2.593n ± 1%  -99.13% (p=0.000 n=15)
GetInflightRequests/128_goroutines-16    318.300n ±  9%   2.583n ± 1%  -99.19% (p=0.000 n=15)
GetInflightRequests/256_goroutines-16    325.700n ±  6%   2.598n ± 1%  -99.20% (p=0.000 n=15)
GetInflightRequests/512_goroutines-16    299.500n ± 16%   2.679n ± 3%  -99.11% (p=0.000 n=15)
GetInflightRequests/768_goroutines-16    327.800n ± 12%   2.752n ± 1%  -99.16% (p=0.000 n=15)
GetInflightRequests/1024_goroutines-16   331.000n ±  7%   2.810n ± 2%  -99.15% (p=0.000 n=15)
GetInflightRequests/1536_goroutines-16   252.300n ± 19%   2.830n ± 2%  -98.88% (p=0.000 n=15)
GetInflightRequests/2048_goroutines-16   245.500n ± 16%   2.874n ± 4%  -98.83% (p=0.000 n=15)
GetInflightRequests/4096_goroutines-16   213.200n ± 19%   2.784n ± 2%  -98.69% (p=0.000 n=15)
IncInflightRequests/1_goroutines-16       20.440n ±  9%   7.043n ± 1%  -65.54% (p=0.000 n=15)
IncInflightRequests/2_goroutines-16        30.88n ±  7%   10.26n ± 4%  -66.77% (p=0.000 n=15)
IncInflightRequests/3_goroutines-16        81.16n ± 16%   11.63n ± 3%  -85.67% (p=0.000 n=15)
IncInflightRequests/4_goroutines-16        94.71n ± 15%   13.48n ± 6%  -85.77% (p=0.000 n=15)
IncInflightRequests/5_goroutines-16        97.11n ± 20%   11.22n ± 4%  -88.45% (p=0.000 n=15)
IncInflightRequests/6_goroutines-16       110.70n ± 11%   10.81n ± 2%  -90.23% (p=0.000 n=15)
IncInflightRequests/7_goroutines-16       109.00n ± 16%   10.71n ± 1%  -90.17% (p=0.000 n=15)
IncInflightRequests/8_goroutines-16       108.50n ± 13%   10.73n ± 2%  -90.11% (p=0.000 n=15)
IncInflightRequests/12_goroutines-16      126.10n ± 11%   10.21n ± 3%  -91.90% (p=0.000 n=15)
IncInflightRequests/16_goroutines-16     117.200n ± 13%   9.842n ± 5%  -91.60% (p=0.000 n=15)
IncInflightRequests/24_goroutines-16       97.68n ± 18%   10.27n ± 4%  -89.49% (p=0.000 n=15)
IncInflightRequests/32_goroutines-16     131.300n ± 13%   9.871n ± 4%  -92.48% (p=0.000 n=15)
IncInflightRequests/48_goroutines-16     116.100n ± 25%   9.925n ± 3%  -91.45% (p=0.000 n=15)
IncInflightRequests/64_goroutines-16      89.740n ± 20%   9.986n ± 1%  -88.87% (p=0.000 n=15)
IncInflightRequests/128_goroutines-16     141.70n ± 10%   10.05n ± 3%  -92.91% (p=0.000 n=15)
IncInflightRequests/256_goroutines-16     153.00n ±  9%   10.26n ± 2%  -93.29% (p=0.000 n=15)
IncInflightRequests/512_goroutines-16     143.90n ±  8%   10.56n ± 3%  -92.66% (p=0.000 n=15)
IncInflightRequests/768_goroutines-16      92.80n ± 45%   10.67n ± 4%  -88.50% (p=0.000 n=15)
IncInflightRequests/1024_goroutines-16    131.30n ± 12%   10.41n ± 4%  -92.07% (p=0.000 n=15)
IncInflightRequests/1536_goroutines-16    106.10n ± 11%   10.26n ± 4%  -90.33% (p=0.000 n=15)
IncInflightRequests/2048_goroutines-16     98.52n ± 19%   10.28n ± 3%  -89.57% (p=0.000 n=15)
IncInflightRequests/4096_goroutines-16     89.42n ± 40%   10.30n ± 1%  -88.48% (p=0.000 n=15)
GetDetectedTime/1_goroutines-16                           7.075n ± 4%
GetDetectedTime/2_goroutines-16                           6.989n ± 4%
GetDetectedTime/3_goroutines-16                           5.359n ± 6%
GetDetectedTime/4_goroutines-16                           4.589n ± 4%
GetDetectedTime/5_goroutines-16                           4.480n ± 5%
GetDetectedTime/6_goroutines-16                           4.389n ± 2%
GetDetectedTime/7_goroutines-16                           4.396n ± 2%
GetDetectedTime/8_goroutines-16                           4.521n ± 2%
GetDetectedTime/12_goroutines-16                          5.307n ± 2%
GetDetectedTime/16_goroutines-16                          6.109n ± 1%
GetDetectedTime/24_goroutines-16                          6.081n ± 2%
GetDetectedTime/32_goroutines-16                          5.974n ± 2%
GetDetectedTime/48_goroutines-16                          5.993n ± 3%
GetDetectedTime/64_goroutines-16                          6.039n ± 3%
GetDetectedTime/128_goroutines-16                         5.996n ± 7%
GetDetectedTime/256_goroutines-16                         5.848n ± 5%
GetDetectedTime/512_goroutines-16                         5.963n ± 3%
GetDetectedTime/768_goroutines-16                         5.870n ± 4%
GetDetectedTime/1024_goroutines-16                        5.984n ± 4%
GetDetectedTime/1536_goroutines-16                        5.986n ± 2%
GetDetectedTime/2048_goroutines-16                        5.941n ± 3%
GetDetectedTime/4096_goroutines-16                        5.939n ± 1%
geomean                                    159.8n         5.394n       -96.69%

                                       │  master.txt  │       endpointregistrySyncMap.txt       │
                                       │     B/op     │    B/op     vs base                     │
GetInflightRequests/1_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/2_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/3_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/4_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/5_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/6_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/7_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/8_goroutines-16      32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/12_goroutines-16     32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/16_goroutines-16     32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/24_goroutines-16     32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/32_goroutines-16     32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/48_goroutines-16     32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/64_goroutines-16     32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/128_goroutines-16    32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/256_goroutines-16    32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/512_goroutines-16    32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/768_goroutines-16    32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/1024_goroutines-16   32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/1536_goroutines-16   32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/2048_goroutines-16   32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/4096_goroutines-16   32.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=15)
IncInflightRequests/1_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/2_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/3_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/4_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/5_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/6_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/7_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/8_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/12_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/16_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/24_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/32_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/48_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/64_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/128_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/256_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/512_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/768_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/1024_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/1536_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/2048_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/4096_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
GetDetectedTime/1_goroutines-16                         0.000 ± 0%
GetDetectedTime/2_goroutines-16                         0.000 ± 0%
GetDetectedTime/3_goroutines-16                         0.000 ± 0%
GetDetectedTime/4_goroutines-16                         0.000 ± 0%
GetDetectedTime/5_goroutines-16                         0.000 ± 0%
GetDetectedTime/6_goroutines-16                         0.000 ± 0%
GetDetectedTime/7_goroutines-16                         0.000 ± 0%
GetDetectedTime/8_goroutines-16                         0.000 ± 0%
GetDetectedTime/12_goroutines-16                        0.000 ± 0%
GetDetectedTime/16_goroutines-16                        0.000 ± 0%
GetDetectedTime/24_goroutines-16                        0.000 ± 0%
GetDetectedTime/32_goroutines-16                        0.000 ± 0%
GetDetectedTime/48_goroutines-16                        0.000 ± 0%
GetDetectedTime/64_goroutines-16                        0.000 ± 0%
GetDetectedTime/128_goroutines-16                       0.000 ± 0%
GetDetectedTime/256_goroutines-16                       0.000 ± 0%
GetDetectedTime/512_goroutines-16                       0.000 ± 0%
GetDetectedTime/768_goroutines-16                       0.000 ± 0%
GetDetectedTime/1024_goroutines-16                      0.000 ± 0%
GetDetectedTime/1536_goroutines-16                      0.000 ± 0%
GetDetectedTime/2048_goroutines-16                      0.000 ± 0%
GetDetectedTime/4096_goroutines-16                      0.000 ± 0%
geomean                                             ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                       │  master.txt  │       endpointregistrySyncMap.txt       │
                                       │  allocs/op   │ allocs/op   vs base                     │
GetInflightRequests/1_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/2_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/3_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/4_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/5_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/6_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/7_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/8_goroutines-16      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/12_goroutines-16     1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/16_goroutines-16     1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/24_goroutines-16     1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/32_goroutines-16     1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/48_goroutines-16     1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/64_goroutines-16     1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/128_goroutines-16    1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/256_goroutines-16    1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/512_goroutines-16    1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/768_goroutines-16    1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/1024_goroutines-16   1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/1536_goroutines-16   1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/2048_goroutines-16   1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
GetInflightRequests/4096_goroutines-16   1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=15)
IncInflightRequests/1_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/2_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/3_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/4_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/5_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/6_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/7_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/8_goroutines-16      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/12_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/16_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/24_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/32_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/48_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/64_goroutines-16     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/128_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/256_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/512_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/768_goroutines-16    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/1024_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/1536_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/2048_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
IncInflightRequests/4096_goroutines-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=15) ¹
GetDetectedTime/1_goroutines-16                         0.000 ± 0%
GetDetectedTime/2_goroutines-16                         0.000 ± 0%
GetDetectedTime/3_goroutines-16                         0.000 ± 0%
GetDetectedTime/4_goroutines-16                         0.000 ± 0%
GetDetectedTime/5_goroutines-16                         0.000 ± 0%
GetDetectedTime/6_goroutines-16                         0.000 ± 0%
GetDetectedTime/7_goroutines-16                         0.000 ± 0%
GetDetectedTime/8_goroutines-16                         0.000 ± 0%
GetDetectedTime/12_goroutines-16                        0.000 ± 0%
GetDetectedTime/16_goroutines-16                        0.000 ± 0%
GetDetectedTime/24_goroutines-16                        0.000 ± 0%
GetDetectedTime/32_goroutines-16                        0.000 ± 0%
GetDetectedTime/48_goroutines-16                        0.000 ± 0%
GetDetectedTime/64_goroutines-16                        0.000 ± 0%
GetDetectedTime/128_goroutines-16                       0.000 ± 0%
GetDetectedTime/256_goroutines-16                       0.000 ± 0%
GetDetectedTime/512_goroutines-16                       0.000 ± 0%
GetDetectedTime/768_goroutines-16                       0.000 ± 0%
GetDetectedTime/1024_goroutines-16                      0.000 ± 0%
GetDetectedTime/1536_goroutines-16                      0.000 ± 0%
GetDetectedTime/2048_goroutines-16                      0.000 ± 0%
GetDetectedTime/4096_goroutines-16                      0.000 ± 0%
geomean                                             ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```