### PR TITLE
Avoid calling EndpointRegistry.GetMetrics() in filterFadeIn

### DIFF
--- a/proxy/fadein.go
+++ b/proxy/fadein.go
@@ -37,7 +37,7 @@ func filterFadeIn(endpoints []routing.LBEndpoint, rt *routing.Route, registry *r
 	filtered := make([]routing.LBEndpoint, 0, len(endpoints))
 	for _, e := range endpoints {
 		f := fadeIn(
-			now.Sub(registry.GetMetrics(e.Host).DetectedTime()),
+			now.Sub(e.Metrics.DetectedTime()),
 			rt.LBFadeInDuration,
 			rt.LBFadeInExponent,
 		)


### PR DESCRIPTION
This function is called from hotpath, and it is possible not to call GetMetrics() which calls sync.Map.Load(). This will increase performance of the hotpath.