### PR TITLE
config: refactor test defaultConfig

### DIFF
--- a/config/testdata/test.yaml
+++ b/config/testdata/test.yaml
@@ -2,6 +2,8 @@ address: localhost:9090
 max-loopbacks: 12
 etcd-timeout: 2s
 status-checks:
+  - http://foo.test/bar
+  - http://baz.test/qux
 swarm-redis-password: set_from_file
 refuse-payload:
   - foo


### PR DESCRIPTION
Make `defaultConfig` return configuration equal to one created from default flags and modified by a helper function for defining expected test case values.