### PR TITLE
Revert "build: fix go1.22 issue with capslock"

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -26,7 +26,7 @@ jobs:
       - run: make check-race
       - run: make osv-scanner
       - run: make govulncheck
-      #- run: make capslock # see https://github.com/google/capslock/issues/87
+      - run: make capslock
       - run: make coverprofile
       - name: Convert coverage to lcov
         uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5


### PR DESCRIPTION
Reverts zalando/skipper#2908

https://github.com/google/capslock/issues/87 was fixed and tested locally. 