### PR TITLE
routing: log route update id

### DIFF
--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -511,6 +511,7 @@ func processRouteDefs(o Options, fr filters.Registry, defs []*eskip.Route) (rout
 }
 
 type routeTable struct {
+	id            int
 	m             *matcher
 	once          sync.Once
 	routes        []*Route // only used for closing
@@ -543,10 +544,10 @@ func receiveRouteMatcher(o Options, out chan<- *routeTable, quit <-chan struct{}
 		updatesRelay <-chan []*eskip.Route
 	)
 	updatesRelay = updates
-	for {
+	for id := 1; ; id++ {
 		select {
 		case defs := <-updatesRelay:
-			o.Log.Info("route settings received")
+			o.Log.Infof("route settings received, id: %d", id)
 
 			for i := range o.PreProcessors {
 				defs = o.PreProcessors[i].Do(defs)
@@ -582,6 +583,7 @@ func receiveRouteMatcher(o Options, out chan<- *routeTable, quit <-chan struct{}
 			})
 
 			rt = &routeTable{
+				id:            id,
 				m:             m,
 				routes:        routes,
 				validRoutes:   validRoutes,

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -353,7 +353,7 @@ func (r *Routing) startReceivingUpdates(o Options) {
 						r.firstLoadSignaled = true
 					}
 				}
-				r.log.Info("route settings applied")
+				r.log.Infof("route settings applied, id: %d", rt.id)
 				if r.metrics != nil { // existing codebases might not supply metrics instance
 					r.metrics.UpdateGauge("routes.total", float64(len(rt.validRoutes)))
 					r.metrics.UpdateGauge("routes.updated_timestamp", float64(rt.created.Unix()))


### PR DESCRIPTION
Add and log route update counter to observe delay between receiving and applying routes.