### PR TITLE
use standard `errors.Join` since we already use go1.22

### DIFF
--- a/dataclients/kubernetes/definitions/definitions.go
+++ b/dataclients/kubernetes/definitions/definitions.go
@@ -1,7 +1,6 @@
 package definitions
 
 import (
-	"strings"
 	"time"
 
 	"errors"
@@ -43,18 +42,4 @@ func namespaceString(ns string) string {
 type WeightedBackend interface {
 	GetName() string
 	GetWeight() float64
-}
-
-// TODO: use https://pkg.go.dev/errors#Join with go1.21
-func errorsJoin(errs ...error) error {
-	var errVals []string
-	for _, err := range errs {
-		if err != nil {
-			errVals = append(errVals, err.Error())
-		}
-	}
-	if len(errVals) > 0 {
-		return errors.New(strings.Join(errVals, "\n"))
-	}
-	return nil
 }

--- a/dataclients/kubernetes/definitions/ingressvalidator.go
+++ b/dataclients/kubernetes/definitions/ingressvalidator.go
@@ -1,6 +1,7 @@
 package definitions
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/zalando/skipper/eskip"
@@ -15,7 +16,7 @@ func (igv *IngressV1Validator) Validate(item *IngressV1Item) error {
 	errs = append(errs, igv.validatePredicateAnnotation(item.Metadata.Annotations))
 	errs = append(errs, igv.validateRoutesAnnotation(item.Metadata.Annotations))
 
-	return errorsJoin(errs...)
+	return errors.Join(errs...)
 }
 
 func (igv *IngressV1Validator) validateFilterAnnotation(annotations map[string]string) error {

--- a/dataclients/kubernetes/definitions/routegroupvalidator.go
+++ b/dataclients/kubernetes/definitions/routegroupvalidator.go
@@ -27,7 +27,7 @@ func ValidateRouteGroups(rgl *RouteGroupList) error {
 	for _, rg := range rgl.Items {
 		errs = append(errs, defaultRouteGroupValidator.Validate(rg))
 	}
-	return errorsJoin(errs...)
+	return errors.Join(errs...)
 }
 
 func (rgv *RouteGroupValidator) Validate(item *RouteGroupItem) error {
@@ -41,7 +41,7 @@ func (rgv *RouteGroupValidator) Validate(item *RouteGroupItem) error {
 	errs = append(errs, rgv.validateBackends(item))
 	errs = append(errs, rgv.validateHosts(item))
 
-	return errorsJoin(errs...)
+	return errors.Join(errs...)
 }
 
 // TODO: we need to pass namespace/name in all errors
@@ -76,7 +76,7 @@ func (rgv *RouteGroupValidator) validateFilters(item *RouteGroupItem) error {
 		}
 	}
 
-	return errorsJoin(errs...)
+	return errors.Join(errs...)
 }
 
 func (rgv *RouteGroupValidator) validatePredicates(item *RouteGroupItem) error {
@@ -91,7 +91,7 @@ func (rgv *RouteGroupValidator) validatePredicates(item *RouteGroupItem) error {
 			}
 		}
 	}
-	return errorsJoin(errs...)
+	return errors.Join(errs...)
 }
 
 func (rgv *RouteGroupValidator) validateBackends(item *RouteGroupItem) error {
@@ -108,7 +108,7 @@ func (rgv *RouteGroupValidator) validateBackends(item *RouteGroupItem) error {
 			}
 		}
 	}
-	return errorsJoin(errs...)
+	return errors.Join(errs...)
 }
 
 func (rgv *RouteGroupValidator) validateHosts(item *RouteGroupItem) error {
@@ -120,7 +120,7 @@ func (rgv *RouteGroupValidator) validateHosts(item *RouteGroupItem) error {
 		}
 		uniqueHosts[host] = struct{}{}
 	}
-	return errorsJoin(errs...)
+	return errors.Join(errs...)
 }
 
 // TODO: we need to pass namespace/name in all errors


### PR DESCRIPTION
check https://pkg.go.dev/errors#Join
follow up on https://github.com/zalando/skipper/pull/2492