### PR TITLE
webhook filter: allow client redirects via 302 responses (#3130)

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1237,6 +1237,7 @@ headers to copy as an optional second argument to the filter.
 Responses from the webhook will be treated as follows:
 
 * Authorized if the status code is less than 300
+* Redirection, using the `Location` header, if the status code is 302
 * Forbidden if the status code is 403
 * Unauthorized for remaining status codes
 

--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -105,6 +105,7 @@ func reject(
 	reason rejectReason,
 	hostname,
 	debuginfo string,
+	destination string,
 ) {
 	if debuginfo == "" {
 		ctx.Logger().Debugf(
@@ -125,6 +126,10 @@ func reject(
 		Header:     make(map[string][]string),
 	}
 
+	if status == http.StatusFound && destination != "" {
+		rsp.Header.Add("Location", destination)
+	}
+
 	if hostname != "" {
 		// https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
 		rsp.Header.Add("WWW-Authenticate", hostname)
@@ -133,12 +138,16 @@ func reject(
 	ctx.Serve(rsp)
 }
 
+func redirect(ctx filters.FilterContext, username string, reason rejectReason, destination, debuginfo string) {
+	reject(ctx, http.StatusFound, username, reason, "", debuginfo, destination)
+}
+
 func unauthorized(ctx filters.FilterContext, username string, reason rejectReason, hostname, debuginfo string) {
-	reject(ctx, http.StatusUnauthorized, username, reason, hostname, debuginfo)
+	reject(ctx, http.StatusUnauthorized, username, reason, hostname, debuginfo, "")
 }
 
 func forbidden(ctx filters.FilterContext, username string, reason rejectReason, debuginfo string) {
-	reject(ctx, http.StatusForbidden, username, reason, "", debuginfo)
+	reject(ctx, http.StatusForbidden, username, reason, "", debuginfo, "")
 }
 
 func authorized(ctx filters.FilterContext, username string) {

--- a/filters/auth/auth_test.go
+++ b/filters/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 const (
 	testToken                    = "test-token"
 	testWebhookInvalidScopeToken = "test-webhook-invalid-scope-token"
+	testWebhookRedirectToken     = "test-webhook-redirect"
 	testUID                      = "jdoe"
 	testScope                    = "test-scope"
 	testScope2                   = "test-scope2"

--- a/filters/auth/authclient.go
+++ b/filters/auth/authclient.go
@@ -36,7 +36,7 @@ type tokeninfoClient interface {
 
 var _ tokeninfoClient = &authClient{}
 
-func newAuthClient(baseURL, spanName string, timeout time.Duration, maxIdleConns int, tracer opentracing.Tracer) (*authClient, error) {
+func newAuthClient(baseURL, spanName string, timeout time.Duration, maxIdleConns int, tracer opentracing.Tracer, followRedirects bool) (*authClient, error) {
 	if tracer == nil {
 		tracer = opentracing.NoopTracer{}
 	}
@@ -49,6 +49,13 @@ func newAuthClient(baseURL, spanName string, timeout time.Duration, maxIdleConns
 		return nil, err
 	}
 
+	var checkRedirectFn func(req *http.Request, via []*http.Request) error
+	if followRedirects {
+		checkRedirectFn = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
 	cli := net.NewClient(net.Options{
 		ResponseHeaderTimeout:   timeout,
 		TLSHandshakeTimeout:     timeout,
@@ -56,6 +63,7 @@ func newAuthClient(baseURL, spanName string, timeout time.Duration, maxIdleConns
 		Tracer:                  tracer,
 		OpentracingComponentTag: "skipper",
 		OpentracingSpanName:     spanName,
+		CheckRedirect:           checkRedirectFn,
 	})
 
 	return &authClient{url: u, cli: cli}, nil

--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -179,6 +179,7 @@ func (c *OAuthConfig) Init() error {
 			c.ConnectionTimeout,
 			c.MaxIdleConnectionsPerHost,
 			c.Tracer,
+			false,
 		)
 		if err != nil {
 			return err

--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -85,7 +85,7 @@ func (o *TokeninfoOptions) getTokeninfoClient() (tokeninfoClient, error) {
 func (o *TokeninfoOptions) newTokeninfoClient() (tokeninfoClient, error) {
 	var c tokeninfoClient
 
-	c, err := newAuthClient(o.URL, tokenInfoSpanName, o.Timeout, o.MaxIdleConns, o.Tracer)
+	c, err := newAuthClient(o.URL, tokenInfoSpanName, o.Timeout, o.MaxIdleConns, o.Tracer, false)
 	if err != nil {
 		return nil, err
 	}

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -289,7 +289,7 @@ func (s *tokenIntrospectionSpec) CreateFilter(args []interface{}) (filters.Filte
 	var ac *authClient
 	var ok bool
 	if ac, ok = issuerAuthClient[issuerURL]; !ok {
-		ac, err = newAuthClient(cfg.IntrospectionEndpoint, tokenIntrospectionSpanName, s.options.Timeout, s.options.MaxIdleConns, s.options.Tracer)
+		ac, err = newAuthClient(cfg.IntrospectionEndpoint, tokenIntrospectionSpanName, s.options.Timeout, s.options.MaxIdleConns, s.options.Tracer, false)
 		if err != nil {
 			return nil, filters.ErrInvalidFilterParameters
 		}

--- a/proxy/proxytest/proxytest.go
+++ b/proxy/proxytest/proxytest.go
@@ -123,6 +123,14 @@ func (p *TestProxy) Client() *TestClient {
 	return &TestClient{p.server.Client()}
 }
 
+func (p *TestProxy) ClientWithoutRedirectFollow() *TestClient {
+	client := p.server.Client()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &TestClient{client}
+}
+
 func (p *TestProxy) Close() error {
 	p.Log.Close()
 	if p.dc != nil {


### PR DESCRIPTION
This commit changes the behaviour of the webhook filter when a 302 Found response is received from the AuthN/AuthZ endpoint. As a result, it allows front-end facing (i.e. non-API) traffic to be filtered via the webhook.

Documentation updates and increased test coverage are included.

**Incidental**: Prevent the webhook client from following redirects from the AuthN/AuthZ endpoint: during testing I realised that the default `net/http` behaviour was in use - i.e. redirects were followed. Is this an intended behaviour of the filter: it's not documented, and it seems potentially risky?

Please take a look at #3130 for more details.

---

Changes:

1. Update to the documentation - `filters.md`.
2. Update to the auth `reject()` function, whereby the `Location` header is forwarded to the client if a `302` is encountered from the AuthN/AuthZ endpoint.
3. Prevent the webhook filter from following 302 redirects.
4. Update tests to cover 302 redirect forwarding.