### PR TITLE
Update Go runtime to 1.22.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -180,4 +180,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-go 1.21
+go 1.22.1


### PR DESCRIPTION
I have already run `go mod tidy`, this command finished succesfully and changed no go.{mod,sum} files.