### PR TITLE
oid_introspection: add SetOIDCClaims

### DIFF
--- a/filters/auth/grant.go
+++ b/filters/auth/grant.go
@@ -175,11 +175,7 @@ func (f *grantFilter) setupToken(token *oauth2.Token, tokeninfo map[string]inter
 
 	// By piggy-backing on the OIDC token container,
 	// we gain downstream compatibility with the oidcClaimsQuery filter.
-	ctx.StateBag()[oidcClaimsCacheKey] = tokenContainer{
-		OAuth2Token: token,
-		Subject:     subject,
-		Claims:      tokeninfo,
-	}
+	SetOIDCClaims(ctx, tokeninfo)
 
 	// Set the tokeninfo also in the tokeninfoCacheKey state bag, so we
 	// can reuse e.g. the forwardToken() filter.

--- a/filters/auth/grant_test.go
+++ b/filters/auth/grant_test.go
@@ -210,6 +210,7 @@ func newAuthProxy(t *testing.T, config *auth.OAuthConfig, routes []*eskip.Route,
 	fr.Register(config.NewGrantCallback())
 	fr.Register(config.NewGrantClaimsQuery())
 	fr.Register(config.NewGrantLogout())
+	fr.Register(auth.NewOIDCQueryClaimsFilter())
 
 	pc := proxytest.Config{
 		RoutingOptions: routing.Options{
@@ -331,6 +332,7 @@ func TestGrantFlow(t *testing.T) {
 	config := newGrantTestConfig(tokeninfo.URL, provider.URL)
 
 	routes := eskip.MustParse(`* -> oauthGrant()
+		-> oidcClaimsQuery("/:sub")
 		-> status(204)
 		-> setResponseHeader("Backend-Request-Cookie", "${request.header.Cookie}")
 		-> <shunt>

--- a/filters/auth/oidc_introspection.go
+++ b/filters/auth/oidc_introspection.go
@@ -42,6 +42,14 @@ func NewOIDCQueryClaimsFilter() filters.Spec {
 	}
 }
 
+// Sets OIDC claims in the state bag.
+// Intended for use with the oidcClaimsQuery filter.
+func SetOIDCClaims(ctx filters.FilterContext, claims map[string]interface{}) {
+	ctx.StateBag()[oidcClaimsCacheKey] = tokenContainer{
+		Claims: claims,
+	}
+}
+
 func (spec *oidcIntrospectionSpec) Name() string {
 	switch spec.typ {
 	case checkOIDCQueryClaims:


### PR DESCRIPTION
This method allows third-party filters to set the oidcClaimsCacheKey which enables the use of the oidcClaimsQuery filter.

Closes #3139