### PR TITLE
dataclients/kubernetes: append predicates to routes of Ingress/RouteGroup having specific annotation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,34 +149,38 @@ type Config struct {
 	RefusePayload    multiFlag `yaml:"refuse-payload"`
 
 	// Kubernetes:
-	KubernetesIngress                       bool                               `yaml:"kubernetes"`
-	KubernetesInCluster                     bool                               `yaml:"kubernetes-in-cluster"`
-	KubernetesURL                           string                             `yaml:"kubernetes-url"`
-	KubernetesTokenFile                     string                             `yaml:"kubernetes-token-file"`
-	KubernetesHealthcheck                   bool                               `yaml:"kubernetes-healthcheck"`
-	KubernetesHTTPSRedirect                 bool                               `yaml:"kubernetes-https-redirect"`
-	KubernetesHTTPSRedirectCode             int                                `yaml:"kubernetes-https-redirect-code"`
-	KubernetesDisableCatchAllRoutes         bool                               `yaml:"kubernetes-disable-catchall-routes"`
-	KubernetesIngressClass                  string                             `yaml:"kubernetes-ingress-class"`
-	KubernetesRouteGroupClass               string                             `yaml:"kubernetes-routegroup-class"`
-	WhitelistedHealthCheckCIDR              string                             `yaml:"whitelisted-healthcheck-cidr"`
-	KubernetesPathModeString                string                             `yaml:"kubernetes-path-mode"`
-	KubernetesPathMode                      kubernetes.PathMode                `yaml:"-"`
-	KubernetesNamespace                     string                             `yaml:"kubernetes-namespace"`
-	KubernetesEnableEndpointSlices          bool                               `yaml:"enable-kubernetes-endpointslices"`
-	KubernetesEnableEastWest                bool                               `yaml:"enable-kubernetes-east-west"`
-	KubernetesEastWestDomain                string                             `yaml:"kubernetes-east-west-domain"`
-	KubernetesEastWestRangeDomains          *listFlag                          `yaml:"kubernetes-east-west-range-domains"`
-	KubernetesEastWestRangePredicatesString string                             `yaml:"kubernetes-east-west-range-predicates"`
-	KubernetesEastWestRangePredicates       []*eskip.Predicate                 `yaml:"-"`
-	KubernetesOnlyAllowedExternalNames      bool                               `yaml:"kubernetes-only-allowed-external-names"`
-	KubernetesAllowedExternalNames          regexpListFlag                     `yaml:"kubernetes-allowed-external-names"`
-	KubernetesRedisServiceNamespace         string                             `yaml:"kubernetes-redis-service-namespace"`
-	KubernetesRedisServiceName              string                             `yaml:"kubernetes-redis-service-name"`
-	KubernetesRedisServicePort              int                                `yaml:"kubernetes-redis-service-port"`
-	KubernetesBackendTrafficAlgorithmString string                             `yaml:"kubernetes-backend-traffic-algorithm"`
-	KubernetesBackendTrafficAlgorithm       kubernetes.BackendTrafficAlgorithm `yaml:"-"`
-	KubernetesDefaultLoadBalancerAlgorithm  string                             `yaml:"kubernetes-default-lb-algorithm"`
+	KubernetesIngress                                 bool                               `yaml:"kubernetes"`
+	KubernetesInCluster                               bool                               `yaml:"kubernetes-in-cluster"`
+	KubernetesURL                                     string                             `yaml:"kubernetes-url"`
+	KubernetesTokenFile                               string                             `yaml:"kubernetes-token-file"`
+	KubernetesHealthcheck                             bool                               `yaml:"kubernetes-healthcheck"`
+	KubernetesHTTPSRedirect                           bool                               `yaml:"kubernetes-https-redirect"`
+	KubernetesHTTPSRedirectCode                       int                                `yaml:"kubernetes-https-redirect-code"`
+	KubernetesDisableCatchAllRoutes                   bool                               `yaml:"kubernetes-disable-catchall-routes"`
+	KubernetesIngressClass                            string                             `yaml:"kubernetes-ingress-class"`
+	KubernetesRouteGroupClass                         string                             `yaml:"kubernetes-routegroup-class"`
+	WhitelistedHealthCheckCIDR                        string                             `yaml:"whitelisted-healthcheck-cidr"`
+	KubernetesPathModeString                          string                             `yaml:"kubernetes-path-mode"`
+	KubernetesPathMode                                kubernetes.PathMode                `yaml:"-"`
+	KubernetesNamespace                               string                             `yaml:"kubernetes-namespace"`
+	KubernetesEnableEndpointSlices                    bool                               `yaml:"enable-kubernetes-endpointslices"`
+	KubernetesEnableEastWest                          bool                               `yaml:"enable-kubernetes-east-west"`
+	KubernetesEastWestDomain                          string                             `yaml:"kubernetes-east-west-domain"`
+	KubernetesEastWestRangeDomains                    *listFlag                          `yaml:"kubernetes-east-west-range-domains"`
+	KubernetesEastWestRangePredicatesString           string                             `yaml:"kubernetes-east-west-range-predicates"`
+	KubernetesEastWestRangeAnnotationPredicatesString multiFlag                          `yaml:"kubernetes-east-west-range-annotation-predicates"`
+	KubernetesAnnotationPredicatesString              multiFlag                          `yaml:"kubernetes-annotation-predicates"`
+	KubernetesEastWestRangeAnnotationPredicates       []kubernetes.AnnotationPredicates  `yaml:"-"`
+	KubernetesAnnotationPredicates                    []kubernetes.AnnotationPredicates  `yaml:"-"`
+	KubernetesEastWestRangePredicates                 []*eskip.Predicate                 `yaml:"-"`
+	KubernetesOnlyAllowedExternalNames                bool                               `yaml:"kubernetes-only-allowed-external-names"`
+	KubernetesAllowedExternalNames                    regexpListFlag                     `yaml:"kubernetes-allowed-external-names"`
+	KubernetesRedisServiceNamespace                   string                             `yaml:"kubernetes-redis-service-namespace"`
+	KubernetesRedisServiceName                        string                             `yaml:"kubernetes-redis-service-name"`
+	KubernetesRedisServicePort                        int                                `yaml:"kubernetes-redis-service-port"`
+	KubernetesBackendTrafficAlgorithmString           string                             `yaml:"kubernetes-backend-traffic-algorithm"`
+	KubernetesBackendTrafficAlgorithm                 kubernetes.BackendTrafficAlgorithm `yaml:"-"`
+	KubernetesDefaultLoadBalancerAlgorithm            string                             `yaml:"kubernetes-default-lb-algorithm"`
 
 	// Default filters
 	DefaultFiltersDir string `yaml:"default-filters-dir"`
@@ -470,6 +474,8 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.KubernetesEastWestDomain, "kubernetes-east-west-domain", "", "*Deprecated*: use kubernetes-east-west-range feature. Sets the east-west domain, defaults to .skipper.cluster.local")
 	flag.Var(cfg.KubernetesEastWestRangeDomains, "kubernetes-east-west-range-domains", "set the the cluster internal domains for east west traffic. Identified routes to such domains will include the -kubernetes-east-west-range-predicates")
 	flag.StringVar(&cfg.KubernetesEastWestRangePredicatesString, "kubernetes-east-west-range-predicates", "", "set the predicates that will be appended to routes identified as to -kubernetes-east-west-range-domains")
+	flag.Var(&cfg.KubernetesAnnotationPredicatesString, "kubernetes-annotation-predicates", "configures predicates appended to non east-west routes of annotated resources. E.g. -kubernetes-annotation-predicates='zone-a=true=Foo() && Bar()' will add 'Foo() && Bar()' predicates to all non east-west routes of ingress or routegroup annotated with 'zone-a: true'. For east-west routes use -kubernetes-east-west-range-annotation-predicates.")
+	flag.Var(&cfg.KubernetesEastWestRangeAnnotationPredicatesString, "kubernetes-east-west-range-annotation-predicates", "similar to -kubernetes-annotation-predicates configures predicates appended to east-west routes of annotated resources. See also -kubernetes-east-west-range-domains.")
 	flag.BoolVar(&cfg.KubernetesOnlyAllowedExternalNames, "kubernetes-only-allowed-external-names", false, "only accept external name services, route group network backends and route group explicit LB endpoints from an allow list defined by zero or more -kubernetes-allowed-external-name flags")
 	flag.Var(&cfg.KubernetesAllowedExternalNames, "kubernetes-allowed-external-name", "set zero or more regular expressions from which at least one should be matched by the external name services, route group network addresses and explicit endpoints domain names")
 	flag.StringVar(&cfg.KubernetesRedisServiceNamespace, "kubernetes-redis-service-namespace", "", "Sets namespace for redis to be used to lookup endpoints")
@@ -611,6 +617,17 @@ func validate(c *Config) error {
 	if err != nil {
 		return fmt.Errorf("invalid east-west-range-predicates: %w", err)
 	}
+
+	_, err = parseAnnotationPredicates(c.KubernetesAnnotationPredicatesString)
+	if err != nil {
+		return fmt.Errorf("invalid annotation predicates: %q, %w", c.KubernetesAnnotationPredicatesString, err)
+	}
+
+	_, err = parseAnnotationPredicates(c.KubernetesEastWestRangeAnnotationPredicatesString)
+	if err != nil {
+		return fmt.Errorf("invalid east-west annotation predicates: %q, %w", c.KubernetesEastWestRangeAnnotationPredicatesString, err)
+	}
+
 	_, err = kubernetes.ParseBackendTrafficAlgorithm(c.KubernetesBackendTrafficAlgorithmString)
 	if err != nil {
 		return err
@@ -673,6 +690,8 @@ func (c *Config) ParseArgs(progname string, args []string) error {
 	c.ApplicationLogLevel, _ = log.ParseLevel(c.ApplicationLogLevelString)
 	c.KubernetesPathMode, _ = kubernetes.ParsePathMode(c.KubernetesPathModeString)
 	c.KubernetesEastWestRangePredicates, _ = eskip.ParsePredicates(c.KubernetesEastWestRangePredicatesString)
+	c.KubernetesAnnotationPredicates, _ = parseAnnotationPredicates(c.KubernetesAnnotationPredicatesString)
+	c.KubernetesEastWestRangeAnnotationPredicates, _ = parseAnnotationPredicates(c.KubernetesEastWestRangeAnnotationPredicatesString)
 	c.KubernetesBackendTrafficAlgorithm, _ = kubernetes.ParseBackendTrafficAlgorithm(c.KubernetesBackendTrafficAlgorithmString)
 	c.HistogramMetricBuckets, _ = c.parseHistogramBuckets()
 
@@ -815,31 +834,33 @@ func (c *Config) ToOptions() skipper.Options {
 		WaitFirstRouteLoad: c.WaitFirstRouteLoad,
 
 		// Kubernetes:
-		Kubernetes:                             c.KubernetesIngress,
-		KubernetesInCluster:                    c.KubernetesInCluster,
-		KubernetesURL:                          c.KubernetesURL,
-		KubernetesTokenFile:                    c.KubernetesTokenFile,
-		KubernetesHealthcheck:                  c.KubernetesHealthcheck,
-		KubernetesHTTPSRedirect:                c.KubernetesHTTPSRedirect,
-		KubernetesHTTPSRedirectCode:            c.KubernetesHTTPSRedirectCode,
-		KubernetesDisableCatchAllRoutes:        c.KubernetesDisableCatchAllRoutes,
-		KubernetesIngressClass:                 c.KubernetesIngressClass,
-		KubernetesRouteGroupClass:              c.KubernetesRouteGroupClass,
-		WhitelistedHealthCheckCIDR:             whitelistCIDRS,
-		KubernetesPathMode:                     c.KubernetesPathMode,
-		KubernetesNamespace:                    c.KubernetesNamespace,
-		KubernetesEnableEndpointslices:         c.KubernetesEnableEndpointSlices,
-		KubernetesEnableEastWest:               c.KubernetesEnableEastWest,
-		KubernetesEastWestDomain:               c.KubernetesEastWestDomain,
-		KubernetesEastWestRangeDomains:         c.KubernetesEastWestRangeDomains.values,
-		KubernetesEastWestRangePredicates:      c.KubernetesEastWestRangePredicates,
-		KubernetesOnlyAllowedExternalNames:     c.KubernetesOnlyAllowedExternalNames,
-		KubernetesAllowedExternalNames:         c.KubernetesAllowedExternalNames,
-		KubernetesRedisServiceNamespace:        c.KubernetesRedisServiceNamespace,
-		KubernetesRedisServiceName:             c.KubernetesRedisServiceName,
-		KubernetesRedisServicePort:             c.KubernetesRedisServicePort,
-		KubernetesBackendTrafficAlgorithm:      c.KubernetesBackendTrafficAlgorithm,
-		KubernetesDefaultLoadBalancerAlgorithm: c.KubernetesDefaultLoadBalancerAlgorithm,
+		Kubernetes:                                  c.KubernetesIngress,
+		KubernetesInCluster:                         c.KubernetesInCluster,
+		KubernetesURL:                               c.KubernetesURL,
+		KubernetesTokenFile:                         c.KubernetesTokenFile,
+		KubernetesHealthcheck:                       c.KubernetesHealthcheck,
+		KubernetesHTTPSRedirect:                     c.KubernetesHTTPSRedirect,
+		KubernetesHTTPSRedirectCode:                 c.KubernetesHTTPSRedirectCode,
+		KubernetesDisableCatchAllRoutes:             c.KubernetesDisableCatchAllRoutes,
+		KubernetesIngressClass:                      c.KubernetesIngressClass,
+		KubernetesRouteGroupClass:                   c.KubernetesRouteGroupClass,
+		WhitelistedHealthCheckCIDR:                  whitelistCIDRS,
+		KubernetesPathMode:                          c.KubernetesPathMode,
+		KubernetesNamespace:                         c.KubernetesNamespace,
+		KubernetesEnableEndpointslices:              c.KubernetesEnableEndpointSlices,
+		KubernetesEnableEastWest:                    c.KubernetesEnableEastWest,
+		KubernetesEastWestDomain:                    c.KubernetesEastWestDomain,
+		KubernetesEastWestRangeDomains:              c.KubernetesEastWestRangeDomains.values,
+		KubernetesEastWestRangePredicates:           c.KubernetesEastWestRangePredicates,
+		KubernetesEastWestRangeAnnotationPredicates: c.KubernetesEastWestRangeAnnotationPredicates,
+		KubernetesAnnotationPredicates:              c.KubernetesAnnotationPredicates,
+		KubernetesOnlyAllowedExternalNames:          c.KubernetesOnlyAllowedExternalNames,
+		KubernetesAllowedExternalNames:              c.KubernetesAllowedExternalNames,
+		KubernetesRedisServiceNamespace:             c.KubernetesRedisServiceNamespace,
+		KubernetesRedisServiceName:                  c.KubernetesRedisServiceName,
+		KubernetesRedisServicePort:                  c.KubernetesRedisServicePort,
+		KubernetesBackendTrafficAlgorithm:           c.KubernetesBackendTrafficAlgorithm,
+		KubernetesDefaultLoadBalancerAlgorithm:      c.KubernetesDefaultLoadBalancerAlgorithm,
 
 		// API Monitoring:
 		ApiUsageMonitoringEnable:                c.ApiUsageMonitoringEnable,
@@ -1149,4 +1170,45 @@ func (c *Config) checkDeprecated(configKeys map[string]interface{}, options ...s
 			log.Warnf("%s: %s", f.Name, f.Usage)
 		}
 	}
+}
+
+func parseAnnotationPredicates(s []string) ([]kubernetes.AnnotationPredicates, error) {
+	var annotationPredicates []kubernetes.AnnotationPredicates
+
+	for _, annotationPredicate := range s {
+		if annotationPredicate == "" {
+			continue
+		}
+
+		annotationKey, rest, found := strings.Cut(annotationPredicate, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid annotation predicate flag: %q, failed to get annotation key", annotationPredicate)
+		}
+
+		annotationValue, predicates, found := strings.Cut(rest, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid annotation predicate flag: %q, faild to get annotation value", annotationPredicate)
+		}
+
+		predicateList, err := eskip.ParsePredicates(predicates)
+		if err != nil {
+			return nil, fmt.Errorf("invalid annotation predicate flag: %q, %w", annotationPredicate, err)
+		}
+
+		// We throw an err because having duplicate annotation keys will override each others
+		for _, ap := range annotationPredicates {
+			if ap.Key == annotationKey && ap.Value == annotationValue {
+				return nil, fmt.Errorf("invalid annotation predicate flag: %q, duplicate annotation key and value", annotationPredicate)
+			}
+		}
+
+		annotationPredicates = append(annotationPredicates, kubernetes.AnnotationPredicates{
+			Key:        annotationKey,
+			Value:      annotationValue,
+			Predicates: predicateList,
+		})
+	}
+
+	return annotationPredicates, nil
+
 }

--- a/dataclients/kubernetes/annotations.go
+++ b/dataclients/kubernetes/annotations.go
@@ -1,0 +1,21 @@
+package kubernetes
+
+import (
+	"github.com/zalando/skipper/eskip"
+)
+
+type AnnotationPredicates struct {
+	Key        string
+	Value      string
+	Predicates []*eskip.Predicate
+}
+
+func addAnnotationPredicates(annotationPredicates []AnnotationPredicates, annotations map[string]string, r *eskip.Route) {
+	for _, ap := range annotationPredicates {
+		if objAnnotationVal, ok := annotations[ap.Key]; ok && ap.Value == objAnnotationVal {
+			// since this annotation is managed by skipper operator, we can safely assume that the predicate is valid
+			// and we can append it to the route
+			r.Predicates = append(r.Predicates, ap.Predicates...)
+		}
+	}
+}

--- a/dataclients/kubernetes/hosts.go
+++ b/dataclients/kubernetes/hosts.go
@@ -81,3 +81,12 @@ func isExternalAddressAllowed(allowedDomains []*regexp.Regexp, address string) b
 
 	return isExternalDomainAllowed(allowedDomains, u.Hostname())
 }
+
+func isEastWestHost(host string, eastWestRangeDomains []string) bool {
+	for _, domainSuffix := range eastWestRangeDomains {
+		if strings.HasSuffix(host, domainSuffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/dataclients/kubernetes/ingress.go
+++ b/dataclients/kubernetes/ingress.go
@@ -46,18 +46,20 @@ type ingressContext struct {
 }
 
 type ingress struct {
-	eastWestRangeDomains         []string
-	eastWestRangePredicates      []*eskip.Predicate
-	allowedExternalNames         []*regexp.Regexp
-	kubernetesEastWestDomain     string
-	pathMode                     PathMode
-	httpsRedirectCode            int
-	kubernetesEnableEastWest     bool
-	provideHTTPSRedirect         bool
-	disableCatchAllRoutes        bool
-	forceKubernetesService       bool
-	backendTrafficAlgorithm      BackendTrafficAlgorithm
-	defaultLoadBalancerAlgorithm string
+	eastWestRangeDomains                        []string
+	eastWestRangePredicates                     []*eskip.Predicate
+	allowedExternalNames                        []*regexp.Regexp
+	kubernetesEastWestDomain                    string
+	pathMode                                    PathMode
+	httpsRedirectCode                           int
+	kubernetesEnableEastWest                    bool
+	provideHTTPSRedirect                        bool
+	disableCatchAllRoutes                       bool
+	forceKubernetesService                      bool
+	backendTrafficAlgorithm                     BackendTrafficAlgorithm
+	defaultLoadBalancerAlgorithm                string
+	kubernetesAnnotationPredicates              []AnnotationPredicates
+	kubernetesEastWestRangeAnnotationPredicates []AnnotationPredicates
 }
 
 var nonWord = regexp.MustCompile(`\W`)
@@ -70,18 +72,20 @@ func (ic *ingressContext) addHostRoute(host string, route *eskip.Route) {
 
 func newIngress(o Options) *ingress {
 	return &ingress{
-		provideHTTPSRedirect:         o.ProvideHTTPSRedirect,
-		httpsRedirectCode:            o.HTTPSRedirectCode,
-		disableCatchAllRoutes:        o.DisableCatchAllRoutes,
-		pathMode:                     o.PathMode,
-		kubernetesEnableEastWest:     o.KubernetesEnableEastWest,
-		kubernetesEastWestDomain:     o.KubernetesEastWestDomain,
-		eastWestRangeDomains:         o.KubernetesEastWestRangeDomains,
-		eastWestRangePredicates:      o.KubernetesEastWestRangePredicates,
-		allowedExternalNames:         o.AllowedExternalNames,
-		forceKubernetesService:       o.ForceKubernetesService,
-		backendTrafficAlgorithm:      o.BackendTrafficAlgorithm,
-		defaultLoadBalancerAlgorithm: o.DefaultLoadBalancerAlgorithm,
+		provideHTTPSRedirect:                        o.ProvideHTTPSRedirect,
+		httpsRedirectCode:                           o.HTTPSRedirectCode,
+		disableCatchAllRoutes:                       o.DisableCatchAllRoutes,
+		pathMode:                                    o.PathMode,
+		kubernetesEnableEastWest:                    o.KubernetesEnableEastWest,
+		kubernetesEastWestDomain:                    o.KubernetesEastWestDomain,
+		eastWestRangeDomains:                        o.KubernetesEastWestRangeDomains,
+		eastWestRangePredicates:                     o.KubernetesEastWestRangePredicates,
+		allowedExternalNames:                        o.AllowedExternalNames,
+		forceKubernetesService:                      o.ForceKubernetesService,
+		backendTrafficAlgorithm:                     o.BackendTrafficAlgorithm,
+		defaultLoadBalancerAlgorithm:                o.DefaultLoadBalancerAlgorithm,
+		kubernetesAnnotationPredicates:              o.KubernetesAnnotationPredicates,
+		kubernetesEastWestRangeAnnotationPredicates: o.KubernetesEastWestRangeAnnotationPredicates,
 	}
 }
 
@@ -178,12 +182,14 @@ func applyAnnotationPredicates(m PathMode, r *eskip.Route, annotation string) er
 	return nil
 }
 
-func addExtraRoutes(ic *ingressContext, ruleHost, path, pathType, eastWestDomain string, enableEastWest bool) {
+func (ing *ingress) addExtraRoutes(ic *ingressContext, ruleHost, path, pathType string) {
 	hosts := []string{createHostRx(ruleHost)}
 	var ns, name string
 	name = ic.ingressV1.Metadata.Name
 	ns = ic.ingressV1.Metadata.Namespace
-
+	eastWestDomain := ing.kubernetesEastWestDomain
+	enableEastWest := ing.kubernetesEnableEastWest
+	ewHost := isEastWestHost(ruleHost, ing.eastWestRangeDomains)
 	// add extra routes from optional annotation
 	for extraIndex, r := range ic.extraRoutes {
 		route := *r
@@ -196,6 +202,11 @@ func addExtraRoutes(ic *ingressContext, ruleHost, path, pathType, eastWestDomain
 			extraIndex)
 		setPathV1(ic.pathMode, &route, pathType, path)
 		if n := countPathPredicates(&route); n <= 1 {
+			if ewHost {
+				addAnnotationPredicates(ing.kubernetesEastWestRangeAnnotationPredicates, ic.ingressV1.Metadata.Annotations, &route)
+			} else {
+				addAnnotationPredicates(ing.kubernetesAnnotationPredicates, ic.ingressV1.Metadata.Annotations, &route)
+			}
 			ic.addHostRoute(ruleHost, &route)
 			ic.redirect.updateHost(ruleHost)
 		} else {

--- a/dataclients/kubernetes/ingress_test.go
+++ b/dataclients/kubernetes/ingress_test.go
@@ -20,5 +20,6 @@ func TestIngressV1Fixtures(t *testing.T) {
 		"testdata/ingressV1/traffic",
 		"testdata/ingressV1/traffic-segment",
 		"testdata/ingressV1/loadbalancer-algorithm",
+		"testdata/ingressV1/annotation-predicates",
 	)
 }

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -208,6 +208,13 @@ type Options struct {
 	// appended to routes identified as to KubernetesEastWestRangeDomains.
 	KubernetesEastWestRangePredicates []*eskip.Predicate
 
+	// KubernetesEastWestRangeAnnotationPredicates same as KubernetesAnnotationPredicates but will append to
+	// routes that has KubernetesEastWestRangeDomains suffix.
+	KubernetesEastWestRangeAnnotationPredicates []AnnotationPredicates
+
+	// KubernetesAnnotationPredicates set a list predicates for each annotation key and value
+	KubernetesAnnotationPredicates []AnnotationPredicates
+
 	// DefaultFiltersDir enables default filters mechanism and sets the location of the default filters.
 	// The provided filters are then applied to all routes.
 	DefaultFiltersDir string

--- a/dataclients/kubernetes/kubernetestest/fixtures.go
+++ b/dataclients/kubernetes/kubernetestest/fixtures.go
@@ -32,27 +32,29 @@ type fixtureSet struct {
 }
 
 type kubeOptionsParser struct {
-	IngressV1                      bool               `yaml:"ingressv1"`
-	EastWest                       bool               `yaml:"eastWest"`
-	EastWestDomain                 string             `yaml:"eastWestDomain"`
-	EastWestRangeDomains           []string           `yaml:"eastWestRangeDomains"`
-	EastWestRangePredicates        []*eskip.Predicate `yaml:"eastWestRangePredicatesAppend"`
-	HTTPSRedirect                  bool               `yaml:"httpsRedirect"`
-	HTTPSRedirectCode              int                `yaml:"httpsRedirectCode"`
-	DisableCatchAllRoutes          bool               `yaml:"disableCatchAllRoutes"`
-	BackendNameTracingTag          bool               `yaml:"backendNameTracingTag"`
-	OnlyAllowedExternalNames       bool               `yaml:"onlyAllowedExternalNames"`
-	AllowedExternalNames           []string           `yaml:"allowedExternalNames"`
-	IngressClass                   string             `yaml:"kubernetes-ingress-class"`
-	KubernetesEnableEndpointSlices bool               `yaml:"enable-kubernetes-endpointslices"`
-	KubernetesEnableTLS            bool               `yaml:"kubernetes-enable-tls"`
-	IngressesLabels                map[string]string  `yaml:"kubernetes-ingresses-label-selector"`
-	ServicesLabels                 map[string]string  `yaml:"kubernetes-services-label-selector"`
-	EndpointsLabels                map[string]string  `yaml:"kubernetes-endpoints-label-selector"`
-	EndpointsliceLabels            map[string]string  `yaml:"kubernetes-endpointslice-label-selector"`
-	ForceKubernetesService         bool               `yaml:"force-kubernetes-service"`
-	BackendTrafficAlgorithm        string             `yaml:"backend-traffic-algorithm"`
-	DefaultLoadBalancerAlgorithm   string             `yaml:"default-lb-algorithm"`
+	IngressV1                                   bool                              `yaml:"ingressv1"`
+	EastWest                                    bool                              `yaml:"eastWest"`
+	EastWestDomain                              string                            `yaml:"eastWestDomain"`
+	EastWestRangeDomains                        []string                          `yaml:"eastWestRangeDomains"`
+	EastWestRangePredicates                     []*eskip.Predicate                `yaml:"eastWestRangePredicatesAppend"`
+	HTTPSRedirect                               bool                              `yaml:"httpsRedirect"`
+	HTTPSRedirectCode                           int                               `yaml:"httpsRedirectCode"`
+	DisableCatchAllRoutes                       bool                              `yaml:"disableCatchAllRoutes"`
+	BackendNameTracingTag                       bool                              `yaml:"backendNameTracingTag"`
+	OnlyAllowedExternalNames                    bool                              `yaml:"onlyAllowedExternalNames"`
+	AllowedExternalNames                        []string                          `yaml:"allowedExternalNames"`
+	IngressClass                                string                            `yaml:"kubernetes-ingress-class"`
+	KubernetesEnableEndpointSlices              bool                              `yaml:"enable-kubernetes-endpointslices"`
+	KubernetesEnableTLS                         bool                              `yaml:"kubernetes-enable-tls"`
+	IngressesLabels                             map[string]string                 `yaml:"kubernetes-ingresses-label-selector"`
+	ServicesLabels                              map[string]string                 `yaml:"kubernetes-services-label-selector"`
+	EndpointsLabels                             map[string]string                 `yaml:"kubernetes-endpoints-label-selector"`
+	EndpointsliceLabels                         map[string]string                 `yaml:"kubernetes-endpointslice-label-selector"`
+	ForceKubernetesService                      bool                              `yaml:"force-kubernetes-service"`
+	BackendTrafficAlgorithm                     string                            `yaml:"backend-traffic-algorithm"`
+	DefaultLoadBalancerAlgorithm                string                            `yaml:"default-lb-algorithm"`
+	KubernetesAnnotationPredicates              []kubernetes.AnnotationPredicates `yaml:"kubernetesAnnotationPredicates"`
+	KubernetesEastWestRangeAnnotationPredicates []kubernetes.AnnotationPredicates `yaml:"kubernetesEastWestRangeAnnotationPredicates"`
 }
 
 func baseNoExt(n string) string {
@@ -229,6 +231,8 @@ func testFixture(t *testing.T, f fixtureSet) {
 		o.KubernetesEastWestDomain = kop.EastWestDomain
 		o.KubernetesEastWestRangeDomains = kop.EastWestRangeDomains
 		o.KubernetesEastWestRangePredicates = kop.EastWestRangePredicates
+		o.KubernetesAnnotationPredicates = kop.KubernetesAnnotationPredicates
+		o.KubernetesEastWestRangeAnnotationPredicates = kop.KubernetesEastWestRangeAnnotationPredicates
 		o.ProvideHTTPSRedirect = kop.HTTPSRedirect
 		o.HTTPSRedirectCode = kop.HTTPSRedirectCode
 		o.DisableCatchAllRoutes = kop.DisableCatchAllRoutes

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -591,6 +591,10 @@ func (r *routeGroups) convert(s *clusterState, df defaultFilters, loggingEnabled
 				}
 			}
 
+			for _, route := range ri {
+				addAnnotationPredicates(r.options.KubernetesAnnotationPredicates, rg.Metadata.Annotations, route)
+			}
+
 			rs = append(rs, ri...)
 		}
 
@@ -629,6 +633,9 @@ func (r *routeGroups) convert(s *clusterState, df defaultFilters, loggingEnabled
 			}
 
 			applyEastWestRangePredicates(internalRi, r.options.KubernetesEastWestRangePredicates)
+			for _, route := range internalRi {
+				addAnnotationPredicates(r.options.KubernetesEastWestRangeAnnotationPredicates, rg.Metadata.Annotations, route)
+			}
 
 			if internalCtx.certificateRegistry != nil {
 				for _, ctxTls := range rg.Spec.TLS {

--- a/dataclients/kubernetes/routegroups_test.go
+++ b/dataclients/kubernetes/routegroups_test.go
@@ -61,3 +61,7 @@ func TestRouteGroupDefaultLoadBalancerAlgorithm(t *testing.T) {
 func TestRouteGroupTLS(t *testing.T) {
 	kubernetestest.FixturesToTest(t, "testdata/routegroups/tls")
 }
+
+func TestAnnotationPredicates(t *testing.T) {
+	kubernetestest.FixturesToTest(t, "testdata/routegroups/annotation-predicates")
+}

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-ew-enabled.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-ew-enabled.eskip
@@ -1,0 +1,43 @@
+kube_default__myapp1__zone1_rule1_test____myapp:
+	Host("^(zone1[.]rule1[.]test[.]?(:[0-9]+)?)$")
+	&& Zone("zone1")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp1_r1_0__zone1_rule1_test____:
+	Host("^(zone1[.]rule1[.]test[.]?(:[0-9]+)?)$")
+	&& Path("/zone1")
+	&& Zone("zone1")
+	&& True()
+    -> "https://zone1.route.test";
+
+kube_default__myapp1__zone1_rule2_ingress_cluster_local____myapp:
+	Host("^(zone1-rule2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp1_r1_0__zone1_rule2_ingress_cluster_local____:
+	Host("^(zone1-rule2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& Path("/zone1")
+    -> "https://zone1.route.test";
+
+kubeew_default__myapp1__zone1_rule1_test____myapp:
+	Host("^(myapp1[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& True()
+	&& Zone("zone1")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kubeew_default__myapp1__zone1_rule2_ingress_cluster_local____myapp:
+	Host("^(myapp1[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kubeew_default__myapp1_r1_0__zone1_rule1_test____:
+	Host("^(myapp1[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& Path("/zone1")
+	&& True()
+	&& Zone("zone1")
+	-> "https://zone1.route.test";
+
+kubeew_default__myapp1_r1_0__zone1_rule2_ingress_cluster_local____:
+	Host("^(myapp1[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& Path("/zone1")
+	-> "https://zone1.route.test";

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-ew-enabled.kube
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-ew-enabled.kube
@@ -1,0 +1,11 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "Zone"
+        args: ["zone1"]
+      - name: "True"
+        args: []
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWest: true

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-ew-enabled.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-ew-enabled.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp1
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone1"
+    zalando.org/skipper-routes: |
+      r1: Path("/zone1") -> "https://zone1.route.test";
+spec:
+  rules:
+  - host: zone1.rule1.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+  - host: zone1-rule2.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP
+    targetPort: web
+  - name: web
+    port: 80
+    protocol: TCP
+    targetPort: foo
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname-predicates.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname-predicates.eskip
@@ -1,0 +1,100 @@
+kube_default__myapp1__app1_alias1_test____myapp:
+	Host("^(app1[.]alias1[.]test[.]?(:[0-9]+)?)$")
+	&& Zone("zone1")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp1_r1_0__app1_alias1_test____:
+	Host("^(app1[.]alias1[.]test[.]?(:[0-9]+)?)$")
+	&& Path("/zone1")
+	&& Zone("zone1")
+	&& True()
+    -> "https://app1.route.test";
+
+kube_default__myapp1__app1_alias2_ingress_cluster_local____myapp:
+	Host("^(app1-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp1_r1_0__app1_alias2_ingress_cluster_local____:
+	Host("^(app1-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& Path("/zone1")
+    -> "https://app1.route.test";
+
+
+kube_default__myapp2__app2_alias1_test____myapp:
+	Host("^(app2[.]alias1[.]test[.]?(:[0-9]+)?)$")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp2__app2_alias2_ingress_cluster_local____myapp:
+	Host("^(app2-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp2_r1_0__app2_alias1_test____:
+	Host("^(app2[.]alias1[.]test[.]?(:[0-9]+)?)$")
+	&& Path("/internal-zone")
+	-> "https://app2.route.test";
+
+kube_default__myapp2_r1_0__app2_alias2_ingress_cluster_local____:
+	Host("^(app2-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& Path("/internal-zone")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> "https://app2.route.test";
+
+kube_default__myapp3__app3_alias1_ingress_cluster_local____myapp:
+	Host("^(app3-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp3__app3_alias2_ingress_cluster_local____myapp:
+	Host("^(app3-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp3_r1_0__app3_alias1_ingress_cluster_local____:
+	Host("^(app3-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& Path("/internal-zone")
+	&& True()
+	-> "https://app3.route.test";
+
+kube_default__myapp3_r1_0__app3_alias2_ingress_cluster_local____:
+	Host("^(app3-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& Path("/internal-zone")
+	&& True()
+	-> "https://app3.route.test";
+
+kube_default__myapp4__app4_alias1_ingress_cluster_local____myapp:
+	Host("^(app4-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp4__app4_alias2_ingress_cluster_local____myapp:
+	Host("^(app4-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp4_r1_0__app4_alias1_ingress_cluster_local____:
+	Host("^(app4-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& Path("/internal-zone")
+	-> "https://app4.route.test";
+
+kube_default__myapp4_r1_0__app4_alias2_ingress_cluster_local____:
+	Host("^(app4-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& Path("/internal-zone")
+	-> "https://app4.route.test";

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname-predicates.kube
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname-predicates.kube
@@ -1,0 +1,21 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "Zone"
+        args: ["zone1"]
+      - name: "True"
+        args: []
+kubernetesEastWestRangeAnnotationPredicates:
+  - key: zalando.org/zone
+    value: internal
+    predicates:
+      - name: "InternalZone"
+        args: ["internal-zone"]
+      - name: "True"
+        args: []
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname-predicates.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname-predicates.yaml
@@ -1,0 +1,155 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp1
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone1"
+    zalando.org/skipper-routes: |
+      r1: Path("/zone1") -> "https://app1.route.test";
+spec:
+  rules:
+  - host: app1.alias1.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+  - host: app1-alias2.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp2
+  namespace: default
+  annotations:
+    zalando.org/zone: "internal"
+    zalando.org/skipper-routes: |
+      r1: Path("/internal-zone") -> "https://app2.route.test";
+spec:
+  rules:
+  - host: app2.alias1.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+  - host: app2-alias2.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp3
+  namespace: default
+  annotations:
+    zalando.org/zone: "internal"
+    zalando.org/skipper-routes: |
+      r1: Path("/internal-zone") -> "https://app3.route.test";
+spec:
+  rules:
+  - host: app3-alias1.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+  - host: app3-alias2.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp4
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone1"
+    zalando.org/skipper-routes: |
+      r1: Path("/internal-zone") -> "https://app4.route.test";
+spec:
+  rules:
+  - host: app4-alias1.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+  - host: app4-alias2.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP
+    targetPort: web
+  - name: web
+    port: 80
+    protocol: TCP
+    targetPort: foo
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname.eskip
@@ -1,0 +1,23 @@
+kube_default__myapp1__zone1_rule1_test____myapp:
+	Host("^(zone1[.]rule1[.]test[.]?(:[0-9]+)?)$")
+	&& Zone("zone1")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp1_r1_0__zone1_rule1_test____:
+	Host("^(zone1[.]rule1[.]test[.]?(:[0-9]+)?)$")
+	&& Path("/zone1")
+	&& Zone("zone1")
+	&& True()
+    -> "https://zone1.route.test";
+
+kube_default__myapp1__zone1_rule2_ingress_cluster_local____myapp:
+	Host("^(zone1-rule2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp1_r1_0__zone1_rule2_ingress_cluster_local____:
+	Host("^(zone1-rule2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& Path("/zone1")
+    -> "https://zone1.route.test";

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname.kube
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname.kube
@@ -1,0 +1,13 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "Zone"
+        args: ["zone1"]
+      - name: "True"
+        args: []
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates-with-internal-hostname.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp1
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone1"
+    zalando.org/skipper-routes: |
+      r1: Path("/zone1") -> "https://zone1.route.test";
+spec:
+  rules:
+  - host: zone1.rule1.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+  - host: zone1-rule2.ingress.cluster.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP
+    targetPort: web
+  - name: web
+    port: 80
+    protocol: TCP
+    targetPort: foo
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates.eskip
@@ -1,0 +1,52 @@
+kube_default__myapp1__zone1_test____myapp:
+	Host("^(zone1[.]test[.]?(:[0-9]+)?)$")
+	&& False()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp2__zone2_test____myapp:
+	Host("^(zone2[.]test[.]?(:[0-9]+)?)$")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp3__zone3_test____myapp:
+	Host("^(zone3[.]test[.]?(:[0-9]+)?)$")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp4__zone4_test____myapp:
+	Host("^(zone4[.]test[.]?(:[0-9]+)?)$")
+	&& Foo("xyz")
+	&& Bar("123")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp5__zone5_test____myapp:
+	Host("^(zone5[.]test[.]?(:[0-9]+)?)$")
+	&& Zone("zone5")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp5_r1_0__zone5_test____: 
+	Host("^(zone5[.]test[.]?(:[0-9]+)?)$") 
+	&& Path("/zone5")
+	&& Zone("zone5")
+    -> "https://zone5.route.test";
+
+kube_default__myapp6__zone6_rule1_test____myapp:
+	Host("^(zone6[.]rule1[.]test[.]?(:[0-9]+)?)$")
+	&& Zone("zone6")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp6_r1_0__zone6_rule1_test____: 
+	Host("^(zone6[.]rule1[.]test[.]?(:[0-9]+)?)$") 
+	&& Path("/zone6")
+	&& Zone("zone6")
+    -> "https://zone6.route.test";
+
+kube_default__myapp6__zone6_rule2_test____myapp:
+	Host("^(zone6[.]rule2[.]test[.]?(:[0-9]+)?)$")
+	&& Zone("zone6")
+	-> <roundRobin, "http://10.2.9.103:8080", "http://10.2.9.104:8080">;
+
+kube_default__myapp6_r1_0__zone6_rule2_test____: 
+	Host("^(zone6[.]rule2[.]test[.]?(:[0-9]+)?)$") 
+	&& Path("/zone6")
+	&& Zone("zone6")
+    -> "https://zone6.route.test";

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates.kube
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates.kube
@@ -1,0 +1,26 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "False"
+        args: [] 
+  - key: zalando.org/zone
+    value: zone3
+    predicates:
+      - name: "True"
+        args: []
+  - key: zalando.org/zone
+    value: zone4
+    predicates:
+      - name: "Bar"
+        args: ["123"]
+  - key: zalando.org/zone
+    value: zone5
+    predicates:
+      - name: "Zone"
+        args: ["zone5"]
+  - key: zalando.org/zone
+    value: zone6
+    predicates:
+      - name: "Zone"
+        args: ["zone6"]

--- a/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/annotation-predicates/annotation-predicates.yaml
@@ -1,0 +1,163 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp1
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone1"
+spec:
+  rules:
+  - host: zone1.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp2
+  namespace: default
+  annotations:
+    zalando.org/zone: "unknown"
+spec:
+  rules:
+  - host: zone2.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp3
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone3"
+spec:
+  rules:
+  - host: zone3.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp4
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone4"
+    zalando.org/skipper-predicate: Foo("xyz")
+spec:
+  rules:
+  - host: zone4.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp5
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone5"
+    zalando.org/skipper-routes: |
+      r1: Path("/zone5") -> "https://zone5.route.test";
+spec:
+  rules:
+  - host: zone5.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp6
+  namespace: default
+  annotations:
+    zalando.org/zone: "zone6"
+    zalando.org/skipper-routes: |
+      r1: Path("/zone6") -> "https://zone6.route.test";
+spec:
+  rules:
+  - host: zone6.rule1.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+  - host: zone6.rule2.test
+    http:
+      paths:
+      - backend:
+          service:
+            name: myapp
+            port:
+              number: 8080
+        pathType: ImplementationSpecific
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP
+    targetPort: web
+  - name: web
+    port: 80
+    protocol: TCP
+    targetPort: foo
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: foo
+    port: 8080
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-ew-enabled.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-ew-enabled.eskip
@@ -1,0 +1,38 @@
+kube_rg__default__myapp1__all__0_0:
+	Host("^(zone1[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& False()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__default__myapp1__all__1_0:
+	Host("^(zone1[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& False()
+	-> <shunt>;
+
+kube_rg____zone1_test__catchall__0_0: Host("^(zone1[.]test[.]?(:[0-9]+)?)$") && False() -> <shunt>;
+
+kube_rg__internal_default__myapp1__all__0_0:
+	Host("^(zone1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__internal_default__myapp1__all__1_0:
+	Host("^(zone1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	-> <shunt>;
+
+kube_rg__internal___zone1_ingress_cluster_local__catchall__0_0: Host("^(zone1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") -> <shunt>;
+
+
+kubeew_rg__default__myapp1__all__0_0:
+	Host("^(myapp1[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& False()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kubeew_rg__default__myapp1__all__1_0:
+	Host("^(myapp1[.]default[.]skipper[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& False()
+	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-ew-enabled.kube
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-ew-enabled.kube
@@ -1,0 +1,9 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "False"
+        args: []
+eastWest: true
+eastWestRangeDomains:
+    - "ingress.cluster.local"

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-ew-enabled.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-ew-enabled.yaml
@@ -1,0 +1,57 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp1
+  annotations:
+    zalando.org/zone: "zone1"
+spec:
+  hosts:
+  - zone1.test
+  - zone1.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: shunt
+    type: shunt
+  defaultBackends:
+  - backendName: shunt
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+  - pathSubtree: /shunt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 7272
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+  namespace: default
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: main
+    port: 7272
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host-predicates.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host-predicates.eskip
@@ -1,0 +1,115 @@
+kube_rg__default__myapp1__all__0_0:
+	Host("^(app1[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& False()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__default__myapp1__all__1_0:
+	Host("^(app1[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& False()
+	-> <shunt>;
+
+kube_rg____app1_test__catchall__0_0: Host("^(app1[.]test[.]?(:[0-9]+)?)$") && False() -> <shunt>;
+
+kube_rg__internal_default__myapp1__all__0_0:
+	Host("^(app1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__internal_default__myapp1__all__1_0:
+	Host("^(app1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& ClientIP("10.2.0.0/16")
+	-> <shunt>;
+
+kube_rg__internal___app1_ingress_cluster_local__catchall__0_0: Host("^(app1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;
+
+
+kube_rg__default__myapp2__all__0_0:
+	Host("^(app2[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__default__myapp2__all__1_0:
+	Host("^(app2[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	-> <shunt>;
+
+kube_rg____app2_test__catchall__0_0: Host("^(app2[.]test[.]?(:[0-9]+)?)$") -> <shunt>;
+
+kube_rg__internal_default__myapp2__all__0_0:
+	Host("^(app2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__internal_default__myapp2__all__1_0:
+	Host("^(app2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <shunt>;
+
+kube_rg__internal___app2_ingress_cluster_local__catchall__0_0:
+	Host("^(app2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <shunt>;
+
+kube_rg__internal_default__myapp3__all__0_0:
+	Host("^(app3-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?|app3-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__internal_default__myapp3__all__1_0:
+	Host("^(app3-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?|app3-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <shunt>;
+
+kube_rg__internal___app3_alias1_ingress_cluster_local__catchall__0_0:
+	Host("^(app3-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <shunt>;
+
+kube_rg__internal___app3_alias2_ingress_cluster_local__catchall__0_0:
+	Host("^(app3-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	&& InternalZone("internal-zone")
+	&& True()
+	-> <shunt>;
+
+kube_rg__internal_default__myapp4__all__0_0:
+	Host("^(app4-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?|app4-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__internal_default__myapp4__all__1_0:
+	Host("^(app4-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?|app4-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& ClientIP("10.2.0.0/16")
+	-> <shunt>;
+
+kube_rg__internal___app4_alias1_ingress_cluster_local__catchall__0_0:
+	Host("^(app4-alias1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	-> <shunt>;
+
+kube_rg__internal___app4_alias2_ingress_cluster_local__catchall__0_0:
+	Host("^(app4-alias2[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& ClientIP("10.2.0.0/16")
+	-> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host-predicates.kube
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host-predicates.kube
@@ -1,0 +1,19 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "False"
+        args: []
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]
+kubernetesEastWestRangeAnnotationPredicates:
+  - key: zalando.org/zone
+    value: internal
+    predicates:
+      - name: "InternalZone"
+        args: ["internal-zone"]
+      - name: "True"
+        args: []

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host-predicates.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host-predicates.yaml
@@ -1,0 +1,132 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp1
+  annotations:
+    zalando.org/zone: "zone1"
+spec:
+  hosts:
+  - app1.test
+  - app1.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: shunt
+    type: shunt
+  defaultBackends:
+  - backendName: shunt
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+  - pathSubtree: /shunt
+---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp2
+  annotations:
+    zalando.org/zone: "internal"
+spec:
+  hosts:
+  - app2.test
+  - app2.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: shunt
+    type: shunt
+  defaultBackends:
+  - backendName: shunt
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+  - pathSubtree: /shunt
+---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp3
+  annotations:
+    zalando.org/zone: "internal"
+spec:
+  hosts:
+  - app3-alias1.ingress.cluster.local
+  - app3-alias2.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: shunt
+    type: shunt
+  defaultBackends:
+  - backendName: shunt
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+  - pathSubtree: /shunt
+---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp4
+  annotations:
+    zalando.org/zone: "zone1"
+spec:
+  hosts:
+  - app4-alias1.ingress.cluster.local
+  - app4-alias2.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: shunt
+    type: shunt
+  defaultBackends:
+  - backendName: shunt
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+  - pathSubtree: /shunt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 7272
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+  namespace: default
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: main
+    port: 7272
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host.eskip
@@ -1,0 +1,27 @@
+kube_rg__default__myapp1__all__0_0:
+	Host("^(zone1[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& False()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__default__myapp1__all__1_0:
+	Host("^(zone1[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& False()
+	-> <shunt>;
+
+kube_rg____zone1_test__catchall__0_0: Host("^(zone1[.]test[.]?(:[0-9]+)?)$") && False() -> <shunt>;
+
+kube_rg__internal_default__myapp1__all__0_0:
+	Host("^(zone1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& ClientIP("10.2.0.0/16")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__internal_default__myapp1__all__1_0:
+	Host("^(zone1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/shunt")
+	&& ClientIP("10.2.0.0/16")
+	-> <shunt>;
+
+kube_rg__internal___zone1_ingress_cluster_local__catchall__0_0: Host("^(zone1[.]ingress[.]cluster[.]local[.]?(:[0-9]+)?)$") && ClientIP("10.2.0.0/16") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host.kube
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host.kube
@@ -1,0 +1,11 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "False"
+        args: []
+eastWestRangeDomains:
+    - "ingress.cluster.local"
+eastWestRangePredicatesAppend:
+    - name: "ClientIP"
+      args: ["10.2.0.0/16"]

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates-with-internal-host.yaml
@@ -1,0 +1,57 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp1
+  annotations:
+    zalando.org/zone: "zone1"
+spec:
+  hosts:
+  - zone1.test
+  - zone1.ingress.cluster.local
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: shunt
+    type: shunt
+  defaultBackends:
+  - backendName: shunt
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+  - pathSubtree: /shunt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 7272
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+  namespace: default
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: main
+    port: 7272
+    protocol: TCP

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates.eskip
@@ -1,0 +1,36 @@
+kube_rg__default__myapp1__all__0_0:
+	Host("^(zone1[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& False()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg____zone1_test__catchall__0_0: Host("^(zone1[.]test[.]?(:[0-9]+)?)$") && False() -> <shunt>;
+
+kube_rg__default__myapp2__all__0_0:
+	Host("^(zone2[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg____zone2_test__catchall__0_0: Host("^(zone2[.]test[.]?(:[0-9]+)?)$") -> <shunt>;
+
+kube_rg__default__myapp3__all__0_0:
+	Host("^(zone3[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& True()
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg____zone3_test__catchall__0_0: Host("^(zone3[.]test[.]?(:[0-9]+)?)$") && True() -> <shunt>;
+
+kube_rg__default__myapp4__all__0_0:
+	Host("^(zone4[.]test[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	&& Traffic("10")
+	-> <roundRobin, "http://10.2.9.103:7272", "http://10.2.9.104:7272">;
+
+kube_rg__default__myapp4__all__1_0:
+	Host("^(zone4[.]test[.]?(:[0-9]+)?)$") 
+	&& PathSubtree("/shunt") 
+	&& Traffic("10")
+	-> <shunt>;
+
+kube_rg____zone4_test__catchall__0_0: Host("^(zone4[.]test[.]?(:[0-9]+)?)$") && Traffic("10") -> <shunt>;

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates.kube
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates.kube
@@ -1,0 +1,16 @@
+kubernetesAnnotationPredicates:
+  - key: zalando.org/zone
+    value: zone1
+    predicates:
+      - name: "False"
+        args: [] 
+  - key: zalando.org/zone
+    value: zone3
+    predicates:
+      - name: "True"
+        args: []
+  - key: zalando.org/zone
+    value: zone4
+    predicates:
+      - name: "Traffic"
+        args: ["10"]

--- a/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/annotation-predicates/annotation-predicates.yaml
@@ -1,0 +1,113 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp1
+  annotations:
+    zalando.org/zone: "zone1"
+spec:
+  hosts:
+  - zone1.test
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp2
+  annotations:
+    zalando.org/zone: "unknown"
+spec:
+  hosts:
+  - zone2.test
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp3
+  annotations:
+    zalando.org/zone: "zone3"
+spec:
+  hosts:
+  - zone3.test
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp4
+  annotations:
+    zalando.org/zone: "zone4"
+spec:
+  hosts:
+  - zone4.test
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  - name: shunt
+    type: shunt
+  defaultBackends:
+  - backendName: shunt
+  routes:
+  - pathSubtree: /
+    backends:
+    - backendName: myapp
+  - pathSubtree: /shunt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+spec:
+  clusterIP: 10.3.190.97
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 7272
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    application: myapp
+  name: myapp
+  namespace: default
+subsets:
+- addresses:
+  - ip: 10.2.9.103
+  - ip: 10.2.9.104
+  ports:
+  - name: main
+    port: 7272
+    protocol: TCP

--- a/skipper.go
+++ b/skipper.go
@@ -268,6 +268,13 @@ type Options struct {
 	// appended to routes identified as to KubernetesEastWestRangeDomains.
 	KubernetesEastWestRangePredicates []*eskip.Predicate
 
+	// KubernetesEastWestRangeAnnotationPredicates same as KubernetesAnnotationPredicates but will append to
+	// routes that has KubernetesEastWestRangeDomains suffix.
+	KubernetesEastWestRangeAnnotationPredicates []kubernetes.AnnotationPredicates
+
+	// KubernetesAnnotationPredicates set a list predicates for each annotation key and value
+	KubernetesAnnotationPredicates []kubernetes.AnnotationPredicates
+
 	// KubernetesOnlyAllowedExternalNames will enable validation of ingress external names and route groups network
 	// backend addresses, explicit LB endpoints validation against the list of patterns in
 	// AllowedExternalNames.
@@ -951,37 +958,39 @@ type Options struct {
 
 func (o *Options) KubernetesDataClientOptions() kubernetes.Options {
 	return kubernetes.Options{
-		AllowedExternalNames:              o.KubernetesAllowedExternalNames,
-		BackendNameTracingTag:             o.OpenTracingBackendNameTag,
-		DefaultFiltersDir:                 o.DefaultFiltersDir,
-		KubernetesInCluster:               o.KubernetesInCluster,
-		KubernetesURL:                     o.KubernetesURL,
-		TokenFile:                         o.KubernetesTokenFile,
-		KubernetesNamespace:               o.KubernetesNamespace,
-		KubernetesEnableEastWest:          o.KubernetesEnableEastWest,
-		KubernetesEnableEndpointslices:    o.KubernetesEnableEndpointslices,
-		KubernetesEastWestDomain:          o.KubernetesEastWestDomain,
-		KubernetesEastWestRangeDomains:    o.KubernetesEastWestRangeDomains,
-		KubernetesEastWestRangePredicates: o.KubernetesEastWestRangePredicates,
-		HTTPSRedirectCode:                 o.KubernetesHTTPSRedirectCode,
-		DisableCatchAllRoutes:             o.KubernetesDisableCatchAllRoutes,
-		IngressClass:                      o.KubernetesIngressClass,
-		IngressLabelSelectors:             o.KubernetesIngressLabelSelectors,
-		ServicesLabelSelectors:            o.KubernetesServicesLabelSelectors,
-		EndpointsLabelSelectors:           o.KubernetesEndpointsLabelSelectors,
-		SecretsLabelSelectors:             o.KubernetesSecretsLabelSelectors,
-		RouteGroupsLabelSelectors:         o.KubernetesRouteGroupsLabelSelectors,
-		OnlyAllowedExternalNames:          o.KubernetesOnlyAllowedExternalNames,
-		OriginMarker:                      o.EnableRouteCreationMetrics,
-		PathMode:                          o.KubernetesPathMode,
-		ProvideHealthcheck:                o.KubernetesHealthcheck,
-		ProvideHTTPSRedirect:              o.KubernetesHTTPSRedirect,
-		ReverseSourcePredicate:            o.ReverseSourcePredicate,
-		RouteGroupClass:                   o.KubernetesRouteGroupClass,
-		WhitelistedHealthCheckCIDR:        o.WhitelistedHealthCheckCIDR,
-		ForceKubernetesService:            o.KubernetesForceService,
-		BackendTrafficAlgorithm:           o.KubernetesBackendTrafficAlgorithm,
-		DefaultLoadBalancerAlgorithm:      o.KubernetesDefaultLoadBalancerAlgorithm,
+		AllowedExternalNames:                        o.KubernetesAllowedExternalNames,
+		BackendNameTracingTag:                       o.OpenTracingBackendNameTag,
+		DefaultFiltersDir:                           o.DefaultFiltersDir,
+		KubernetesInCluster:                         o.KubernetesInCluster,
+		KubernetesURL:                               o.KubernetesURL,
+		TokenFile:                                   o.KubernetesTokenFile,
+		KubernetesNamespace:                         o.KubernetesNamespace,
+		KubernetesEnableEastWest:                    o.KubernetesEnableEastWest,
+		KubernetesEnableEndpointslices:              o.KubernetesEnableEndpointslices,
+		KubernetesEastWestDomain:                    o.KubernetesEastWestDomain,
+		KubernetesEastWestRangeDomains:              o.KubernetesEastWestRangeDomains,
+		KubernetesEastWestRangePredicates:           o.KubernetesEastWestRangePredicates,
+		KubernetesEastWestRangeAnnotationPredicates: o.KubernetesEastWestRangeAnnotationPredicates,
+		KubernetesAnnotationPredicates:              o.KubernetesAnnotationPredicates,
+		HTTPSRedirectCode:                           o.KubernetesHTTPSRedirectCode,
+		DisableCatchAllRoutes:                       o.KubernetesDisableCatchAllRoutes,
+		IngressClass:                                o.KubernetesIngressClass,
+		IngressLabelSelectors:                       o.KubernetesIngressLabelSelectors,
+		ServicesLabelSelectors:                      o.KubernetesServicesLabelSelectors,
+		EndpointsLabelSelectors:                     o.KubernetesEndpointsLabelSelectors,
+		SecretsLabelSelectors:                       o.KubernetesSecretsLabelSelectors,
+		RouteGroupsLabelSelectors:                   o.KubernetesRouteGroupsLabelSelectors,
+		OnlyAllowedExternalNames:                    o.KubernetesOnlyAllowedExternalNames,
+		OriginMarker:                                o.EnableRouteCreationMetrics,
+		PathMode:                                    o.KubernetesPathMode,
+		ProvideHealthcheck:                          o.KubernetesHealthcheck,
+		ProvideHTTPSRedirect:                        o.KubernetesHTTPSRedirect,
+		ReverseSourcePredicate:                      o.ReverseSourcePredicate,
+		RouteGroupClass:                             o.KubernetesRouteGroupClass,
+		WhitelistedHealthCheckCIDR:                  o.WhitelistedHealthCheckCIDR,
+		ForceKubernetesService:                      o.KubernetesForceService,
+		BackendTrafficAlgorithm:                     o.KubernetesBackendTrafficAlgorithm,
+		DefaultLoadBalancerAlgorithm:                o.KubernetesDefaultLoadBalancerAlgorithm,
 	}
 }
 


### PR DESCRIPTION
The main purpose of this change is to allow skipper operators to dynamically add predicates to routes based on annotations key-value pairs in Kubernetes resources (metadata.annotation). This provides more flexibility in routing configuration without modifying the core Ingress or RouteGroup definitions.

Key changes:
- Added KubernetesAnnotationPredicates option & `-kubernetes-annotation-predicates` flag for public hostnames, which can be specified multiple times.
- Added KubernetesEastWestRangeAnnotationPredicates option & `-kubernetes-east-west-range-annotation-predicates` flag for internal hostnames, which can be specified multiple times.
- Modified Ingress and RouteGroup clients to apply annotation predicates depending on the host
- Added test cases for new functionality

Run & test with

```sh

➜ ./bin/skipper -kubernetes -kubernetes-annotation-predicates="zalando.org/traffic-disabled=true=False()" -kubernetes-east-west-range-annotation-predicates="zalando.org/traffic-disabled=true=False()"
➜ #or
➜ ./bin/routesrv -kubernetes -kubernetes-annotation-predicates="zalando.org/traffic-disabled=true=False()" -kubernetes-east-west-range-annotation-predicates="zalando.org/traffic-disabled=true=False()"
```

Having both flags with same value will append configured predicates to all routes of Ingress/RouteGroup resources annotated with `zalando.org/traffic-disabled: true`, routes defined in:

* The `spec.rules` section of Ingress resources.
* Routes specified using the `zalando.org/skipper-routes` annotation of Ingress resources.
* The `spec.routes` section of RouteGroup resources.