### PR TITLE
feature: httpclient before and after hooks

### DIFF
--- a/net/httpclient_example_test.go
+++ b/net/httpclient_example_test.go
@@ -10,10 +10,23 @@ import (
 
 	"github.com/lightstep/lightstep-tracer-go"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/net"
 	"github.com/zalando/skipper/secrets"
 )
+
+func waitForSpanViaMockTracer(mockTracer *mocktracer.MockTracer) {
+	for i := 0; i < 20; i++ {
+		if n := len(mockTracer.FinishedSpans()); n > 0 {
+			logrus.Printf("found %d spans", n)
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	logrus.Println("no span found")
+}
 
 func ExampleTransport() {
 	tracer := lightstep.NewTracer(lightstep.Options{})
@@ -220,6 +233,9 @@ func ExampleClient_customTracer() {
 
 	cli.Get("http://" + srv.Listener.Addr().String() + "/")
 
+	// wait for the span to be finished
+	waitForSpanViaMockTracer(mockTracer)
+
 	fmt.Printf("customtag: %s", mockTracer.FinishedSpans()[0].Tags()["customtag"])
 
 	// Output:
@@ -324,4 +340,84 @@ func ExampleClient_hostSecret() {
 		log.Printf("rsp code: %v", rsp.StatusCode)
 		time.Sleep(1 * time.Second)
 	}
+}
+
+func ExampleClient_withBeforeSendHook() {
+	mockTracer := mocktracer.New()
+	peerService := "my-peer-service"
+	cli := net.NewClient(net.Options{
+		Tracer:                  &customTracer{mockTracer},
+		OpentracingComponentTag: "testclient",
+		OpentracingSpanName:     "clientSpan",
+		IdleConnTimeout:         2 * time.Second,
+		BeforeSend: func(req *http.Request) {
+			req.Header.Set("X-Foo", "qux")
+			if span := opentracing.SpanFromContext(req.Context()); span != nil {
+				logrus.Println("BeforeSend: found span")
+				span.SetTag(string(ext.PeerService), peerService)
+			} else {
+				logrus.Println("BeforeSend: no span found")
+			}
+		},
+	})
+	defer cli.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("X-Foo: %s\n", r.Header.Get("X-Foo"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cli.Get("http://" + srv.Listener.Addr().String() + "/")
+
+	// wait for the span to be finished
+	waitForSpanViaMockTracer(mockTracer)
+
+	fmt.Printf("request tag %q set to %q", string(ext.PeerService), mockTracer.FinishedSpans()[0].Tags()[string(ext.PeerService)])
+
+	// Output:
+	// X-Foo: qux
+	// request tag "peer.service" set to "my-peer-service"
+}
+
+func ExampleClient_withAfterResponseHook() {
+	mockTracer := mocktracer.New()
+	cli := net.NewClient(net.Options{
+		Tracer:                     &customTracer{mockTracer},
+		OpentracingComponentTag:    "testclient",
+		OpentracingSpanName:        "clientSpan",
+		BearerTokenRefreshInterval: 10 * time.Second,
+		BearerTokenFile:            "/tmp/foo.token",
+		IdleConnTimeout:            2 * time.Second,
+		AfterResponse: func(rsp *http.Response, err error) {
+			if span := opentracing.SpanFromContext(rsp.Request.Context()); span != nil {
+				span.SetTag("status.code", rsp.StatusCode)
+				if err != nil {
+					span.SetTag("error", err.Error())
+				}
+			}
+			rsp.StatusCode = 255
+		},
+	})
+	defer cli.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rsp, err := cli.Get("http://" + srv.Listener.Addr().String() + "/")
+	if err != nil {
+		log.Fatalf("Failed to get: %v", err)
+	}
+
+	// wait for the span to be finished
+	waitForSpanViaMockTracer(mockTracer)
+
+	fmt.Printf("response code: %d\n", rsp.StatusCode)
+	fmt.Printf("span status.code: %d", mockTracer.FinishedSpans()[0].Tags()["status.code"])
+
+	// Output:
+	// response code: 255
+	// span status.code: 200
 }


### PR DESCRIPTION
feature: net.Transport got beforeSend and afterResponse hooks that a user can set via net.Options 
```go
	// BeforeSend is a hook function that runs just before executing RoundTrip(*http.Request)
	BeforeSend func(*http.Request)
	// AfterResponse is a hook function that runs just after executing RoundTrip(*http.Request)
	AfterResponse func(*http.Response, error)
```

replaces https://github.com/zalando/skipper/pull/3137