### PR TITLE
filters/auth: add grant cookie encoder

### DIFF
--- a/filters/auth/grant.go
+++ b/filters/auth/grant.go
@@ -92,14 +92,10 @@ func loginRedirectWithOverride(ctx filters.FilterContext, config *OAuthConfig, o
 	})
 }
 
-func (f *grantFilter) refreshToken(c *cookie, req *http.Request) (*oauth2.Token, error) {
+func (f *grantFilter) refreshToken(token *oauth2.Token, req *http.Request) (*oauth2.Token, error) {
 	// Set the expiry of the token to the past to trigger oauth2.TokenSource
 	// to refresh the access token.
-	token := &oauth2.Token{
-		AccessToken:  c.AccessToken,
-		RefreshToken: c.RefreshToken,
-		Expiry:       time.Now().Add(-time.Minute),
-	}
+	token.Expiry = time.Now().Add(-time.Minute)
 
 	ctx := providerContext(f.config)
 
@@ -114,12 +110,12 @@ func (f *grantFilter) refreshToken(c *cookie, req *http.Request) (*oauth2.Token,
 	return tokenSource.Token()
 }
 
-func (f *grantFilter) refreshTokenIfRequired(c *cookie, ctx filters.FilterContext) (*oauth2.Token, error) {
-	canRefresh := c.RefreshToken != ""
+func (f *grantFilter) refreshTokenIfRequired(t *oauth2.Token, ctx filters.FilterContext) (*oauth2.Token, error) {
+	canRefresh := t.RefreshToken != ""
 
-	if c.isAccessTokenExpired() {
+	if time.Now().After(t.Expiry) {
 		if canRefresh {
-			token, err := f.refreshToken(c, ctx.Request())
+			token, err := f.refreshToken(t, ctx.Request())
 			if err == nil {
 				// Remember that this token was just successfully refreshed
 				// so that we can send an updated cookie in the response.
@@ -130,12 +126,7 @@ func (f *grantFilter) refreshTokenIfRequired(c *cookie, ctx filters.FilterContex
 			return nil, errExpiredToken
 		}
 	} else {
-		return &oauth2.Token{
-			AccessToken:  c.AccessToken,
-			TokenType:    "Bearer",
-			RefreshToken: c.RefreshToken,
-			Expiry:       c.Expiry,
-		}, nil
+		return t, nil
 	}
 }
 
@@ -179,15 +170,13 @@ func (f *grantFilter) setupToken(token *oauth2.Token, tokeninfo map[string]inter
 }
 
 func (f *grantFilter) Request(ctx filters.FilterContext) {
-	req := ctx.Request()
-
-	c, err := extractCookie(req, f.config)
+	token, err := f.config.GrantCookieEncoder.Read(ctx.Request())
 	if err == http.ErrNoCookie {
 		loginRedirect(ctx, f.config)
 		return
 	}
 
-	token, err := f.refreshTokenIfRequired(c, ctx)
+	token, err = f.refreshTokenIfRequired(token, ctx)
 	if err != nil {
 		// Refresh failed and we no longer have a valid access token.
 		loginRedirect(ctx, f.config)
@@ -221,11 +210,13 @@ func (f *grantFilter) Response(ctx filters.FilterContext) {
 		return
 	}
 
-	c, err := createCookie(f.config, ctx.Request().Host, token)
+	cookies, err := f.config.GrantCookieEncoder.Update(ctx.Request(), token)
 	if err != nil {
 		ctx.Logger().Errorf("Failed to generate cookie: %v.", err)
 		return
 	}
 
-	ctx.Response().Header.Add("Set-Cookie", c.String())
+	for _, c := range cookies {
+		ctx.Response().Header.Add("Set-Cookie", c.String())
+	}
 }

--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -261,7 +261,16 @@ func (c *OAuthConfig) Init() error {
 	}
 
 	if c.GrantCookieEncoder == nil {
-		c.GrantCookieEncoder = &EncryptedCookieEncoder{config: c}
+		encryption, err := c.Secrets.GetEncrypter(secretsRefreshInternal, c.SecretFile)
+		if err != nil {
+			return err
+		}
+		c.GrantCookieEncoder = &EncryptedCookieEncoder{
+			Encryption:       encryption,
+			CookieName:       c.TokenCookieName,
+			RemoveSubdomains: *c.TokenCookieRemoveSubdomains,
+			Insecure:         c.Insecure,
+		}
 	}
 
 	c.initialized = true

--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -97,6 +97,9 @@ type OAuthConfig struct {
 	// GrantTokeninfoKeys, optional. When not empty, keys not in this list are removed from the tokeninfo map.
 	GrantTokeninfoKeys []string
 
+	// GrantCookieEncoder, optional. Cookie encoder stores and extracts OAuth token from cookies.
+	GrantCookieEncoder CookieEncoder
+
 	// TokeninfoSubjectKey, optional. When set, it is used to look up the subject
 	// ID in the tokeninfo map received from a tokeninfo endpoint request.
 	TokeninfoSubjectKey string
@@ -255,6 +258,10 @@ func (c *OAuthConfig) Init() error {
 		for _, key := range c.GrantTokeninfoKeys {
 			c.grantTokeninfoKeysLookup[key] = struct{}{}
 		}
+	}
+
+	if c.GrantCookieEncoder == nil {
+		c.GrantCookieEncoder = &EncryptedCookieEncoder{config: c}
 	}
 
 	c.initialized = true

--- a/filters/auth/grantcookie_test.go
+++ b/filters/auth/grantcookie_test.go
@@ -18,10 +18,9 @@ const (
 )
 
 func newGrantCookies(t *testing.T, config *OAuthConfig, host string, token oauth2.Token) []*http.Cookie {
-	cookie, err := createCookie(config, host, &token)
+	cookies, err := config.GrantCookieEncoder.Update(&http.Request{Host: host}, &token)
 	require.NoError(t, err)
-
-	return []*http.Cookie{cookie}
+	return cookies
 }
 
 func NewGrantCookies(t *testing.T, config *OAuthConfig) []*http.Cookie {


### PR DESCRIPTION
Add CookerEncoder interface to allow custom implementation of grant cookie encoding.

For example custom implementation may store token value in some permanent key-value storage and encode key into the cookie.

Another implementation may encode token value into multiple cookies.