### PR TITLE
filters/auth: add token validator filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1343,6 +1343,35 @@ Examples:
 oauthTokeninfoAllKV("k1", "v1", "k2", "v2")
 ```
 
+#### oauthTokeninfoValidate
+
+> This filter is experimental and may change in the future, please see tests for example usage.
+
+The filter obtains token info and allows request if there was no error
+otherwise it responds with `401 Unauthorized` status and configured response body.
+
+It does nothing if any preceding filter already validated the token or if route is annotated with configured annotations.
+
+It is useful as a default filter to ensure each request has a valid token.
+[jwtMetrics](#jwtmetrics) filter may be used to discover routes serving requests without a valid token.
+
+The filter requires single string argument that is parsed as YAML.
+For convenience use [flow style format](https://yaml.org/spec/1.2.2/#chapter-7-flow-style-productions).
+
+Examples:
+
+```
+// without opt-out annotation validates the token
+oauthTokeninfoValidate("{optOutAnnotations: [oauth.disabled], unauthorizedResponse: 'Authentication required, see https://auth.test/foo'}")
+```
+
+```
+// with opt-out annotation does not validate the token
+annotate("oauth.disabled", "this endpoint is public") ->
+oauthTokeninfoValidate("{optOutAnnotations: [oauth.disabled], unauthorizedResponse: 'Authentication required, see https://auth.test/foo'}")
+```
+
+
 ### Tokenintrospection
 
 Tokenintrospection handled by another service.

--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -17,6 +17,7 @@ const (
 	checkOAuthTokeninfoAllScopes
 	checkOAuthTokeninfoAnyKV
 	checkOAuthTokeninfoAllKV
+	checkOAuthTokeninfoValidate
 	checkOAuthTokenintrospectionAnyClaims
 	checkOAuthTokenintrospectionAllClaims
 	checkOAuthTokenintrospectionAnyKV

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -287,6 +287,7 @@ const (
 	OAuthTokeninfoAllScopeName                 = "oauthTokeninfoAllScope"
 	OAuthTokeninfoAnyKVName                    = "oauthTokeninfoAnyKV"
 	OAuthTokeninfoAllKVName                    = "oauthTokeninfoAllKV"
+	OAuthTokeninfoValidateName                 = "oauthTokeninfoValidate"
 	OAuthTokenintrospectionAnyClaimsName       = "oauthTokenintrospectionAnyClaims"
 	OAuthTokenintrospectionAllClaimsName       = "oauthTokenintrospectionAllClaims"
 	OAuthTokenintrospectionAnyKVName           = "oauthTokenintrospectionAnyKV"

--- a/skipper.go
+++ b/skipper.go
@@ -1591,6 +1591,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			auth.NewOAuthTokeninfoAnyScopeWithOptions(tio),
 			auth.NewOAuthTokeninfoAllKVWithOptions(tio),
 			auth.NewOAuthTokeninfoAnyKVWithOptions(tio),
+			auth.NewOAuthTokeninfoValidate(tio),
 		)
 	}
 


### PR DESCRIPTION
The `oauthTokeninfoValidate` filter obtains token info and allows request if there was no error otherwise it responds with
`401 Unauthorized` status and configured response body.

It does nothing if any preceding filter already validated the token or if route is annotated with configured annotations.

It is useful as a default filter to ensure each request has a valid token.

Since its logic is diffrent from existing oauthTokeninfo* filters it is implemented as a separate filter type.