### PR TITLE
crd: update RouteGroup CRD

### DIFF
--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -1,10 +1,11 @@
+# This is a copy of https://github.com/szuecs/routegroup-client/blob/master/zalando.org_routegroups.yaml
+# DO NOT EDIT.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: routegroups.zalando.org
 spec:
   group: zalando.org
@@ -34,14 +35,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -55,19 +61,12 @@ spec:
                       description: Address is required for type `network`
                       type: string
                     algorithm:
-                      description: Algorithm is required for type `lb`. `roundRobin`
-                        - backend is chosen by the round robin algorithm, starting
-                        with a random selected backend to spread across all backends
-                        from the beginning. `random` - backend is chosen at random.
-                        `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing)
-                        algorithm based on the request key. The request key is derived
-                        from `X-Forwarded-For` header or request remote IP address
-                        as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey)
-                        filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor)
-                        to prevent popular keys from overloading a single backend
-                        endpoint. `powerOfRandomNChoices` - backend is chosen by selecting
-                        N random endpoints and picking the one with least outstanding
-                        requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
+                      description: |-
+                        Algorithm is required for type `lb`.
+                        `roundRobin` - backend is chosen by the round robin algorithm, starting with a random selected backend to spread across all backends from the beginning.
+                        `random` - backend is chosen at random.
+                        `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to prevent popular keys from overloading a single backend endpoint.
+                        `powerOfRandomNChoices` - backend is chosen by selecting N random endpoints and picking the one with least outstanding requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
                       enum:
                       - roundRobin
                       - random
@@ -91,23 +90,14 @@ spec:
                       description: ServicePort is required for type `service`
                       type: integer
                     type:
-                      description: Type of the backend. `service`- resolve Kubernetes
-                        service to the available Endpoints belonging to the Service,
-                        and generate load balanced routes using them. `shunt` - reply
-                        directly from the proxy itself. This can be used to shortcut,
-                        for example have a default that replies with 404 or use skipper
-                        as a backend serving static content in demos. `loopback` -
-                        lookup again the routing table to a better matching route
-                        after processing the current route. Like this you can add
-                        some headers or change the request path for some specific
-                        matching requests. `dynamic` - use the backend provided by
-                        filters. This allows skipper as library users to do proxy
-                        calls to a certain target from their own implementation dynamically
-                        looked up by their filters. `lb` - balance the load across
-                        multiple network endpoints using specified algorithm. If algorithm
-                        is not specified it will use the default algorithm set by
-                        Skipper at start. `network` - use arbitrary HTTP or HTTPS
-                        URL.
+                      description: |-
+                        Type of the backend.
+                        `service`- resolve Kubernetes service to the available Endpoints belonging to the Service, and generate load balanced routes using them.
+                        `shunt` - reply directly from the proxy itself. This can be used to shortcut, for example have a default that replies with 404 or use skipper as a backend serving static content in demos.
+                        `loopback` - lookup again the routing table to a better matching route after processing the current route. Like this you can add some headers or change the request path for some specific matching requests.
+                        `dynamic` - use the backend provided by filters. This allows skipper as library users to do proxy calls to a certain target from their own implementation dynamically looked up by their filters.
+                        `lb` - balance the load across multiple network endpoints using specified algorithm. If algorithm is not specified it will use the default algorithm set by Skipper at start.
+                        `network` - use arbitrary HTTP or HTTPS URL.
                       enum:
                       - service
                       - shunt
@@ -122,18 +112,19 @@ spec:
                   type: object
                 type: array
               defaultBackends:
-                description: DefaultBackends is a list of default backends defined
-                  if no explicit backend is defined for a route
+                description: |-
+                  DefaultBackends is a list of default backends defined if no explicit
+                  backend is defined for a route
                 items:
                   properties:
                     backendName:
                       description: BackendName references backend by name
                       type: string
                     weight:
-                      description: Weight defines a portion of traffic for the referenced
-                        backend. It equals to weight divided by the sum of all backend
-                        weights. When all references have zero (or unspecified) weight
-                        then traffic is split equally between them.
+                      description: |-
+                        Weight defines a portion of traffic for the referenced backend.
+                        It equals to weight divided by the sum of all backend weights.
+                        When all references have zero (or unspecified) weight then traffic is split equally between them.
                       minimum: 0
                       type: integer
                   required:
@@ -145,6 +136,7 @@ spec:
                 items:
                   pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
                   type: string
+                minItems: 1
                 type: array
               routes:
                 description: Routes describe how a matching HTTP request is handled
@@ -152,19 +144,19 @@ spec:
                 items:
                   properties:
                     backends:
-                      description: RouteGroupBackendReference specifies the list of
-                        backendReference that should be applied to override the defaultBackends
+                      description: |-
+                        RouteGroupBackendReference specifies the list of backendReference that should
+                        be applied to override the defaultBackends
                       items:
                         properties:
                           backendName:
                             description: BackendName references backend by name
                             type: string
                           weight:
-                            description: Weight defines a portion of traffic for the
-                              referenced backend. It equals to weight divided by the
-                              sum of all backend weights. When all references have
-                              zero (or unspecified) weight then traffic is split equally
-                              between them.
+                            description: |-
+                              Weight defines a portion of traffic for the referenced backend.
+                              It equals to weight divided by the sum of all backend weights.
+                              When all references have zero (or unspecified) weight then traffic is split equally between them.
                             minimum: 0
                             type: integer
                         required:
@@ -215,24 +207,25 @@ spec:
                 minItems: 1
                 type: array
               tls:
-                description: TLS defines which Kubernetes secret will be used to terminate
-                  the connection based on the matching hostnames
+                description: |-
+                  TLS defines which Kubernetes secret will be used to terminate the connection
+                  based on the matching hostnames
                 items:
                   properties:
                     hosts:
-                      description: TLS hosts specify the list of hosts included in
-                        the TLS secret. The values in this list must match the host
-                        name(s) used for the RouteGroup in order to terminate TLS
-                        for the host(s).
+                      description: |-
+                        TLS hosts specify the list of hosts included in the TLS secret.
+                        The values in this list must match the host name(s) used for
+                        the RouteGroup in order to terminate TLS for the host(s).
                       items:
                         pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
                         type: string
                       minItems: 1
                       type: array
                     secretName:
-                      description: SecretName is the name of the secret used to terminate
-                        TLS traffic. Secret should reside in the same namespace as
-                        the RouteGroup.
+                      description: |-
+                        SecretName is the name of the secret used to terminate TLS traffic.
+                        Secret should reside in the same namespace as the RouteGroup.
                       type: string
                   required:
                   - hosts
@@ -245,7 +238,8 @@ spec:
           status:
             properties:
               loadBalancer:
-                description: LoadBalancer is similar to ingress status, such that
+                description: |-
+                  LoadBalancer is similar to ingress status, such that
                   external-dns has the same style as in ingress
                 properties:
                   routegroup:
@@ -275,9 +269,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
See changes
* https://github.com/szuecs/routegroup-client/pull/31
* https://github.com/szuecs/routegroup-client/pull/32

It restores a link to the origin removed by #2814
to make it clear that CRD is the copy.