### PR TITLE
feat: deduplicate OIDC cookies for subdomains

### DIFF
--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -205,6 +205,10 @@ func (s *tokenOidcSpec) CreateFilter(args []interface{}) (filters.Filter, error)
 		if i == paramCallbackURL {
 			continue
 		}
+		// SubdomainsToRemove not taken into account for cookie hashing for additional sub-domain ingresses
+		if i == paramSubdomainsToRemove {
+			continue
+		}
 		h.Write([]byte(s))
 	}
 	byteSlice := h.Sum(nil)


### PR DESCRIPTION
Removed subdomains should share the cookie with the corresponding hostname if all other parameters are the same

e.g. foo.bar.baz (with `SubdomainsToRemove` = 1) and bar.baz (with `SubdomainsToRemove` = 0) should share the same OIDC cookie to prevent duplication. Currently this parameter is taken into account for cookie hashing which leads to multiple cookies.

See also d1457a3c7de06f72c614ce194d7cdd0eb6925ccb