### PR TITLE
fix logBody to escape unprintable chars.

### DIFF
--- a/filters/diag/logbody.go
+++ b/filters/diag/logbody.go
@@ -68,7 +68,7 @@ func (lb *logBody) Request(ctx filters.FilterContext) {
 			lb.limit,
 			func(chunk []byte) {
 				ctx.Logger().Infof(
-					`logBody("request") %s: %s`,
+					`logBody("request") %s: %q`,
 					req.Header.Get(flowid.HeaderName),
 					chunk)
 			},
@@ -88,7 +88,7 @@ func (lb *logBody) Response(ctx filters.FilterContext) {
 			lb.limit,
 			func(chunk []byte) {
 				ctx.Logger().Infof(
-					`logBody("response") %s: %s`,
+					`logBody("response") %s: %q`,
 					ctx.Request().Header.Get(flowid.HeaderName),
 					chunk)
 			},

--- a/filters/diag/logbody_test.go
+++ b/filters/diag/logbody_test.go
@@ -84,7 +84,7 @@ func TestLogBody(t *testing.T) {
 		logbuf := bytes.NewBuffer(nil)
 		log.SetOutput(logbuf)
 		buf := bytes.NewBufferString(content)
-		rsp, err := http.DefaultClient.Post(p.URL, "text/plain", buf)
+		rsp, err := p.Client().Post(p.URL, "text/plain", buf)
 		log.SetOutput(os.Stderr)
 		if err != nil {
 			t.Fatalf("Failed to POST: %v", err)
@@ -112,7 +112,7 @@ func TestLogBody(t *testing.T) {
 		logbuf := bytes.NewBuffer(nil)
 		log.SetOutput(logbuf)
 		buf := bytes.NewBufferString(content)
-		rsp, err := http.DefaultClient.Post(p.URL, "text/plain", buf)
+		rsp, err := p.Client().Post(p.URL, "text/plain", buf)
 		if err != nil {
 			t.Fatalf("Failed to do post request: %v", err)
 		}
@@ -147,7 +147,7 @@ func TestLogBody(t *testing.T) {
 		logbuf := bytes.NewBuffer(nil)
 		log.SetOutput(logbuf)
 		buf := bytes.NewBufferString(requestContent)
-		rsp, err := http.DefaultClient.Post(p.URL, "text/plain", buf)
+		rsp, err := p.Client().Post(p.URL, "text/plain", buf)
 		if err != nil {
 			t.Fatalf("Failed to get respone: %v", err)
 		}
@@ -196,16 +196,18 @@ func TestLogBody(t *testing.T) {
 		logbuf := bytes.NewBuffer(nil)
 		log.SetOutput(logbuf)
 		buf := bytes.NewBufferString(content)
-		rsp, err := http.DefaultClient.Post(p.URL, "text/plain", buf)
+		rsp, err := p.Client().Post(p.URL, "text/plain", buf)
 		log.SetOutput(os.Stderr)
 		if err != nil {
 			t.Fatalf("Failed to POST: %v", err)
 		}
 		defer rsp.Body.Close()
 
-		want := " " + content[:limit] + `"` + "\n"
-		if got := logbuf.String(); want != got[len(got)-limit-3:] {
-			t.Fatalf("Failed want suffix: %q, got: %q\nwant hex: %x\ngot hex : %x", want, got, want, got[len(got)-limit-3:])
+		want := ` \"` + content[:limit] + "\\\"\"" + "\n"
+		got := logbuf.String()
+		from := len(got) - limit - 7
+		if want != got[from:] {
+			t.Fatalf("Failed want suffix: %q, got: %q\nwant hex: %x\ngot hex : %x", want, got, want, got[from:])
 		}
 	})
 
@@ -226,7 +228,7 @@ func TestLogBody(t *testing.T) {
 		logbuf := bytes.NewBuffer(nil)
 		log.SetOutput(logbuf)
 		buf := bytes.NewBufferString(content)
-		rsp, err := http.DefaultClient.Post(p.URL, "text/plain", buf)
+		rsp, err := p.Client().Post(p.URL, "text/plain", buf)
 		if err != nil {
 			t.Fatalf("Failed to do post request: %v", err)
 		}
@@ -242,7 +244,7 @@ func TestLogBody(t *testing.T) {
 		}
 
 		// repeatContent("a", 1024) but only 10 bytes
-		want := " " + strings.Repeat("a", 10) + `"` + "\n"
+		want := " \\\"" + strings.Repeat("a", 10) + "\\\"\"" + "\n"
 		if !strings.HasSuffix(got, want) {
 			t.Fatalf("Failed to find rsp content %q log, got: %q", want, got)
 		}


### PR DESCRIPTION
fixes the `logBody()` filter for handling unprintable chars correctly (by escaping them).

before:
```bash
# completely overwrites flowid
$ ./bin/skipper -inline-routes='* -> flowId("reuse") -> logBody("request", 1024) -> inlineContent("ok") -> <shunt>'
[APP]INFO[0001] logBody("request") lol       

$ curl 127.0.0.1:9090 -d $'\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08lol      ' -H"X-Flow-Id: 11111111"
ok
```

after:
```bash
$ ./bin/skipper -inline-routes='* -> flowId("reuse") -> logBody("request", 1024) -> inlineContent("ok") -> <shunt>'
[APP]INFO[0001] logBody("request") 11111111: "\b\b\b\b\b\b\b\b\b\blol      "

$ curl 127.0.0.1:9090 -d $'\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08lol      ' -H"X-Flow-Id: 11111111"
ok
```

**Note:** `logHeader()` is not affected since it http server send 400 error when a header has unprintable chars in it.