### PR TITLE
filters/auth: implement opt-out support for jwtMetrics

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1584,6 +1584,10 @@ Examples:
 
 ```
 jwtMetrics("{issuers: ['https://example.com', 'https://example.org']}")
+
+// opt-out
+annotate("oauth.disabled", "this endpoint is public") ->
+jwtMetrics("{issuers: ['https://example.com', 'https://example.org'], optOutAnnotations: [oauth.disabled]}")
 ```
 
 


### PR DESCRIPTION
Extend configuration of `jwtMetrics` (#3020) to support opt-out - disable metrics collection when any of the configured route annotations (#3022) is present.

This can be used to collect data about missing/invalid JWT tokens per hostname in multitenant ingress setup.

Add `jwtMetrics` filter to all routes using `-default-filters-append` flag and allow users to annotate routes that do not require JWT token.