### PR TITLE
routing: measure route update latency

### DIFF
--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -547,6 +547,8 @@ func receiveRouteMatcher(o Options, out chan<- *routeTable, quit <-chan struct{}
 	for id := 1; ; id++ {
 		select {
 		case defs := <-updatesRelay:
+			start := time.Now()
+
 			o.Log.Infof("route settings received, id: %d", id)
 
 			for i := range o.PreProcessors {
@@ -588,7 +590,7 @@ func receiveRouteMatcher(o Options, out chan<- *routeTable, quit <-chan struct{}
 				routes:        routes,
 				validRoutes:   validRoutes,
 				invalidRoutes: invalidRoutes,
-				created:       time.Now().UTC(),
+				created:       start,
 			}
 			updatesRelay = nil
 			outRelay = out

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -269,7 +269,7 @@ func New(o Options) *Routing {
 	initialMatcher, _ := newMatcher(nil, MatchingOptionsNone)
 	rt := &routeTable{
 		m:       initialMatcher,
-		created: time.Now().UTC(),
+		created: time.Now(),
 	}
 	r.routeTable.Store(rt)
 	r.startReceivingUpdates(o)
@@ -357,6 +357,7 @@ func (r *Routing) startReceivingUpdates(o Options) {
 				if r.metrics != nil { // existing codebases might not supply metrics instance
 					r.metrics.UpdateGauge("routes.total", float64(len(rt.validRoutes)))
 					r.metrics.UpdateGauge("routes.updated_timestamp", float64(rt.created.Unix()))
+					r.metrics.MeasureSince("routes.update_latency", rt.created)
 				}
 			case <-r.quit:
 				var rt *routeTable


### PR DESCRIPTION
* add route update latency metric - the time it takes to apply routes update after receival.
* remove redundant setting of `created` location to UTC - its value is only exposed via Unix() which is always in UTC.