### PR TITLE
dataclients/kubernetes: enable network backend address validation

### DIFF
--- a/cmd/webhook/admission/admission_test.go
+++ b/cmd/webhook/admission/admission_test.go
@@ -133,6 +133,11 @@ func TestRouteGroupAdmitter(t *testing.T) {
 			inputFile: "rg-with-multiple-predicates.json",
 			message:   `single predicate expected at \"Method(\\\"GET\\\") && Path(\\\"/\\\")\"\nsingle predicate expected at \" \"`,
 		},
+		{
+			name:      "routegroup with invalid backends",
+			inputFile: "rg-with-invalid-backend-path.json",
+			message:   `backend address \"http://example.com/foo\" does not match scheme://host format\nbackend address \"http://example.com/foo/bar\" does not match scheme://host format\nbackend address \"http://example.com/foo/\" does not match scheme://host format\nbackend address \"/foo\" does not match scheme://host format\nbackend address \"http://example.com/\" does not match scheme://host format\nbackend address \"example.com/\" does not match scheme://host format\nbackend address \"example.com/foo\" does not match scheme://host format\nbackend address \"http://example.com?foo=bar\" does not match scheme://host format\nbackend address \"example.com\" does not match scheme://host format`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			expectedResponse := responseAllowedFmt

--- a/dataclients/kubernetes/definitions/routegroupvalidator.go
+++ b/dataclients/kubernetes/definitions/routegroupvalidator.go
@@ -38,7 +38,7 @@ func (rgv *RouteGroupValidator) Validate(item *RouteGroupItem) error {
 	var errs []error
 	errs = append(errs, rgv.validateFilters(item))
 	errs = append(errs, rgv.validatePredicates(item))
-	// errs = append(errs, rgv.validateBackends(item))
+	errs = append(errs, rgv.validateBackends(item))
 
 	return errorsJoin(errs...)
 }
@@ -93,7 +93,6 @@ func (rgv *RouteGroupValidator) validatePredicates(item *RouteGroupItem) error {
 	return errorsJoin(errs...)
 }
 
-//lint:ignore U1000 Disable address validation to prevent errors for existing RouteGroups
 func (rgv *RouteGroupValidator) validateBackends(item *RouteGroupItem) error {
 	var errs []error
 	for _, backend := range item.Spec.Backends {

--- a/dataclients/kubernetes/definitions/testdata/errorwrapdata/errors.log
+++ b/dataclients/kubernetes/definitions/testdata/errorwrapdata/errors.log
@@ -4,3 +4,10 @@ single predicate expected at "Path(\"/foo\") && Method(\"GET\")"
 single predicate expected at ""
 single filter expected at "inlineContent(\"/foo\") -> status(200)"
 single filter expected at " "
+backend address "http://example.com/foo" does not match scheme://host format
+backend address "http://example.com/foo/bar" does not match scheme://host format
+backend address "http://example.com/foo/" does not match scheme://host format
+backend address "/foo" does not match scheme://host format
+backend address "example.com/" does not match scheme://host format
+backend address "http://example.com?foo=bar" does not match scheme://host format
+backend address "example.com" does not match scheme://host format

--- a/dataclients/kubernetes/definitions/testdata/validation/route-with-invalid-backend-with-path.log
+++ b/dataclients/kubernetes/definitions/testdata/validation/route-with-invalid-backend-with-path.log
@@ -1,0 +1,8 @@
+backend address \\\"http://example\.com/foo\\\" does not match scheme://host format
+backend address \\\"http://example\.com/foo/bar\\\" does not match scheme://host format
+backend address \\\"/foo\\\" does not match scheme://host format
+backend address \\\"/foo/bar\\\" does not match scheme://host format
+backend address \\\"example\.com/foo\\\" does not match scheme://host format
+backend address \\\"http://example\.com/\\\" does not match scheme://host format
+backend address \\\"http://example\.com\?foo=bar\\\" does not match scheme://host format
+backend address \\\"example\.com\\\" does not match scheme://host format


### PR DESCRIPTION
Revert "dataclients/kubernetes: disable network backend address validation (#2780)"

This reverts commit 4502bb6c445fb81c551e6c44c2a9b46b8099803e.