### PR TITLE
eskip: add gob unmarshal benchmark

### DIFF
--- a/eskip/eskip_test.go
+++ b/eskip/eskip_test.go
@@ -768,6 +768,8 @@ func BenchmarkParse(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
+	b.ReportMetric(float64(len(benchmarkRoutes10k)), "bytes/op")
+
 	for i := 0; i < b.N; i++ {
 		_, _ = Parse(benchmarkRoutes10k)
 	}

--- a/eskip/gob_test.go
+++ b/eskip/gob_test.go
@@ -1,0 +1,37 @@
+package eskip
+
+import (
+	"bytes"
+	"encoding/gob"
+	"reflect"
+	"testing"
+)
+
+func BenchmarkGobUnmarshal(b *testing.B) {
+	var buf bytes.Buffer
+
+	in := MustParse(benchmarkRoutes10k)
+	err := gob.NewEncoder(&buf).Encode(in)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	content := buf.Bytes()
+
+	var out []*Route
+	if err := gob.NewDecoder(bytes.NewReader(content)).Decode(&out); err != nil {
+		b.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		b.Fatal("input does not match output")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(float64(len(content)), "bytes/op")
+
+	for i := 0; i < b.N; i++ {
+		_ = gob.NewDecoder(bytes.NewReader(content)).Decode(&out)
+	}
+}


### PR DESCRIPTION
```
$ benchstat -col .name <(go test ./eskip -run=NONE -bench='BenchmarkGobUnmarshal|BenchmarkParse$' -count=10)
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/eskip
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
    │    Parse    │            GobUnmarshal            │
    │   sec/op    │   sec/op     vs base               │
*-8   238.8m ± 1%   227.9m ± 1%  -4.57% (p=0.000 n=10)

    │    Parse     │            GobUnmarshal             │
    │   bytes/op   │   bytes/op    vs base               │
*-8   15.99Mi ± 0%   17.05Mi ± 0%  +6.62% (p=0.000 n=10)

    │    Parse     │             GobUnmarshal             │
    │     B/op     │     B/op      vs base                │
*-8   49.02Mi ± 0%   70.53Mi ± 0%  +43.88% (p=0.000 n=10)

    │    Parse    │            GobUnmarshal            │
    │  allocs/op  │  allocs/op   vs base               │
*-8   1.080M ± 0%   1.020M ± 0%  -5.52% (p=0.000 n=10)
```