### PR TITLE
filters: move annotate into own package

### DIFF
--- a/filters/annotate/annotate.go
+++ b/filters/annotate/annotate.go
@@ -1,4 +1,4 @@
-package builtin
+package annotate
 
 import (
 	"fmt"
@@ -16,10 +16,10 @@ type (
 
 const annotateStateBagKey = "filter." + filters.AnnotateName
 
-// NewAnnotate is a filter to annotate a filter chain.
+// New creates filters to annotate a filter chain.
 // It stores its key and value arguments into the filter context.
 // Use [GetAnnotations] to retrieve the annotations from the context.
-func NewAnnotate() filters.Spec {
+func New() filters.Spec {
 	return annotateSpec{}
 }
 

--- a/filters/annotate/annotate_test.go
+++ b/filters/annotate/annotate_test.go
@@ -1,4 +1,4 @@
-package builtin_test
+package annotate_test
 
 import (
 	"testing"
@@ -6,12 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/eskip"
-	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/filters/annotate"
 	"github.com/zalando/skipper/filters/filtertest"
 )
 
 func TestAnnotate(t *testing.T) {
-	spec := builtin.NewAnnotate()
+	spec := annotate.New()
 
 	for _, tc := range []struct {
 		name     string
@@ -46,13 +46,13 @@ func TestAnnotate(t *testing.T) {
 				filter.Request(ctx)
 			}
 
-			assert.Equal(t, tc.expected, builtin.GetAnnotations(ctx))
+			assert.Equal(t, tc.expected, annotate.GetAnnotations(ctx))
 		})
 	}
 }
 
 func TestAnnotateArgs(t *testing.T) {
-	spec := builtin.NewAnnotate()
+	spec := annotate.New()
 
 	t.Run("valid", func(t *testing.T) {
 		for _, def := range []string{

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -6,6 +6,7 @@ package builtin
 import (
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/accesslog"
+	"github.com/zalando/skipper/filters/annotate"
 	"github.com/zalando/skipper/filters/auth"
 	"github.com/zalando/skipper/filters/circuit"
 	"github.com/zalando/skipper/filters/consistenthash"
@@ -117,7 +118,7 @@ func Filters() []filters.Spec {
 	return []filters.Spec{
 		NewBackendIsProxy(),
 		NewComment(),
-		NewAnnotate(),
+		annotate.New(),
 		NewRequestHeader(),
 		NewSetRequestHeader(),
 		NewAppendRequestHeader(),


### PR DESCRIPTION
This avoids import cycle when GetAnnotations helper is imported from subpackage of filters.

Followup on #3022