### PR TITLE
Reduce errors in decision logs that are operational

### DIFF
--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/topdown"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -36,6 +37,11 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 	var input map[string]interface{}
 	defer func() {
 		stopeval()
+		if topdown.IsCancel(err) {
+			// If the evaluation was canceled, we don't want to log the decision.
+			return
+		}
+
 		err := opa.logDecision(ctx, input, result, err)
 		if err != nil {
 			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go
@@ -121,7 +121,11 @@ func (f *opaAuthorizeRequestFilter) Request(fc filters.FilterContext) {
 		req.Body = body
 	}
 
-	authzreq := envoy.AdaptToExtAuthRequest(req, f.opa.InstanceConfig().GetEnvoyMetadata(), f.envoyContextExtensions, rawBodyBytes)
+	authzreq, err := envoy.AdaptToExtAuthRequest(req, f.opa.InstanceConfig().GetEnvoyMetadata(), f.envoyContextExtensions, rawBodyBytes)
+	if err != nil {
+		f.opa.HandleEvaluationError(fc, span, nil, err, !f.opa.EnvoyPluginConfig().DryRun, http.StatusBadRequest)
+		return
+	}
 
 	start := time.Now()
 	result, err := f.opa.Eval(ctx, authzreq)

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -255,6 +255,20 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			backendHeaders:  make(http.Header),
 			removeHeaders:   make(http.Header),
 		},
+		{
+			msg:               "Invalid UTF-8 in Path",
+			filterName:        "opaAuthorizeRequest",
+			bundleName:        "somebundle.tar.gz",
+			regoQuery:         "envoy/authz/allow",
+			requestPath:       "/allow/%c0%ae%c0%ae",
+			requestMethod:     "GET",
+			contextExtensions: "",
+			expectedStatus:    http.StatusBadRequest,
+			expectedBody:      "",
+			expectedHeaders:   make(http.Header),
+			backendHeaders:    make(http.Header),
+			removeHeaders:     make(http.Header),
+		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
 			t.Logf("Running test for %v", ti)


### PR DESCRIPTION
Currently the Open Policy Agent filters send decision logs with an error to the control plane if the http path is invalid UTF-8 or if the evaluation is cancelled (the client closes the connection before the evaluation finishes). 

This disguises real errors and leads to a non-zero baseline of decision errors in the control plane. 

This PR pre-validates if paths are valid UTF-8 and do not send decisions for cancelled evalutations to the control plane. 