### PR TITLE
dataclients/kubernetes: export ClusterClient

### DIFF
--- a/dataclients/kubernetes/clusterclient_test.go
+++ b/dataclients/kubernetes/clusterclient_test.go
@@ -237,13 +237,13 @@ spec:
 			s := httptest.NewServer(a)
 			defer s.Close()
 
-			c, err := kubernetes.New(kubernetes.Options{KubernetesURL: s.URL, RouteGroupClass: tt.rgClass})
+			c, err := kubernetes.NewClusterClient(kubernetes.Options{KubernetesURL: s.URL, RouteGroupClass: tt.rgClass})
 			if err != nil {
 				t.Error(err)
 			}
 			defer c.Close()
 
-			rgs, err := c.ClusterClient.LoadRouteGroups()
+			rgs, err := c.LoadRouteGroups()
 			if err != nil {
 				t.Error(err)
 			}

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -2,9 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
-	"net"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -74,7 +72,7 @@ var internalIPs = []interface{}{
 	"::1/128",
 }
 
-// Options is used to initialize the Kubernetes DataClient.
+// Options is used to initialize the Kubernetes DataClient or ClusterClient.
 type Options struct {
 	// KubernetesInCluster defines if skipper is deployed and running in the kubernetes cluster
 	// this would make authentication with API server happen through the service account, rather than
@@ -245,7 +243,7 @@ type Options struct {
 // Client is a Skipper DataClient implementation used to create routes based on Kubernetes Ingress settings.
 type Client struct {
 	mu                     sync.Mutex
-	ClusterClient          *clusterClient
+	clusterClient          *ClusterClient
 	ingress                *ingress
 	routeGroups            *routeGroups
 	provideHealthcheck     bool
@@ -253,7 +251,6 @@ type Client struct {
 	reverseSourcePredicate bool
 	httpsRedirectCode      int
 	current                map[string]*eskip.Route
-	quit                   chan struct{}
 	defaultFiltersDir      string
 	state                  *clusterState
 	loggingInterval        time.Duration
@@ -265,27 +262,11 @@ func New(o Options) (*Client, error) {
 	if o.OriginMarker {
 		log.Warning("OriginMarker is deprecated")
 	}
-	quit := make(chan struct{})
 
-	apiURL, err := buildAPIURL(o)
+	clusterClient, err := NewClusterClient(o)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create cluster client: %v", err)
 	}
-
-	ingCls := defaultIngressClass
-	if o.IngressClass != "" {
-		ingCls = o.IngressClass
-	}
-
-	rgCls := defaultRouteGroupClass
-	if o.RouteGroupClass != "" {
-		rgCls = o.RouteGroupClass
-	}
-
-	log.Debugf(
-		"running in-cluster: %t. api server url: %s. provide health check: %t. ingress.class filter: %s. routegroup.class filter: %s. namespace: %s",
-		o.KubernetesInCluster, apiURL, o.ProvideHealthcheck, ingCls, rgCls, o.KubernetesNamespace,
-	)
 
 	if len(o.WhitelistedHealthCheckCIDR) > 0 {
 		whitelistCIDRS := make([]interface{}, len(o.WhitelistedHealthCheckCIDR))
@@ -308,11 +289,6 @@ func New(o Options) (*Client, error) {
 		}
 	}
 
-	clusterClient, err := newClusterClient(o, apiURL, ingCls, rgCls, quit)
-	if err != nil {
-		return nil, err
-	}
-
 	if !o.OnlyAllowedExternalNames {
 		o.AllowedExternalNames = []*regexp.Regexp{regexp.MustCompile(".*")}
 	}
@@ -325,7 +301,7 @@ func New(o Options) (*Client, error) {
 	rg := newRouteGroups(o)
 
 	return &Client{
-		ClusterClient:          clusterClient,
+		clusterClient:          clusterClient,
 		ingress:                ing,
 		routeGroups:            rg,
 		provideHealthcheck:     o.ProvideHealthcheck,
@@ -333,26 +309,9 @@ func New(o Options) (*Client, error) {
 		httpsRedirectCode:      o.HTTPSRedirectCode,
 		current:                make(map[string]*eskip.Route),
 		reverseSourcePredicate: o.ReverseSourcePredicate,
-		quit:                   quit,
 		defaultFiltersDir:      o.DefaultFiltersDir,
 		loggingInterval:        1 * time.Minute,
 	}, nil
-}
-
-func buildAPIURL(o Options) (string, error) {
-	if !o.KubernetesInCluster {
-		if o.KubernetesURL == "" {
-			return defaultKubernetesURL, nil
-		}
-		return o.KubernetesURL, nil
-	}
-
-	host, port := os.Getenv(serviceHostEnvVar), os.Getenv(servicePortEnvVar)
-	if host == "" || port == "" {
-		return "", errAPIServerURLNotFound
-	}
-
-	return "https://" + net.JoinHostPort(host, port), nil
 }
 
 // String returns the string representation of the path mode, the same
@@ -402,7 +361,7 @@ func mapRoutes(routes []*eskip.Route) (map[string]*eskip.Route, []*eskip.Route) 
 
 func (c *Client) loadAndConvert() ([]*eskip.Route, error) {
 	c.mu.Lock()
-	state, err := c.ClusterClient.fetchClusterState()
+	state, err := c.clusterClient.fetchClusterState()
 	if err != nil {
 		c.mu.Unlock()
 		return nil, err
@@ -417,12 +376,12 @@ func (c *Client) loadAndConvert() ([]*eskip.Route, error) {
 
 	defaultFilters := c.fetchDefaultFilterConfigs()
 
-	ri, err := c.ingress.convert(state, defaultFilters, c.ClusterClient.certificateRegistry, loggingEnabled)
+	ri, err := c.ingress.convert(state, defaultFilters, c.clusterClient.certificateRegistry, loggingEnabled)
 	if err != nil {
 		return nil, err
 	}
 
-	rg, err := c.routeGroups.convert(state, defaultFilters, loggingEnabled, c.ClusterClient.certificateRegistry)
+	rg, err := c.routeGroups.convert(state, defaultFilters, loggingEnabled, c.clusterClient.certificateRegistry)
 	if err != nil {
 		return nil, err
 	}
@@ -553,9 +512,7 @@ func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
 }
 
 func (c *Client) Close() {
-	if c != nil && c.quit != nil {
-		close(c.quit)
-	}
+	c.clusterClient.Close()
 }
 
 func (c *Client) fetchDefaultFilterConfigs() defaultFilters {


### PR DESCRIPTION
Refactor and export cluster client to allow usage without dataclient.