### PR TITLE
proxy: support configurable metrics

### DIFF
--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -9,19 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/filters/builtin"
-	"github.com/zalando/skipper/metrics"
 	"github.com/zalando/skipper/metrics/metricstest"
+	"github.com/zalando/skipper/proxy"
 	"github.com/zalando/skipper/proxy/proxytest"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/routing/testdataclient"
 )
 
 func TestMetricsUncompressed(t *testing.T) {
-	dm := metrics.Default
-	t.Cleanup(func() { metrics.Default = dm })
-
 	m := &metricstest.MockMetrics{}
-	metrics.Default = m
 
 	// will update routes after proxy address is known
 	dc := testdataclient.New(nil)
@@ -31,6 +27,9 @@ func TestMetricsUncompressed(t *testing.T) {
 		RoutingOptions: routing.Options{
 			FilterRegistry: builtin.MakeRegistry(),
 			DataClients:    []routing.DataClient{dc},
+		},
+		ProxyParams: proxy.Params{
+			Metrics: m,
 		},
 	}.Create()
 	defer p.Close()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -217,6 +217,10 @@ type Params struct {
 	// Control flags. See the Flags values.
 	Flags Flags
 
+	// Metrics collector.
+	// If not specified proxy uses global metrics.Default.
+	Metrics metrics.Metrics
+
 	// And optional list of priority routes to be used for matching
 	// before the general lookup tree.
 	PriorityRoutes []PriorityRoute
@@ -766,7 +770,11 @@ func WithParams(p Params) *Proxy {
 		}
 	}
 
-	m := metrics.Default
+	m := p.Metrics
+	if m == nil {
+		m = metrics.Default
+	}
+
 	if p.Flags.Debug() {
 		m = metrics.Void
 	}


### PR DESCRIPTION
Use configed metrics and fallback to global for backwards compatibility.

Updates #3026