### PR TITLE
Open-policy-agent: Insert config labels in opa runtime

### DIFF
--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -54,6 +54,17 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			removeHeaders:     make(http.Header),
 		},
 		{
+			msg:             "Allow Matching Environment",
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_runtime_environment",
+			requestPath:     "/allow",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "Welcome!",
+			expectedHeaders: make(http.Header),
+			backendHeaders:  make(http.Header),
+			removeHeaders:   make(http.Header),
+		},
+		{
 			msg:               "Simple Forbidden",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow",
@@ -159,6 +170,10 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 						allow_context_extensions {
 							input.attributes.contextExtensions["com.mycompany.myprop"] == "myvalue"
 						}
+
+						allow_runtime_environment {
+							opa.runtime().config.labels.environment == "test"
+						}
 						
 						default allow_object = {
 							"allowed": false,
@@ -212,6 +227,9 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 					"test": {
 						"resource": "/bundles/{{ .bundlename }}"
 					}
+				},
+				"labels": {
+					"environment": "test"
 				},
 				"plugins": {
 					"envoy_ext_authz_grpc": {    

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -153,7 +153,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 							response := {
 								"allowed": true,
 								"headers": {"x-ext-auth-allow": "yes"},
-								"body": "Welcome to production evaluation!",
+								"body": "Welcome to test evaluation!",
 								"http_status": 200
 							}
 						}

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -188,12 +188,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			config := []byte(fmt.Sprintf(`{
 				"services": {
 					"test": {
-						"url": %q,
-						"credentials": {
-							"bearer": { 
-								"token": "432423342"
-							}
-						}
+						"url": %q
 					}
 				},
 				"labels": {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -356,11 +356,10 @@ func New(store storage.Store, configBytes []byte, instanceConfig OpenPolicyAgent
 	}
 
 	runtime.RegisterPlugin(envoy.PluginName, envoy.Factory{})
-	info := configLabelsInfo(*opaConfig)
 
 	var logger logging.Logger = &QuietLogger{target: logging.Get()}
 	logger = logger.WithFields(map[string]interface{}{"skipper-filter": filterName})
-	manager, err := plugins.New(configBytes, id, store, plugins.Info(info), plugins.Logger(logger))
+	manager, err := plugins.New(configBytes, id, store, configLabelsInfo(*opaConfig), plugins.Logger(logger))
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +449,7 @@ func waitFunc(ctx context.Context, fun func() bool, interval time.Duration) erro
 	}
 }
 
-func configLabelsInfo(opaConfig config.Config) *ast.Term {
+func configLabelsInfo(opaConfig config.Config) func(*plugins.Manager) {
 	info := ast.NewObject()
 	labels := ast.NewObject()
 	labelsWrapper := ast.NewObject()
@@ -462,7 +461,7 @@ func configLabelsInfo(opaConfig config.Config) *ast.Term {
 	labelsWrapper.Insert(ast.StringTerm("labels"), ast.NewTerm(labels))
 	info.Insert(ast.StringTerm("config"), ast.NewTerm(labelsWrapper))
 
-	return ast.NewTerm(info)
+	return plugins.Info(ast.NewTerm(info))
 }
 
 func (opa *OpenPolicyAgentInstance) InstanceConfig() *OpenPolicyAgentInstanceConfig {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -356,11 +356,11 @@ func New(store storage.Store, configBytes []byte, instanceConfig OpenPolicyAgent
 	}
 
 	runtime.RegisterPlugin(envoy.PluginName, envoy.Factory{})
-	info := runtimeConfigInfo(*opaConfig)
+	info := configLabelsInfo(*opaConfig)
 
 	var logger logging.Logger = &QuietLogger{target: logging.Get()}
 	logger = logger.WithFields(map[string]interface{}{"skipper-filter": filterName})
-	manager, err := plugins.New(configBytes, id, store, plugins.Info(ast.NewTerm(info)), plugins.Logger(logger))
+	manager, err := plugins.New(configBytes, id, store, plugins.Info(info), plugins.Logger(logger))
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +450,7 @@ func waitFunc(ctx context.Context, fun func() bool, interval time.Duration) erro
 	}
 }
 
-func runtimeConfigInfo(opaConfig config.Config) ast.Object {
+func configLabelsInfo(opaConfig config.Config) *ast.Term {
 	info := ast.NewObject()
 	labels := ast.NewObject()
 	labelsWrapper := ast.NewObject()
@@ -462,7 +462,7 @@ func runtimeConfigInfo(opaConfig config.Config) ast.Object {
 	labelsWrapper.Insert(ast.StringTerm("labels"), ast.NewTerm(labels))
 	info.Insert(ast.StringTerm("config"), ast.NewTerm(labelsWrapper))
 
-	return info
+	return ast.NewTerm(info)
 }
 
 func (opa *OpenPolicyAgentInstance) InstanceConfig() *OpenPolicyAgentInstanceConfig {

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -270,6 +270,7 @@ func TestOpaLabelsSetInRuntimeWithDiscovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	instance, err := registry.NewOpenPolicyAgentInstance("test", *cfg, "testfilter")
+	assert.NoError(t, err)
 	assert.NotNil(t, instance)
 	assert.NotNil(t, instance.Runtime())
 
@@ -279,7 +280,7 @@ func TestOpaLabelsSetInRuntimeWithDiscovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	if m, ok := j.(map[string]interface{}); ok {
-		configObject, _ := m["config"]
+		configObject := m["config"]
 		assert.NotNil(t, configObject)
 
 		jsonData, err := json.Marshal(configObject)

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	authv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/open-policy-agent/opa-envoy-plugin/envoyauth"
+	opaconf "github.com/open-policy-agent/opa/config"
 	opasdktest "github.com/open-policy-agent/opa/sdk/test"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
@@ -121,6 +123,9 @@ func mockControlPlaneWithDiscoveryBundle(discoveryBundle string) (*opasdktest.Se
 			"test": {
 				"url": %q
 			}
+		},
+		"labels": {
+			"environment": "envValue"
 		},
 		"discovery": {
 			"name": "discovery",
@@ -254,6 +259,40 @@ func TestOpaActivationSuccessWithDiscovery(t *testing.T) {
 	assert.NotNil(t, instance)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(registry.instances))
+}
+
+func TestOpaLabelsSetInRuntimeWithDiscovery(t *testing.T) {
+	_, config := mockControlPlaneWithDiscoveryBundle("bundles/discovery")
+
+	registry := NewOpenPolicyAgentRegistry(WithReuseDuration(1*time.Second), WithCleanInterval(1*time.Second))
+
+	cfg, err := NewOpenPolicyAgentConfig(WithConfigTemplate(config))
+	assert.NoError(t, err)
+
+	instance, err := registry.NewOpenPolicyAgentInstance("test", *cfg, "testfilter")
+	assert.NotNil(t, instance)
+	assert.NotNil(t, instance.Runtime())
+
+	value := instance.Runtime().Value
+
+	j, err := ast.JSON(value)
+	assert.NoError(t, err)
+
+	if m, ok := j.(map[string]interface{}); ok {
+		configObject, _ := m["config"]
+		assert.NotNil(t, configObject)
+
+		jsonData, err := json.Marshal(configObject)
+		assert.NoError(t, err)
+
+		var parsed *opaconf.Config
+		json.Unmarshal(jsonData, &parsed)
+
+		labels := parsed.Labels
+		assert.Equal(t, labels["environment"], "envValue")
+	} else {
+		t.Fatalf("Failed to process runtime value %v", j)
+	}
 }
 
 func TestOpaActivationFailureWithWrongServiceConfig(t *testing.T) {


### PR DESCRIPTION
**Insert config labels in opa runtime**

Without runtime config, it is not possible to determine the environment information within rego code. With this PR, non sensitive configuration are added so that they will be available with opa.runtime() built-in function.

https://github.com/open-policy-agent/opa/blob/main/plugins/plugins.go#L302 this function is used to set runtime.