### PR TITLE
OPA: Add tracing for outbound http calls

### DIFF
--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -11,7 +11,6 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/server"
-	"github.com/open-policy-agent/opa/tracing"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -58,7 +57,7 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 		return nil, err
 	}
 
-	err = envoyauth.Eval(ctx, opa, inputValue, result, rego.DistributedTracingOpts(tracing.Options{opa}))
+	err = envoyauth.Eval(ctx, opa, inputValue, result, rego.DistributedTracingOpts(buildTracingOptions(opa.registry.tracer, opa.bundleName, opa.manager)))
 	if err != nil {
 		return nil, err
 	}

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -57,7 +57,7 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 		return nil, err
 	}
 
-	err = envoyauth.Eval(ctx, opa, inputValue, result, rego.DistributedTracingOpts(buildTracingOptions(opa.registry.tracer, opa.bundleName, opa.manager)))
+	err = envoyauth.Eval(ctx, opa, inputValue, result, rego.DistributedTracingOpts(opa.DistributedTracing()))
 	if err != nil {
 		return nil, err
 	}

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/metrics/metricstest"
 	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/tracing/tracingtest"
 
 	"github.com/zalando/skipper/filters/filtertest"
 	"github.com/zalando/skipper/filters/openpolicyagent"
@@ -359,7 +360,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 				}
 			}`, opaControlPlane.URL(), ti.regoQuery))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry()
+			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(&tracingtest.Tracer{}))
 			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
 			fr.Register(ftSpec)
 			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, openpolicyagent.WithConfigTemplate(config))

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/proxy/proxytest"
+	"github.com/zalando/skipper/tracing/tracingtest"
 
 	"github.com/zalando/skipper/filters/openpolicyagent"
 )
@@ -239,7 +240,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 				}
 			}`, opaControlPlane.URL(), ti.regoQuery))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry()
+			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(&tracingtest.Tracer{}))
 			ftSpec := NewOpaServeResponseSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
 			fr.Register(ftSpec)
 			ftSpec = NewOpaServeResponseWithReqBodySpec(opaFactory, openpolicyagent.WithConfigTemplate(config))

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -766,7 +766,7 @@ func (opa *OpenPolicyAgentInstance) Config() *config.Config { return opa.opaConf
 
 // DistributedTracing is an implementation of the envoyauth.EvalContext interface
 func (opa *OpenPolicyAgentInstance) DistributedTracing() opatracing.Options {
-	return opatracing.NewOptions(opa.registry.tracer, opa.bundleName, opa.manager)
+	return buildTracingOptions(opa.registry.tracer, opa.bundleName, opa.manager)
 }
 
 // logging.Logger that does not pollute info with debug logs

--- a/filters/openpolicyagent/tracing.go
+++ b/filters/openpolicyagent/tracing.go
@@ -3,8 +3,14 @@ package openpolicyagent
 import (
 	"net/http"
 
+	"github.com/open-policy-agent/opa/plugins"
 	opatracing "github.com/open-policy-agent/opa/tracing"
 	"github.com/opentracing/opentracing-go"
+	"github.com/zalando/skipper/proxy"
+)
+
+const (
+	spanName = "open-policy-agent.http"
 )
 
 func init() {
@@ -14,14 +20,43 @@ func init() {
 type tracingFactory struct{}
 
 type transport struct {
-	opa     *OpenPolicyAgentInstance
+	tracer     opentracing.Tracer
+	bundleName string
+	manager    *plugins.Manager
+
 	wrapped http.RoundTripper
 }
 
 func (*tracingFactory) NewTransport(tr http.RoundTripper, opts opatracing.Options) http.RoundTripper {
+	var tracer opentracing.Tracer
+
+	if len(opts) < 3 {
+		panic("insufficient tracing options provided for outbound http calls from Open Policy Agent")
+	}
+
+	if opts[0] != nil {
+		var ok bool
+		tracer, ok = opts[0].(opentracing.Tracer)
+		if !ok {
+			panic("invalid type for first argument of tracing options, expected opentracing.Tracer")
+		}
+	}
+
+	bundleName, ok := opts[1].(string)
+	if !ok {
+		panic("invalid type for second argument of tracing options, expected string")
+	}
+
+	manager, ok := opts[2].(*plugins.Manager)
+	if !ok {
+		panic("invalid type third argument of tracing options, expected *plugins.Manager")
+	}
+
 	return &transport{
-		opa:     opts[0].(*OpenPolicyAgentInstance),
-		wrapped: tr,
+		tracer:     tracer,
+		bundleName: bundleName,
+		manager:    manager,
+		wrapped:    tr,
 	}
 }
 
@@ -32,15 +67,36 @@ func (*tracingFactory) NewHandler(f http.Handler, label string, opts opatracing.
 func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 	parentSpan := opentracing.SpanFromContext(ctx)
+	var span opentracing.Span
 
 	if parentSpan != nil {
-		span := parentSpan.Tracer().StartSpan("http.send", opentracing.ChildOf(parentSpan.Context()))
+		span = parentSpan.Tracer().StartSpan(spanName, opentracing.ChildOf(parentSpan.Context()))
+	} else if tr.tracer != nil {
+		span = tr.tracer.StartSpan(spanName)
+	}
+
+	if span != nil {
 		defer span.Finish()
+
+		span.SetTag(proxy.HTTPMethodTag, req.Method)
+		span.SetTag(proxy.HTTPUrlTag, req.URL.String())
+		span.SetTag(proxy.HostnameTag, req.Host)
+		span.SetTag(proxy.HTTPPathTag, req.URL.Path)
+		span.SetTag(proxy.ComponentTag, "skipper")
+		span.SetTag(proxy.SpanKindTag, proxy.SpanKindClient)
+
+		setSpanTags(span, tr.bundleName, tr.manager)
 		req = req.WithContext(opentracing.ContextWithSpan(ctx, span))
 
 		carrier := opentracing.HTTPHeadersCarrier(req.Header)
 		span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier)
 	}
 
-	return tr.wrapped.RoundTrip(req)
+	resp, err := tr.wrapped.RoundTrip(req)
+	if err != nil && span != nil {
+		span.SetTag("error", true)
+		span.LogKV("event", "error", "message", err.Error())
+	}
+
+	return resp, err
 }

--- a/filters/openpolicyagent/tracing.go
+++ b/filters/openpolicyagent/tracing.go
@@ -56,7 +56,7 @@ func (*tracingFactory) NewTransport(tr http.RoundTripper, opts opatracing.Option
 	for _, o := range opts {
 		opt, ok := o.(func(*transport))
 		if !ok {
-			log.Warn("invalid type for OPA tracing option, expected func(*transport), tracing information might be incomplete")
+			log.Warnf("invalid type for OPA tracing option, expected func(*transport) got %T, tracing information might be incomplete", o)
 		} else {
 			opt(wrapper)
 		}

--- a/filters/openpolicyagent/tracing_test.go
+++ b/filters/openpolicyagent/tracing_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/open-policy-agent/opa/config"
 	"github.com/open-policy-agent/opa/plugins"
-	opatracing "github.com/open-policy-agent/opa/tracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/zalando/skipper/tracing/tracingtest"
@@ -84,12 +83,12 @@ func TestTracingFactory(t *testing.T) {
 			f := &tracingFactory{}
 			tracer.Reset("")
 
-			tr := f.NewTransport(&MockTransport{tc.resp, tc.resperr}, opatracing.Options{tc.tracer, "bundle", &plugins.Manager{
+			tr := f.NewTransport(&MockTransport{tc.resp, tc.resperr}, buildTracingOptions(tc.tracer, "bundle", &plugins.Manager{
 				ID: "manager-id",
 				Config: &config.Config{
 					Labels: map[string]string{"label": "value"},
 				},
-			}})
+			}))
 
 			if tc.parentSpan != nil {
 				ctx := opentracing.ContextWithSpan(context.Background(), tc.parentSpan)

--- a/skipper.go
+++ b/skipper.go
@@ -1835,7 +1835,8 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		opaRegistry = openpolicyagent.NewOpenPolicyAgentRegistry(
 			openpolicyagent.WithMaxRequestBodyBytes(o.OpenPolicyAgentMaxRequestBodySize),
 			openpolicyagent.WithMaxMemoryBodyParsing(o.OpenPolicyAgentMaxMemoryBodyParsing),
-			openpolicyagent.WithCleanInterval(o.OpenPolicyAgentCleanerInterval))
+			openpolicyagent.WithCleanInterval(o.OpenPolicyAgentCleanerInterval),
+			openpolicyagent.WithTracer(tracer))
 		defer opaRegistry.Close()
 
 		opts := make([]func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error, 0)


### PR DESCRIPTION
For the Open Policy Agent filters, tracing information is currently mainly added for the evaluation path of the filters. This is useful for monitoring everything that is related to requests passing through Skipper.
The PR adds tracing for asynchronous http calls that happen during discovery, bundle download, status updates and decision uppload. This allows to monitor how the OPA instances interact with their control plane. 