### PR TITLE
cmd/skipper: do not show empty commit

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -38,6 +38,7 @@ func init() {
 			for _, setting := range info.Settings {
 				if setting.Key == "vcs.revision" {
 					commit = setting.Value[:min(8, len(setting.Value))]
+					break
 				}
 			}
 		}
@@ -51,11 +52,11 @@ func main() {
 	}
 
 	if cfg.PrintVersion {
-		fmt.Printf(
-			"Skipper version %s (commit: %s, runtime: %s)\n",
-			version, commit, runtime.Version(),
-		)
-
+		fmt.Printf("Skipper version %s (", version)
+		if commit != "" {
+			fmt.Printf("commit: %s, ", commit)
+		}
+		fmt.Printf("runtime: %s)\n", runtime.Version())
 		return
 	}
 


### PR DESCRIPTION
Binary installed via `go install github.com/zalando/skipper/cmd/skipper@latest` does not contain `vcs.revision`, see https://github.com/golang/go/issues/65904

Followup on #2954