### PR TITLE
Use endpointregistry in the hotpath (the non-breaking try)

### DIFF
--- a/filters/fadein/fadein.go
+++ b/filters/fadein/fadein.go
@@ -205,8 +205,8 @@ func (p *postProcessor) Do(r []*routing.Route) []*routing.Route {
 			ep.Detected = detected
 			if p.endpointRegisty != nil {
 				metrics := p.endpointRegisty.GetMetrics(ep.Host)
-				if endpointsCreated[key].After(metrics.DetectedTime()) {
-					metrics.SetDetected(endpointsCreated[key])
+				if endpointsCreated[key].After(metrics.GetDetectedTime()) {
+					metrics.SetDetectedTime(endpointsCreated[key])
 				}
 			}
 			p.detected[key] = detectedFadeIn{

--- a/filters/fadein/fadein_test.go
+++ b/filters/fadein/fadein_test.go
@@ -252,7 +252,7 @@ func TestPostProcessor(t *testing.T) {
 			if ep.Detected.IsZero() {
 				t.Fatal("failed to set detection time")
 			}
-			if endpointRegistry.GetMetrics(ep.Host).DetectedTime().IsZero() {
+			if endpointRegistry.GetMetrics(ep.Host).GetDetectedTime().IsZero() {
 				t.Fatal("failed to set detection time")
 			}
 		}
@@ -287,7 +287,7 @@ func TestPostProcessor(t *testing.T) {
 		if r == nil || len(r.LBEndpoints) == 0 || !r.LBEndpoints[0].Detected.IsZero() {
 			t.Fatal("failed to ignore negative duration")
 		}
-		if endpointRegisty.GetMetrics(r.LBEndpoints[0].Host).DetectedTime().IsZero() {
+		if endpointRegisty.GetMetrics(r.LBEndpoints[0].Host).GetDetectedTime().IsZero() {
 			t.Fatal("failed to ignore negative duration")
 		}
 	})
@@ -314,7 +314,7 @@ func TestPostProcessor(t *testing.T) {
 				if ep.Detected.After(firstDetected) {
 					t.Fatal("Failed to keep detection time.")
 				}
-				if endpointRegistry.GetMetrics(ep.Host).DetectedTime().After(firstDetected) {
+				if endpointRegistry.GetMetrics(ep.Host).GetDetectedTime().After(firstDetected) {
 					t.Fatal("Failed to keep detection time.")
 				}
 
@@ -351,7 +351,7 @@ func TestPostProcessor(t *testing.T) {
 				if ep.Detected.After(firstDetected) {
 					t.Fatal("Failed to keep detection time.")
 				}
-				if endpointRegistry.GetMetrics(ep.Host).DetectedTime().After(firstDetected) {
+				if endpointRegistry.GetMetrics(ep.Host).GetDetectedTime().After(firstDetected) {
 					t.Fatal("Failed to keep detection time.")
 				}
 
@@ -390,7 +390,7 @@ func TestPostProcessor(t *testing.T) {
 				if !ep.Detected.After(firstDetected) {
 					t.Fatal("Failed to clear detection time.")
 				}
-				if !endpointRegistry.GetMetrics(ep.Host).DetectedTime().After(firstDetected) {
+				if !endpointRegistry.GetMetrics(ep.Host).GetDetectedTime().After(firstDetected) {
 					t.Fatal("Failed to clear detection time.")
 				}
 
@@ -431,7 +431,7 @@ func TestPostProcessor(t *testing.T) {
 				if !ep.Detected.After(firstDetected) {
 					t.Fatal("Failed to reset detection time.")
 				}
-				if !endpointRegistry.GetMetrics(ep.Host).DetectedTime().After(firstDetected) {
+				if !endpointRegistry.GetMetrics(ep.Host).GetDetectedTime().After(firstDetected) {
 					t.Fatal("Failed to reset detection time.")
 				}
 

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -30,6 +30,7 @@ func TestSelectAlgorithm(t *testing.T) {
 
 	t.Run("LB route with default algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -38,6 +39,7 @@ func TestSelectAlgorithm(t *testing.T) {
 		}
 
 		rr := p.Do([]*routing.Route{r})
+		endpointRegistry.Do([]*routing.Route{r})
 		if len(rr) != 1 {
 			t.Fatal("failed to process LB route")
 		}
@@ -56,6 +58,7 @@ func TestSelectAlgorithm(t *testing.T) {
 
 	t.Run("LB route with explicit round-robin algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -65,6 +68,7 @@ func TestSelectAlgorithm(t *testing.T) {
 		}
 
 		rr := p.Do([]*routing.Route{r})
+		endpointRegistry.Do([]*routing.Route{r})
 		if len(rr) != 1 {
 			t.Fatal("failed to process LB route")
 		}
@@ -83,6 +87,7 @@ func TestSelectAlgorithm(t *testing.T) {
 
 	t.Run("LB route with explicit consistentHash algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -92,6 +97,7 @@ func TestSelectAlgorithm(t *testing.T) {
 		}
 
 		rr := p.Do([]*routing.Route{r})
+		endpointRegistry.Do([]*routing.Route{r})
 		if len(rr) != 1 {
 			t.Fatal("failed to process LB route")
 		}
@@ -110,6 +116,7 @@ func TestSelectAlgorithm(t *testing.T) {
 
 	t.Run("LB route with explicit random algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -119,6 +126,7 @@ func TestSelectAlgorithm(t *testing.T) {
 		}
 
 		rr := p.Do([]*routing.Route{r})
+		endpointRegistry.Do([]*routing.Route{r})
 		if len(rr) != 1 {
 			t.Fatal("failed to process LB route")
 		}
@@ -137,6 +145,7 @@ func TestSelectAlgorithm(t *testing.T) {
 
 	t.Run("LB route with explicit powerOfRandomNChoices algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -146,6 +155,7 @@ func TestSelectAlgorithm(t *testing.T) {
 		}
 
 		rr := p.Do([]*routing.Route{r})
+		endpointRegistry.Do([]*routing.Route{r})
 		if len(rr) != 1 {
 			t.Fatal("failed to process LB route")
 		}
@@ -264,6 +274,7 @@ func TestApply(t *testing.T) {
 				LBEndpoints: rt[0].LBEndpoints,
 				Registry:    routing.NewEndpointRegistry(routing.RegistryOptions{}),
 			}
+			lbctx.Registry.Do([]*routing.Route{r})
 
 			h := make(map[string]int)
 			for i := 0; i < R; i++ {
@@ -316,6 +327,7 @@ func TestConsistentHashBoundedLoadSearch(t *testing.T) {
 			LBEndpoints: endpoints,
 		},
 	}})[0]
+
 	ch := route.LBAlgorithm.(*consistentHash)
 	ctx := &routing.LBContext{
 		Request:     r,
@@ -324,6 +336,7 @@ func TestConsistentHashBoundedLoadSearch(t *testing.T) {
 		Params:      map[string]interface{}{ConsistentHashBalanceFactor: 1.25},
 		Registry:    routing.NewEndpointRegistry(routing.RegistryOptions{}),
 	}
+	ctx.Registry.Do([]*routing.Route{route})
 	noLoad := ch.Apply(ctx)
 	nonBounded := ch.Apply(&routing.LBContext{Request: r, Route: route, LBEndpoints: route.LBEndpoints, Params: map[string]interface{}{}})
 
@@ -393,6 +406,7 @@ func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 			LBEndpoints: endpoints,
 		},
 	}})[0]
+
 	ch := route.LBAlgorithm.(*consistentHash)
 	balanceFactor := 1.25
 	ctx := &routing.LBContext{
@@ -402,6 +416,7 @@ func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 		Params:      map[string]interface{}{ConsistentHashBalanceFactor: balanceFactor},
 		Registry:    routing.NewEndpointRegistry(routing.RegistryOptions{}),
 	}
+	ctx.Registry.Do([]*routing.Route{route})
 
 	for i := 0; i < 100; i++ {
 		ep := ch.Apply(ctx)
@@ -409,16 +424,15 @@ func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 		ifr1 := route.LBEndpoints[1].Metrics.GetInflightRequests()
 		ifr2 := route.LBEndpoints[2].Metrics.GetInflightRequests()
 
-		assert.Equal(t, int64(ifr0), ctx.Registry.GetMetrics(route.LBEndpoints[0].Host).InflightRequests())
-		assert.Equal(t, int64(ifr1), ctx.Registry.GetMetrics(route.LBEndpoints[1].Host).InflightRequests())
-		assert.Equal(t, int64(ifr2), ctx.Registry.GetMetrics(route.LBEndpoints[2].Host).InflightRequests())
+		assert.Equal(t, ifr0, ctx.Registry.GetMetrics(route.LBEndpoints[0].Host).GetInflightRequests())
+		assert.Equal(t, ifr1, ctx.Registry.GetMetrics(route.LBEndpoints[1].Host).GetInflightRequests())
+		assert.Equal(t, ifr2, ctx.Registry.GetMetrics(route.LBEndpoints[2].Host).GetInflightRequests())
 
 		avg := float64(ifr0+ifr1+ifr2) / 3.0
 		limit := int(avg*balanceFactor) + 1
 		if ifr0 > limit || ifr1 > limit || ifr2 > limit {
 			t.Errorf("Expected in-flight requests for each endpoint to be less than %d. In-flight request counts: %d, %d, %d", limit, ifr0, ifr1, ifr2)
 		}
-		ep.Metrics.IncInflightRequest()
 		ctx.Registry.GetMetrics(ep.Host).IncInflightRequest()
 	}
 }

--- a/loadbalancer/fadein_test.go
+++ b/loadbalancer/fadein_test.go
@@ -69,8 +69,9 @@ func initializeEndpoints(endpointAges []time.Duration, fadeInDuration time.Durat
 		ctx.Route.LBEndpoints = append(ctx.Route.LBEndpoints, routing.LBEndpoint{
 			Host:     eps[i],
 			Detected: detectionTimes[i],
+			Metrics:  ctx.Registry.GetMetrics(eps[i]),
 		})
-		ctx.Registry.GetMetrics(eps[i]).SetDetected(detectionTimes[i])
+		ctx.Route.LBEndpoints[i].Metrics.SetDetectedTime(detectionTimes[i])
 	}
 	ctx.LBEndpoints = ctx.Route.LBEndpoints
 
@@ -331,8 +332,9 @@ func benchmarkFadeIn(
 			route.LBEndpoints = append(route.LBEndpoints, routing.LBEndpoint{
 				Host:     eps[i],
 				Detected: detectionTimes[i],
+				Metrics:  registry.GetMetrics(eps[i]),
 			})
-			registry.GetMetrics(eps[i]).SetDetected(detectionTimes[i])
+			registry.GetMetrics(eps[i]).SetDetectedTime(detectionTimes[i])
 		}
 
 		var wg sync.WaitGroup

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -208,11 +208,12 @@ func newTestProxyWithFiltersAndParams(fr filters.Registry, doc string, params Pa
 	}
 
 	tl := loggingtest.New()
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 	opts := routing.Options{
 		FilterRegistry: fr,
 		PollTimeout:    sourcePollTimeout,
 		DataClients:    []routing.DataClient{dc},
-		PostProcessors: []routing.PostProcessor{loadbalancer.NewAlgorithmProvider()},
+		PostProcessors: []routing.PostProcessor{loadbalancer.NewAlgorithmProvider(), endpointRegistry},
 		Log:            tl,
 		Predicates:     []routing.PredicateSpec{teePredicate.New()},
 	}

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -74,6 +74,7 @@ func New(fr filters.Registry, routes ...*eskip.Route) *TestProxy {
 }
 
 func (c Config) Create() *TestProxy {
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 	tl := loggingtest.New()
 	var dc *testdataclient.Client
 
@@ -83,7 +84,7 @@ func (c Config) Create() *TestProxy {
 	}
 
 	c.RoutingOptions.Log = tl
-	c.RoutingOptions.PostProcessors = append(c.RoutingOptions.PostProcessors, loadbalancer.NewAlgorithmProvider())
+	c.RoutingOptions.PostProcessors = append(c.RoutingOptions.PostProcessors, loadbalancer.NewAlgorithmProvider(), endpointRegistry)
 
 	rt := routing.New(c.RoutingOptions)
 	c.ProxyParams.Routing = rt

--- a/redis_test.go
+++ b/redis_test.go
@@ -192,6 +192,7 @@ r2: PathRegexp("/endpoints") -> enableAccessLog(2,4,5) -> fifo(100,100,"3s") -> 
 	if err != nil {
 		t.Fatalf("Failed to create testdataclient: %v", err)
 	}
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 
 	// create LB in front of apiservers to be able to switch the data served by apiserver
 	ro := routing.Options{
@@ -200,6 +201,7 @@ r2: PathRegexp("/endpoints") -> enableAccessLog(2,4,5) -> fifo(100,100,"3s") -> 
 		DataClients:     []routing.DataClient{dc},
 		PostProcessors: []routing.PostProcessor{
 			loadbalancer.NewAlgorithmProvider(),
+			endpointRegistry,
 			reg,
 		},
 		SuppressLogs: true,
@@ -460,6 +462,7 @@ r2: PathRegexp("/endpoints") -> enableAccessLog(2,4,5) -> fifo(100,100,"3s") -> 
 	if err != nil {
 		t.Fatalf("Failed to create testdataclient: %v", err)
 	}
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 
 	// create LB in front of apiservers to be able to switch the data served by apiserver
 	ro := routing.Options{
@@ -468,6 +471,7 @@ r2: PathRegexp("/endpoints") -> enableAccessLog(2,4,5) -> fifo(100,100,"3s") -> 
 		DataClients:     []routing.DataClient{dc},
 		PostProcessors: []routing.PostProcessor{
 			loadbalancer.NewAlgorithmProvider(),
+			endpointRegistry,
 			reg,
 		},
 		SuppressLogs: true,

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -152,22 +152,42 @@ type RouteFilter struct {
 
 // LBMetrics contains metrics used by LB algorithms
 type LBMetrics struct {
-	inflightRequests int64
+	endpointRegistryEntry Metrics
 }
 
 // IncInflightRequest increments the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) IncInflightRequest() {
-	atomic.AddInt64(&m.inflightRequests, 1)
+	m.endpointRegistryEntry.IncInflightRequest()
 }
 
 // DecInflightRequest decrements the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) DecInflightRequest() {
-	atomic.AddInt64(&m.inflightRequests, -1)
+	m.endpointRegistryEntry.DecInflightRequest()
 }
 
 // GetInflightRequests decrements the number of outstanding requests from the proxy to a given backend.
 func (m *LBMetrics) GetInflightRequests() int {
-	return int(atomic.LoadInt64(&m.inflightRequests))
+	return int(m.endpointRegistryEntry.InflightRequests())
+}
+
+// GetDetectedTime returns the time when skipper instance first detected a host of a given backend.
+func (m *LBMetrics) GetDetectedTime() time.Time {
+	return m.endpointRegistryEntry.DetectedTime()
+}
+
+// SetDetectedTime sets the time when skipper instance first detected a host of a given backend.
+func (m *LBMetrics) SetDetectedTime(t time.Time) {
+	m.endpointRegistryEntry.SetDetected(t)
+}
+
+// GetLastSeen returns the time when skipper instance last saw a host of a given backend.
+func (m *LBMetrics) GetLastSeenTime() time.Time {
+	return m.endpointRegistryEntry.LastSeen()
+}
+
+// SetLastSeen sets the time when skipper instance last saw a host of a given backend.
+func (m *LBMetrics) SetLastSeenTime(t time.Time) {
+	m.endpointRegistryEntry.SetLastSeen(t)
 }
 
 // LBEndpoint represents the scheme and the host of load balanced

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -527,6 +527,8 @@ func TestDataClients(t *testing.T) {
 	})
 	defer reg.Close()
 
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+
 	// create LB in front of apiservers to be able to switch the data served by apiserver
 	ro := routing.Options{
 		SignalFirstLoad: true,
@@ -534,6 +536,7 @@ func TestDataClients(t *testing.T) {
 		DataClients:     dcs, //[]routing.DataClient{dc},
 		PostProcessors: []routing.PostProcessor{
 			loadbalancer.NewAlgorithmProvider(),
+			endpointRegistry,
 			reg,
 		},
 		SuppressLogs: true,


### PR DESCRIPTION
The another option to do https://github.com/zalando/skipper/pull/2823 without breaking LBMetrics.