### PR TITLE
packaging: add opencontainers image labels

### DIFF
--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -68,6 +68,9 @@ jobs:
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor="Zalando SE"
 
       - name: Build and push
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,7 +1,20 @@
 ARG BASE_IMAGE=default
 FROM registry.opensource.zalan.do/library/alpine-3:latest AS default
 FROM ${BASE_IMAGE}
+
+ARG VERSION
+ARG REVISION
+
 LABEL maintainer="Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>"
+LABEL org.opencontainers.image.title=skipper
+LABEL org.opencontainers.image.description="An HTTP router and reverse proxy for service composition, including use cases like Kubernetes Ingress"
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.url=https://github.com/zalando/skipper
+LABEL org.opencontainers.image.licenses=Apache-2.0
+LABEL org.opencontainers.image.vendor="Zalando SE"
+LABEL org.opencontainers.image.source=https://github.com/zalando/skipper
+LABEL org.opencontainers.image.revision=$REVISION
+
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 RUN mkdir -p /usr/bin
 ARG BUILD_FOLDER=build

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -13,6 +13,7 @@ GOARCH             ?= amd64
 GOARM              ?=
 BUILD_FLAGS        ?= -v -trimpath
 COMMIT_HASH        = $(shell git rev-parse --short HEAD)
+REVISION           = $(shell git rev-parse HEAD)
 
 default: docker-build
 
@@ -36,11 +37,19 @@ clean:
 	rm -rf $(BINARIES) build/
 
 docker.build: clean $(BINARIES)
-	docker build -t $(IMAGE) --build-arg BUILD_FOLDER=. --build-arg TARGETPLATFORM= .
+	docker build -t $(IMAGE) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg REVISION=$(REVISION) \
+		--build-arg BUILD_FOLDER=. \
+		--build-arg TARGETPLATFORM= \
+		.
 
 docker-build: docker.build.amd64 docker.build.arm64 docker.build.armv7
 docker.build.amd64: clean build.linux.amd64 docker.build.enable
-	docker buildx build -t $(IMAGE) --platform linux/amd64 -f Dockerfile --load .
+	docker buildx build -t $(IMAGE) --platform linux/amd64 \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg REVISION=$(REVISION) \
+		-f Dockerfile --load .
 docker.build.arm64: clean build.linux.arm64 docker.build.enable
 	docker buildx build -t $(ARM64_IMAGE) --platform linux/arm64 -f Dockerfile.arm64 --load .
 docker.build.armv7: clean build.linux.armv7 docker.build.enable
@@ -57,7 +66,10 @@ docker.push.armv7: docker.build.armv7
 # build multi-arch container image using a trusted multi-arch base image
 docker.push.multiarch: clean build.linux docker.build.enable
 	docker buildx build --rm -t $(MULTIARCH_IMAGE) --platform linux/amd64,linux/arm64 --push \
-	  --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3:latest .
+		--build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3:latest \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg REVISION=$(REVISION) \
+		.
 
 # https://docs.docker.com/build/working-with-build/
 # ~/.docker/config.json add: "experimental": "enabled",


### PR DESCRIPTION
Add [opencontainer image labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md) (except org.opencontainers.image.created) to multiarch image.

Decided not touch Dockerfile.arm* because it is better to unify them with Dockerfile (see e.g. #2566).

Github action already adds opencontainer image labels:
```console
docker inspect ghcr.io/zalando/skipper:v0.21.209 | jq .[0].Config.Labels
{
  "maintainer": "Team Gateway&Proxy @ Zalando SE <team-gwproxy@zalando.de>",
  "org.opencontainers.image.created": "2024-09-26T09:40:09.452Z",
  "org.opencontainers.image.description": "An HTTP router and reverse proxy for service composition, including use cases like Kubernetes Ingress",
  "org.opencontainers.image.licenses": "NOASSERTION",
  "org.opencontainers.image.revision": "08a295f2cbf443d5d87f680d6ba3335fba57daef",
  "org.opencontainers.image.source": "https://github.com/zalando/skipper",
  "org.opencontainers.image.title": "skipper",
  "org.opencontainers.image.url": "https://github.com/zalando/skipper",
  "org.opencontainers.image.version": "v0.21.209"
}
```
This change also fixes licenses and adds vendor label.