### PR TITLE
Ensure normalizeSchemeHost is IPv6-safe

### DIFF
--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -486,7 +486,12 @@ func normalizeSchemeHost(s, h string) (string, string, error) {
 		p = "443"
 	}
 
-	h = net.JoinHostPort(h, p)
+	if p != "" {
+		// IPv6 addresses are enclosed in brackets by SplitHostPort, so we need to remove
+		// them before JoinHostPort insert one more brackets pair
+		h = strings.Trim(h, "[]")
+		h = net.JoinHostPort(h, p)
+	}
 	return s, h, nil
 }
 


### PR DESCRIPTION
Addressing the comment https://github.com/zalando/skipper/pull/2824#discussion_r1443503926 about IPv6 safety.
Fixed small issue in `normalizeSchemeHost` function and created tests to prove its IPv4 and IPv6 safety.