### PR TITLE
predicates/primitive: document False predicates ignores arguments

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -229,13 +229,13 @@ route2: Path("/test") && True() -> "http://www.github.com";
 
 ## False
 
-Does not match. Can be used to disable certain routes.
+Does not match. Can be used to disable certain routes. Ignores all arguments.
 
 Example where `route2` is disabled.
 
 ```
 route1: Path("/test") -> "http://www.zalando.de";
-route2: Path("/test") && False() -> "http://www.github.com";
+route2: Path("/test") && False("Disabled due to maintenance") -> "http://www.github.com";
 ```
 
 ## Shutdown

--- a/predicates/primitive/false_test.go
+++ b/predicates/primitive/false_test.go
@@ -1,0 +1,30 @@
+package primitive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/eskip"
+)
+
+func TestFalseIgnoreArguments(t *testing.T) {
+	spec := NewFalse()
+
+	for _, def := range []string{
+		`False()`,
+		`False(1)`,
+		`False("foo")`,
+		`False(0, "foo")`,
+	} {
+		t.Run(def, func(t *testing.T) {
+			pp := eskip.MustParsePredicates(def)
+			require.Len(t, pp, 1)
+
+			p, err := spec.Create(pp[0].Args)
+			assert.NoError(t, err)
+
+			assert.False(t, p.Match(nil))
+		})
+	}
+}


### PR DESCRIPTION
This feature could be used to a add comment why route has it.