### PR TITLE
OPA: Add decision outcome to span

### DIFF
--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go
@@ -151,6 +151,7 @@ func (f *opaAuthorizeRequestFilter) Request(fc filters.FilterContext) {
 		f.opa.HandleInvalidDecisionError(fc, span, result, err, !f.opa.EnvoyPluginConfig().DryRun)
 		return
 	}
+	span.SetTag("opa.decision.allowed", allowed)
 	if !allowed {
 		fc.Metrics().IncCounter(f.opa.MetricsKey("decision.deny"))
 		f.opa.ServeResponse(fc, span, result)


### PR DESCRIPTION
This PR brings the information on the span for the `opaAuthorizeRequest*` filters to the same level as the metrics by including the decision's result if it is available under the `opa.decision.allowed` tag. 

This allows to pull similar metrics from the traces as directly from the Skipper instances.