### PR TITLE
filters/auth: handle trailing question mark in grant flow

### DIFF
--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -370,10 +371,11 @@ func (c *OAuthConfig) RedirectURLs(req *http.Request) (redirect, original string
 
 	original = u.String()
 
-	u.Path = c.CallbackPath
-	u.RawQuery = ""
-
-	redirect = u.String()
+	redirect = (&url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   c.CallbackPath,
+	}).String()
 
 	return
 }


### PR DESCRIPTION
Do not propagate trailing question mark from the initial request to redirect URI.

Construct redirect url from scratch instead of resetting URL.ForceQuery.

See related https://github.com/golang/go/issues/13488