### PR TITLE
Address vet issues found in Go 1.22

### DIFF
--- a/cmd/webhook/admission/admission.go
+++ b/cmd/webhook/admission/admission.go
@@ -120,7 +120,9 @@ func Handler(admitter admitter) http.HandlerFunc {
 		}
 
 		start := time.Now()
-		defer admissionDuration.With(labelValues).Observe(float64(time.Since(start)) / float64(time.Second))
+		defer func() {
+			admissionDuration.With(labelValues).Observe(float64(time.Since(start)) / float64(time.Second))
+		}()
 
 		admResp, err := admitter.admit(request)
 		if err != nil {

--- a/proxy/longpoll_test.go
+++ b/proxy/longpoll_test.go
@@ -122,6 +122,7 @@ func cancelableRequest(
 	ctx, cancel := stdlibcontext.WithCancel(stdlibcontext.Background())
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 


### PR DESCRIPTION
This fixes `go vet` issues discovered in Go 1.22: https://go.dev/doc/go1.22

```
cmd/webhook/admission/admission.go:123:61: call to time.Since is not deferred
# github.com/zalando/skipper/proxy
# [github.com/zalando/skipper/proxy]
proxy/longpoll_test.go:122:2: the cancel function is not used on all paths (possible context leak)
proxy/longpoll_test.go:125:3: this return statement may be reached without using the cancel var defined on line 122
```