### PR TITLE
dataclients/kubernetes: add inlineContent to healthcheck routes

### DIFF
--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -109,8 +109,9 @@ type Options struct {
 	// healthcheck endpoint can be accessed from internal IPs on any hostname, with the path
 	// /kube-system/healthz.
 	//
-	// When used in a custom configuration, the current filter registry needs to include the status()
-	// filter, and the available predicates need to include the Source() predicate.
+	// When used in a custom configuration, the current filter registry needs to include
+	// the status(), inlineContent() and disableAccessLog() filters, and the available predicates need to include
+	// the Shutdown(), Source() and SourceFromLast() predicates.
 	ProvideHealthcheck bool
 
 	// ProvideHTTPSRedirect, when set, tells the data client to append an HTTPS redirect route to the
@@ -466,8 +467,8 @@ func shuntRoute(r *eskip.Route) {
 
 func healthcheckRoutes(reverseSourcePredicate bool) []*eskip.Route {
 	template := template.Must(template.New("healthcheck").Parse(`
-		kube__healthz_up:   Path("/kube-system/healthz") && {{.Source}}({{.SourceCIDRs}}) -> {{.DisableAccessLog}} status(200) -> <shunt>;
-		kube__healthz_down: Path("/kube-system/healthz") && {{.Source}}({{.SourceCIDRs}}) && Shutdown() -> status(503) -> <shunt>;
+		kube__healthz_up:   Path("/kube-system/healthz") && {{.Source}}({{.SourceCIDRs}}) -> {{.DisableAccessLog}} inlineContent("OK\n") -> <shunt>;
+		kube__healthz_down: Path("/kube-system/healthz") && {{.Source}}({{.SourceCIDRs}}) && Shutdown() -> status(503) -> inlineContent("Shutting down\n") -> <shunt>;
 	`))
 
 	params := struct {

--- a/dataclients/kubernetes/kube_test.go
+++ b/dataclients/kubernetes/kube_test.go
@@ -1493,32 +1493,32 @@ func TestHealthcheckRoutes(t *testing.T) {
 			logLevel:               log.InfoLevel,
 			reverseSourcePredicate: false,
 			expected: `
-				kube__healthz_up:   Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> disableAccessLog(200) -> status(200) -> <shunt>;
-				kube__healthz_down: Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> <shunt>;
+				kube__healthz_up:   Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> disableAccessLog(200) -> inlineContent("OK\n") -> <shunt>;
+				kube__healthz_down: Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> inlineContent("Shutting down\n") -> <shunt>;
 			`,
 		},
 		{
 			logLevel:               log.InfoLevel,
 			reverseSourcePredicate: true,
 			expected: `
-				kube__healthz_up:   Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> disableAccessLog(200) -> status(200) -> <shunt>;
-				kube__healthz_down: Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> <shunt>;
+				kube__healthz_up:   Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> disableAccessLog(200) -> inlineContent("OK\n") -> <shunt>;
+				kube__healthz_down: Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> inlineContent("Shutting down\n") -> <shunt>;
 			`,
 		},
 		{
 			logLevel:               log.DebugLevel,
 			reverseSourcePredicate: false,
 			expected: `
-				kube__healthz_up:   Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> status(200) -> <shunt>;
-				kube__healthz_down: Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> <shunt>;
+				kube__healthz_up:   Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> inlineContent("OK\n") -> <shunt>;
+				kube__healthz_down: Path("/kube-system/healthz") && Source("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> inlineContent("Shutting down\n") -> <shunt>;
 			`,
 		},
 		{
 			logLevel:               log.DebugLevel,
 			reverseSourcePredicate: true,
 			expected: `
-				kube__healthz_up:   Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> status(200) -> <shunt>;
-				kube__healthz_down: Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> <shunt>;
+				kube__healthz_up:   Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") -> inlineContent("OK\n") -> <shunt>;
+				kube__healthz_down: Path("/kube-system/healthz") && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128") && Shutdown() -> status(503) -> inlineContent("Shutting down\n") -> <shunt>;
 			`,
 		},
 	} {


### PR DESCRIPTION
Add shunting `inlineContent` filter to healthcheck routes so that filters added via `-default-filters-append` do not modify healthcheck response.

Note that users may disable healthcheck routes via `-kubernetes-healthcheck=false` and define custom healthcheck routes if needed.