### PR TITLE
skipper: add TLS client authentication config

### DIFF
--- a/skipper.go
+++ b/skipper.go
@@ -617,6 +617,10 @@ type Options struct {
 	// multiple keys, the order must match the one given in CertPathTLS
 	KeyPathTLS string
 
+	// TLSClientAuth sets the policy the server will follow for
+	// TLS Client Authentication, see [tls.ClientAuthType]
+	TLSClientAuth tls.ClientAuthType
+
 	// TLS Settings for Proxy Server
 	ProxyTLS *tls.Config
 
@@ -1198,6 +1202,7 @@ func (o *Options) tlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 
 	config := &tls.Config{
 		MinVersion: o.TLSMinVersion,
+		ClientAuth: o.TLSClientAuth,
 	}
 
 	if o.CipherSuites != nil {


### PR DESCRIPTION
Add an option and a flag to configure TLS Client Authentication policy of the Server.

Fixes https://github.com/zalando/skipper/issues/3280