### PR TITLE
eskip: copy symbol token value

### DIFF
--- a/eskip/lexer.go
+++ b/eskip/lexer.go
@@ -271,7 +271,8 @@ func scanSymbol(code string) (t token, rest string, err error) {
 	t.id = symbol
 	for i := 0; i < len(code); i++ {
 		if !isSymbolChar(code[i]) {
-			t.val, rest = code[0:i], code[i:]
+			// make a copy to avoid referencing the possibly large underlying data array
+			t.val, rest = strings.Clone(code[:i]), code[i:]
 			return
 		}
 	}


### PR DESCRIPTION
Create a copy of symbol token value in lexer
to avoid referencing input data array.

The symbol value becomes a filter or predicate name or a route id value. Using such value as a long-living cache key may create a memory leak.

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/eskip
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                  │    HEAD~1    │                 HEAD                 │
                  │    sec/op    │    sec/op     vs base                │
ParsePredicates-8   17.07µ ±  3%   18.80µ ± 18%  +10.17% (p=0.000 n=10)
Parse-8             538.9m ± 19%   545.5m ± 21%        ~ (p=0.631 n=10)
geomean             3.033m         3.203m         +5.60%

                  │    HEAD~1    │                HEAD                 │
                  │     B/op     │     B/op      vs base               │
ParsePredicates-8   2.352Ki ± 0%   2.375Ki ± 0%  +1.00% (p=0.000 n=10)
Parse-8             58.86Mi ± 0%   61.84Mi ± 0%  +5.05% (p=0.000 n=10)
geomean             376.5Ki        387.8Ki       +3.00%

                  │   HEAD~1    │                HEAD                 │
                  │  allocs/op  │  allocs/op   vs base                │
ParsePredicates-8    52.00 ± 0%    53.00 ± 0%   +1.92% (p=0.000 n=10)
Parse-8             1.330M ± 0%   1.510M ± 0%  +13.53% (p=0.000 n=10)
geomean             8.316k        8.946k        +7.57%

        │    HEAD~1    │               HEAD               │
        │   bytes/op   │   bytes/op    vs base            │
Parse-8   15.99Mi ± 0%   15.99Mi ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

See previous #2903
Followup on #2755