### PR TITLE
refactor: sync.Mutex is fine as value object and needs no initialization

### DIFF
--- a/circuit/ratebreaker.go
+++ b/circuit/ratebreaker.go
@@ -1,8 +1,9 @@
 package circuit
 
 import (
-	log "github.com/sirupsen/logrus"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/sony/gobreaker"
 )
@@ -14,7 +15,7 @@ import (
 
 type rateBreaker struct {
 	settings BreakerSettings
-	mx       *sync.Mutex
+	mx       sync.Mutex
 	sampler  *binarySampler
 	gb       *gobreaker.TwoStepCircuitBreaker
 }
@@ -22,7 +23,6 @@ type rateBreaker struct {
 func newRate(s BreakerSettings) *rateBreaker {
 	b := &rateBreaker{
 		settings: s,
-		mx:       &sync.Mutex{},
 	}
 
 	b.gb = gobreaker.NewTwoStepCircuitBreaker(gobreaker.Settings{

--- a/circuit/registry.go
+++ b/circuit/registry.go
@@ -13,7 +13,7 @@ type Registry struct {
 	defaults     BreakerSettings
 	hostSettings map[string]BreakerSettings
 	lookup       map[BreakerSettings]*Breaker
-	mx           *sync.Mutex
+	mx           sync.Mutex
 }
 
 // NewRegistry initializes a registry with the provided default settings. Settings with an empty Host field are
@@ -50,7 +50,6 @@ func NewRegistry(settings ...BreakerSettings) *Registry {
 		defaults:     defaults,
 		hostSettings: hs,
 		lookup:       make(map[BreakerSettings]*Breaker),
-		mx:           &sync.Mutex{},
 	}
 }
 

--- a/proxy/fadeintesting_test.go
+++ b/proxy/fadeintesting_test.go
@@ -64,7 +64,7 @@ type fadeInProxyInstance struct {
 
 type fadeInProxy struct {
 	test      *testing.T
-	mx        *sync.Mutex
+	mx        sync.Mutex
 	backend   *fadeInBackend
 	instances []*fadeInProxyInstance
 }
@@ -251,7 +251,6 @@ func (p *fadeInProxyInstance) close() {
 func startProxy(t *testing.T, b *fadeInBackend) *fadeInProxy {
 	return &fadeInProxy{
 		test:    t,
-		mx:      &sync.Mutex{},
 		backend: b,
 	}
 }

--- a/secrets/certregistry/certregistry.go
+++ b/secrets/certregistry/certregistry.go
@@ -13,7 +13,7 @@ import (
 // ensuring synchronized access to them.
 type CertRegistry struct {
 	lookup map[string]*tls.Certificate
-	mx     *sync.Mutex
+	mx     sync.Mutex
 }
 
 // NewCertRegistry initializes the certificate registry.
@@ -22,7 +22,6 @@ func NewCertRegistry() *CertRegistry {
 
 	return &CertRegistry{
 		lookup: l,
-		mx:     &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
refactor: sync.Mutex is fine as value object and needs no initialization