### PR TITLE
build: remove outdated docs hint

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -112,10 +112,6 @@ pipeline:
   - desc: build docs
     cmd: |
       build-docs
-
-      if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
-        echo "Please update the docs with: mkdocs gh-deploy"
-      fi
   artifacts:
   - type: docs
     name: skipper


### PR DESCRIPTION
`build-docs` deploys documentation so no additional step is necessary

Followup on #2736