### PR TITLE
filters: update godoc for deprecated FilterContext OpenTracing fields

### DIFF
--- a/filters/filters.go
+++ b/filters/filters.go
@@ -110,14 +110,14 @@ type FilterContext interface {
 	// Allow filters to add Tags, Baggage to the trace or set the ComponentName.
 	//
 	// Deprecated: OpenTracing is deprecated, see https://github.com/zalando/skipper/issues/2104.
-	// Use opentracing.SpanFromContext(ctx.Request().Context()).Tracer() to get the proxy span Tracer.
+	// Use opentracing.SpanFromContext(ctx.Request().Context()).Tracer() to get the Tracer.
 	Tracer() opentracing.Tracer
 
 	// Allow filters to create their own spans
 	//
 	// Deprecated: OpenTracing is deprecated, see https://github.com/zalando/skipper/issues/2104.
-	// Filter spans should be children of the proxy span,
-	// use opentracing.SpanFromContext(ctx.Request().Context()) to get the proxy span.
+	// Filter spans should be children of the request span,
+	// use opentracing.SpanFromContext(ctx.Request().Context()) to get it.
 	ParentSpan() opentracing.Span
 
 	// Returns a clone of the FilterContext including a brand new request object.


### PR DESCRIPTION
The ParentSpan is not a proxy span but either ingress span of "filters" span when enabled.

Follow up on #3044