### PR TITLE
filters/builtin: minor performance optimization for sanitize in StripQuery Filter

### DIFF
--- a/filters/builtin/stripquery.go
+++ b/filters/builtin/stripquery.go
@@ -15,7 +15,6 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -52,14 +51,14 @@ func validHeaderFieldByte(b byte) bool {
 
 // make sure we don't generate invalid headers
 func sanitize(input string) string {
+	var s strings.Builder
 	toAscii := strconv.QuoteToASCII(input)
-	var b bytes.Buffer
 	for _, i := range toAscii {
 		if validHeaderFieldByte(byte(i)) {
-			b.WriteRune(i)
+			s.WriteRune(i)
 		}
 	}
-	return b.String()
+	return s.String()
 }
 
 // Strips the query parameters and optionally preserves them in the X-Query-Param-xyz headers.

--- a/filters/builtin/stripquery_test.go
+++ b/filters/builtin/stripquery_test.go
@@ -15,11 +15,12 @@
 package builtin
 
 import (
-	"github.com/zalando/skipper/filters/filtertest"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
 )
 
 func TestCreateStripQueryFilter(t *testing.T) {
@@ -88,6 +89,24 @@ func TestPreserveQuery(t *testing.T) {
 			if c.FRequest.Header.Get(k) != strings.Join(h, ",") {
 				t.Errorf("Uri %q => %q, want %q (%v)", tt.uri, c.FRequest.Header.Get(k), h, c.FRequest.Header)
 			}
+		}
+	}
+}
+
+func BenchmarkSanitize(b *testing.B) {
+	piece := "query=cXVlcnkgUGRwKCRjb25maWdTa3U6IElEIS&variables=%7B%0A%20%20%20%20%22beautyColorImageWidth%22:%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20200,%0A%20%20%20%20%22portraitGalleryWidth%22:%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20828,%0A%20%20%20%20%22segmentedBannerHeaderLogoWidth%22:%20%20%20%20%20%20%20%20%20%20%20%20%20%2084,%0A%20%20%20%20%22shouldIncludeCtaTrackingKey%22:%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20false,%0A%20%20%20%20%22shouldIncludeFlagInfo%22:%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20false,%0A%20%20%20%20%22shouldIncludeHistogramValues%22:%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20false,%0A%20%20%20%20%22shouldIncludeOfferSelectionValues%22:%20%20%20%20%20%20%20%20%20%20%20true,%0A%20%20%20%20%22shouldIncludeOmnibusConfigModeChanges%22:%20%20%20%20%20%20%20false,%0A%20%20%20%20%22shouldIncludeOmnibusPriceLabelChanges%22:%20%20%20%20%20%20%20false,&apiEndpoint=https%253A%252F%252Fmodified%252Fsecret%252Fgraphql%252Fsecret&frontendType=secret&zalandoFeature=secret"
+	q := strings.Repeat(piece, 2)
+	v, e := url.ParseQuery(q)
+
+	if e != nil {
+		b.Error(e)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for k := range v {
+			sanitize(k)
 		}
 	}
 }


### PR DESCRIPTION
This is continuation of https://github.com/zalando/skipper/pull/2918/files

I have discovered that for certain cases string builder performs better than buffer, which is usually a go-to option for Go Developers. String builder was introduced in 1.10+ Go.

results (also attached to last commit message)

```
pkg: github.com/zalando/skipper/filters/builtin
           │   HEAD~1    │                HEAD                │
           │   sec/op    │   sec/op     vs base               │
Sanitize-8   802.1n ± 0%   748.3n ± 0%  -6.71% (p=0.000 n=10)

           │   HEAD~1   │                HEAD                │
           │    B/op    │    B/op     vs base                │
Sanitize-8   472.0 ± 0%   192.0 ± 0%  -59.32% (p=0.000 n=10)

           │   HEAD~1   │               HEAD                │
           │ allocs/op  │ allocs/op   vs base               │
Sanitize-8   15.00 ± 0%   14.00 ± 0%  -6.67% (p=0.000 n=10)
```