### PR TITLE
Remove duplicate hostname from ingressValidator

### DIFF
--- a/dataclients/kubernetes/definitions/ingressvalidator.go
+++ b/dataclients/kubernetes/definitions/ingressvalidator.go
@@ -14,7 +14,6 @@ func (igv *IngressV1Validator) Validate(item *IngressV1Item) error {
 	errs = append(errs, igv.validateFilterAnnotation(item.Metadata.Annotations))
 	errs = append(errs, igv.validatePredicateAnnotation(item.Metadata.Annotations))
 	errs = append(errs, igv.validateRoutesAnnotation(item.Metadata.Annotations))
-	errs = append(errs, igv.validateHosts(item))
 
 	return errorsJoin(errs...)
 }
@@ -50,16 +49,4 @@ func (igv *IngressV1Validator) validateRoutesAnnotation(annotations map[string]s
 		return err
 	}
 	return nil
-}
-
-func (igv *IngressV1Validator) validateHosts(item *IngressV1Item) error {
-	var errs []error
-	uniqueHosts := make(map[string]struct{}, len(item.Spec.Rules))
-	for _, rule := range item.Spec.Rules {
-		if _, ok := uniqueHosts[rule.Host]; ok {
-			errs = append(errs, fmt.Errorf("duplicate host %q", rule.Host))
-		}
-		uniqueHosts[rule.Host] = struct{}{}
-	}
-	return errorsJoin(errs...)
 }


### PR DESCRIPTION
Relates to https://github.com/zalando/skipper/pull/2753

Disabling duplicate hostname for ingress can have other side effects since we can have duplicate hostname but for different service/path.