### PR TITLE
eskip: improve lexer performance 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ opentracingplugin/build
 build/
 skptesting/lorem.html
 .vscode/*
+*.test
+

--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -3,6 +3,7 @@ package eskip
 import (
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -846,6 +847,39 @@ func BenchmarkParsePredicates(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = ParsePredicates(doc)
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	doc := strings.Repeat(`xxxx_xx__xxxxx__xxx_xxxxxxxx_xxxxxxxxxx_xxxxxxx_xxxxxxx_xxxxxxx_xxxxx__xxx__40_0:
+		Path("/xxxxxxxxx/:xxxxxxxx_xx/xxxxxxxx-xxxxxxxxxx-xxxxxxxxx")
+		&& Host("^(xxx-xxxxxxxx-xxxxxxxxxx-xxxxxxx-xxxxxxx-xxxx-18[.]xxx-xxxx[.]xxxxx[.]xx[.]?(:[0-9]+)?|xxx-xxxxxxxx-xxxxxxxxxx-xxxxxxx-xxxxxxx-xxxx-19[.]xxx-xxxx[.]xxxxx[.]xx[.]?(:[0-9]+)?|xxx-xxxxxxxx-xxxxxxxxxx-xxxxxxx-xxxxxxx-xxxx-20[.]xxx-xxxx[.]xxxxx[.]xx[.]?(:[0-9]+)?|xxx-xxxxxxxx-xxxxxxxxxx-xxxxxxx-xxxxxxx-xxxx-21[.]xxx-xxxx[.]xxxxx[.]xx[.]?(:[0-9]+)?|xxx-xxxxxxxx-xxxxxxxxxx-xxxxxxx-xxxxxxx[.]xxx-xxxx[.]xxxxx[.]xx[.]?(:[0-9]+)?|xxxxxxxxx-xxxxxxxx-xxxxxxxxxx-xxxxxxx[.]xxxxxxxxxxx[.]xxx[.]?(:[0-9]+)?)$")
+		&& Host("^(xxx-xxxxxxxx-xxxxxxxxxx-xxxxxxx-xxxxxxx-xxxx-21[.]xxx-xxxx[.]xxxxx[.]xx[.]?(:[0-9]+)?)$")
+		&& Weight(4)
+		&& Method("GET")
+		&& JWTPayloadAllKV("xxxxx://xxxxxxxx.xxxxxxx.xxx/xxxxx", "xxxxx")
+		&& Header("X-Xxxxxxxxx-Xxxxx", "xxxxx")
+		-> disableAccessLog(2, 3, 40, 500)
+		-> fifo(1000, 100, "10s")
+		-> apiUsageMonitoring("{\"xxx_xx\":\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",\"xxxxxxxxxxx_xx\":\"xxx-xxxxxxxx-xxxxxxxxxx\",\"xxxx_xxxxxxxxx\":[\"/xxxxxxxxx/{xxxxxxxx_xx}/xxxxxxxx-xxxxxxxxxx\",\"/xxxxxxxxx/{xxxxxxxx_xx}/xxxxxxxx-xxxxxxxxxx-xxxxxxx\",\"/xxxxxxxxx/{xxxxxxxx_xx}/xxxxxxxx-xxxxxxxxxx-xxxxxxxxx\"]}")
+		-> oauthTokeninfoAnyKV("xxxxx", "/xxxxxxxxx")
+		-> unverifiedAuditLog("xxxxx://xxxxxxxx.xxxxxxx.xxx/xxxxxxx-xx")
+		-> oauthTokeninfoAllScope("xxx")
+		-> flowId("reuse")
+		-> forwardToken("X-XxxxxXxxx-Xxxxxxx", "xxx", "xxxxx", "xxxxx")
+		-> stateBagToTag("xxxx-xxxx", "xxxxxx.xxx")
+		-> <powerOfRandomNChoices, "http://1.2.1.1:8080", "http://1.2.1.2:8080", "http://1.2.1.3:8080", "http://1.2.1.4:8080", "http://1.2.1.5:8080">;
+	`, 10_000)
+
+	_, err := Parse(doc)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Parse(doc)
 	}
 }
 


### PR DESCRIPTION
* use plain ascii instead of unicode package
* use loop for scanSymbol
* call scan functions directly instead of selectScanner to aid inlining

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/eskip
                  │    HEAD~1    │                HEAD                 │
                  │    sec/op    │   sec/op     vs base                │
ParsePredicates-8   9.637µ ± 11%   8.894µ ± 4%   -7.71% (p=0.001 n=10)
Parse-8             329.1m ±  4%   272.7m ± 2%  -17.15% (p=0.000 n=10)
geomean             1.781m         1.557m       -12.56%

                  │    HEAD~1    │                HEAD                 │
                  │     B/op     │     B/op      vs base               │
ParsePredicates-8   2.008Ki ± 0%   2.008Ki ± 0%       ~ (p=1.000 n=10)
Parse-8             49.94Mi ± 0%   49.94Mi ± 0%       ~ (p=0.926 n=10)
geomean             320.4Ki        320.4Ki       -0.00%

                  │   HEAD~1    │                 HEAD                 │
                  │  allocs/op  │  allocs/op   vs base                 │
ParsePredicates-8    33.00 ± 0%    33.00 ± 0%       ~ (p=1.000 n=10) ¹
Parse-8             1.100M ± 0%   1.100M ± 0%       ~ (p=0.367 n=10)
geomean             6.025k        6.025k       +0.00%
¹ all samples are equal
```

See previous https://github.com/zalando/skipper/pull/2755