### PR TITLE
eskip: use Predicate instead of matcher

### DIFF
--- a/eskip/parser.go
+++ b/eskip/parser.go
@@ -19,8 +19,8 @@ type eskipSymType struct {
 	token       string
 	route       *parsedRoute
 	routes      []*parsedRoute
-	matchers    []*matcher
-	matcher     *matcher
+	predicates  []*Predicate
+	predicate   *Predicate
 	filter      *Filter
 	filters     []*Filter
 	args        []interface{}
@@ -543,7 +543,7 @@ eskipdefault:
 		eskipDollar = eskipS[eskippt-3 : eskippt+1]
 		{
 			eskipVAL.route = &parsedRoute{
-				matchers:    eskipDollar[1].matchers,
+				predicates:  eskipDollar[1].predicates,
 				backend:     eskipDollar[3].backend,
 				shunt:       eskipDollar[3].shunt,
 				loopback:    eskipDollar[3].loopback,
@@ -552,14 +552,14 @@ eskipdefault:
 				lbAlgorithm: eskipDollar[3].lbAlgorithm,
 				lbEndpoints: eskipDollar[3].lbEndpoints,
 			}
-			eskipDollar[1].matchers = nil
+			eskipDollar[1].predicates = nil
 			eskipDollar[3].lbEndpoints = nil
 		}
 	case 10:
 		eskipDollar = eskipS[eskippt-5 : eskippt+1]
 		{
 			eskipVAL.route = &parsedRoute{
-				matchers:    eskipDollar[1].matchers,
+				predicates:  eskipDollar[1].predicates,
 				filters:     eskipDollar[3].filters,
 				backend:     eskipDollar[5].backend,
 				shunt:       eskipDollar[5].shunt,
@@ -569,30 +569,30 @@ eskipdefault:
 				lbAlgorithm: eskipDollar[5].lbAlgorithm,
 				lbEndpoints: eskipDollar[5].lbEndpoints,
 			}
-			eskipDollar[1].matchers = nil
+			eskipDollar[1].predicates = nil
 			eskipDollar[3].filters = nil
 			eskipDollar[5].lbEndpoints = nil
 		}
 	case 11:
 		eskipDollar = eskipS[eskippt-1 : eskippt+1]
 		{
-			eskipVAL.matchers = []*matcher{eskipDollar[1].matcher}
+			eskipVAL.predicates = []*Predicate{eskipDollar[1].predicate}
 		}
 	case 12:
 		eskipDollar = eskipS[eskippt-3 : eskippt+1]
 		{
-			eskipVAL.matchers = eskipDollar[1].matchers
-			eskipVAL.matchers = append(eskipVAL.matchers, eskipDollar[3].matcher)
+			eskipVAL.predicates = eskipDollar[1].predicates
+			eskipVAL.predicates = append(eskipVAL.predicates, eskipDollar[3].predicate)
 		}
 	case 13:
 		eskipDollar = eskipS[eskippt-1 : eskippt+1]
 		{
-			eskipVAL.matcher = &matcher{"*", nil}
+			eskipVAL.predicate = &Predicate{"*", nil}
 		}
 	case 14:
 		eskipDollar = eskipS[eskippt-4 : eskippt+1]
 		{
-			eskipVAL.matcher = &matcher{eskipDollar[1].token, eskipDollar[3].args}
+			eskipVAL.predicate = &Predicate{eskipDollar[1].token, eskipDollar[3].args}
 			eskipDollar[3].args = nil
 		}
 	case 15:

--- a/eskip/parser.y
+++ b/eskip/parser.y
@@ -1,11 +1,11 @@
 // Copyright 2015 Zalando SE
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,8 +32,8 @@ func convertNumber(s string) float64 {
 	token string
 	route *parsedRoute
 	routes []*parsedRoute
-	matchers []*matcher
-	matcher *matcher
+	predicates []*Predicate
+	predicate *Predicate
 	filter *Filter
 	filters []*Filter
 	args []interface{}
@@ -110,9 +110,9 @@ routeid:
 	}
 
 route:
-	frontend arrow backend {
+	predicates arrow backend {
 		$$.route = &parsedRoute{
-			matchers: $1.matchers,
+			predicates: $1.predicates,
 			backend: $3.backend,
 			shunt: $3.shunt,
 			loopback: $3.loopback,
@@ -121,13 +121,13 @@ route:
 			lbAlgorithm: $3.lbAlgorithm,
 			lbEndpoints: $3.lbEndpoints,
 		}
-		$1.matchers = nil
+		$1.predicates = nil
 		$3.lbEndpoints = nil
 	}
 	|
-	frontend arrow filters arrow backend {
+	predicates arrow filters arrow backend {
 		$$.route = &parsedRoute{
-			matchers: $1.matchers,
+			predicates: $1.predicates,
 			filters: $3.filters,
 			backend: $5.backend,
 			shunt: $5.shunt,
@@ -137,28 +137,28 @@ route:
 			lbAlgorithm: $5.lbAlgorithm,
 			lbEndpoints: $5.lbEndpoints,
 		}
-		$1.matchers = nil
+		$1.predicates = nil
 		$3.filters = nil
 		$5.lbEndpoints = nil
 	}
 
-frontend:
-	matcher {
-		$$.matchers = []*matcher{$1.matcher}
+predicates:
+	predicate {
+		$$.predicates = []*Predicate{$1.predicate}
 	}
 	|
-	frontend and matcher {
-		$$.matchers = $1.matchers
-		$$.matchers = append($$.matchers, $3.matcher)
+	predicates and predicate {
+		$$.predicates = $1.predicates
+		$$.predicates = append($$.predicates, $3.predicate)
 	}
 
-matcher:
+predicate:
 	any {
-		$$.matcher = &matcher{"*", nil}
+		$$.predicate = &Predicate{"*", nil}
 	}
 	|
 	symbol openparen args closeparen {
-		$$.matcher = &matcher{$1.token, $3.args}
+		$$.predicate = &Predicate{$1.token, $3.args}
 		$3.args = nil
 	}
 

--- a/eskip/parser_test.go
+++ b/eskip/parser_test.go
@@ -45,11 +45,11 @@ const (
 )
 
 func checkSingleRouteExample(r *parsedRoute, t *testing.T) {
-	if len(r.matchers) != 2 ||
-		r.matchers[0].name != "PathRegexp" || len(r.matchers[0].args) != 1 ||
-		r.matchers[0].args[0] != "\\.html$" ||
-		r.matchers[1].name != "Header" || len(r.matchers[1].args) != 2 ||
-		r.matchers[1].args[0] != "Accept" || r.matchers[1].args[1] != "text/html" {
+	if len(r.predicates) != 2 ||
+		r.predicates[0].Name != "PathRegexp" || len(r.predicates[0].Args) != 1 ||
+		r.predicates[0].Args[0] != "\\.html$" ||
+		r.predicates[1].Name != "Header" || len(r.predicates[1].Args) != 2 ||
+		r.predicates[1].Args[0] != "Accept" || r.predicates[1].Args[1] != "text/html" {
 		t.Error("failed to parse match expression")
 	}
 
@@ -227,7 +227,7 @@ func testRegExpOnce(t *testing.T, regexpStr string, expectedRegExp string) {
 		return
 	}
 
-	if expectedRegExp != routes[0].matchers[0].args[0] {
+	if expectedRegExp != routes[0].predicates[0].Args[0] {
 		t.Error("failed to parse PathRegexp:"+regexpStr+", expected regexp to be "+expectedRegExp, err)
 	}
 }


### PR DESCRIPTION
They are equivalent and using predicate reduces unnecessary copying. This is also consistent with parsing filters straight into `[]*Filter`.

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/eskip
                  │   HEAD~1    │                HEAD                │
                  │   sec/op    │   sec/op     vs base               │
ParsePredicates-8   9.192µ ± 2%   8.788µ ± 3%  -4.40% (p=0.007 n=10)
Parse-8             273.1m ± 2%   260.6m ± 2%  -4.58% (p=0.000 n=10)
geomean             1.585m        1.513m       -4.49%

                  │    HEAD~1    │                HEAD                 │
                  │     B/op     │     B/op      vs base               │
ParsePredicates-8   2.008Ki ± 0%   1.961Ki ± 0%  -2.33% (p=0.000 n=10)
Parse-8             49.94Mi ± 0%   49.02Mi ± 0%  -1.83% (p=0.000 n=10)
geomean             320.4Ki        313.7Ki       -2.08%

                  │   HEAD~1    │                HEAD                │
                  │  allocs/op  │  allocs/op   vs base               │
ParsePredicates-8    33.00 ± 0%    32.00 ± 0%  -3.03% (p=0.000 n=10)
Parse-8             1.100M ± 0%   1.080M ± 0%  -1.82% (p=0.000 n=10)
geomean             6.025k        5.879k       -2.43%
```