### PR TITLE
Fix Open Policy Agent filter in standalone use

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -1813,7 +1813,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	var opaRegistry *openpolicyagent.OpenPolicyAgentRegistry
 	if o.EnableOpenPolicyAgent {
-		opaRegistry := openpolicyagent.NewOpenPolicyAgentRegistry(
+		opaRegistry = openpolicyagent.NewOpenPolicyAgentRegistry(
 			openpolicyagent.WithMaxRequestBodyBytes(o.OpenPolicyAgentMaxRequestBodySize),
 			openpolicyagent.WithMaxMemoryBodyParsing(o.OpenPolicyAgentMaxMemoryBodyParsing),
 			openpolicyagent.WithCleanInterval(o.OpenPolicyAgentCleanerInterval))


### PR DESCRIPTION
PR #2518 introduced a variable re-declaration that effectively renders the Open Policy Agent filters useless when used in standalone mode (this does not apply to use as a go library).  