### PR TITLE
options: test filter registration order

### DIFF
--- a/skipper_test.go
+++ b/skipper_test.go
@@ -117,6 +117,10 @@ func TestOptionsFilterRegistry(t *testing.T) {
 			CustomFilters: []filters.Spec{auth.NewBearerInjector(nil)},
 			RegisterFilters: func(registry filters.Registry) {
 				registry.Register(auth.NewWebhook(0))
+
+				// Check that built-in and CustomFilters are already registered
+				assert.Contains(t, registry, filters.SetRequestHeaderName)
+				assert.Contains(t, registry, filters.BearerInjectorName)
 			},
 		}
 		fr := o.filterRegistry()


### PR DESCRIPTION
Test that built-in and CustomFilters are registered before RegisterFilters callback.

Follow up on #3203