### PR TITLE
predicates/traffic: deflake TestTrafficSegmentSplit

### DIFF
--- a/predicates/traffic/export_test.go
+++ b/predicates/traffic/export_test.go
@@ -1,3 +1,14 @@
 package traffic
 
+import "github.com/zalando/skipper/routing"
+
 var ExportRandomValue = randomValue
+
+func WithRandFloat64(ps routing.PredicateSpec, randFloat64 func() float64) routing.PredicateSpec {
+	if s, ok := ps.(*segmentSpec); ok {
+		s.randFloat64 = randFloat64
+	} else {
+		panic("invalid predicate spec, expected *segmentSpec")
+	}
+	return ps
+}

--- a/predicates/traffic/rand_test.go
+++ b/predicates/traffic/rand_test.go
@@ -1,0 +1,22 @@
+package traffic_test
+
+import (
+	"math/rand/v2"
+	"sync"
+)
+
+// newTestRandFloat64 returns a function that generates fixed sequence of random float64 values for testing.
+func newTestRandFloat64() func() float64 {
+	return rand.New(&lockedSource{s: rand.NewPCG(0x5EED_1, 0x5EED_2)}).Float64
+}
+
+type lockedSource struct {
+	mu sync.Mutex
+	s  rand.Source
+}
+
+func (s *lockedSource) Uint64() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.s.Uint64()
+}

--- a/predicates/traffic/segment_test.go
+++ b/predicates/traffic/segment_test.go
@@ -148,7 +148,9 @@ func TestTrafficSegmentSplit(t *testing.T) {
 		RoutingOptions: routing.Options{
 			FilterRegistry: builtin.MakeRegistry(),
 			Predicates: []routing.PredicateSpec{
-				traffic.NewSegment(),
+				// Use fixed random sequence to deflake the test,
+				// see https://github.com/zalando/skipper/issues/2665
+				traffic.WithRandFloat64(traffic.NewSegment(), newTestRandFloat64()),
 			},
 		},
 		Routes: eskip.MustParse(`


### PR DESCRIPTION
Use fixed random sequence to deflake TestTrafficSegmentSplit.

Fixes #2665