### PR TITLE
eskip: remove flowid dependency

### DIFF
--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -493,6 +493,7 @@ func (c *Client) Delete(id string) error {
 
 func (c *Client) UpsertAll(routes []*eskip.Route) error {
 	for _, r := range routes {
+		//lint:ignore SA1019 due to backward compatibility
 		r.Id = eskip.GenerateIfNeeded(r.Id)
 		err := c.Upsert(r)
 		if err != nil {


### PR DESCRIPTION
eskip package is generally useful without proxy or filters and therefore ideally should have minimal number of dependencies.

This change deprecates GenerateIfNeeded which is only used by etcd dataclient and reimplements it to remove dependency on github.com/zalando/skipper/filters/flowid

See 35ba6cc76dee89a57cc7869e79824bd9fc56e750