### PR TITLE
fix: dependabot should update clusterfuzzlite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,7 @@ updates:
     directory: "/fuzz"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/.clusterfuzzlite"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
fix: dependabot should update clusterfuzzlite

build failure happened in https://github.com/zalando/skipper/pull/3193