### PR TITLE
Remove GO111MODULE env variable which is required only for Go 1.11

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -32,7 +32,7 @@ Each plugin should be built with Go version >= 1.11, enabled Go
 modules support similar to the following build command line:
 
 ```sh
-GO111MODULE=on go build -buildmode=plugin -o example.so example.go
+go build -buildmode=plugin -o example.so example.go
 ```
 
 There are some pitfalls:
@@ -66,7 +66,7 @@ Install filter plugins:
 % ls plugins/filters
 geoip/  glide.lock  glide.yaml  ldapauth/  Makefile  noop/  plugin_test.go
 % cd plugins/filters/geoip
-% GO111MODULE=on go build -buildmode=plugin -o geoip.so geoip.go
+% go build -buildmode=plugin -o geoip.so geoip.go
 % cd -
 ~/go/src/github.com/zalando/skipper
 ```

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -11,13 +11,11 @@ CGO_ENABLED        ?= 0
 GOOS               ?= linux
 GOARCH             ?= amd64
 GOARM              ?=
-GO111              ?= on
 COMMIT_HASH        = $(shell git rev-parse --short HEAD)
 
 default: docker-build
 
 skipper:
-	GO111MODULE=$(GO111) \
 	GOOS=$(GOOS) \
 	GOARCH=$(GOARCH) \
 	$(GOARM) \
@@ -25,13 +23,13 @@ skipper:
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o skipper ../cmd/skipper/*.go
 
 eskip:
-	GO111MODULE=$(GO111) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOARM) CGO_ENABLED=$(CGO_ENABLED) go build -o eskip ../cmd/eskip/*.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOARM) CGO_ENABLED=$(CGO_ENABLED) go build -o eskip ../cmd/eskip/*.go
 
 webhook:
-	GO111MODULE=$(GO111) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOARM) CGO_ENABLED=$(CGO_ENABLED) go build -o webhook ../cmd/webhook/*.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOARM) CGO_ENABLED=$(CGO_ENABLED) go build -o webhook ../cmd/webhook/*.go
 
 routesrv:
-	GO111MODULE=$(GO111) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOARM) CGO_ENABLED=$(CGO_ENABLED) go build -o routesrv ../cmd/routesrv/*.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOARM) CGO_ENABLED=$(CGO_ENABLED) go build -o routesrv ../cmd/routesrv/*.go
 
 clean:
 	rm -rf $(BINARIES) build/
@@ -80,21 +78,18 @@ build.darwin.arm64: $(addprefix build/darwin/arm64/,$(BINARIES))
 build.windows: $(addprefix build/windows/amd64/,$(BINARIES))
 
 build/linux/amd64/%:
-	GO111MODULE=$(GO111) \
 	GOOS=linux \
 	GOARCH=amd64 \
 	CGO_ENABLED=$(CGO_ENABLED) \
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o build/linux/amd64/$(notdir $@) ../cmd/$(notdir $@)/*.go
 
 build/linux/arm64/%:
-	GO111MODULE=$(GO111) \
 	GOOS=linux \
 	GOARCH=arm64 \
 	CGO_ENABLED=$(CGO_ENABLED) \
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o build/linux/arm64/$(notdir $@) ../cmd/$(notdir $@)/*.go
 
 build/linux/arm/v7/%:
-	GO111MODULE=$(GO111) \
 	GOOS=linux \
 	GOARCH=arm \
 	GOARM=7 \
@@ -102,21 +97,18 @@ build/linux/arm/v7/%:
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o build/linux/arm/v7/$(notdir $@) ../cmd/$(notdir $@)/*.go
 
 build/darwin/amd64/%:
-	GO111MODULE=$(GO111) \
 	GOOS=darwin \
 	GOARCH=amd64 \
 	CGO_ENABLED=$(CGO_ENABLED) \
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o build/darwin/amd64/$(notdir $@) ../cmd/$(notdir $@)/*.go
 
 build/darwin/arm64/%:
-	GO111MODULE=$(GO111) \
 	GOOS=darwin \
 	GOARCH=arm64 \
 	CGO_ENABLED=$(CGO_ENABLED) \
 	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT_HASH)" -o build/darwin/arm64/$(notdir $@) ../cmd/$(notdir $@)/*.go
 
 build/windows/amd64/%:
-	GO111MODULE=$(GO111) \
 	GOOS=windows \
 	GOARCH=amd64 \
 	CGO_ENABLED=$(CGO_ENABLED) \

--- a/skptesting/run_fadein_test.sh
+++ b/skptesting/run_fadein_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function run_test() {
-  GO111MODULE=on go test ./loadbalancer -run="$1" -count=1 -v | awk '/fadein_test.go:[0-9]+: CSV/ {print $3}'
+  go test ./loadbalancer -run="$1" -count=1 -v | awk '/fadein_test.go:[0-9]+: CSV/ {print $3}'
 }
 
 cwd=$( dirname "${BASH_SOURCE[0]}" )


### PR DESCRIPTION
Signed-off-by: Roman Zavodskikh <roman.zavodskikh@zalando.de>