### PR TITLE
Specify tracing span kind on creation

### DIFF
--- a/filters/shedder/admission.go
+++ b/filters/shedder/admission.go
@@ -456,7 +456,6 @@ func (ac *admissionControl) startSpan(ctx context.Context) (span opentracing.Spa
 	if parent != nil {
 		span = ac.tracer.StartSpan(admissionControlSpanName, opentracing.ChildOf(parent.Context()))
 		ext.Component.Set(span, "skipper")
-		ext.SpanKind.Set(span, "shedder")
 		span.SetTag("mode", ac.mode.String())
 	}
 	return

--- a/ratelimit/leakybucket.go
+++ b/ratelimit/leakybucket.go
@@ -112,13 +112,12 @@ func (b *ClusterLeakyBucket) getBucketId(label string) string {
 }
 
 func (b *ClusterLeakyBucket) startSpan(ctx context.Context) (span opentracing.Span) {
-	parent := opentracing.SpanFromContext(ctx)
-	if parent != nil {
-		span = b.ringClient.StartSpan(leakyBucketSpanName, opentracing.ChildOf(parent.Context()))
-	} else {
-		span = opentracing.NoopTracer{}.StartSpan("")
+	spanOpts := []opentracing.StartSpanOption{opentracing.Tags{
+		string(ext.Component): "skipper",
+		string(ext.SpanKind):  "client",
+	}}
+	if parent := opentracing.SpanFromContext(ctx); parent != nil {
+		spanOpts = append(spanOpts, opentracing.ChildOf(parent.Context()))
 	}
-	ext.Component.Set(span, "skipper")
-	ext.SpanKind.Set(span, "client")
-	return
+	return b.ringClient.StartSpan(leakyBucketSpanName, spanOpts...)
 }

--- a/tracing/tracingtest/testtracer.go
+++ b/tracing/tracingtest/testtracer.go
@@ -102,6 +102,9 @@ func (t *Tracer) StartSpan(operationName string, opts ...tracing.StartSpanOption
 	s := t.createSpanBase()
 	s.operationName = operationName
 	s.Refs = sso.References
+	for k, v := range sso.Tags {
+		s.Tags[k] = v
+	}
 	return s
 }
 


### PR DESCRIPTION
OpenTelemetry-OpenTracing bridge span kind can not be changed after creation, see https://github.com/open-telemetry/opentelemetry-go/issues/3953

The workaround is to specify span kind on creation which works for both Open Tracing and Open Telemetry bridge spans.

For #2104