### PR TITLE
cdp: disable testcontainers Ryuk

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -49,6 +49,7 @@ pipeline:
         MULTIARCH_IMAGE="${MULTIARCH_REGISTRY}/teapot/skipper-test:${CDP_BUILD_VERSION}"
       fi
       export IMAGE MULTIARCH_IMAGE
+      export TESTCONTAINERS_RYUK_DISABLED=true
 
       make deps check-fmt vet staticcheck shortcheck
 


### PR DESCRIPTION
Disable reaper container for CDP builds.
This should hopefully eliminate testcontainer-related test flakes.

See https://golang.testcontainers.org/features/garbage_collector/#ryuk and previous #2930

Updates #2668
Updates #2621
Updates #2556