### PR TITLE
filters: deprecate OpenTracing in FilterContext

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -108,9 +108,16 @@ type FilterContext interface {
 	Metrics() Metrics
 
 	// Allow filters to add Tags, Baggage to the trace or set the ComponentName.
+	//
+	// Deprecated: OpenTracing is deprecated, see https://github.com/zalando/skipper/issues/2104.
+	// Use opentracing.SpanFromContext(ctx.Request().Context()).Tracer() to get the proxy span Tracer.
 	Tracer() opentracing.Tracer
 
 	// Allow filters to create their own spans
+	//
+	// Deprecated: OpenTracing is deprecated, see https://github.com/zalando/skipper/issues/2104.
+	// Filter spans should be children of the proxy span,
+	// use opentracing.SpanFromContext(ctx.Request().Context()) to get the proxy span.
 	ParentSpan() opentracing.Span
 
 	// Returns a clone of the FilterContext including a brand new request object.

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -599,7 +599,7 @@ func (opa *OpenPolicyAgentInstance) startSpanFromContextWithTracer(tr opentracin
 }
 
 func (opa *OpenPolicyAgentInstance) StartSpanFromFilterContext(fc filters.FilterContext) (opentracing.Span, context.Context) {
-	return opa.startSpanFromContextWithTracer(fc.Tracer(), fc.ParentSpan(), fc.Request().Context())
+	return opa.StartSpanFromContext(fc.Request().Context())
 }
 
 func (opa *OpenPolicyAgentInstance) StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Context) {

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -296,7 +296,7 @@ func (c *context) Split() (filters.FilterContext, error) {
 }
 
 func (c *context) Loopback() {
-	loopSpan := c.Tracer().StartSpan(c.proxy.tracing.initialOperationName, opentracing.ChildOf(c.ParentSpan().Context()))
+	loopSpan := c.tracer.StartSpan(c.proxy.tracing.initialOperationName, opentracing.ChildOf(c.parentSpan.Context()))
 	defer loopSpan.Finish()
 	err := c.proxy.do(c, loopSpan)
 	if c.response != nil && c.response.Body != nil {


### PR DESCRIPTION
Deprecate OpenTracing FilterContext getters and remove their usage from filters.

For #2104