### PR TITLE
routesrv: do not log empty routes as error

### DIFF
--- a/routesrv/polling.go
+++ b/routesrv/polling.go
@@ -69,14 +69,9 @@ func (p *poller) poll(wg *sync.WaitGroup) {
 				"message", fmt.Sprintf("%s: %s", LogRoutesFetchingFailed, err),
 			)
 		case routesCount == 0:
-			log.Error(LogRoutesEmpty)
+			log.Info(LogRoutesEmpty)
 			p.metrics.IncCounter("routes.empty")
-
-			span.SetTag("error", true)
-			span.LogKV(
-				"event", "error",
-				"message", LogRoutesEmpty,
-			)
+			span.SetTag("routes.count", routesCount)
 		case routesCount > 0:
 			routesBytes, routesHash, initialized, updated := p.b.formatAndSet(routes)
 			logger := log.WithFields(log.Fields{"count": routesCount, "bytes": routesBytes, "hash": routesHash})


### PR DESCRIPTION
`routesrv` may be configured to produce no routes,
e.g. to only serve Redis endpoints from the namespace without
Ingresses/RouteGroups:
```sh
bin/routesrv \
-enable-kubernetes-endpointslices \
-kubernetes-namespace=my-redis-ns \
-kubernetes-redis-service-namespace=my-redis-ns \
-kubernetes-redis-service-name=my-redis \
-kubernetes-https-redirect=false \
-kubernetes-healthcheck=false \
...
```

For #2476