### PR TITLE
Minor improvements to opaServeResponse filter

### DIFF
--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse.go
@@ -126,9 +126,15 @@ func (f *opaServeResponseFilter) Request(fc filters.FilterContext) {
 	fc.Metrics().MeasureSince(f.opa.MetricsKey("eval_time"), start)
 	if err != nil {
 		f.opa.ServeInvalidDecisionError(fc, span, result, err)
-
 		return
 	}
+
+	allowed, err := result.IsAllowed()
+	if err != nil {
+		f.opa.ServeInvalidDecisionError(fc, span, result, err)
+		return
+	}
+	span.SetTag("opa.decision.allowed", allowed)
 
 	f.opa.ServeResponse(fc, span, result)
 }

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse.go
@@ -136,6 +136,12 @@ func (f *opaServeResponseFilter) Request(fc filters.FilterContext) {
 	}
 	span.SetTag("opa.decision.allowed", allowed)
 
+	if allowed {
+		fc.Metrics().IncCounter(f.opa.MetricsKey("decision.allow"))
+	} else {
+		fc.Metrics().IncCounter(f.opa.MetricsKey("decision.deny"))
+	}
+
 	f.opa.ServeResponse(fc, span, result)
 }
 


### PR DESCRIPTION
This PR adds to two minor improvements to make the opaServeResponse* filters symmetric with opaAuthorizeRequest* filters

1. **Include the `decision['allowed']` outcome to the trace span**
Similar to the change introduced in [PR](https://github.com/zalando/skipper/pull/3096), this PR adds the OPA decision's result (if available `decision['allowed']` outcome, without the body) under the `opa.decision.allowed` tag of spans for `opaServeResponse*` filters.

2. Increment/Update the decision count as a skipper custom filter metric [similar](https://github.com/zalando/skipper/blob/168e443c979d155f581940aaf8e25460232c0f84/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go#L154-L161) to the opaAuthorizeRequest filter
