### PR TITLE
dataclients/kubernetes: do not log route index

### DIFF
--- a/dataclients/kubernetes/clusterclient_test.go
+++ b/dataclients/kubernetes/clusterclient_test.go
@@ -266,7 +266,7 @@ func TestLoggingInterval(t *testing.T) {
 	defer log.SetOutput(os.Stderr)
 
 	countMessages := func() int {
-		return strings.Count(out.String(), "Ignoring route 0: service not found: default/myapp")
+		return strings.Count(out.String(), "Ignoring route: service not found: default/myapp")
 	}
 
 	a, err := kubernetestest.NewAPI(kubernetestest.TestAPIOptions{}, manifest)

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -443,7 +443,7 @@ nextRoute:
 					backend:    be,
 				})
 				if err != nil {
-					ctx.logger.Errorf("Ignoring route %d: %v", routeIndex, err)
+					ctx.logger.Errorf("Ignoring route: %v", err)
 					continue nextRoute
 				}
 

--- a/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/failing-route-groups-ignored.log
@@ -1,2 +1,2 @@
-Ignoring route 0: service not found: foo/non-existent
+Ignoring route: service not found: foo/non-existent
 kind=RouteGroup name=myapp-no-service ns=foo

--- a/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.log
+++ b/dataclients/kubernetes/testdata/routegroups/convert/missing-service-1-of-2.log
@@ -1,4 +1,2 @@
 kind=RouteGroup name=myapp
-Ignoring route 1: service not found: default/myapp-2
-Ignoring route 2: service not found: default/myapp-2
-Ignoring route 3: service not found: default/myapp-2
+Ignoring route: service not found: default/myapp-2

--- a/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
+++ b/dataclients/kubernetes/testdata/routegroups/east-west-range/internal-host-error-transforming.log
@@ -1,2 +1,2 @@
-Ignoring route 0: service not found: default/myapp
+Ignoring route: service not found: default/myapp
 kind=RouteGroup name=myapp


### PR DESCRIPTION
Do not log ignored route index to avoid logs bloat. The error message should be enough to figure out which routes were ignored. RouteGroup logger logs message without index only once per routegroup (see #2637).

Followup on #2796