### PR TITLE
Passive health checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -285,6 +285,8 @@ type Config struct {
 	OpenPolicyAgentStartupTimeout       time.Duration `yaml:"open-policy-agent-startup-timeout"`
 	OpenPolicyAgentMaxRequestBodySize   int64         `yaml:"open-policy-agent-max-request-body-size"`
 	OpenPolicyAgentMaxMemoryBodyParsing int64         `yaml:"open-policy-agent-max-memory-body-parsing"`
+
+	PassiveHealthCheck mapFlags `yaml:"passive-health-check"`
 }
 
 const (
@@ -570,6 +572,9 @@ func NewConfig() *Config {
 
 	flag.Var(cfg.LuaModules, "lua-modules", "comma separated list of lua filter modules. Use <module>.<symbol> to selectively enable module symbols, for example: package,base._G,base.print,json")
 	flag.Var(cfg.LuaSources, "lua-sources", `comma separated list of lua input types for the lua() filter. Valid sources "", "file", "inline", "file,inline" and "none". Use "file" to only allow lua file references in lua filter. Default "" is the same as "file","inline". Use "none" to disable lua filters.`)
+
+	// Passive Health Checks
+	flag.Var(&cfg.PassiveHealthCheck, "passive-health-check", "sets the parameters for passive health check feature")
 
 	cfg.flags = flag
 	return cfg
@@ -912,6 +917,8 @@ func (c *Config) ToOptions() skipper.Options {
 		OpenPolicyAgentStartupTimeout:       c.OpenPolicyAgentStartupTimeout,
 		OpenPolicyAgentMaxRequestBodySize:   c.OpenPolicyAgentMaxRequestBodySize,
 		OpenPolicyAgentMaxMemoryBodyParsing: c.OpenPolicyAgentMaxMemoryBodyParsing,
+
+		PassiveHealthCheck: c.PassiveHealthCheck.values,
 	}
 	for _, rcci := range c.CloneRoute {
 		eskipClone := eskip.NewClone(rcci.Reg, rcci.Repl)

--- a/filters/fadein/fadein_test.go
+++ b/filters/fadein/fadein_test.go
@@ -236,6 +236,7 @@ func TestPostProcessor(t *testing.T) {
 		`
 
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		rt, _ := createRouting(t, routes, endpointRegistry)
 
 		foo := route(rt, "/foo")
@@ -266,6 +267,7 @@ func TestPostProcessor(t *testing.T) {
 		`
 
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		rt, _ := createRouting(t, routes, endpointRegistry)
 		r := route(rt, "/")
 		if r != nil {
@@ -278,13 +280,14 @@ func TestPostProcessor(t *testing.T) {
 			* -> fadeIn("-1m") -> <"http://10.0.0.1:8080">
 		`
 
-		endpointRegisty := routing.NewEndpointRegistry(routing.RegistryOptions{})
-		rt, _ := createRouting(t, routes, endpointRegisty)
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
+		rt, _ := createRouting(t, routes, endpointRegistry)
 		r := route(rt, "/")
 		if r == nil || len(r.LBEndpoints) == 0 {
 			t.Fatal("failed to ignore negative duration")
 		}
-		if endpointRegisty.GetMetrics(r.LBEndpoints[0].Host).DetectedTime().IsZero() {
+		if endpointRegistry.GetMetrics(r.LBEndpoints[0].Host).DetectedTime().IsZero() {
 			t.Fatal("failed to ignore negative duration")
 		}
 	})
@@ -295,6 +298,7 @@ func TestPostProcessor(t *testing.T) {
 		`
 
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		rt, update := createRouting(t, routes, endpointRegistry)
 		firstDetected := time.Now()
 
@@ -327,6 +331,7 @@ func TestPostProcessor(t *testing.T) {
 		`
 
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		rt, update := createRouting(t, initialRoutes, endpointRegistry)
 		firstDetected := time.Now()
 
@@ -362,6 +367,7 @@ func TestPostProcessor(t *testing.T) {
 
 		const lastSeenTimeout = 2 * time.Second
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{LastSeenTimeout: lastSeenTimeout})
+		defer endpointRegistry.Close()
 		rt, update := createRouting(t, initialRoutes, endpointRegistry)
 		firstDetected := time.Now()
 
@@ -397,6 +403,7 @@ func TestPostProcessor(t *testing.T) {
 		`
 
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		routes := fmt.Sprintf(routesFmt, nows(t))
 		rt, update := createRouting(t, routes, endpointRegistry)
 		firstDetected := time.Now()

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -31,6 +31,7 @@ func TestSelectAlgorithm(t *testing.T) {
 	t.Run("LB route with default algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -59,6 +60,7 @@ func TestSelectAlgorithm(t *testing.T) {
 	t.Run("LB route with explicit round-robin algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -88,6 +90,7 @@ func TestSelectAlgorithm(t *testing.T) {
 	t.Run("LB route with explicit consistentHash algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -117,6 +120,7 @@ func TestSelectAlgorithm(t *testing.T) {
 	t.Run("LB route with explicit random algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -146,6 +150,7 @@ func TestSelectAlgorithm(t *testing.T) {
 	t.Run("LB route with explicit powerOfRandomNChoices algorithm", func(t *testing.T) {
 		p := NewAlgorithmProvider()
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -260,6 +265,7 @@ func TestApply(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
 			p := NewAlgorithmProvider()
 			endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+			defer endpointRegistry.Close()
 			r := &routing.Route{
 				Route: eskip.Route{
 					BackendType: eskip.LBBackend,
@@ -293,6 +299,7 @@ func TestConsistentHashSearch(t *testing.T) {
 	apply := func(key string, endpoints []string) string {
 		p := NewAlgorithmProvider()
 		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
 		r := &routing.Route{
 			Route: eskip.Route{
 				BackendType: eskip.LBBackend,
@@ -349,6 +356,7 @@ func TestConsistentHashBoundedLoadSearch(t *testing.T) {
 		Params:      map[string]interface{}{ConsistentHashBalanceFactor: 1.25},
 	}
 	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
 	endpointRegistry.Do([]*routing.Route{route})
 	noLoad := ch.Apply(ctx)
 	nonBounded := ch.Apply(&routing.LBContext{Request: r, Route: route, LBEndpoints: route.LBEndpoints, Params: map[string]interface{}{}})
@@ -429,6 +437,7 @@ func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 		Params:      map[string]interface{}{ConsistentHashBalanceFactor: balanceFactor},
 	}
 	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
 	endpointRegistry.Do([]*routing.Route{route})
 
 	for i := 0; i < 100; i++ {

--- a/metricsinit_test.go
+++ b/metricsinit_test.go
@@ -53,6 +53,11 @@ func TestInitOrderAndDefault(t *testing.T) {
 			SwarmRedisURLs:                []string{fmt.Sprintf("localhost:%d", redisPort)},
 			EnableRatelimiters:            true,
 			SwarmRedisConnMetricsInterval: ringMetricsUpdatePeriod,
+			PassiveHealthCheck: map[string]string{
+				"period":               "1m",
+				"min-requests":         "10",
+				"max-drop-probability": "0.9",
+			},
 		}
 
 		tornDown := make(chan struct{})

--- a/proxy/healthy_endpoints.go
+++ b/proxy/healthy_endpoints.go
@@ -1,0 +1,34 @@
+package proxy
+
+import (
+	"math/rand"
+
+	"github.com/zalando/skipper/routing"
+)
+
+type healthyEndpoints struct {
+	rnd              *rand.Rand
+	endpointRegistry *routing.EndpointRegistry
+}
+
+func (h *healthyEndpoints) filterHealthyEndpoints(endpoints []routing.LBEndpoint, rt *routing.Route) []routing.LBEndpoint {
+	if h == nil {
+		return endpoints
+	}
+
+	p := h.rnd.Float64()
+
+	filtered := make([]routing.LBEndpoint, 0, len(endpoints))
+	for _, e := range endpoints {
+		if p < e.Metrics.HealthCheckDropProbability() {
+			/* drop */
+		} else {
+			filtered = append(filtered, e)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return endpoints
+	}
+	return filtered
+}

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -88,6 +88,7 @@ func (c Config) Create() *TestProxy {
 
 	rt := routing.New(c.RoutingOptions)
 	c.ProxyParams.Routing = rt
+	c.ProxyParams.EndpointRegistry = endpointRegistry
 
 	pr := proxy.WithParams(c.ProxyParams)
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -109,6 +109,7 @@ spec:
 	defer dc.Close()
 
 	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
 
 	// create LB in front of apiservers to be able to switch the data served by apiserver
 	ro := routing.Options{
@@ -282,6 +283,7 @@ spec:
 	defer dc.Close()
 
 	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
 
 	// create LB in front of apiservers to be able to switch the data served by apiserver
 	ro := routing.Options{

--- a/routing/endpointregistry_test.go
+++ b/routing/endpointregistry_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestEmptyRegistry(t *testing.T) {
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
+
 	m := r.GetMetrics("some key")
 
 	assert.Equal(t, time.Time{}, m.DetectedTime())
@@ -24,6 +26,7 @@ func TestEmptyRegistry(t *testing.T) {
 func TestSetAndGet(t *testing.T) {
 	now := time.Now()
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
 
 	mBefore := r.GetMetrics("some key")
 	assert.Equal(t, time.Time{}, mBefore.DetectedTime())
@@ -47,6 +50,7 @@ func TestSetAndGet(t *testing.T) {
 func TestSetAndGetAnotherKey(t *testing.T) {
 	now := time.Now()
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
 
 	mToChange := r.GetMetrics("some key")
 	mToChange.IncInflightRequest()
@@ -66,6 +70,7 @@ func TestSetAndGetAnotherKey(t *testing.T) {
 func TestDoRemovesOldEntries(t *testing.T) {
 	beginTestTs := time.Now()
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
 
 	routing.SetNow(r, func() time.Time {
 		return beginTestTs
@@ -117,6 +122,7 @@ func TestDoRemovesOldEntries(t *testing.T) {
 func TestEndpointRegistryPostProcessor(t *testing.T) {
 	beginTestTs := time.Now()
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
 
 	routing.SetNow(r, func() time.Time {
 		return beginTestTs
@@ -163,6 +169,8 @@ func TestEndpointRegistryPostProcessor(t *testing.T) {
 
 func TestMetricsMethodsDoNotAllocate(t *testing.T) {
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
+
 	metrics := r.GetMetrics("some key")
 	now := time.Now()
 	metrics.SetDetected(now.Add(-time.Hour))
@@ -186,6 +194,7 @@ func TestMetricsMethodsDoNotAllocate(t *testing.T) {
 
 func TestRaceReadWrite(t *testing.T) {
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
 	duration := time.Second
 
 	wg := sync.WaitGroup{}
@@ -219,6 +228,7 @@ func TestRaceReadWrite(t *testing.T) {
 
 func TestRaceTwoWriters(t *testing.T) {
 	r := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer r.Close()
 	duration := time.Second
 
 	wg := sync.WaitGroup{}

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -528,6 +528,7 @@ func TestDataClients(t *testing.T) {
 	defer reg.Close()
 
 	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
 
 	// create LB in front of apiservers to be able to switch the data served by apiserver
 	ro := routing.Options{


### PR DESCRIPTION
There is huge ongoing effort to enable Passive Health Checks is Skipper to check backends for errors and try not to send requests to the backends that tend to fail the requests.

The initial idea I have at the moment is the following:
+ leverage the endpointregistry component (https://github.com/zalando/skipper/pull/2535) developed recently to collect more data about endpoints (total amount of reqs sent to the endpoint, amount of reqs that were timed out because of backend outage)
+ if ratio of requests that were timed out is too high for particular endpoint, then send lower amount of requests to this endpoint, the decrease of RPS is configurable
+ once in a while (once in `statsResetPeriod`) update the stats to check endpoints' states change