### PR TITLE
fix: remove polyfill.io js

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,6 @@ markdown_extensions:
         class: mermaid
         format: !!python/name:pymdownx.superfences.fence_code_format
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
ref: https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/ was introduced by a0fa5d8e99117d5a43b84c4948cf819c16715efe "enable math rendering" (#2041)