### PR TITLE
dependabot: ingore OPA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       all-go-mod-patch-and-minor:
         patterns: ["*"]
         update-types: ["patch", "minor"]
+    ignore:
+      - dependency-name: "github.com/open-policy-agent/opa"
+      - dependency-name: "github.com/open-policy-agent/opa-envoy-plugin"
   - package-ecosystem: "github-actions"
     directory: "/" # For GitHub Actions, set the directory to / to check for workflow files in .github/workflows
     schedule:


### PR DESCRIPTION
We decided to ignore automatically updating OPA dependencies. It was already done in https://github.com/zalando/skipper/pull/3332#issuecomment-2522944619 & https://github.com/zalando/skipper/pull/3320#issuecomment-2522931582

This PR is to add visibility and we will run `@dependabot unignore ...` after merging.

See [`ignore` docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore)