### PR TITLE
routing: avoid allocating new entry in EndpointRegistry.GetMetrics

### DIFF
--- a/routing/endpointregistry.go
+++ b/routing/endpointregistry.go
@@ -70,9 +70,7 @@ func newEntry() *entry {
 type EndpointRegistry struct {
 	lastSeenTimeout time.Duration
 	now             func() time.Time
-
-	// map[string]*entry
-	data sync.Map
+	data            sync.Map // map[string]*entry
 }
 
 var _ PostProcessor = &EndpointRegistry{}
@@ -129,7 +127,11 @@ func NewEndpointRegistry(o RegistryOptions) *EndpointRegistry {
 	}
 }
 
-func (r *EndpointRegistry) GetMetrics(key string) Metrics {
-	e, _ := r.data.LoadOrStore(key, newEntry())
+func (r *EndpointRegistry) GetMetrics(hostPort string) Metrics {
+	// https://github.com/golang/go/issues/44159#issuecomment-780774977
+	e, ok := r.data.Load(hostPort)
+	if !ok {
+		e, _ = r.data.LoadOrStore(hostPort, newEntry())
+	}
 	return e.(*entry)
 }


### PR DESCRIPTION
EndpointRegistry.GetMetrics always allocates new entry even when data for the key already exists.

sync.Map does not provide lazy initialization for the new value, see https://github.com/golang/go/issues/44159

This change uses suggested best-effort to avoid allocating a new value on each load.

Follow up on #2795