### PR TITLE
config: fix defaultFiltersFlags.String

### DIFF
--- a/config/defaultfilterflags.go
+++ b/config/defaultfilterflags.go
@@ -21,10 +21,10 @@ func (dpf *defaultFiltersFlags) Set(value string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse default filters: %w", err)
 	}
-
-	dpf.values = append(dpf.values, value)
-	dpf.filters = append(dpf.filters, fs...)
-
+	if len(fs) > 0 {
+		dpf.values = append(dpf.values, value)
+		dpf.filters = append(dpf.filters, fs...)
+	}
 	return nil
 }
 

--- a/config/defaultfilterflags_test.go
+++ b/config/defaultfilterflags_test.go
@@ -60,6 +60,19 @@ field:
 			want:       manyMoreFilters,
 			wantString: `ratelimit(5, "10s") -> tee("https://www.zalando.de/") -> inlineContent("OK\n")`,
 		},
+		{
+			name: "test multiple with empty filters in between",
+			args: []string{
+				`    `, // whitespaces only
+				`ratelimit(5, "10s")`,
+				`// not a filter, just an eskip comment`,
+				`tee("https://www.zalando.de/")`,
+				``, // empty
+			},
+			yaml:       `field: ratelimit(5, "10s") -> tee("https://www.zalando.de/")`,
+			want:       manyFilters,
+			wantString: `ratelimit(5, "10s") -> tee("https://www.zalando.de/")`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Do not store values that contaion no filters,
e.g. empty strings or eskip comments only.

Follow up on #3084