### PR TITLE
predicates/host: add HostAny benchmark

### DIFF
--- a/predicates/host/any_test.go
+++ b/predicates/host/any_test.go
@@ -106,3 +106,33 @@ func TestHostAnyMatch(t *testing.T) {
 		})
 	}
 }
+
+var matchSink bool
+
+func BenchmarkHostAny(b *testing.B) {
+	for _, n := range []int{1, 2, 5, 10, 20, 50, 100} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			s := NewAny()
+			args := make([]any, n)
+			for i := 0; i < n; i++ {
+				args[i] = fmt.Sprintf("example%d.org", i)
+			}
+			p, err := s.Create(args)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			req := &http.Request{Host: args[len(args)/2].(string)}
+			matchSink = p.Match(req)
+			if !matchSink {
+				b.Fatal("expected to match")
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				matchSink = p.Match(req)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Current implementation uses linear probe that works well for small number of hosts.

I thought about implementing it using map lookup but that is slower for less than 50 hosts so I propose to only keep the benchmark that may be used for future improvements.

Here is comparison with map-based implementation for reference:
```
              │    HEAD~1    │                 HEAD                  │
              │    sec/op    │    sec/op      vs base                │
HostAny/1-8      3.738n ± 3%    5.844n ±  3%  +56.36% (p=0.000 n=10)
HostAny/2-8      7.728n ± 4%    9.274n ±  2%  +20.02% (p=0.000 n=10)
HostAny/5-8      11.32n ± 4%    13.09n ±  4%  +15.63% (p=0.000 n=10)
HostAny/10-8     22.35n ± 3%    11.86n ± 15%  -46.94% (p=0.000 n=10)
HostAny/20-8     7.684n ± 2%   11.310n ±  9%  +47.19% (p=0.000 n=10)
HostAny/50-8     66.75n ± 4%    12.10n ± 12%  -81.87% (p=0.000 n=10)
HostAny/100-8   161.80n ± 1%    11.92n ± 13%  -92.63% (p=0.000 n=10)
geomean          17.98n         10.46n        -41.79%

              │    HEAD~1    │                HEAD                 │
              │     B/op     │    B/op     vs base                 │
HostAny/1-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/2-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/5-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/10-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/20-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/50-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/100-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

              │    HEAD~1    │                HEAD                 │
              │  allocs/op   │ allocs/op   vs base                 │
HostAny/1-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/2-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/5-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/10-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/20-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/50-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
HostAny/100-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```