### PR TITLE
opa: pass URL query parameters to OPA policy evaluation

### DIFF
--- a/filters/openpolicyagent/internal/envoy/skipperadapter.go
+++ b/filters/openpolicyagent/internal/envoy/skipperadapter.go
@@ -29,7 +29,7 @@ func AdaptToExtAuthRequest(req *http.Request, metadata *ext_authz_v3_core.Metada
 				Http: &ext_authz_v3.AttributeContext_HttpRequest{
 					Host:    req.Host,
 					Method:  req.Method,
-					Path:    buildPathWithQueryParams(req),
+					Path:    req.URL.RequestURI(),
 					Headers: headers,
 					RawBody: rawBody,
 				},
@@ -40,13 +40,6 @@ func AdaptToExtAuthRequest(req *http.Request, metadata *ext_authz_v3_core.Metada
 	}
 
 	return ereq, nil
-}
-
-func buildPathWithQueryParams(req *http.Request) string {
-	if req.URL.RawQuery == "" {
-		return url.PathEscape(req.URL.Path)
-	}
-	return url.PathEscape(req.URL.Path) + "?" + req.URL.RawQuery
 }
 
 func validateURLForInvalidUTF8(u *url.URL) error {

--- a/filters/openpolicyagent/internal/envoy/skipperadapter.go
+++ b/filters/openpolicyagent/internal/envoy/skipperadapter.go
@@ -56,7 +56,7 @@ func validateURLForInvalidUTF8(u *url.URL) error {
 
 	decodedQuery, err := url.QueryUnescape(u.RawQuery)
 	if err != nil {
-		return fmt.Errorf("error decoding query string: %w", err)
+		return fmt.Errorf("error unescaping query string %q: %w", u.RawQuery, err)
 	}
 
 	if !utf8.ValidString(decodedQuery) {

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -58,11 +58,25 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			removeHeaders:     make(http.Header),
 		},
 		{
+			msg:               "Allow Requests with trailing ? in URL",
+			filterName:        "opaAuthorizeRequest",
+			bundleName:        "somebundle.tar.gz",
+			regoQuery:         "envoy/authz/allow",
+			requestPath:       "/allow?",
+			requestMethod:     "GET",
+			contextExtensions: "",
+			expectedStatus:    http.StatusOK,
+			expectedBody:      "Welcome!",
+			expectedHeaders:   make(http.Header),
+			backendHeaders:    make(http.Header),
+			removeHeaders:     make(http.Header),
+		},
+		{
 			msg:               "Allow Requests with query parameters",
 			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow",
-			requestPath:       "/allow-with-query?pass=yes&q2=v2",
+			requestPath:       "/allow-with-query?pass=yes&id=1&id=2",
 			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusOK,
@@ -341,6 +355,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 						allow {
 							input.parsed_path = [ "allow-with-query" ]
 							input.parsed_query.pass == ["yes"]
+							input.parsed_query.id == ["1", "2"]
 						}
 
 						allow_context_extensions {

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -93,7 +93,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow",
-			requestPath:       "/allow-with-query?pass=yes&id=1&id=2",
+			requestPath:       "/allow-with-query?pass=yes&id=1&id=2&msg=help%20me",
 			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusOK,
@@ -411,6 +411,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 							input.parsed_path = [ "allow-with-query" ]
 							input.parsed_query.pass == ["yes"]
 							input.parsed_query.id == ["1", "2"]
+							input.parsed_query.msg == ["help me"]
 						}
 
 						allow_context_extensions {

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -58,6 +58,20 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			removeHeaders:     make(http.Header),
 		},
 		{
+			msg:               "Allow Requests with query parameters",
+			filterName:        "opaAuthorizeRequest",
+			bundleName:        "somebundle.tar.gz",
+			regoQuery:         "envoy/authz/allow",
+			requestPath:       "/allow-with-query?pass=yes&q2=v2",
+			requestMethod:     "GET",
+			contextExtensions: "",
+			expectedStatus:    http.StatusOK,
+			expectedBody:      "Welcome!",
+			expectedHeaders:   make(http.Header),
+			backendHeaders:    make(http.Header),
+			removeHeaders:     make(http.Header),
+		},
+		{
 			msg:               "Allow Matching Context Extension",
 			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
@@ -89,6 +103,19 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow",
 			requestPath:       "/forbidden",
+			requestMethod:     "GET",
+			contextExtensions: "",
+			expectedStatus:    http.StatusForbidden,
+			expectedHeaders:   make(http.Header),
+			backendHeaders:    make(http.Header),
+			removeHeaders:     make(http.Header),
+		},
+		{
+			msg:               "Simple Forbidden with Query Parameters",
+			filterName:        "opaAuthorizeRequest",
+			bundleName:        "somebundle.tar.gz",
+			regoQuery:         "envoy/authz/allow",
+			requestPath:       "/allow-with-query?tofail=true",
 			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusForbidden,
@@ -309,6 +336,11 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 
 						allow {
 							input.parsed_path = [ "allow" ]
+						}
+
+						allow {
+							input.parsed_path = [ "allow-with-query" ]
+							input.parsed_query.pass == ["yes"]
 						}
 
 						allow_context_extensions {

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -2,6 +2,7 @@ package opaauthorizerequest
 
 import (
 	"fmt"
+	"github.com/zalando/skipper/filters/builtin"
 	"io"
 	"log"
 	"net/http"
@@ -29,7 +30,8 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 	for _, ti := range []struct {
 		msg               string
 		filterName        string
-		extraeskip        string
+		extraeskipBefore  string
+		extraeskipAfter   string
 		bundleName        string
 		regoQuery         string
 		requestPath       string
@@ -58,11 +60,26 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			removeHeaders:     make(http.Header),
 		},
 		{
-			msg:               "Allow Requests with trailing ? in URL",
+			msg:               "Allow Requests with spaces in path",
 			filterName:        "opaAuthorizeRequest",
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow",
-			requestPath:       "/allow?",
+			requestPath:       "/my%20path",
+			requestMethod:     "GET",
+			contextExtensions: "",
+			expectedStatus:    http.StatusOK,
+			expectedBody:      "Welcome!",
+			expectedHeaders:   make(http.Header),
+			backendHeaders:    make(http.Header),
+			removeHeaders:     make(http.Header),
+		},
+		{
+			msg:               "Allow Requests with request path overridden by the setPath filter",
+			filterName:        "opaAuthorizeRequest",
+			extraeskipBefore:  `setPath("/allow") ->`,
+			bundleName:        "somebundle.tar.gz",
+			regoQuery:         "envoy/authz/allow",
+			requestPath:       "/some-random-path-that-would-fail",
 			requestMethod:     "GET",
 			contextExtensions: "",
 			expectedStatus:    http.StatusOK,
@@ -91,6 +108,20 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			bundleName:        "somebundle.tar.gz",
 			regoQuery:         "envoy/authz/allow_context_extensions",
 			requestPath:       "/allow",
+			requestMethod:     "GET",
+			contextExtensions: "com.mycompany.myprop: myvalue",
+			expectedStatus:    http.StatusOK,
+			expectedBody:      "Welcome!",
+			expectedHeaders:   make(http.Header),
+			backendHeaders:    make(http.Header),
+			removeHeaders:     make(http.Header),
+		},
+		{
+			msg:               "Allow Requests with an empty query string",
+			filterName:        "opaAuthorizeRequest",
+			bundleName:        "somebundle.tar.gz",
+			regoQuery:         "envoy/authz/allow_context_extensions",
+			requestPath:       "/path-with-empty-query?",
 			requestMethod:     "GET",
 			contextExtensions: "com.mycompany.myprop: myvalue",
 			expectedStatus:    http.StatusOK,
@@ -283,7 +314,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 		{
 			msg:             "Chained OPA filter with body",
 			filterName:      "opaAuthorizeRequestWithBody",
-			extraeskip:      `-> opaAuthorizeRequestWithBody("somebundle.tar.gz")`,
+			extraeskipAfter: `-> opaAuthorizeRequestWithBody("somebundle.tar.gz")`,
 			bundleName:      "somebundle.tar.gz",
 			regoQuery:       "envoy/authz/allow_body",
 			requestMethod:   "POST",
@@ -325,6 +356,20 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			backendHeaders:    make(http.Header),
 			removeHeaders:     make(http.Header),
 		},
+		{
+			msg:               "Invalid UTF-8 in Query",
+			filterName:        "opaAuthorizeRequest",
+			bundleName:        "somebundle.tar.gz",
+			regoQuery:         "envoy/authz/allow",
+			requestPath:       "/allow?%c0%ae=%c0%ae%c0%ae",
+			requestMethod:     "GET",
+			contextExtensions: "",
+			expectedStatus:    http.StatusBadRequest,
+			expectedBody:      "",
+			expectedHeaders:   make(http.Header),
+			backendHeaders:    make(http.Header),
+			removeHeaders:     make(http.Header),
+		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
 			t.Logf("Running test for %v", ti)
@@ -350,6 +395,16 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 
 						allow {
 							input.parsed_path = [ "allow" ]
+							input.parsed_query = {}
+						}
+
+						allow {
+							input.parsed_path = [ "my path" ]
+						}
+
+						allow {
+							input.parsed_path = [ "/path-with-empty-query" ]
+							input.parsed_query = {}
 						}
 
 						allow {
@@ -467,8 +522,9 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			fr.Register(ftSpec)
 			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, opts...)
 			fr.Register(ftSpec)
+			fr.Register(builtin.NewSetPath())
 
-			r := eskip.MustParse(fmt.Sprintf(`* -> %s("%s", "%s") %s -> "%s"`, ti.filterName, ti.bundleName, ti.contextExtensions, ti.extraeskip, clientServer.URL))
+			r := eskip.MustParse(fmt.Sprintf(`* -> %s %s("%s", "%s") %s -> "%s"`, ti.extraeskipBefore, ti.filterName, ti.bundleName, ti.contextExtensions, ti.extraeskipAfter, clientServer.URL))
 
 			proxy := proxytest.New(fr, r...)
 

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -71,6 +71,16 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			expectedHeaders: map[string][]string{"X-Ext-Auth-Allow": {"yes"}},
 		},
 		{
+			msg:             "Allow With Structured Rules and Query Params",
+			filterName:      "opaServeResponse",
+			bundleName:      "somebundle.tar.gz",
+			regoQuery:       "envoy/authz/allow_object",
+			requestPath:     "/allow/structured/with-query?pass=yes",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "Welcome from policy!",
+			expectedHeaders: map[string][]string{"X-Ext-Auth-Allow": {"yes"}},
+		},
+		{
 			msg:             "Allow With opa.runtime execution",
 			filterName:      "opaServeResponse",
 			bundleName:      "somebundle.tar.gz",
@@ -157,6 +167,17 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 						  
 						allow_object = response {
 							input.parsed_path = [ "allow", "structured" ]
+							response := {
+								"allowed": true,
+								"headers": {"x-ext-auth-allow": "yes"},
+								"body": "Welcome from policy!",
+								"http_status": 200
+							}
+						}
+
+						allow_object = response {
+							input.parsed_path = [ "allow", "structured", "with-query" ]
+							input.parsed_query.pass == ["yes"]
 							response := {
 								"allowed": true,
 								"headers": {"x-ext-auth-allow": "yes"},


### PR DESCRIPTION
Improve the envoy request adapting logic to include query parameters sent in the request.

This would allow the policy evaluation `opaAuthorizeRequest*` and `opaServeResponse*` filters to make use of query parameters/values in the policy.