### PR TITLE
dataclients/kubernetes/kubernetestest: support getting resource by name

### DIFF
--- a/dataclients/kubernetes/kubernetestest/api_test.go
+++ b/dataclients/kubernetes/kubernetestest/api_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/dataclients/kubernetes"
 )
 
@@ -189,6 +191,22 @@ func getJSON(u string, o interface{}) error {
 	return json.Unmarshal(b, o)
 }
 
+func getField(o map[string]interface{}, names ...string) interface{} {
+	name := names[0]
+	if f, ok := o[name]; ok {
+		if len(names) == 1 {
+			return f
+		}
+
+		if m, ok := f.(map[string]interface{}); ok {
+			return getField(m, names[1:]...)
+		} else {
+			return nil
+		}
+	}
+	return nil
+}
+
 func TestTestAPI(t *testing.T) {
 	kindListSpec, err := os.Open("testdata/kind-list.yaml")
 	if err != nil {
@@ -208,11 +226,14 @@ func TestTestAPI(t *testing.T) {
 	s := httptest.NewServer(a)
 	defer s.Close()
 
-	get := func(uri string, o interface{}) error {
-		return getJSON(s.URL+uri, o)
+	get := func(t *testing.T, uri string, o interface{}) {
+		t.Helper()
+		err := getJSON(s.URL+uri, o)
+		require.NoError(t, err)
 	}
 
 	check := func(t *testing.T, data map[string]interface{}, itemsLength int, kind string) {
+		t.Helper()
 		items, ok := data["items"].([]interface{})
 		if !ok || len(items) != itemsLength {
 			t.Fatalf("failed to get the right number of %s: expected %d, got %d", kind, itemsLength, len(items))
@@ -224,7 +245,7 @@ func TestTestAPI(t *testing.T) {
 
 		resource, ok := items[0].(map[string]interface{})
 		if !ok {
-			t.Fatalf("failed to get the right resource:  %s", kind)
+			t.Fatalf("failed to get the right resource: %s", kind)
 		}
 		if resource["kind"] != kind {
 			t.Fatalf("failed to get the right resource: %s != %s", resource["kind"], kind)
@@ -235,77 +256,53 @@ func TestTestAPI(t *testing.T) {
 		const namespace = "internal"
 
 		var s map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.ServicesNamespaceFmt, namespace), &s); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.ServicesNamespaceFmt, namespace), &s)
 		check(t, s, 1, "Service")
 
 		var i map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.IngressesV1NamespaceFmt, namespace), &i); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.IngressesV1NamespaceFmt, namespace), &i)
 		check(t, i, 0, "Ingress")
 
 		var r map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.RouteGroupsNamespaceFmt, namespace), &r); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.RouteGroupsNamespaceFmt, namespace), &r)
 		check(t, r, 1, "RouteGroup")
 
 		var e map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.EndpointsNamespaceFmt, namespace), &e); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.EndpointsNamespaceFmt, namespace), &e)
 		check(t, e, 1, "Endpoints")
 
 		var eps map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.EndpointSlicesNamespaceFmt, namespace), &eps); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.EndpointSlicesNamespaceFmt, namespace), &eps)
 		check(t, eps, 1, "EndpointSlice")
 
 		var sec map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.SecretsNamespaceFmt, namespace), &sec); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.SecretsNamespaceFmt, namespace), &sec)
 		check(t, sec, 1, "Secret")
 	})
 
 	t.Run("without namespace", func(t *testing.T) {
 		var s map[string]interface{}
-		if err := get(kubernetes.ServicesClusterURI, &s); err != nil {
-			t.Fatal(err)
-		}
+		get(t, kubernetes.ServicesClusterURI, &s)
 		check(t, s, 3, "Service")
 
 		var i map[string]interface{}
-		if err := get(kubernetes.IngressesV1ClusterURI, &i); err != nil {
-			t.Fatal(err)
-		}
+		get(t, kubernetes.IngressesV1ClusterURI, &i)
 		check(t, i, 1, "Ingress")
 
 		var r map[string]interface{}
-		if err := get(kubernetes.RouteGroupsClusterURI, &r); err != nil {
-			t.Fatal(err)
-		}
+		get(t, kubernetes.RouteGroupsClusterURI, &r)
 		check(t, r, 2, "RouteGroup")
 
 		var e map[string]interface{}
-		if err := get(kubernetes.EndpointsClusterURI, &e); err != nil {
-			t.Fatal(err)
-		}
+		get(t, kubernetes.EndpointsClusterURI, &e)
 		check(t, e, 3, "Endpoints")
 
 		var eps map[string]interface{}
-		if err := get(kubernetes.EndpointSlicesClusterURI, &eps); err != nil {
-			t.Fatal(err)
-		}
+		get(t, kubernetes.EndpointSlicesClusterURI, &eps)
 		check(t, eps, 3, "EndpointSlice")
 
 		var sec map[string]interface{}
-		if err := get(kubernetes.SecretsClusterURI, &sec); err != nil {
-			t.Fatal(err)
-		}
+		get(t, kubernetes.SecretsClusterURI, &sec)
 		check(t, sec, 1, "Secret")
 	})
 
@@ -313,39 +310,54 @@ func TestTestAPI(t *testing.T) {
 		const namespace = "baz"
 
 		var s map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.ServicesNamespaceFmt, namespace), &s); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.ServicesNamespaceFmt, namespace), &s)
 		check(t, s, 1, "Service")
 
 		var i map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.IngressesV1NamespaceFmt, namespace), &i); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.IngressesV1NamespaceFmt, namespace), &i)
 		check(t, i, 0, "Ingress")
 
 		var r map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.RouteGroupsNamespaceFmt, namespace), &r); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.RouteGroupsNamespaceFmt, namespace), &r)
 		check(t, r, 1, "RouteGroup")
 
 		var e map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.EndpointsNamespaceFmt, namespace), &e); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.EndpointsNamespaceFmt, namespace), &e)
 		check(t, e, 1, "Endpoints")
 
 		var eps map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.EndpointSlicesNamespaceFmt, namespace), &eps); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.EndpointSlicesNamespaceFmt, namespace), &eps)
 		check(t, eps, 1, "EndpointSlice")
 
 		var sec map[string]interface{}
-		if err := get(fmt.Sprintf(kubernetes.SecretsNamespaceFmt, namespace), &sec); err != nil {
-			t.Fatal(err)
-		}
+		get(t, fmt.Sprintf(kubernetes.SecretsNamespaceFmt, namespace), &sec)
 		check(t, sec, 0, "Secret")
+	})
+
+	t.Run("resource by name", func(t *testing.T) {
+		const namespace = "internal"
+
+		var s map[string]interface{}
+		get(t, fmt.Sprintf(kubernetes.ServicesNamespaceFmt, namespace)+"/bar", &s)
+
+		assert.Equal(t, "Service", getField(s, "kind"))
+		assert.Equal(t, namespace, getField(s, "metadata", "namespace"))
+		assert.Equal(t, "bar", getField(s, "metadata", "name"))
+
+		var e map[string]interface{}
+		get(t, fmt.Sprintf(kubernetes.EndpointsNamespaceFmt, namespace)+"/bar", &e)
+
+		assert.Equal(t, "Endpoints", getField(e, "kind"))
+		assert.Equal(t, namespace, getField(e, "metadata", "namespace"))
+		assert.Equal(t, "bar", getField(e, "metadata", "name"))
+	})
+
+	t.Run("resource name does not exist", func(t *testing.T) {
+		const namespace = "internal"
+
+		var o map[string]interface{}
+		err := getJSON(s.URL+fmt.Sprintf(kubernetes.ServicesNamespaceFmt, namespace)+"/does-not-exist", &o)
+
+		assert.EqualError(t, err, "unexpected status code: 404")
 	})
 }


### PR DESCRIPTION
This is useful for testing getting endpoints by service name.

For #2476