### PR TITLE
minor: remove unused endpointRegistry field from healthyEndpoints and fadeIn

### DIFF
--- a/proxy/fadein.go
+++ b/proxy/fadein.go
@@ -9,8 +9,7 @@ import (
 )
 
 type fadeIn struct {
-	rnd              *rand.Rand
-	endpointRegistry *routing.EndpointRegistry
+	rnd *rand.Rand
 }
 
 func (f *fadeIn) fadeInScore(lifetime time.Duration, duration time.Duration, exponent float64) float64 {

--- a/proxy/fadein_internal_test.go
+++ b/proxy/fadein_internal_test.go
@@ -92,7 +92,7 @@ func initializeEndpoints(endpointAges []float64, algorithmName string, fadeInDur
 		registry.GetMetrics(eps[i]).SetDetected(detectionTimes[i])
 	}
 
-	proxy := &Proxy{registry: registry, fadein: &fadeIn{rnd: rand.New(loadbalancer.NewLockedSource()), endpointRegistry: registry}, quit: make(chan struct{})}
+	proxy := &Proxy{registry: registry, fadein: &fadeIn{rnd: rand.New(loadbalancer.NewLockedSource())}, quit: make(chan struct{})}
 	return route, proxy, eps
 }
 

--- a/proxy/healthy_endpoints.go
+++ b/proxy/healthy_endpoints.go
@@ -9,7 +9,6 @@ import (
 
 type healthyEndpoints struct {
 	rnd                        *rand.Rand
-	endpointRegistry           *routing.EndpointRegistry
 	maxUnhealthyEndpointsRatio float64
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -848,8 +848,7 @@ func WithParams(p Params) *Proxy {
 		routing:  p.Routing,
 		registry: p.EndpointRegistry,
 		fadein: &fadeIn{
-			rnd:              rand.New(loadbalancer.NewLockedSource()),
-			endpointRegistry: p.EndpointRegistry,
+			rnd: rand.New(loadbalancer.NewLockedSource()),
 		},
 		heathlyEndpoints:         healthyEndpointsChooser,
 		roundTripper:             p.CustomHttpRoundTripperWrap(tr),

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -841,7 +841,6 @@ func WithParams(p Params) *Proxy {
 	if p.EnablePassiveHealthCheck {
 		healthyEndpointsChooser = &healthyEndpoints{
 			rnd:                        rand.New(loadbalancer.NewLockedSource()),
-			endpointRegistry:           p.EndpointRegistry,
 			maxUnhealthyEndpointsRatio: p.PassiveHealthCheck.MaxUnhealthyEndpointsRatio,
 		}
 	}


### PR DESCRIPTION
Just a small removal of unsued field.