### PR TITLE
feature: comment() filter to comment a given filter chain.

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -63,6 +63,22 @@ Example:
 route1: Host(/^all401\.example\.org$/) -> status(401) -> <shunt>;
 ```
 
+## comment
+
+No operation, only to comment the route or a group of filters of a route
+
+Parameters:
+
+* msg (string)
+
+Example:
+
+```
+route1: *
+    -> comment("nothing to see")
+    -> <shunt>;
+```
+
 ## HTTP Headers
 ### preserveHost
 

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -115,6 +115,7 @@ const (
 func Filters() []filters.Spec {
 	return []filters.Spec{
 		NewBackendIsProxy(),
+		NewComment(),
 		NewRequestHeader(),
 		NewSetRequestHeader(),
 		NewAppendRequestHeader(),

--- a/filters/builtin/comment.go
+++ b/filters/builtin/comment.go
@@ -1,0 +1,40 @@
+package builtin
+
+import (
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/routing"
+)
+
+type comment struct{}
+
+// NewComment is a filter to comment a filter chain. It does nothing
+func NewComment() filters.Spec {
+	return &comment{}
+}
+
+func (*comment) Name() string {
+	return filters.CommentName
+}
+
+func (c *comment) CreateFilter(args []interface{}) (filters.Filter, error) {
+	return c, nil
+}
+
+func (*comment) Request(filters.FilterContext) {}
+
+func (*comment) Response(filters.FilterContext) {}
+
+type CommentPostProcessor struct{}
+
+func (CommentPostProcessor) Do(routes []*routing.Route) []*routing.Route {
+	for _, r := range routes {
+		var ff []*routing.RouteFilter
+		for _, f := range r.Filters {
+			if f.Name != filters.CommentName {
+				ff = append(ff, f)
+			}
+		}
+		r.Filters = ff
+	}
+	return routes
+}

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -207,6 +207,7 @@ func (r Registry) Register(s Spec) {
 // All Skipper filter names
 const (
 	BackendIsProxyName                         = "backendIsProxy"
+	CommentName                                = "comment"
 	ModRequestHeaderName                       = "modRequestHeader"
 	SetRequestHeaderName                       = "setRequestHeader"
 	AppendRequestHeaderName                    = "appendRequestHeader"

--- a/skipper.go
+++ b/skipper.go
@@ -1910,6 +1910,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			builtin.NewRouteCreationMetrics(mtr),
 			fadein.NewPostProcessor(fadein.PostProcessorOptions{EndpointRegistry: endpointRegistry}),
 			admissionControlSpec.PostProcessor(),
+			builtin.CommentPostProcessor{},
 		},
 		SignalFirstLoad: o.WaitFirstRouteLoad,
 	}


### PR DESCRIPTION
One example use case is to use it in more complex objects like RouteGroups and have something that is shown also on kubectl edit rg case