### PR TITLE
dataclients/kubernetes: partially create RouteGroup routes on missing service

### DIFF
--- a/dataclients/kubernetes/clusterclient_test.go
+++ b/dataclients/kubernetes/clusterclient_test.go
@@ -266,7 +266,7 @@ func TestLoggingInterval(t *testing.T) {
 	defer log.SetOutput(os.Stderr)
 
 	countMessages := func() int {
-		return strings.Count(out.String(), "Error transforming external hosts")
+		return strings.Count(out.String(), "Ignoring route 0: service not found: default/myapp")
 	}
 
 	a, err := kubernetestest.NewAPI(kubernetestest.TestAPIOptions{}, manifest)

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.log
@@ -1,2 +1,2 @@
-Error transforming external hosts: service not found: foo/non-existent
+Ignoring route 0: service not found: foo/non-existent
 kind=RouteGroup name=myapp-no-service ns=foo

--- a/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.eskip
@@ -1,0 +1,2 @@
+kube_rg____example_org__catchall__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <shunt>;
+kube_rg__default__myapp__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") && Path("/app1") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.log
@@ -1,0 +1,4 @@
+kind=RouteGroup name=myapp
+Ignoring route 1: service not found: default/myapp-2
+Ignoring route 2: service not found: default/myapp-2
+Ignoring route 3: service not found: default/myapp-2

--- a/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.yaml
@@ -1,0 +1,55 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: myapp-1
+      type: service
+      serviceName: myapp-1
+      servicePort: 80
+    - name: myapp-2
+      type: service
+      serviceName: myapp-2
+      servicePort: 80
+  defaultBackends:
+    - backendName: myapp-2
+  routes:
+    - path: /app1
+      backends:
+        - backendname: myapp-1
+    - path: /app2
+      backends:
+        - backendname: myapp-2
+    - path: /split
+      backends:
+        - backendname: myapp-1
+        - backendname: myapp-2
+    - path: /default
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp-1
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: myapp-1
+subsets:
+  - addresses:
+      - ip: 10.2.4.8
+      - ip: 10.2.4.16
+    ports:
+      - port: 80

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
@@ -1,2 +1,2 @@
-Error transforming internal hosts: service not found: default/myapp
+Ignoring route 0: service not found: default/myapp
 kind=RouteGroup name=myapp


### PR DESCRIPTION
Ignore routes that reference missing service.