### PR TITLE
docs: document SubdomainsToRemove parameter for other two OIDC filters

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1701,6 +1701,7 @@ The filter needs the following parameters:
 * **Claims** Several claims can be specified and the request is allowed as long as at least one of them is present.
 * **Auth Code Options** (optional) Passes key/value parameters to a provider's authorization endpoint. The value can be dynamically set by a query parameter with the same key name if the placeholder `skipper-request-query` is used.
 * **Upstream Headers** (optional) The upstream endpoint will receive these headers which values are parsed from the OIDC information. The header definition can be one or more header-query pairs, space delimited. The query syntax is [GJSON](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+* **SubdomainsToRemove** (optional, default "1") Configures number of subdomains to remove from the request hostname to derive OIDC cookie domain. By default one subdomain is removed, e.g. for the www.example.com request hostname the OIDC cookie domain will be example.com (to support SSO for all subdomains of the example.com). Configure "0" to use the same hostname. Note that value is a string.
 
 #### oauthOidcAllClaims
 
@@ -1721,6 +1722,7 @@ The filter needs the following parameters:
 * **Claims** Several claims can be specified and the request is allowed only when all claims are present.
 * **Auth Code Options** (optional) Passes key/value parameters to a provider's authorization endpoint. The value can be dynamically set by a query parameter with the same key name if the placeholder `skipper-request-query` is used.
 * **Upstream Headers** (optional) The upstream endpoint will receive these headers which values are parsed from the OIDC information. The header definition can be one or more header-query pairs, space delimited. The query syntax is [GJSON](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+* **SubdomainsToRemove** (optional, default "1") Configures number of subdomains to remove from the request hostname to derive OIDC cookie domain. By default one subdomain is removed, e.g. for the www.example.com request hostname the OIDC cookie domain will be example.com (to support SSO for all subdomains of the example.com). Configure "0" to use the same hostname. Note that value is a string.
 
 #### oidcClaimsQuery
 


### PR DESCRIPTION
PR #1923 added SubdomainsToRemove which is applicable to all three OIDC filters: oauthOidcUserInfo, oauthOidcAnyClaims and oauthOidcAllClaims.