### PR TITLE
Move testTracer struct in tracingtest package and reuse it

### DIFF
--- a/filters/scheduler/fifo_test.go
+++ b/filters/scheduler/fifo_test.go
@@ -11,7 +11,6 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/sirupsen/logrus"
 
 	"github.com/zalando/skipper/eskip"
@@ -22,7 +21,6 @@ import (
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/routing/testdataclient"
 	"github.com/zalando/skipper/scheduler"
-	"github.com/zalando/skipper/tracing/tracingtest"
 )
 
 func TestCreateFifoName(t *testing.T) {
@@ -297,10 +295,8 @@ func TestFifoWithBody(t *testing.T) {
 			rt := routing.New(ro)
 			defer rt.Close()
 			<-rt.FirstLoad()
-			tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
 			pr := proxy.WithParams(proxy.Params{
-				Routing:     rt,
-				OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
+				Routing: rt,
 			})
 			defer pr.Close()
 			ts := stdlibhttptest.NewServer(pr)
@@ -509,10 +505,8 @@ func TestFifo(t *testing.T) {
 			defer rt.Close()
 			<-rt.FirstLoad()
 
-			tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
 			pr := proxy.WithParams(proxy.Params{
-				Routing:     rt,
-				OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
+				Routing: rt,
 			})
 			defer pr.Close()
 
@@ -637,10 +631,8 @@ func TestFifoConstantRouteUpdates(t *testing.T) {
 			defer rt.Close()
 			<-rt.FirstLoad()
 
-			tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
 			pr := proxy.WithParams(proxy.Params{
-				Routing:     rt,
-				OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
+				Routing: rt,
 			})
 			defer pr.Close()
 

--- a/filters/scheduler/fifo_test.go
+++ b/filters/scheduler/fifo_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/routing/testdataclient"
 	"github.com/zalando/skipper/scheduler"
+	"github.com/zalando/skipper/tracing/tracingtest"
 )
 
 func TestCreateFifoName(t *testing.T) {
@@ -296,7 +297,7 @@ func TestFifoWithBody(t *testing.T) {
 			rt := routing.New(ro)
 			defer rt.Close()
 			<-rt.FirstLoad()
-			tracer := &testTracer{MockTracer: mocktracer.New()}
+			tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
 			pr := proxy.WithParams(proxy.Params{
 				Routing:     rt,
 				OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
@@ -508,7 +509,7 @@ func TestFifo(t *testing.T) {
 			defer rt.Close()
 			<-rt.FirstLoad()
 
-			tracer := &testTracer{MockTracer: mocktracer.New()}
+			tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
 			pr := proxy.WithParams(proxy.Params{
 				Routing:     rt,
 				OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
@@ -636,7 +637,7 @@ func TestFifoConstantRouteUpdates(t *testing.T) {
 			defer rt.Close()
 			<-rt.FirstLoad()
 
-			tracer := &testTracer{MockTracer: mocktracer.New()}
+			tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
 			pr := proxy.WithParams(proxy.Params{
 				Routing:     rt,
 				OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},

--- a/filters/scheduler/lifo_test.go
+++ b/filters/scheduler/lifo_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aryszka/jobqueue"
-	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/metrics/metricstest"
 	"github.com/zalando/skipper/proxy"
@@ -475,7 +474,7 @@ func TestLifoErrors(t *testing.T) {
 
 	<-rt.FirstLoad()
 
-	tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
+	tracer := tracingtest.NewMockTracer()
 	pr := proxy.WithParams(proxy.Params{
 		Routing:     rt,
 		OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},

--- a/filters/scheduler/lifo_test.go
+++ b/filters/scheduler/lifo_test.go
@@ -474,7 +474,7 @@ func TestLifoErrors(t *testing.T) {
 
 	<-rt.FirstLoad()
 
-	tracer := tracingtest.NewMockTracer()
+	tracer := tracingtest.NewTracer()
 	pr := proxy.WithParams(proxy.Params{
 		Routing:     rt,
 		OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},

--- a/filters/scheduler/lifo_test.go
+++ b/filters/scheduler/lifo_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aryszka/jobqueue"
-	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/metrics/metricstest"
@@ -22,6 +20,7 @@ import (
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/routing/testdataclient"
 	"github.com/zalando/skipper/scheduler"
+	"github.com/zalando/skipper/tracing/tracingtest"
 )
 
 func TestNewLIFO(t *testing.T) {
@@ -442,38 +441,6 @@ func TestNewLIFO(t *testing.T) {
 	}
 }
 
-type testTracer struct {
-	*mocktracer.MockTracer
-	spans int32
-}
-
-func (t *testTracer) Reset() {
-	atomic.StoreInt32(&t.spans, 0)
-	t.MockTracer.Reset()
-}
-
-func (t *testTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
-	atomic.AddInt32(&t.spans, 1)
-	return t.MockTracer.StartSpan(operationName, opts...)
-}
-
-func (t *testTracer) FinishedSpans() []*mocktracer.MockSpan {
-	timeout := time.After(1 * time.Second)
-	retry := time.NewTicker(100 * time.Millisecond)
-	defer retry.Stop()
-	for {
-		finished := t.MockTracer.FinishedSpans()
-		if len(finished) == int(atomic.LoadInt32(&t.spans)) {
-			return finished
-		}
-		select {
-		case <-retry.C:
-		case <-timeout:
-			return nil
-		}
-	}
-}
-
 func TestLifoErrors(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		time.Sleep(time.Second)
@@ -508,7 +475,7 @@ func TestLifoErrors(t *testing.T) {
 
 	<-rt.FirstLoad()
 
-	tracer := &testTracer{MockTracer: mocktracer.New()}
+	tracer := &tracingtest.MockTracer{MockTracer: mocktracer.New()}
 	pr := proxy.WithParams(proxy.Params{
 		Routing:     rt,
 		OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},

--- a/filters/tracing/tag_test.go
+++ b/filters/tracing/tag_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/tracing/tracingtest"
 )
 
 func TestTracingTagNil(t *testing.T) {
@@ -196,7 +197,7 @@ func TestTagCreateFilter(t *testing.T) {
 }
 
 func TestTracingTag(t *testing.T) {
-	tracer := mocktracer.New()
+	tracer := tracingtest.NewTracer()
 
 	for _, ti := range []struct {
 		name     string

--- a/net/httpclient_test.go
+++ b/net/httpclient_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/AlexanderYastrebov/noleak"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/zalando/skipper/secrets"
 	"github.com/zalando/skipper/tracing/tracers/basic"
+	"github.com/zalando/skipper/tracing/tracingtest"
 )
 
 var testToken = []byte("mytoken1")
@@ -208,7 +208,7 @@ func TestClient(t *testing.T) {
 }
 
 func TestTransport(t *testing.T) {
-	mtracer := mocktracer.New()
+	mtracer := tracingtest.NewTracer()
 	tracer, err := basic.InitTracer(nil)
 	if err != nil {
 		t.Fatalf("Failed to get a tracer: %v", err)

--- a/tracing/tracingtest/mocktracer.go
+++ b/tracing/tracingtest/mocktracer.go
@@ -1,0 +1,41 @@
+package tracingtest
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+)
+
+type MockTracer struct {
+	*mocktracer.MockTracer
+	spans int32
+}
+
+func (t *MockTracer) Reset() {
+	atomic.StoreInt32(&t.spans, 0)
+	t.MockTracer.Reset()
+}
+
+func (t *MockTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	atomic.AddInt32(&t.spans, 1)
+	return t.MockTracer.StartSpan(operationName, opts...)
+}
+
+func (t *MockTracer) FinishedSpans() []*mocktracer.MockSpan {
+	timeout := time.After(1 * time.Second)
+	retry := time.NewTicker(100 * time.Millisecond)
+	defer retry.Stop()
+	for {
+		finished := t.MockTracer.FinishedSpans()
+		if len(finished) == int(atomic.LoadInt32(&t.spans)) {
+			return finished
+		}
+		select {
+		case <-retry.C:
+		case <-timeout:
+			return nil
+		}
+	}
+}

--- a/tracing/tracingtest/mocktracer.go
+++ b/tracing/tracingtest/mocktracer.go
@@ -44,10 +44,10 @@ func (t *MockTracer) FinishedSpans() []*mocktracer.MockSpan {
 	}
 }
 
-func (t *MockTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+func (t *MockTracer) Inject(sm opentracing.SpanContext, format any, carrier any) error {
 	return t.mockTracer.Inject(sm, format, carrier)
 }
 
-func (t *MockTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+func (t *MockTracer) Extract(format any, carrier any) (opentracing.SpanContext, error) {
 	return t.mockTracer.Extract(format, carrier)
 }

--- a/tracing/tracingtest/mocktracer.go
+++ b/tracing/tracingtest/mocktracer.go
@@ -13,8 +13,8 @@ type MockTracer struct {
 	spans      atomic.Int32
 }
 
-func NewMockTracer() *MockTracer {
-	return &MockTracer{mockTracer: &mocktracer.MockTracer{}}
+func NewTracer() *MockTracer {
+	return &MockTracer{mockTracer: mocktracer.New()}
 }
 
 func (t *MockTracer) Reset() {


### PR DESCRIPTION
This pull requests is split from https://github.com/zalando/skipper/pull/3318 to refactor change of testTracer to make it more reusable.