### PR TITLE
Change condition of PHC to reduce amount of produced logs 

### DIFF
--- a/proxy/healthy_endpoints.go
+++ b/proxy/healthy_endpoints.go
@@ -22,7 +22,7 @@ func (h *healthyEndpoints) filterHealthyEndpoints(ctx *context, endpoints []rout
 	filtered := make([]routing.LBEndpoint, 0, len(endpoints))
 	for _, e := range endpoints {
 		dropProbability := e.Metrics.HealthCheckDropProbability()
-		if p < dropProbability {
+		if dropProbability > 0.05 && p < dropProbability {
 			ctx.Logger().Infof("Dropping endpoint %q due to passive health check: p=%0.2f, dropProbability=%0.2f",
 				e.Host, p, dropProbability)
 			metrics.IncCounter("passive-health-check.endpoints.dropped")


### PR DESCRIPTION
Logging every request produces too many log lines.
However, we can still keep the logs of stats updater https://github.com/zalando/skipper/blob/v0.21.65/routing/endpointregistry.go#L172 because their amount does not depend on requests count.