### PR TITLE
Add url path normalizer

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -365,6 +365,32 @@ Parameters:
 The replacement may contain [template placeholders](#template-placeholders).
 If a template placeholder can't be resolved then empty value is used for it.
 
+### normalizePath
+
+Normalize the URL path by removing empty path segments and trailing slashes.
+
+Parameters:
+
+- The URL path
+
+Example:
+
+```
+all: * -> normalizePath() -> "https://backend.example.org/api/v1;
+```
+
+Requests to
+
+```
+https://backend.example.org//api/v1/
+https://backend.example.org//api/v1
+https://backend.example.org/api//v1
+https://backend.example.org/api//v1/
+https://backend.example.org/api/v1/
+```
+
+will all be normalized to `https://backend.example.org/api/v1`. 
+
 ## HTTP Redirect
 ### redirectTo
 

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zalando/skipper/filters/fadein"
 	"github.com/zalando/skipper/filters/flowid"
 	logfilter "github.com/zalando/skipper/filters/log"
+	"github.com/zalando/skipper/filters/normalizepath"
 	"github.com/zalando/skipper/filters/rfc"
 	"github.com/zalando/skipper/filters/scheduler"
 	"github.com/zalando/skipper/filters/sed"
@@ -233,6 +234,7 @@ func Filters() []filters.Spec {
 		consistenthash.NewConsistentHashKey(),
 		consistenthash.NewConsistentHashBalanceFactor(),
 		tls.New(),
+		normalizepath.NewNormalizePath(),
 	}
 }
 

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -370,4 +370,5 @@ const (
 	SetFastCgiFilenameName = "setFastCgiFilename"
 	DisableRatelimitName   = "disableRatelimit"
 	UnknownRatelimitName   = "unknownRatelimit"
+	NormalizePath          = "normalizePath"
 )

--- a/filters/normalizepath/normalizepath.go
+++ b/filters/normalizepath/normalizepath.go
@@ -32,11 +32,6 @@ func (f normalizePath) Request(ctx filters.FilterContext) {
 	}
 	normalizedPath := "/" + strings.Join(filteredSegments, "/")
 
-	// Ensure there's no trailing slash, unless the path is just "/"
-	if len(normalizedPath) > 1 && strings.HasSuffix(normalizedPath, "/") {
-		normalizedPath = normalizedPath[:len(normalizedPath)-1]
-	}
-
 	req.URL.Path = normalizedPath
 }
 

--- a/filters/normalizepath/normalizepath.go
+++ b/filters/normalizepath/normalizepath.go
@@ -1,7 +1,7 @@
 package normalizepath
 
 import (
-	"path"
+	"strings"
 
 	"github.com/zalando/skipper/filters"
 )
@@ -22,7 +22,22 @@ func (spec normalizePath) CreateFilter(config []interface{}) (filters.Filter, er
 
 func (f normalizePath) Request(ctx filters.FilterContext) {
 	req := ctx.Request()
-	req.URL.Path = path.Clean(req.URL.Path)
+
+	segments := strings.Split(req.URL.Path, "/")
+	var filteredSegments []string
+	for _, seg := range segments {
+		if seg != "" {
+			filteredSegments = append(filteredSegments, seg)
+		}
+	}
+	normalizedPath := "/" + strings.Join(filteredSegments, "/")
+
+	// Ensure there's no trailing slash, unless the path is just "/"
+	if len(normalizedPath) > 1 && strings.HasSuffix(normalizedPath, "/") {
+		normalizedPath = normalizedPath[:len(normalizedPath)-1]
+	}
+
+	req.URL.Path = normalizedPath
 }
 
 func (f normalizePath) Response(ctx filters.FilterContext) {}

--- a/filters/normalizepath/normalizepath.go
+++ b/filters/normalizepath/normalizepath.go
@@ -1,0 +1,28 @@
+package normalizepath
+
+import (
+	"path"
+
+	"github.com/zalando/skipper/filters"
+)
+
+const (
+	Name = filters.NormalizePath
+)
+
+type normalizePath struct{}
+
+func NewNormalizePath() filters.Spec { return normalizePath{} }
+
+func (spec normalizePath) Name() string { return "normalizePath" }
+
+func (spec normalizePath) CreateFilter(config []interface{}) (filters.Filter, error) {
+	return normalizePath{}, nil
+}
+
+func (f normalizePath) Request(ctx filters.FilterContext) {
+	req := ctx.Request()
+	req.URL.Path = path.Clean(req.URL.Path)
+}
+
+func (f normalizePath) Response(ctx filters.FilterContext) {}

--- a/filters/normalizepath/normalizepath_test.go
+++ b/filters/normalizepath/normalizepath_test.go
@@ -42,4 +42,18 @@ func TestNormalizePath(t *testing.T) {
 			t.Errorf("failed to normalize the path: %s", req.URL.Path)
 		}
 	}
+
+	// Ensure that root paths work as expected
+	req := &http.Request{URL: &url.URL{Path: "/"}}
+	ctx := &filtertest.Context{
+		FRequest: req,
+	}
+	f, err := NewNormalizePath().CreateFilter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Request(ctx)
+	if req.URL.Path != "/" {
+		t.Errorf("unexpected URL path change: %s, expected /", req.URL.Path)
+	}
 }

--- a/filters/normalizepath/normalizepath_test.go
+++ b/filters/normalizepath/normalizepath_test.go
@@ -1,0 +1,45 @@
+package normalizepath
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+// TestNormalizePath tests the NormalizePath function in accordance to the
+// https://opensource.zalando.com/restful-api-guidelines/#136
+// specifically the notion of normalization of request paths:
+//
+// All services should normalize request paths before processing by removing
+// duplicate and trailing slashes. Hence, the following requests should refer
+// to the same resource:
+// GET /orders/{order-id}
+// GET /orders/{order-id}/
+// GET /orders//{order-id}
+func TestNormalizePath(t *testing.T) {
+	urls := []string{
+		"/orders/{order-id}",
+		"/orders/{order-id}/",
+		"/orders//{order-id}",
+		"/orders/{order-id}//",
+		"/orders/{order-id}///",
+		"/orders///{order-id}//",
+	}
+
+	for _, u := range urls {
+		req := &http.Request{URL: &url.URL{Path: u}}
+		ctx := &filtertest.Context{
+			FRequest: req,
+		}
+		f, err := NewNormalizePath().CreateFilter(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Request(ctx)
+		if req.URL.Path != "/orders/{order-id}" {
+			t.Errorf("failed to normalize the path: %s", req.URL.Path)
+		}
+	}
+}


### PR DESCRIPTION
Adds a filter called `normalizePath` which implements URL Path
normalization by removing empty path segments and trailing slashes from
the path. This follows the guidance from the Zalando Restful API
Guidelines rule [136][1].

[1]: https://opensource.zalando.com/restful-api-guidelines/#136


Closes #3236 
