### PR TITLE
OPA: Fail fast on discovery or bundle download errors

### DIFF
--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -501,6 +501,7 @@ func (opa *OpenPolicyAgentInstance) Start(ctx context.Context, timeout time.Dura
 		discoveryPlugin.RegisterListener(DiscoveryPluginStartupListener, func(status bundle.Status) {
 			handleStatusErrors(status, failed, "discovery plugin")
 		})
+		//defer discoveryPlugin.Unregister(DiscoveryPluginStartupListener) //ToDo
 	})
 
 	opa.manager.RegisterPluginStatusListener(PluginStatusStartupListener, func(status map[string]*plugins.Status) {
@@ -510,6 +511,7 @@ func (opa *OpenPolicyAgentInstance) Start(ctx context.Context, timeout time.Dura
 				opa.registerBundleListenerOnce.Do(func() {
 					bundlePlugin.Register(BundlePluginStartupListener, func(status bundle.Status) {
 						handleStatusErrors(status, failed, "bundle plugin")
+						//defer bundlePlugin.Unregister(BundlePluginStartupListener)   //ToDo
 					})
 				})
 			}
@@ -525,13 +527,6 @@ func (opa *OpenPolicyAgentInstance) Start(ctx context.Context, timeout time.Dura
 			}
 		}
 		close(done)
-
-		//unregister discovery and bundle plugin listeners, post successful plugin startup
-		discoveryPlugin.Unregister(DiscoveryPluginStartupListener)
-		bundlePlugin := bundle.Lookup(opa.manager)
-		if bundlePlugin != nil {
-			bundlePlugin.Unregister(BundlePluginStartupListener)
-		}
 	})
 	defer opa.manager.UnregisterPluginStatusListener(GeneralPluginStatusStartupListener)
 


### PR DESCRIPTION
As part of #3119, this PR changes the behaviour on starting up OPA instances inside the OPA based Skipper filters.

Currently even in the face of download errors of bundles, the default timeout of 30s is applied. 

By using listeners both for bundle download and discovery bundle download, we can detect a failure early despite the respective plugins still waiting for the bundles to become available.

Still a draft because tests are missing, there are some cleanups in the code that need to be done. 

Pending: Unregister discovery and bundle plugin listeners.