### PR TITLE
OPA filters: Reduce default buffer size for reading the requests' body

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -284,14 +284,14 @@ type Config struct {
 	LuaModules *listFlag `yaml:"lua-modules"`
 	LuaSources *listFlag `yaml:"lua-sources"`
 
-	EnableOpenPolicyAgent               bool          `yaml:"enable-open-policy-agent"`
-	OpenPolicyAgentConfigTemplate       string        `yaml:"open-policy-agent-config-template"`
-	OpenPolicyAgentEnvoyMetadata        string        `yaml:"open-policy-agent-envoy-metadata"`
-	OpenPolicyAgentCleanerInterval      time.Duration `yaml:"open-policy-agent-cleaner-interval"`
-	OpenPolicyAgentStartupTimeout       time.Duration `yaml:"open-policy-agent-startup-timeout"`
-	OpenPolicyAgentBodyReadBufferSize   int64         `yaml:"open-policy-agent-body-read-buffer-size"`
-	OpenPolicyAgentMaxRequestBodySize   int64         `yaml:"open-policy-agent-max-request-body-size"`
-	OpenPolicyAgentMaxMemoryBodyParsing int64         `yaml:"open-policy-agent-max-memory-body-parsing"`
+	EnableOpenPolicyAgent                bool          `yaml:"enable-open-policy-agent"`
+	OpenPolicyAgentConfigTemplate        string        `yaml:"open-policy-agent-config-template"`
+	OpenPolicyAgentEnvoyMetadata         string        `yaml:"open-policy-agent-envoy-metadata"`
+	OpenPolicyAgentCleanerInterval       time.Duration `yaml:"open-policy-agent-cleaner-interval"`
+	OpenPolicyAgentStartupTimeout        time.Duration `yaml:"open-policy-agent-startup-timeout"`
+	OpenPolicyAgentRequestBodyBufferSize int64         `yaml:"open-policy-agent-request-body-buffer-size"`
+	OpenPolicyAgentMaxRequestBodySize    int64         `yaml:"open-policy-agent-max-request-body-size"`
+	OpenPolicyAgentMaxMemoryBodyParsing  int64         `yaml:"open-policy-agent-max-memory-body-parsing"`
 
 	PassiveHealthCheck mapFlags `yaml:"passive-health-check"`
 }
@@ -514,7 +514,7 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.OpenPolicyAgentCleanerInterval, "open-policy-agent-cleaner-interval", openpolicyagent.DefaultCleanIdlePeriod, "Duration in seconds to wait before cleaning up unused opa instances")
 	flag.DurationVar(&cfg.OpenPolicyAgentStartupTimeout, "open-policy-agent-startup-timeout", openpolicyagent.DefaultOpaStartupTimeout, "Maximum duration in seconds to wait for the open policy agent to start up")
 	flag.Int64Var(&cfg.OpenPolicyAgentMaxRequestBodySize, "open-policy-agent-max-request-body-size", openpolicyagent.DefaultMaxRequestBodySize, "Maximum number of bytes from a http request body that are passed as input to the policy")
-	flag.Int64Var(&cfg.OpenPolicyAgentBodyReadBufferSize, "open-policy-agent-body-read-buffer-size", openpolicyagent.DefaultBodyBufferSize, "Read buffer size for the request body")
+	flag.Int64Var(&cfg.OpenPolicyAgentRequestBodyBufferSize, "open-policy-agent-request-body-buffer-size", openpolicyagent.DefaultRequestBodyBufferSize, "Read buffer size for the request body")
 	flag.Int64Var(&cfg.OpenPolicyAgentMaxMemoryBodyParsing, "open-policy-agent-max-memory-body-parsing", openpolicyagent.DefaultMaxMemoryBodyParsing, "Total number of bytes used to parse http request bodies across all requests. Once the limit is met, requests will be rejected.")
 
 	// TLS client certs
@@ -928,14 +928,14 @@ func (c *Config) ToOptions() skipper.Options {
 		LuaModules: c.LuaModules.values,
 		LuaSources: c.LuaSources.values,
 
-		EnableOpenPolicyAgent:               c.EnableOpenPolicyAgent,
-		OpenPolicyAgentConfigTemplate:       c.OpenPolicyAgentConfigTemplate,
-		OpenPolicyAgentEnvoyMetadata:        c.OpenPolicyAgentEnvoyMetadata,
-		OpenPolicyAgentCleanerInterval:      c.OpenPolicyAgentCleanerInterval,
-		OpenPolicyAgentStartupTimeout:       c.OpenPolicyAgentStartupTimeout,
-		OpenPolicyAgentMaxRequestBodySize:   c.OpenPolicyAgentMaxRequestBodySize,
-		OpenPolicyAgentBodyReadBufferSize:   c.OpenPolicyAgentBodyReadBufferSize,
-		OpenPolicyAgentMaxMemoryBodyParsing: c.OpenPolicyAgentMaxMemoryBodyParsing,
+		EnableOpenPolicyAgent:                c.EnableOpenPolicyAgent,
+		OpenPolicyAgentConfigTemplate:        c.OpenPolicyAgentConfigTemplate,
+		OpenPolicyAgentEnvoyMetadata:         c.OpenPolicyAgentEnvoyMetadata,
+		OpenPolicyAgentCleanerInterval:       c.OpenPolicyAgentCleanerInterval,
+		OpenPolicyAgentStartupTimeout:        c.OpenPolicyAgentStartupTimeout,
+		OpenPolicyAgentMaxRequestBodySize:    c.OpenPolicyAgentMaxRequestBodySize,
+		OpenPolicyAgentRequestBodyBufferSize: c.OpenPolicyAgentRequestBodyBufferSize,
+		OpenPolicyAgentMaxMemoryBodyParsing:  c.OpenPolicyAgentMaxMemoryBodyParsing,
 
 		PassiveHealthCheck: c.PassiveHealthCheck.values,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -289,6 +289,7 @@ type Config struct {
 	OpenPolicyAgentEnvoyMetadata        string        `yaml:"open-policy-agent-envoy-metadata"`
 	OpenPolicyAgentCleanerInterval      time.Duration `yaml:"open-policy-agent-cleaner-interval"`
 	OpenPolicyAgentStartupTimeout       time.Duration `yaml:"open-policy-agent-startup-timeout"`
+	OpenPolicyAgentBodyReadBufferSize   int64         `yaml:"open-policy-agent-body-read-buffer-size"`
 	OpenPolicyAgentMaxRequestBodySize   int64         `yaml:"open-policy-agent-max-request-body-size"`
 	OpenPolicyAgentMaxMemoryBodyParsing int64         `yaml:"open-policy-agent-max-memory-body-parsing"`
 
@@ -513,6 +514,7 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.OpenPolicyAgentCleanerInterval, "open-policy-agent-cleaner-interval", openpolicyagent.DefaultCleanIdlePeriod, "Duration in seconds to wait before cleaning up unused opa instances")
 	flag.DurationVar(&cfg.OpenPolicyAgentStartupTimeout, "open-policy-agent-startup-timeout", openpolicyagent.DefaultOpaStartupTimeout, "Maximum duration in seconds to wait for the open policy agent to start up")
 	flag.Int64Var(&cfg.OpenPolicyAgentMaxRequestBodySize, "open-policy-agent-max-request-body-size", openpolicyagent.DefaultMaxRequestBodySize, "Maximum number of bytes from a http request body that are passed as input to the policy")
+	flag.Int64Var(&cfg.OpenPolicyAgentBodyReadBufferSize, "open-policy-agent-body-read-buffer-size", openpolicyagent.DefaultBodyBufferSize, "Read buffer size for the request body")
 	flag.Int64Var(&cfg.OpenPolicyAgentMaxMemoryBodyParsing, "open-policy-agent-max-memory-body-parsing", openpolicyagent.DefaultMaxMemoryBodyParsing, "Total number of bytes used to parse http request bodies across all requests. Once the limit is met, requests will be rejected.")
 
 	// TLS client certs
@@ -932,6 +934,7 @@ func (c *Config) ToOptions() skipper.Options {
 		OpenPolicyAgentCleanerInterval:      c.OpenPolicyAgentCleanerInterval,
 		OpenPolicyAgentStartupTimeout:       c.OpenPolicyAgentStartupTimeout,
 		OpenPolicyAgentMaxRequestBodySize:   c.OpenPolicyAgentMaxRequestBodySize,
+		OpenPolicyAgentBodyReadBufferSize:   c.OpenPolicyAgentBodyReadBufferSize,
 		OpenPolicyAgentMaxMemoryBodyParsing: c.OpenPolicyAgentMaxMemoryBodyParsing,
 
 		PassiveHealthCheck: c.PassiveHealthCheck.values,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -163,6 +163,7 @@ func defaultConfig(with func(*Config)) *Config {
 		OpenPolicyAgentStartupTimeout:           30 * time.Second,
 		OpenPolicyAgentMaxRequestBodySize:       openpolicyagent.DefaultMaxRequestBodySize,
 		OpenPolicyAgentMaxMemoryBodyParsing:     openpolicyagent.DefaultMaxMemoryBodyParsing,
+		OpenPolicyAgentRequestBodyBufferSize:    openpolicyagent.DefaultRequestBodyBufferSize,
 	}
 	with(cfg)
 	return cfg

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -45,9 +45,9 @@ const (
 	defaultShutdownGracePeriod = 30 * time.Second
 	DefaultOpaStartupTimeout   = 30 * time.Second
 
-	DefaultMaxRequestBodySize   = 1 << 20 // 1 MB
-	DefaultMaxMemoryBodyParsing = 100 * DefaultMaxRequestBodySize
-	DefaultBodyBufferSize       = 8 * 1024 // 8 KB
+	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
+	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
+	DefaultRequestBodyBufferSize = 8 * 1024 // 8 KB
 
 	spanNameEval = "open-policy-agent"
 )
@@ -130,7 +130,7 @@ func NewOpenPolicyAgentRegistry(opts ...func(*OpenPolicyAgentRegistry) error) *O
 		lastused:            make(map[*OpenPolicyAgentInstance]time.Time),
 		quit:                make(chan struct{}),
 		maxRequestBodyBytes: DefaultMaxMemoryBodyParsing,
-		bodyReadBufferSize:  DefaultBodyBufferSize,
+		bodyReadBufferSize:  DefaultRequestBodyBufferSize,
 	}
 
 	for _, opt := range opts {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/proto"
 	"io"
 	"net/http"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"text/template"
 	"time"
+
+	"google.golang.org/protobuf/proto"
 
 	ext_authz_v3_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/uuid"
@@ -46,7 +47,7 @@ const (
 
 	DefaultMaxRequestBodySize   = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing = 100 * DefaultMaxRequestBodySize
-	defaultBodyBufferSize       = 8192 * 1024
+	DefaultBodyBufferSize       = 8 * 1024 // 8 KB
 
 	spanNameEval = "open-policy-agent"
 )
@@ -129,7 +130,7 @@ func NewOpenPolicyAgentRegistry(opts ...func(*OpenPolicyAgentRegistry) error) *O
 		lastused:            make(map[*OpenPolicyAgentInstance]time.Time),
 		quit:                make(chan struct{}),
 		maxRequestBodyBytes: DefaultMaxMemoryBodyParsing,
-		bodyReadBufferSize:  defaultBodyBufferSize,
+		bodyReadBufferSize:  DefaultBodyBufferSize,
 	}
 
 	for _, opt := range opts {

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -251,7 +251,7 @@ func TestOpaEngineStartFailureWithTimeout(t *testing.T) {
 	cfg, err := NewOpenPolicyAgentConfig(WithConfigTemplate(config), WithStartupTimeout(1*time.Second))
 	assert.NoError(t, err)
 
-	engine, err := registry.new(inmem.New(), config, *cfg, "testfilter", "test", DefaultMaxRequestBodySize, DefaultBodyBufferSize)
+	engine, err := registry.new(inmem.New(), config, *cfg, "testfilter", "test", DefaultMaxRequestBodySize, DefaultRequestBodyBufferSize)
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.startupTimeout)
@@ -534,7 +534,7 @@ func TestBodyExtraction(t *testing.T) {
 			msg:            "Read body ",
 			body:           `{ "welcome": "world" }`,
 			maxBodySize:    1024,
-			readBodyBuffer: DefaultBodyBufferSize,
+			readBodyBuffer: DefaultRequestBodyBufferSize,
 			bodyInPolicy:   `{ "welcome": "world" }`,
 		},
 		{

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	pbstruct "google.golang.org/protobuf/types/known/structpb"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	pbstruct "google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/open-policy-agent/opa/ast"
 
@@ -250,7 +251,7 @@ func TestOpaEngineStartFailureWithTimeout(t *testing.T) {
 	cfg, err := NewOpenPolicyAgentConfig(WithConfigTemplate(config), WithStartupTimeout(1*time.Second))
 	assert.NoError(t, err)
 
-	engine, err := registry.new(inmem.New(), config, *cfg, "testfilter", "test", DefaultMaxRequestBodySize, defaultBodyBufferSize)
+	engine, err := registry.new(inmem.New(), config, *cfg, "testfilter", "test", DefaultMaxRequestBodySize, DefaultBodyBufferSize)
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.startupTimeout)
@@ -533,7 +534,7 @@ func TestBodyExtraction(t *testing.T) {
 			msg:            "Read body ",
 			body:           `{ "welcome": "world" }`,
 			maxBodySize:    1024,
-			readBodyBuffer: defaultBodyBufferSize,
+			readBodyBuffer: DefaultBodyBufferSize,
 			bodyInPolicy:   `{ "welcome": "world" }`,
 		},
 		{

--- a/skipper.go
+++ b/skipper.go
@@ -939,6 +939,7 @@ type Options struct {
 	OpenPolicyAgentCleanerInterval      time.Duration
 	OpenPolicyAgentStartupTimeout       time.Duration
 	OpenPolicyAgentMaxRequestBodySize   int64
+	OpenPolicyAgentBodyReadBufferSize   int64
 	OpenPolicyAgentMaxMemoryBodyParsing int64
 
 	PassiveHealthCheck map[string]string
@@ -1880,6 +1881,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		opaRegistry = openpolicyagent.NewOpenPolicyAgentRegistry(
 			openpolicyagent.WithMaxRequestBodyBytes(o.OpenPolicyAgentMaxRequestBodySize),
 			openpolicyagent.WithMaxMemoryBodyParsing(o.OpenPolicyAgentMaxMemoryBodyParsing),
+			openpolicyagent.WithReadBodyBufferSize(o.OpenPolicyAgentBodyReadBufferSize),
 			openpolicyagent.WithCleanInterval(o.OpenPolicyAgentCleanerInterval),
 			openpolicyagent.WithTracer(tracer))
 		defer opaRegistry.Close()

--- a/skipper.go
+++ b/skipper.go
@@ -933,14 +933,14 @@ type Options struct {
 	// filters.
 	LuaSources []string
 
-	EnableOpenPolicyAgent               bool
-	OpenPolicyAgentConfigTemplate       string
-	OpenPolicyAgentEnvoyMetadata        string
-	OpenPolicyAgentCleanerInterval      time.Duration
-	OpenPolicyAgentStartupTimeout       time.Duration
-	OpenPolicyAgentMaxRequestBodySize   int64
-	OpenPolicyAgentBodyReadBufferSize   int64
-	OpenPolicyAgentMaxMemoryBodyParsing int64
+	EnableOpenPolicyAgent                bool
+	OpenPolicyAgentConfigTemplate        string
+	OpenPolicyAgentEnvoyMetadata         string
+	OpenPolicyAgentCleanerInterval       time.Duration
+	OpenPolicyAgentStartupTimeout        time.Duration
+	OpenPolicyAgentMaxRequestBodySize    int64
+	OpenPolicyAgentRequestBodyBufferSize int64
+	OpenPolicyAgentMaxMemoryBodyParsing  int64
 
 	PassiveHealthCheck map[string]string
 }
@@ -1881,7 +1881,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		opaRegistry = openpolicyagent.NewOpenPolicyAgentRegistry(
 			openpolicyagent.WithMaxRequestBodyBytes(o.OpenPolicyAgentMaxRequestBodySize),
 			openpolicyagent.WithMaxMemoryBodyParsing(o.OpenPolicyAgentMaxMemoryBodyParsing),
-			openpolicyagent.WithReadBodyBufferSize(o.OpenPolicyAgentBodyReadBufferSize),
+			openpolicyagent.WithReadBodyBufferSize(o.OpenPolicyAgentRequestBodyBufferSize),
 			openpolicyagent.WithCleanInterval(o.OpenPolicyAgentCleanerInterval),
 			openpolicyagent.WithTracer(tracer))
 		defer opaRegistry.Close()


### PR DESCRIPTION
This PR

* reduces the default buffer size for reading the request body to 8KB
* and makes it configurable via command line and Skipper config