### PR TITLE
Facilitate OPA decision correlation with business flows

### DIFF
--- a/docs/tutorials/auth.md
+++ b/docs/tutorials/auth.md
@@ -466,6 +466,14 @@ The second argument is parsed as YAML, cannot be nested and values need to be st
 
 In Rego this can be used like this `input.attributes.contextExtensions["com.mycompany.myprop"] == "my value"`
 
+### Decision ID in Policies
+
+Each evaluation yields a distinct decision, identifiable by its unique decision ID.
+This decision ID can be located within the input at:
+`input.attributes.metadataContext.filterMetadata.open_policy_agent.decision_id`
+Typical use cases are either propagation of the decision ID to downstream systems or returning it as part of the response. As an example this can allow to trouble shoot deny requests by looking up details using the full decision in a control plane.
+
+
 ### Quick Start Rego Playground
 
 A quick way without setting up Backend APIs is to use the [Rego Playground](https://play.openpolicyagent.org/).

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -3,8 +3,7 @@ package openpolicyagent
 import (
 	"context"
 	"fmt"
-	"time"
-
+	ext_authz_v3_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"github.com/open-policy-agent/opa-envoy-plugin/envoyauth"
 	"github.com/open-policy-agent/opa-envoy-plugin/opa/decisionlog"
@@ -13,6 +12,8 @@ import (
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/topdown"
 	"github.com/opentracing/opentracing-go"
+	pbstruct "google.golang.org/protobuf/types/known/structpb"
+	"time"
 )
 
 func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.CheckRequest) (*envoyauth.EvalResult, error) {
@@ -20,6 +21,12 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 	decisionId, err := opa.idGenerator.Generate()
 	if err != nil {
 		opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to generate decision ID.")
+		return nil, err
+	}
+
+	err = setDecisionIdInRequest(req, decisionId)
+	if err != nil {
+		opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to set decision ID in Request.")
 		return nil, err
 	}
 
@@ -69,6 +76,29 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 	}
 
 	return result, nil
+}
+
+func setDecisionIdInRequest(req *ext_authz_v3.CheckRequest, decisionId string) error {
+	if req.Attributes.MetadataContext == nil {
+		req.Attributes.MetadataContext = &ext_authz_v3_core.Metadata{
+			FilterMetadata: map[string]*pbstruct.Struct{},
+		}
+	}
+
+	filterMeta, err := FormOpenPolicyAgentMetaDataObject(decisionId)
+	if err != nil {
+		return err
+	}
+	req.Attributes.MetadataContext.FilterMetadata["open_policy_agent"] = filterMeta
+	return nil
+}
+
+func FormOpenPolicyAgentMetaDataObject(decisionId string) (*pbstruct.Struct, error) {
+
+	innerFields := make(map[string]interface{})
+	innerFields["decision_id"] = decisionId
+
+	return pbstruct.NewStruct(innerFields)
 }
 
 func (opa *OpenPolicyAgentInstance) logDecision(ctx context.Context, input interface{}, result *envoyauth.EvalResult, err error) error {

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -256,6 +256,21 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			removeHeaders:   make(http.Header),
 		},
 		{
+			msg:             "Decision id in request header",
+			filterName:      "opaAuthorizeRequest",
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_object_decision_id_in_header",
+			requestMethod:   "POST",
+			body:            `{ "target_id" : "123456" }`,
+			requestHeaders:  map[string][]string{"content-type": {"application/json"}},
+			requestPath:     "/allow/structured",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "Welcome!",
+			expectedHeaders: map[string][]string{"Decision-Id": {"some-random-decision-id-generated-during-evaluation"}},
+			backendHeaders:  make(http.Header),
+			removeHeaders:   make(http.Header),
+		},
+		{
 			msg:               "Invalid UTF-8 in Path",
 			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
@@ -345,8 +360,21 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 
 						allow_body {
 							input.parsed_body.target_id == "123456"
-						}						
-					`,
+						}	
+						
+						decision_id := input.attributes.metadataContext.filterMetadata.open_policy_agent.decision_id
+
+						allow_object_decision_id_in_header = response {
+						    input.parsed_path = ["allow", "structured"]
+						    decision_id 
+						    response := {
+						        "allowed": true,
+						        "response_headers_to_add": {
+						            "decision-id": decision_id
+						        }
+						    }
+						}
+						`,
 				}),
 			)
 
@@ -374,10 +402,23 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 				}
 			}`, opaControlPlane.URL(), ti.regoQuery))
 
+			envoyMetaDataConfig := []byte(`{
+				"filter_metadata": {
+					"envoy.filters.http.header_to_metadata": {
+						"policy_type": "ingress"
+					}
+				}
+			}`)
+
+			opts := make([]func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error, 0)
+			opts = append(opts,
+				openpolicyagent.WithConfigTemplate(config),
+				openpolicyagent.WithEnvoyMetadataBytes(envoyMetaDataConfig))
+
 			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(&tracingtest.Tracer{}))
-			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory, opts...)
 			fr.Register(ftSpec)
-			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, opts...)
 			fr.Register(ftSpec)
 
 			r := eskip.MustParse(fmt.Sprintf(`* -> %s("%s", "%s") %s -> "%s"`, ti.filterName, ti.bundleName, ti.contextExtensions, ti.extraeskip, clientServer.URL))
@@ -436,7 +477,12 @@ func isHeadersPresent(t *testing.T, expectedHeaders http.Header, headers http.He
 			return false
 		}
 
-		assert.ElementsMatch(t, expectedValues, actualValues)
+		// since decision id is randomly generated we are just checking for not nil
+		if headerName == "Decision-Id" {
+			assert.NotNil(t, actualValues)
+		} else {
+			assert.ElementsMatch(t, expectedValues, actualValues)
+		}
 	}
 	return true
 }

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"google.golang.org/protobuf/proto"
 	"io"
 	"net/http"
 	"os"
@@ -205,7 +206,10 @@ func WithStartupTimeout(timeout time.Duration) func(*OpenPolicyAgentInstanceConf
 }
 
 func (cfg *OpenPolicyAgentInstanceConfig) GetEnvoyMetadata() *ext_authz_v3_core.Metadata {
-	return cfg.envoyMetadata
+	if cfg.envoyMetadata != nil {
+		return proto.Clone(cfg.envoyMetadata).(*ext_authz_v3_core.Metadata)
+	}
+	return nil
 }
 
 func NewOpenPolicyAgentConfig(opts ...func(*OpenPolicyAgentInstanceConfig) error) (*OpenPolicyAgentInstanceConfig, error) {


### PR DESCRIPTION
## Context
The release of the feature Facilitate OPA decision correlation with business flows ([PR](https://github.com/zalando/skipper/pull/3041/files)) led to the a [bug](https://github.bus.zalan.do/pg9/issues/issues/624) that leads to the skipper restarts. This is because an object of same reference is being shared among the different instances of opa instances. 

Error log from the reported bug (for those who cannot access the bug details):

```
goroutine 191993 [running]:
github.com/zalando/skipper/filters/openpolicyagent.setDecisionIdInRequest(0x4004494720, {0x40067c6440?, 0x10?})
github.com/zalando/skipper/filters/openpolicyagent/evaluation.go:92 +0xe4
github.com/zalando/skipper/filters/openpolicyagent.(*OpenPolicyAgentInstance).Eval(0x40059ef400, {0x16b6bb0, 0x40044946c0}, 0x4004494720)
github.com/zalando/skipper/filters/openpolicyagent/evaluation.go:27 +0x164
github.com/zalando/skipper/filters/openpolicyagent/opaauthorizerequest.(*opaAuthorizeRequestFilter).Request(0x4002234520, {0x16ccd90, 0x40091ca100})
github.com/zalando/skipper/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go:131 +0x1a4
github.com/zalando/skipper/proxy.(*Proxy).applyFiltersToRequest(0x4003510500, {0x40053e9a40, 0x7, 0x10d1400?}, 0x40091ca100)
github.com/zalando/skipper/proxy/proxy.go:895 +0x248
github.com/zalando/skipper/proxy.(*Proxy).do(0x4003510500, 0x40091ca100, {0x16c8360, 0x400174d810})
github.com/zalando/skipper/proxy/proxy.go:1216 +0x5a0
github.com/zalando/skipper/proxy.(*Proxy).ServeHTTP(0x4003510500, {0x16b33f0, 0x4001d6fdc0}, 0x4003126480)
github.com/zalando/skipper/proxy/proxy.go:1610 +0x648
github.com/zalando/skipper/net.(*ForwardedHeadersHandler).ServeHTTP(0x4001426640, {0x16b33f0, 0x4001d6fdc0}, 0x4003126000)
github.com/zalando/skipper/net/headers.go:77 +0x114
github.com/zalando/skipper/net.(*HostPatchHandler).ServeHTTP(0x4004cc3920, {0x16b33f0, 0x4001d6fdc0}, 0x4003126000)
github.com/zalando/skipper/net/host.go:60 +0x84
github.com/zalando/skipper/net.(*RequestMatchHandler).ServeHTTP(0x4000f7e8d0, {0x16b33f0, 0x4001d6fdc0}, 0x4003126000)
github.com/zalando/skipper/net/request.go:20 +0xb0
net/http.serverHandler.ServeHTTP({0x40044943f0?}, {0x16b33f0?, 0x4001d6fdc0?}, 0x6?)
net/http/server.go:3137 +0xbc
net/http.(*conn).serve(0x4007109050, {0x16b6bb0, 0x4000f7ec00})
net/http/server.go:2039 +0x508
created by net/http.(*Server).Serve in goroutine 1
net/http/server.go:3285 +0x3f0
```
## ACs
 Fix the opaauhorizerequest filter restart issue.