### PR TITLE
cmd/skipper: fix version and commit for go install

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper"
@@ -27,6 +28,21 @@ var (
 	version string
 	commit  string
 )
+
+func init() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if version == "" {
+			version = info.Main.Version
+		}
+		if commit == "" {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					commit = setting.Value[:min(8, len(setting.Value))]
+				}
+			}
+		}
+	}
+}
 
 func main() {
 	cfg := config.NewConfig()


### PR DESCRIPTION
When skipper is installed via `go install` it has empty version and commit values:
```
~$ go install github.com/zalando/skipper/cmd/skipper@latest
go: downloading github.com/zalando/skipper v0.21.2
~$ skipper -version
Skipper version  (commit: , runtime: go1.22.0)
```

Current build process of binaries specifies version and commit via `-ldflags`.

This change uses debug buildinfo to get version and commit if they are not specified by `-ldflags` which is compatible with the current build process but should also work for `go install` case.

If this change fixes `go install` case (which can only be tested after package version is published) then we can add the same snippet to other binaries and get rid of COMMIT_HASH ldflag.

We can not get rid of `-ldflags` fully though because `go build` does not stamp version (see https://github.com/golang/go/issues/50603).