### PR TITLE
Fixed the remaining comments from previous endpointregistry PR

### DIFF
--- a/filters/fadein/fadein.go
+++ b/filters/fadein/fadein.go
@@ -200,10 +200,6 @@ type PostProcessorOptions struct {
 // NewPostProcessor creates post-processor for maintaining the detection time of LB endpoints with fade-in
 // behavior.
 func NewPostProcessor(options PostProcessorOptions) routing.PostProcessor {
-	if options.EndpointRegistry == nil {
-		options.EndpointRegistry = routing.NewEndpointRegistry(routing.RegistryOptions{})
-	}
-
 	return &postProcessor{
 		endpointRegisty: options.EndpointRegistry,
 		detected:        make(map[string]detectedFadeIn),
@@ -245,9 +241,11 @@ func (p *postProcessor) Do(r []*routing.Route) []*routing.Route {
 			}
 
 			ep.Detected = detected
-			metrics := p.endpointRegisty.GetMetrics(ep.Host)
-			if endpointsCreated[key].After(metrics.DetectedTime()) {
-				metrics.SetDetected(endpointsCreated[key])
+			if p.endpointRegisty != nil {
+				metrics := p.endpointRegisty.GetMetrics(ep.Host)
+				if endpointsCreated[key].After(metrics.DetectedTime()) {
+					metrics.SetDetected(endpointsCreated[key])
+				}
 			}
 			p.detected[key] = detectedFadeIn{
 				when:       detected,

--- a/proxy/fadeintesting_test.go
+++ b/proxy/fadeintesting_test.go
@@ -264,12 +264,15 @@ func (p *fadeInProxy) addInstances(n int) {
 		fr := make(filters.Registry)
 		fr.Register(fadein.NewFadeIn())
 		fr.Register(fadein.NewEndpointCreated())
+
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 		rt := routing.New(routing.Options{
 			FilterRegistry: fr,
 			DataClients:    []routing.DataClient{client},
 			PostProcessors: []routing.PostProcessor{
 				loadbalancer.NewAlgorithmProvider(),
-				fadein.NewPostProcessor(fadein.PostProcessorOptions{}),
+				endpointRegistry,
+				fadein.NewPostProcessor(fadein.PostProcessorOptions{EndpointRegistry: endpointRegistry}),
 			},
 		})
 

--- a/routing/endpointregistry.go
+++ b/routing/endpointregistry.go
@@ -60,11 +60,11 @@ func (e *entry) SetLastSeen(ts time.Time) {
 	e.lastSeen.Store(ts)
 }
 
-func newEntry() (result *entry) {
-	result = &entry{}
+func newEntry() *entry {
+	result := &entry{}
 	result.SetDetected(time.Time{})
 	result.SetLastSeen(time.Time{})
-	return
+	return result
 }
 
 type EndpointRegistry struct {
@@ -115,13 +115,11 @@ func NewEndpointRegistry(o RegistryOptions) *EndpointRegistry {
 		o.LastSeenTimeout = defaultLastSeenTimeout
 	}
 
-	result := &EndpointRegistry{
+	return &EndpointRegistry{
 		data:            sync.Map{},
 		lastSeenTimeout: o.LastSeenTimeout,
 		now:             time.Now,
 	}
-
-	return result
 }
 
 func (r *EndpointRegistry) GetMetrics(key string) Metrics {

--- a/routing/endpointregistry_test.go
+++ b/routing/endpointregistry_test.go
@@ -263,7 +263,7 @@ func benchmarkIncInflightRequests(b *testing.B, name string, goroutines int) {
 }
 
 func BenchmarkIncInflightRequests(b *testing.B) {
-	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096}
+	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096, 8192, 16384, 32768}
 	for _, goroutines := range goroutinesNums {
 		benchmarkIncInflightRequests(b, fmt.Sprintf("%d goroutines", goroutines), goroutines)
 	}
@@ -304,7 +304,7 @@ func benchmarkGetInflightRequests(b *testing.B, name string, goroutines int) {
 }
 
 func BenchmarkGetInflightRequests(b *testing.B) {
-	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096}
+	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096, 8192, 16384, 32768}
 	for _, goroutines := range goroutinesNums {
 		benchmarkGetInflightRequests(b, fmt.Sprintf("%d goroutines", goroutines), goroutines)
 	}
@@ -345,7 +345,7 @@ func benchmarkGetDetectedTime(b *testing.B, name string, goroutines int) {
 }
 
 func BenchmarkGetDetectedTime(b *testing.B) {
-	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096}
+	goroutinesNums := []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 24, 32, 48, 64, 128, 256, 512, 768, 1024, 1536, 2048, 4096, 8192, 16384, 32768}
 	for _, goroutines := range goroutinesNums {
 		benchmarkGetDetectedTime(b, fmt.Sprintf("%d goroutines", goroutines), goroutines)
 	}


### PR DESCRIPTION
https://github.com/zalando/skipper/pull/2795

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/routing
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
                                        │ endpointregistryMinor.txt │
                                        │          sec/op           │
GetInflightRequests/1_goroutines-16                    6.960n ±  0%
GetInflightRequests/2_goroutines-16                    3.808n ±  2%
GetInflightRequests/3_goroutines-16                    2.963n ±  4%
GetInflightRequests/4_goroutines-16                    2.499n ±  4%
GetInflightRequests/5_goroutines-16                    2.438n ±  2%
GetInflightRequests/6_goroutines-16                    2.124n ±  2%
GetInflightRequests/7_goroutines-16                    2.035n ±  3%
GetInflightRequests/8_goroutines-16                    1.897n ± 18%
GetInflightRequests/12_goroutines-16                   2.232n ±  5%
GetInflightRequests/16_goroutines-16                   2.592n ±  8%
GetInflightRequests/24_goroutines-16                   2.549n ±  4%
GetInflightRequests/32_goroutines-16                   2.556n ±  1%
GetInflightRequests/48_goroutines-16                   2.563n ±  3%
GetInflightRequests/64_goroutines-16                   2.556n ±  1%
GetInflightRequests/128_goroutines-16                  2.562n ±  0%
GetInflightRequests/256_goroutines-16                  2.561n ±  0%
GetInflightRequests/512_goroutines-16                  2.573n ±  1%
GetInflightRequests/768_goroutines-16                  2.567n ±  1%
GetInflightRequests/1024_goroutines-16                 2.551n ±  1%
GetInflightRequests/1536_goroutines-16                 2.542n ±  0%
GetInflightRequests/2048_goroutines-16                 2.530n ±  0%
GetInflightRequests/4096_goroutines-16                 2.507n ±  0%
GetInflightRequests/8192_goroutines-16                 2.498n ±  0%
GetInflightRequests/16384_goroutines-16                2.473n ±  0%
GetInflightRequests/32768_goroutines-16                2.490n ±  0%
IncInflightRequests/1_goroutines-16                    6.980n ±  0%
IncInflightRequests/2_goroutines-16                    9.861n ±  5%
IncInflightRequests/3_goroutines-16                    11.45n ±  6%
IncInflightRequests/4_goroutines-16                    12.87n ±  4%
IncInflightRequests/5_goroutines-16                    10.99n ±  3%
IncInflightRequests/6_goroutines-16                    10.61n ±  3%
IncInflightRequests/7_goroutines-16                    10.55n ±  2%
IncInflightRequests/8_goroutines-16                    10.53n ±  0%
IncInflightRequests/12_goroutines-16                   10.31n ±  3%
IncInflightRequests/16_goroutines-16                   9.582n ±  2%
IncInflightRequests/24_goroutines-16                   9.407n ±  1%
IncInflightRequests/32_goroutines-16                   9.399n ±  1%
IncInflightRequests/48_goroutines-16                   9.405n ±  1%
IncInflightRequests/64_goroutines-16                   9.428n ±  3%
IncInflightRequests/128_goroutines-16                  9.423n ±  1%
IncInflightRequests/256_goroutines-16                  9.411n ±  0%
IncInflightRequests/512_goroutines-16                  9.416n ±  2%
IncInflightRequests/768_goroutines-16                  9.394n ±  1%
IncInflightRequests/1024_goroutines-16                 9.414n ±  1%
IncInflightRequests/1536_goroutines-16                 9.548n ±  2%
IncInflightRequests/2048_goroutines-16                 9.743n ±  6%
IncInflightRequests/4096_goroutines-16                 9.454n ±  1%
IncInflightRequests/8192_goroutines-16                 9.529n ±  4%
IncInflightRequests/16384_goroutines-16                9.470n ±  1%
IncInflightRequests/32768_goroutines-16                9.477n ±  0%
GetDetectedTime/1_goroutines-16                        7.026n ±  3%
GetDetectedTime/2_goroutines-16                        8.441n ±  6%
GetDetectedTime/3_goroutines-16                        14.00n ± 50%
GetDetectedTime/4_goroutines-16                        33.72n ± 17%
GetDetectedTime/5_goroutines-16                        18.71n ± 14%
GetDetectedTime/6_goroutines-16                        32.51n ± 13%
GetDetectedTime/7_goroutines-16                        29.08n ± 23%
GetDetectedTime/8_goroutines-16                        32.76n ±  2%
GetDetectedTime/12_goroutines-16                       26.05n ±  2%
GetDetectedTime/16_goroutines-16                       22.98n ±  3%
GetDetectedTime/24_goroutines-16                       22.78n ±  2%
GetDetectedTime/32_goroutines-16                       22.40n ±  2%
GetDetectedTime/48_goroutines-16                       22.76n ±  2%
GetDetectedTime/64_goroutines-16                       22.56n ±  1%
GetDetectedTime/128_goroutines-16                      22.36n ±  1%
GetDetectedTime/256_goroutines-16                      22.41n ±  1%
GetDetectedTime/512_goroutines-16                      22.75n ±  1%
GetDetectedTime/768_goroutines-16                      22.53n ±  1%
GetDetectedTime/1024_goroutines-16                     22.76n ±  1%
GetDetectedTime/1536_goroutines-16                     22.61n ±  1%
GetDetectedTime/2048_goroutines-16                     22.65n ±  1%
GetDetectedTime/4096_goroutines-16                     22.89n ±  9%
GetDetectedTime/8192_goroutines-16                     23.14n ±  1%
GetDetectedTime/16384_goroutines-16                    23.83n ±  5%
GetDetectedTime/32768_goroutines-16                    24.47n ±  2%
geomean                                                8.203n

                                        │ endpointregistryMinor.txt │
                                        │           B/op            │
GetInflightRequests/1_goroutines-16                    0.000 ± 0%
GetInflightRequests/2_goroutines-16                    0.000 ± 0%
GetInflightRequests/3_goroutines-16                    0.000 ± 0%
GetInflightRequests/4_goroutines-16                    0.000 ± 0%
GetInflightRequests/5_goroutines-16                    0.000 ± 0%
GetInflightRequests/6_goroutines-16                    0.000 ± 0%
GetInflightRequests/7_goroutines-16                    0.000 ± 0%
GetInflightRequests/8_goroutines-16                    0.000 ± 0%
GetInflightRequests/12_goroutines-16                   0.000 ± 0%
GetInflightRequests/16_goroutines-16                   0.000 ± 0%
GetInflightRequests/24_goroutines-16                   0.000 ± 0%
GetInflightRequests/32_goroutines-16                   0.000 ± 0%
GetInflightRequests/48_goroutines-16                   0.000 ± 0%
GetInflightRequests/64_goroutines-16                   0.000 ± 0%
GetInflightRequests/128_goroutines-16                  0.000 ± 0%
GetInflightRequests/256_goroutines-16                  0.000 ± 0%
GetInflightRequests/512_goroutines-16                  0.000 ± 0%
GetInflightRequests/768_goroutines-16                  0.000 ± 0%
GetInflightRequests/1024_goroutines-16                 0.000 ± 0%
GetInflightRequests/1536_goroutines-16                 0.000 ± 0%
GetInflightRequests/2048_goroutines-16                 0.000 ± 0%
GetInflightRequests/4096_goroutines-16                 0.000 ± 0%
GetInflightRequests/8192_goroutines-16                 0.000 ± 0%
GetInflightRequests/16384_goroutines-16                0.000 ± 0%
GetInflightRequests/32768_goroutines-16                0.000 ± 0%
IncInflightRequests/1_goroutines-16                    0.000 ± 0%
IncInflightRequests/2_goroutines-16                    0.000 ± 0%
IncInflightRequests/3_goroutines-16                    0.000 ± 0%
IncInflightRequests/4_goroutines-16                    0.000 ± 0%
IncInflightRequests/5_goroutines-16                    0.000 ± 0%
IncInflightRequests/6_goroutines-16                    0.000 ± 0%
IncInflightRequests/7_goroutines-16                    0.000 ± 0%
IncInflightRequests/8_goroutines-16                    0.000 ± 0%
IncInflightRequests/12_goroutines-16                   0.000 ± 0%
IncInflightRequests/16_goroutines-16                   0.000 ± 0%
IncInflightRequests/24_goroutines-16                   0.000 ± 0%
IncInflightRequests/32_goroutines-16                   0.000 ± 0%
IncInflightRequests/48_goroutines-16                   0.000 ± 0%
IncInflightRequests/64_goroutines-16                   0.000 ± 0%
IncInflightRequests/128_goroutines-16                  0.000 ± 0%
IncInflightRequests/256_goroutines-16                  0.000 ± 0%
IncInflightRequests/512_goroutines-16                  0.000 ± 0%
IncInflightRequests/768_goroutines-16                  0.000 ± 0%
IncInflightRequests/1024_goroutines-16                 0.000 ± 0%
IncInflightRequests/1536_goroutines-16                 0.000 ± 0%
IncInflightRequests/2048_goroutines-16                 0.000 ± 0%
IncInflightRequests/4096_goroutines-16                 0.000 ± 0%
IncInflightRequests/8192_goroutines-16                 0.000 ± 0%
IncInflightRequests/16384_goroutines-16                0.000 ± 0%
IncInflightRequests/32768_goroutines-16                0.000 ± 0%
GetDetectedTime/1_goroutines-16                        0.000 ± 0%
GetDetectedTime/2_goroutines-16                        0.000 ± 0%
GetDetectedTime/3_goroutines-16                        0.000 ± 0%
GetDetectedTime/4_goroutines-16                        0.000 ± 0%
GetDetectedTime/5_goroutines-16                        0.000 ± 0%
GetDetectedTime/6_goroutines-16                        0.000 ± 0%
GetDetectedTime/7_goroutines-16                        0.000 ± 0%
GetDetectedTime/8_goroutines-16                        0.000 ± 0%
GetDetectedTime/12_goroutines-16                       0.000 ± 0%
GetDetectedTime/16_goroutines-16                       0.000 ± 0%
GetDetectedTime/24_goroutines-16                       0.000 ± 0%
GetDetectedTime/32_goroutines-16                       0.000 ± 0%
GetDetectedTime/48_goroutines-16                       0.000 ± 0%
GetDetectedTime/64_goroutines-16                       0.000 ± 0%
GetDetectedTime/128_goroutines-16                      0.000 ± 0%
GetDetectedTime/256_goroutines-16                      0.000 ± 0%
GetDetectedTime/512_goroutines-16                      0.000 ± 0%
GetDetectedTime/768_goroutines-16                      0.000 ± 0%
GetDetectedTime/1024_goroutines-16                     0.000 ± 0%
GetDetectedTime/1536_goroutines-16                     0.000 ± 0%
GetDetectedTime/2048_goroutines-16                     0.000 ± 0%
GetDetectedTime/4096_goroutines-16                     0.000 ± 0%
GetDetectedTime/8192_goroutines-16                     0.000 ± 0%
GetDetectedTime/16384_goroutines-16                    0.000 ± 0%
GetDetectedTime/32768_goroutines-16                    0.000 ± 0%
geomean                                                           ¹
¹ summaries must be >0 to compute geomean

                                        │ endpointregistryMinor.txt │
                                        │         allocs/op         │
GetInflightRequests/1_goroutines-16                    0.000 ± 0%
GetInflightRequests/2_goroutines-16                    0.000 ± 0%
GetInflightRequests/3_goroutines-16                    0.000 ± 0%
GetInflightRequests/4_goroutines-16                    0.000 ± 0%
GetInflightRequests/5_goroutines-16                    0.000 ± 0%
GetInflightRequests/6_goroutines-16                    0.000 ± 0%
GetInflightRequests/7_goroutines-16                    0.000 ± 0%
GetInflightRequests/8_goroutines-16                    0.000 ± 0%
GetInflightRequests/12_goroutines-16                   0.000 ± 0%
GetInflightRequests/16_goroutines-16                   0.000 ± 0%
GetInflightRequests/24_goroutines-16                   0.000 ± 0%
GetInflightRequests/32_goroutines-16                   0.000 ± 0%
GetInflightRequests/48_goroutines-16                   0.000 ± 0%
GetInflightRequests/64_goroutines-16                   0.000 ± 0%
GetInflightRequests/128_goroutines-16                  0.000 ± 0%
GetInflightRequests/256_goroutines-16                  0.000 ± 0%
GetInflightRequests/512_goroutines-16                  0.000 ± 0%
GetInflightRequests/768_goroutines-16                  0.000 ± 0%
GetInflightRequests/1024_goroutines-16                 0.000 ± 0%
GetInflightRequests/1536_goroutines-16                 0.000 ± 0%
GetInflightRequests/2048_goroutines-16                 0.000 ± 0%
GetInflightRequests/4096_goroutines-16                 0.000 ± 0%
GetInflightRequests/8192_goroutines-16                 0.000 ± 0%
GetInflightRequests/16384_goroutines-16                0.000 ± 0%
GetInflightRequests/32768_goroutines-16                0.000 ± 0%
IncInflightRequests/1_goroutines-16                    0.000 ± 0%
IncInflightRequests/2_goroutines-16                    0.000 ± 0%
IncInflightRequests/3_goroutines-16                    0.000 ± 0%
IncInflightRequests/4_goroutines-16                    0.000 ± 0%
IncInflightRequests/5_goroutines-16                    0.000 ± 0%
IncInflightRequests/6_goroutines-16                    0.000 ± 0%
IncInflightRequests/7_goroutines-16                    0.000 ± 0%
IncInflightRequests/8_goroutines-16                    0.000 ± 0%
IncInflightRequests/12_goroutines-16                   0.000 ± 0%
IncInflightRequests/16_goroutines-16                   0.000 ± 0%
IncInflightRequests/24_goroutines-16                   0.000 ± 0%
IncInflightRequests/32_goroutines-16                   0.000 ± 0%
IncInflightRequests/48_goroutines-16                   0.000 ± 0%
IncInflightRequests/64_goroutines-16                   0.000 ± 0%
IncInflightRequests/128_goroutines-16                  0.000 ± 0%
IncInflightRequests/256_goroutines-16                  0.000 ± 0%
IncInflightRequests/512_goroutines-16                  0.000 ± 0%
IncInflightRequests/768_goroutines-16                  0.000 ± 0%
IncInflightRequests/1024_goroutines-16                 0.000 ± 0%
IncInflightRequests/1536_goroutines-16                 0.000 ± 0%
IncInflightRequests/2048_goroutines-16                 0.000 ± 0%
IncInflightRequests/4096_goroutines-16                 0.000 ± 0%
IncInflightRequests/8192_goroutines-16                 0.000 ± 0%
IncInflightRequests/16384_goroutines-16                0.000 ± 0%
IncInflightRequests/32768_goroutines-16                0.000 ± 0%
GetDetectedTime/1_goroutines-16                        0.000 ± 0%
GetDetectedTime/2_goroutines-16                        0.000 ± 0%
GetDetectedTime/3_goroutines-16                        0.000 ± 0%
GetDetectedTime/4_goroutines-16                        0.000 ± 0%
GetDetectedTime/5_goroutines-16                        0.000 ± 0%
GetDetectedTime/6_goroutines-16                        0.000 ± 0%
GetDetectedTime/7_goroutines-16                        0.000 ± 0%
GetDetectedTime/8_goroutines-16                        0.000 ± 0%
GetDetectedTime/12_goroutines-16                       0.000 ± 0%
GetDetectedTime/16_goroutines-16                       0.000 ± 0%
GetDetectedTime/24_goroutines-16                       0.000 ± 0%
GetDetectedTime/32_goroutines-16                       0.000 ± 0%
GetDetectedTime/48_goroutines-16                       0.000 ± 0%
GetDetectedTime/64_goroutines-16                       0.000 ± 0%
GetDetectedTime/128_goroutines-16                      0.000 ± 0%
GetDetectedTime/256_goroutines-16                      0.000 ± 0%
GetDetectedTime/512_goroutines-16                      0.000 ± 0%
GetDetectedTime/768_goroutines-16                      0.000 ± 0%
GetDetectedTime/1024_goroutines-16                     0.000 ± 0%
GetDetectedTime/1536_goroutines-16                     0.000 ± 0%
GetDetectedTime/2048_goroutines-16                     0.000 ± 0%
GetDetectedTime/4096_goroutines-16                     0.000 ± 0%
GetDetectedTime/8192_goroutines-16                     0.000 ± 0%
GetDetectedTime/16384_goroutines-16                    0.000 ± 0%
GetDetectedTime/32768_goroutines-16                    0.000 ± 0%
geomean                                                           ¹
¹ summaries must be >0 to compute geomean

```
