### PR TITLE
filters/openpolicyagent: use google.golang.org/protobuf

### DIFF
--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -16,7 +16,6 @@ import (
 
 	ext_authz_v3_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	authv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
-	_struct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/open-policy-agent/opa-envoy-plugin/envoyauth"
 	opaconf "github.com/open-policy-agent/opa/config"
 	opasdktest "github.com/open-policy-agent/opa/sdk/test"
@@ -30,6 +29,7 @@ import (
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/tracing/tracingtest"
 	"google.golang.org/protobuf/encoding/protojson"
+	_struct "google.golang.org/protobuf/types/known/structpb"
 )
 
 type MockOpenPolicyAgentFilter struct {
@@ -68,7 +68,7 @@ func TestLoadEnvoyMetadata(t *testing.T) {
 		"filter_metadata": {
 			"envoy.filters.http.header_to_metadata": {
 				"policy_type": "ingress"
-			}	
+			}
 		}
 	}
 	`))(cfg)
@@ -99,7 +99,7 @@ func mockControlPlaneWithDiscoveryBundle(discoveryBundle string) (*opasdktest.Se
 		opasdktest.MockBundle("/bundles/test", map[string]string{
 			"main.rego": `
 				package envoy.authz
-	
+
 				default allow = false
 			`,
 		}),
@@ -144,14 +144,14 @@ func mockControlPlaneWithResourceBundle() (*opasdktest.Server, []byte) {
 		opasdktest.MockBundle("/bundles/test", map[string]string{
 			"main.rego": `
 				package envoy.authz
-	
+
 				default allow = false
 			`,
 		}),
 		opasdktest.MockBundle("/bundles/use_body", map[string]string{
 			"main.rego": `
 				package envoy.authz
-	
+
 				default allow = false
 
 				allow { input.parsed_body }
@@ -160,7 +160,7 @@ func mockControlPlaneWithResourceBundle() (*opasdktest.Server, []byte) {
 		opasdktest.MockBundle("/bundles/anotherbundlename", map[string]string{
 			"main.rego": `
 				package envoy.authz
-	
+
 				default allow = false
 			`,
 		}),
@@ -178,7 +178,7 @@ func mockControlPlaneWithResourceBundle() (*opasdktest.Server, []byte) {
 			}
 		},
 		"plugins": {
-			"envoy_ext_authz_grpc": {    
+			"envoy_ext_authz_grpc": {
 				"path": "/envoy/authz/allow",
 				"dry-run": false,
 				"skip-request-body-parse": false

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/envoyproxy/go-control-plane v0.12.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
-	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/memberlist v0.5.0
@@ -101,6 +100,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/flatbuffers v1.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
-google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Use google.golang.org/protobuf to avoid direct dependency on github.com/golang/protobuf (which is still imported indirectly):

```
$ go mod why -m github.com/golang/protobuf
github.com/zalando/skipper/filters/openpolicyagent
github.com/envoyproxy/go-control-plane/envoy/config/core/v3
github.com/golang/protobuf/ptypes/any
```