### PR TITLE
Optimise sanitize with string builder

### DIFF
--- a/filters/builtin/stripquery.go
+++ b/filters/builtin/stripquery.go
@@ -51,7 +51,8 @@ func validHeaderFieldByte(b byte) bool {
 }
 
 // make sure we don't generate invalid headers
-func sanitize(input string) string {
+// temporary public function to benchmark it
+func Sanitize(input string) string {
 	toAscii := strconv.QuoteToASCII(input)
 	var b bytes.Buffer
 	for _, i := range toAscii {
@@ -60,6 +61,18 @@ func sanitize(input string) string {
 		}
 	}
 	return b.String()
+}
+
+// temporary public function to benchmark it
+func NewSanitize(input string) string {
+	toAscii := strconv.QuoteToASCII(input)
+	var s strings.Builder
+	for _, i := range toAscii {
+		if validHeaderFieldByte(byte(i)) {
+			s.WriteRune(i)
+		}
+	}
+	return s.String()
 }
 
 // Strips the query parameters and optionally preserves them in the X-Query-Param-xyz headers.
@@ -85,7 +98,7 @@ func (f *stripQuery) Request(ctx filters.FilterContext) {
 			if r.Header == nil {
 				r.Header = http.Header{}
 			}
-			r.Header.Add(fmt.Sprintf("X-Query-Param-%s", sanitize(k)), v)
+			r.Header.Add(fmt.Sprintf("X-Query-Param-%s", Sanitize(k)), v)
 		}
 	}
 

--- a/results.md
+++ b/results.md
@@ -1,0 +1,14 @@
+`go test -benchmem -run=^$ -bench ^BenchmarkStripQuery$ -benchtime=10s  github.com/zalando/skipper/filters/builtin`
+
+```
+BenchmarkStripQuery/[old_sanitize]_url_1-8              85732707               118.6 ns/op            80 B/op          4 allocs/op
+BenchmarkStripQuery/[old_sanitize]_url_2-8              14885370               808.2 ns/op           472 B/op         15 allocs/op
+BenchmarkStripQuery/[old_sanitize]_url_3-8              73297474               162.9 ns/op           120 B/op          4 allocs/op
+BenchmarkStripQuery/[old_sanitize]_url_4-8              100000000              114.1 ns/op            80 B/op          4 allocs/op
+
+
+BenchmarkStripQuery/[new_sanitize]_url_1-8              100000000              103.5 ns/op            24 B/op          3 allocs/op
+BenchmarkStripQuery/[new_sanitize]_url_2-8              15854868               778.5 ns/op           192 B/op         14 allocs/op
+BenchmarkStripQuery/[new_sanitize]_url_3-8              71689101               166.3 ns/op            64 B/op          4 allocs/op
+BenchmarkStripQuery/[new_sanitize]_url_4-8              100000000              102.0 ns/op            24 B/op          3 allocs/op
+```


### PR DESCRIPTION
not a big difference, but on large query strings it's noticeable.
can be minor and safe enhancement?

`go test -benchmem -run=^$ -bench ^BenchmarkStripQuery$ -benchtime=10s  github.com/zalando/skipper/filters/builtin`

```
BenchmarkStripQuery/[old_sanitize]_url_1-8              85732707               118.6 ns/op            80 B/op          4 allocs/op
BenchmarkStripQuery/[old_sanitize]_url_2-8              14885370               808.2 ns/op           472 B/op         15 allocs/op
BenchmarkStripQuery/[old_sanitize]_url_3-8              73297474               162.9 ns/op           120 B/op          4 allocs/op
BenchmarkStripQuery/[old_sanitize]_url_4-8              100000000              114.1 ns/op            80 B/op          4 allocs/op


BenchmarkStripQuery/[new_sanitize]_url_1-8              100000000              103.5 ns/op            24 B/op          3 allocs/op
BenchmarkStripQuery/[new_sanitize]_url_2-8              15854868               778.5 ns/op           192 B/op         14 allocs/op
BenchmarkStripQuery/[new_sanitize]_url_3-8              71689101               166.3 ns/op            64 B/op          4 allocs/op
BenchmarkStripQuery/[new_sanitize]_url_4-8              100000000              102.0 ns/op            24 B/op          3 allocs/op
```