### PR TITLE
Use kubernetes cluster client to discover redis shards

### DIFF
--- a/dataclients/kubernetes/clusterclient_test.go
+++ b/dataclients/kubernetes/clusterclient_test.go
@@ -237,13 +237,13 @@ spec:
 			s := httptest.NewServer(a)
 			defer s.Close()
 
-			c, err := kubernetes.New(kubernetes.Options{KubernetesURL: s.URL, RouteGroupClass: tt.rgClass})
+			c, err := kubernetes.NewClusterClient(kubernetes.Options{KubernetesURL: s.URL, RouteGroupClass: tt.rgClass})
 			if err != nil {
 				t.Error(err)
 			}
 			defer c.Close()
 
-			rgs, err := c.ClusterClient.LoadRouteGroups()
+			rgs, err := c.LoadRouteGroups()
 			if err != nil {
 				t.Error(err)
 			}

--- a/dataclients/kubernetes/endpointslices.go
+++ b/dataclients/kubernetes/endpointslices.go
@@ -4,6 +4,8 @@ import (
 	"github.com/zalando/skipper/dataclients/kubernetes/definitions"
 )
 
+const endpointSliceServiceNameLabel = "kubernetes.io/service-name"
+
 // There are [1..N] Kubernetes endpointslices created for a single Kubernetes service.
 // Kubernetes endpointslices of a given service can have duplicates with different states.
 // Therefore Kubernetes endpointslices need to be de-duplicated before usage.
@@ -97,7 +99,7 @@ type endpointSlice struct {
 
 // ToResourceID returns the same string for a group endpointlisces created for the same svc
 func (eps *endpointSlice) ToResourceID() definitions.ResourceID {
-	svcName := eps.Meta.Labels["kubernetes.io/service-name"]
+	svcName := eps.Meta.Labels[endpointSliceServiceNameLabel]
 	namespace := eps.Meta.Namespace
 	return newResourceID(namespace, svcName)
 }

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -803,7 +803,7 @@ func TestIngressClassFilter(t *testing.T) {
 				return
 			}
 
-			c := &clusterClient{
+			c := &ClusterClient{
 				ingressClass: clsRx,
 			}
 
@@ -2009,7 +2009,7 @@ func TestCreateRequest(t *testing.T) {
 	)
 	rc := io.NopCloser(&buf)
 
-	client := &clusterClient{}
+	client := &ClusterClient{}
 
 	url = "A%"
 	_, err = client.createRequest(url, rc)
@@ -2129,7 +2129,7 @@ func TestBuildHTTPClient(t *testing.T) {
 }
 
 func TestScoping(t *testing.T) {
-	client := &clusterClient{}
+	client := &ClusterClient{}
 
 	client.setNamespace("test")
 	assert.Equal(t, "/apis/networking.k8s.io/v1/namespaces/test/ingresses", client.ingressesURI)
@@ -2246,11 +2246,11 @@ func TestLabelSelectorsSet(t *testing.T) {
 			client, err := New(test.options)
 			require.NoError(t, err)
 
-			assert.Equal(t, sortedSlice(test.expectedIngressSelector), sortedSlice(client.ClusterClient.ingressLabelSelectors))
-			assert.Equal(t, sortedSlice(test.expectedServicesSelector), sortedSlice(client.ClusterClient.servicesLabelSelectors))
-			assert.Equal(t, sortedSlice(test.expectedEndpointsSelector), sortedSlice(client.ClusterClient.endpointsLabelSelectors))
-			assert.Equal(t, sortedSlice(test.expectedSecretsSelector), sortedSlice(client.ClusterClient.secretsLabelSelectors))
-			assert.Equal(t, sortedSlice(test.expectedRouteGroupsSelector), sortedSlice(client.ClusterClient.routeGroupsLabelSelectors))
+			assert.Equal(t, sortedSlice(test.expectedIngressSelector), sortedSlice(client.clusterClient.ingressLabelSelectors))
+			assert.Equal(t, sortedSlice(test.expectedServicesSelector), sortedSlice(client.clusterClient.servicesLabelSelectors))
+			assert.Equal(t, sortedSlice(test.expectedEndpointsSelector), sortedSlice(client.clusterClient.endpointsLabelSelectors))
+			assert.Equal(t, sortedSlice(test.expectedSecretsSelector), sortedSlice(client.clusterClient.secretsLabelSelectors))
+			assert.Equal(t, sortedSlice(test.expectedRouteGroupsSelector), sortedSlice(client.clusterClient.routeGroupsLabelSelectors))
 		})
 	}
 }
@@ -3091,7 +3091,7 @@ func TestCertificateRegistry(t *testing.T) {
 
 		defer dc.Close()
 
-		state, err := dc.ClusterClient.fetchClusterState()
+		state, err := dc.clusterClient.fetchClusterState()
 		if err != nil {
 			t.Error(err)
 		}
@@ -3110,7 +3110,7 @@ func TestCertificateRegistry(t *testing.T) {
 
 		defer dc.Close()
 
-		state, err := dc.ClusterClient.fetchClusterState()
+		state, err := dc.clusterClient.fetchClusterState()
 		if err != nil {
 			t.Error(err)
 		}

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -16,7 +16,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -2043,7 +2042,7 @@ func TestCreateRequest(t *testing.T) {
 func TestBuildAPIURL(t *testing.T) {
 	var apiURL string
 	var err error
-	o := Options{}
+	o := &Options{}
 
 	apiURL, err = buildAPIURL(o)
 	if err != nil {
@@ -2095,20 +2094,12 @@ func TestBuildHTTPClient(t *testing.T) {
 	quit := make(chan struct{})
 	defer func() { close(quit) }()
 
-	httpClient, err := buildHTTPClient("", false, quit)
-	if err != nil {
-		t.Error(err)
-	}
-	if !reflect.DeepEqual(httpClient, http.DefaultClient) {
-		t.Errorf("should return default client if outside the cluster``")
-	}
-
-	_, err = buildHTTPClient("rumplestilzchen", true, quit)
+	_, err := buildHTTPClient("rumplestilzchen", quit)
 	if err == nil {
 		t.Errorf("expected to fail for non-existing file")
 	}
 
-	_, err = buildHTTPClient("kube_test.go", true, quit)
+	_, err = buildHTTPClient("kube_test.go", quit)
 	if err != errInvalidCertificate {
 		t.Errorf("should return invalid certificate")
 	}
@@ -2119,7 +2110,7 @@ func TestBuildHTTPClient(t *testing.T) {
 	}
 	defer os.Remove("ca.empty.crt")
 
-	_, err = buildHTTPClient("ca.empty.crt", true, quit)
+	_, err = buildHTTPClient("ca.empty.crt", quit)
 	if err != errInvalidCertificate {
 		t.Error("empty certificate is invalid certificate")
 	}
@@ -2131,7 +2122,7 @@ func TestBuildHTTPClient(t *testing.T) {
 	}
 	defer os.Remove("ca.temp.crt")
 
-	_, err = buildHTTPClient("ca.temp.crt", true, quit)
+	_, err = buildHTTPClient("ca.temp.crt", quit)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
- [x] requires https://github.com/zalando/skipper/pull/2917
- [x] requires https://github.com/zalando/skipper/pull/2929
- [ ] requires https://github.com/zalando/skipper/pull/2933
- [ ] add tests for LoadEndpointAddresses

Allow redis shards discovery using kubernetes cluster client without kubernetes dataclient.

Fixes #2476