### PR TITLE
cmd/skipper: allow exclusion of insecure cipher suites

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -174,6 +175,7 @@ func TestToOptions(t *testing.T) {
 		c.ProxyPreserveHost = true // 4
 		c.RemoveHopHeaders = true  // 16
 		c.RfcPatchPath = true      // 32
+		c.ExcludeInsecureCipherSuites = true
 
 		// config
 		c.EtcdUrls = "127.0.0.1:5555"
@@ -230,6 +232,15 @@ func TestToOptions(t *testing.T) {
 	}
 	if len(opt.EditRoute) != 1 {
 		t.Errorf("Failed to get expected edit route: %s", c.EditRoute)
+	}
+	if opt.CipherSuites == nil {
+		t.Errorf("Failed to get the filtered cipher suites")
+	} else {
+		for _, i := range tls.InsecureCipherSuites() {
+			if slices.Contains(opt.CipherSuites, i.ID) {
+				t.Errorf("Insecure cipher found in list: %s", i.Name)
+			}
+		}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -405,6 +405,23 @@ func TestMinTLSVersion(t *testing.T) {
 	})
 }
 
+func TestExcludeInsecureCipherSuites(t *testing.T) {
+
+	t.Run("test default", func(t *testing.T) {
+		cfg := new(Config)
+		if cfg.filterCipherSuites() != nil {
+			t.Error("No cipher suites should be filtered by default")
+		}
+	})
+	t.Run("test excluded insecure cipher suites", func(t *testing.T) {
+		cfg := new(Config)
+		cfg.ExcludeInsecureCipherSuites = true
+		if cfg.filterCipherSuites() == nil {
+			t.Error(`Failed to get list of filtered cipher suites`)
+		}
+	})
+}
+
 type testFormatter struct {
 	messages map[string]log.Level
 }

--- a/skipper.go
+++ b/skipper.go
@@ -614,6 +614,9 @@ type Options struct {
 	// TLSMinVersion to set the minimal TLS version for all TLS configurations
 	TLSMinVersion uint16
 
+	// CipherSuites sets the list of cipher suites to use for TLS 1.2
+	CipherSuites []uint16
+
 	// Flush interval for upgraded Proxy connections
 	BackendFlushInterval time.Duration
 
@@ -1174,6 +1177,10 @@ func (o *Options) tlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 
 	config := &tls.Config{
 		MinVersion: o.TLSMinVersion,
+	}
+
+	if o.CipherSuites != nil {
+		config.CipherSuites = o.CipherSuites
 	}
 
 	if cr != nil {

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -186,6 +186,13 @@ func TestOptionsTLSConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint16(tls.VersionTLS13), c.MinVersion)
 	require.Equal(t, []tls.Certificate{cert, cert2}, c.Certificates)
+
+	// TLS Cipher Suites
+	o = &Options{CipherSuites: []uint16{1}}
+	c, err = o.tlsConfig(cr)
+	require.NoError(t, err)
+	assert.Equal(t, len(c.CipherSuites), 1)
+
 }
 
 func TestOptionsTLSConfigInvalidPaths(t *testing.T) {


### PR DESCRIPTION
Golang maintains a list of cipher suites considered insecure, which are still allowed if requested. This flag will allow those cipher suites to be completely excluded.

Options considered:

**Use a list of allowed cipher suites**
This may need some maintenance over time as cipher suites are updated, introduced or deprecated. 

**Exclude used cipher suites based on name**
Less maintenance overhead than maintaining desired list of cipher suites, excluding the ones not desired would also require some maintenance overtime as cipher suites are considered insecure.

**Exclude known insecure cipher suites** 
Using golang's list of [InsecureCipherSuites](https://pkg.go.dev/crypto/tls#InsecureCipherSuites) reducing maintenance overhead by allowing list to be maintained by golang.

Fixes https://github.com/zalando/skipper/issues/3121
