### PR TITLE
options: Add RegisterFilters callback

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -130,6 +130,10 @@ type Options struct {
 	// List of custom filter specifications.
 	CustomFilters []filters.Spec
 
+	// RegisterFilters callback can be used to register additional filters.
+	// Built-in and custom filters are registered before the callback is called.
+	RegisterFilters func(registry filters.Registry)
+
 	// Urls of nodes in an etcd cluster, storing route definitions.
 	EtcdUrls []string
 
@@ -1141,7 +1145,8 @@ func initLog(o Options) error {
 }
 
 // filterRegistry creates a filter registry with the builtin and
-// custom filter specs registered excluding disabled filters
+// custom filter specs registered excluding disabled filters.
+// If [Options.RegisterFilters] callback is set, it will be called.
 func (o *Options) filterRegistry() filters.Registry {
 	registry := make(filters.Registry)
 
@@ -1160,6 +1165,10 @@ func (o *Options) filterRegistry() filters.Registry {
 		if _, ok := disabledFilters[f.Name()]; !ok {
 			registry.Register(f)
 		}
+	}
+
+	if o.RegisterFilters != nil {
+		o.RegisterFilters(registry)
 	}
 
 	return registry

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -89,24 +89,42 @@ func findAddress() (string, error) {
 }
 
 func TestOptionsFilterRegistry(t *testing.T) {
-	o := &Options{
-		CustomFilters: []filters.Spec{auth.NewBearerInjector(nil)},
-	}
-	fr := o.filterRegistry()
+	t.Run("custom filters", func(t *testing.T) {
+		o := &Options{
+			CustomFilters: []filters.Spec{auth.NewBearerInjector(nil)},
+		}
+		fr := o.filterRegistry()
 
-	assert.Contains(t, fr, filters.SetRequestHeaderName)
-	assert.Contains(t, fr, filters.LuaName)
-	assert.Contains(t, fr, filters.BearerInjectorName)
+		assert.Contains(t, fr, filters.SetRequestHeaderName)
+		assert.Contains(t, fr, filters.LuaName)
+		assert.Contains(t, fr, filters.BearerInjectorName)
+	})
 
-	o = &Options{
-		CustomFilters:   []filters.Spec{auth.NewBearerInjector(nil)},
-		DisabledFilters: []string{filters.LuaName, filters.BearerInjectorName},
-	}
-	fr = o.filterRegistry()
+	t.Run("disabled filters", func(t *testing.T) {
+		o := &Options{
+			CustomFilters:   []filters.Spec{auth.NewBearerInjector(nil)},
+			DisabledFilters: []string{filters.LuaName, filters.BearerInjectorName},
+		}
+		fr := o.filterRegistry()
 
-	assert.Contains(t, fr, filters.SetRequestHeaderName)
-	assert.NotContains(t, fr, filters.LuaName)
-	assert.NotContains(t, fr, filters.BearerInjectorName)
+		assert.Contains(t, fr, filters.SetRequestHeaderName)
+		assert.NotContains(t, fr, filters.LuaName)
+		assert.NotContains(t, fr, filters.BearerInjectorName)
+	})
+
+	t.Run("register filters", func(t *testing.T) {
+		o := &Options{
+			CustomFilters: []filters.Spec{auth.NewBearerInjector(nil)},
+			RegisterFilters: func(registry filters.Registry) {
+				registry.Register(auth.NewWebhook(0))
+			},
+		}
+		fr := o.filterRegistry()
+
+		assert.Contains(t, fr, filters.SetRequestHeaderName)
+		assert.Contains(t, fr, filters.BearerInjectorName)
+		assert.Contains(t, fr, filters.WebhookName)
+	})
 }
 
 func TestOptionsOpenTracingTracerInstanceOverridesOpenTracing(t *testing.T) {


### PR DESCRIPTION
Add a callback to register additional filters that can also re-use already registered filters.