### PR TITLE
eskip: copy string token value

### DIFF
--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -94,7 +94,8 @@ func scanEscaped(delimiter byte, code string) (string, string) {
 	for i := 0; i < len(code); i++ {
 		c := code[i]
 		if c == delimiter {
-			return code[:i], code[i:]
+			// make a copy to avoid referencing the possibly large underlying data array
+			return strings.Clone(code[:i]), code[i:]
 		} else if c == escapeChar {
 			break
 		}


### PR DESCRIPTION
Create a copy of string token value in lexer
to avoid referencing input data array.

The string value becomes a filter or predicate argument or an endpoint value. Using such value as a long-living cache key may create a memory leak.

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/eskip
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                  │   HEAD~1    │                HEAD                │
                  │   sec/op    │   sec/op     vs base               │
ParsePredicates-8   7.656µ ± 6%   8.281µ ± 3%  +8.16% (p=0.002 n=10)
Parse-8             241.0m ± 1%   252.9m ± 6%  +4.96% (p=0.000 n=10)
geomean             1.358m        1.447m       +6.55%

                  │    HEAD~1    │                 HEAD                 │
                  │     B/op     │     B/op      vs base                │
ParsePredicates-8   1.961Ki ± 0%   2.352Ki ± 0%  +19.92% (p=0.000 n=10)
Parse-8             49.02Mi ± 0%   58.86Mi ± 0%  +20.07% (p=0.000 n=10)
geomean             313.7Ki        376.5Ki       +20.00%

                  │   HEAD~1    │                HEAD                 │
                  │  allocs/op  │  allocs/op   vs base                │
ParsePredicates-8    32.00 ± 0%    52.00 ± 0%  +62.50% (p=0.000 n=10)
Parse-8             1.080M ± 0%   1.330M ± 0%  +23.15% (p=0.000 n=10)
geomean             5.879k        8.316k       +41.46%

        │    HEAD~1    │               HEAD               │
        │   bytes/op   │   bytes/op    vs base            │
Parse-8   15.99Mi ± 0%   15.99Mi ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

Followup on #2755