### PR TITLE
tracing/tracingtest: deprecate Tracer and Span types

### DIFF
--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -464,14 +464,14 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 						allow_runtime_environment {
 							opa.runtime().config.labels.environment == "test"
 						}
-						
+
 						default allow_object := {
 							"allowed": false,
 							"headers": {"x-ext-auth-allow": "no"},
 							"body": "Unauthorized Request",
 							"http_status": 401
 						}
-						  
+
 						allow_object := response {
 							input.parsed_path == [ "allow", "structured" ]
 							response := {
@@ -506,13 +506,13 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 
 						allow_body {
 							input.parsed_body.target_id == "123456"
-						}	
-						
+						}
+
 						decision_id := input.attributes.metadataContext.filterMetadata.open_policy_agent.decision_id
 
 						allow_object_decision_id_in_header := response {
 						    input.parsed_path = ["allow", "structured"]
-						    decision_id 
+						    decision_id
 						    response := {
 						        "allowed": true,
 						        "response_headers_to_add": {
@@ -541,9 +541,9 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 					"environment": "test"
 				},
 				"plugins": {
-					"envoy_ext_authz_grpc": {    
+					"envoy_ext_authz_grpc": {
 						"path": %q,
-						"dry-run": false    
+						"dry-run": false
 					}
 				}
 			}`, opaControlPlane.URL(), ti.regoQuery))
@@ -561,7 +561,7 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 				openpolicyagent.WithConfigTemplate(config),
 				openpolicyagent.WithEnvoyMetadataBytes(envoyMetaDataConfig))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(&tracingtest.Tracer{}))
+			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()))
 			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory, opts...)
 			fr.Register(ftSpec)
 			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, opts...)
@@ -769,11 +769,11 @@ func BenchmarkAuthorizeRequest(b *testing.B) {
 							"cert": public_key_cert,
 							"aud": "nqz3xhorr5"
 						})
-					
+
 						valid
-						
+
 						payload.sub == "5974934733"
-					}				
+					}
 				`, publicKey),
 			}),
 		)
@@ -863,9 +863,9 @@ func generateConfig(opaControlPlane *opasdktest.Server, path string) []byte {
 			"environment": "test"
 		},
 		"plugins": {
-			"envoy_ext_authz_grpc": {    
+			"envoy_ext_authz_grpc": {
 				"path": %q,
-				"dry-run": false    
+				"dry-run": false
 			}
 		}
 	}`, opaControlPlane.URL(), path))

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -176,15 +176,15 @@ func TestServerResponseFilter(t *testing.T) {
 
 						allow {
 							input.parsed_path == [ "allow" ]
-						}	
-						
+						}
+
 						default allow_object := {
 							"allowed": false,
 							"headers": {"x-ext-auth-allow": "no"},
 							"body": "Unauthorized Request",
 							"http_status": 403
 						}
-						  
+
 						allow_object := response {
 							input.parsed_path == [ "allow", "structured" ]
 							response := {
@@ -216,7 +216,7 @@ func TestServerResponseFilter(t *testing.T) {
 								"http_status": 200
 							}
 						}
-						
+
 						allow_object := response {
 							input.parsed_path == [ "allow", "production" ]
 							opa.runtime().config.labels.environment == "production"
@@ -289,7 +289,7 @@ func TestServerResponseFilter(t *testing.T) {
 					}
 				},
 				"plugins": {
-					"envoy_ext_authz_grpc": {    
+					"envoy_ext_authz_grpc": {
 						"path": %q,
 						"dry-run": false,
 						"skip-request-body-parse": false
@@ -300,7 +300,7 @@ func TestServerResponseFilter(t *testing.T) {
 				}
 			}`, opaControlPlane.URL(), ti.regoQuery))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(&tracingtest.Tracer{}))
+			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()))
 			ftSpec := NewOpaServeResponseSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
 			fr.Register(ftSpec)
 			ftSpec = NewOpaServeResponseWithReqBodySpec(opaFactory, openpolicyagent.WithConfigTemplate(config))

--- a/filters/tracing/baggagetotag_test.go
+++ b/filters/tracing/baggagetotag_test.go
@@ -25,7 +25,8 @@ func TestBaggageItemNameToTag(t *testing.T) {
 		t.Run(ti.msg, func(t *testing.T) {
 			req := &http.Request{Header: http.Header{}}
 
-			span := tracingtest.NewSpan("start_span")
+			tracer := tracingtest.NewTracer()
+			span := tracer.StartSpan("start_span").(*tracingtest.MockSpan)
 			span.SetBaggageItem(ti.baggageItemName, ti.baggageItemValue)
 			req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
 			ctx := &filtertest.Context{FRequest: req}
@@ -38,7 +39,9 @@ func TestBaggageItemNameToTag(t *testing.T) {
 
 			f.Request(ctx)
 
-			if tagValue := span.Tags[ti.tagName]; ti.baggageItemValue != tagValue {
+			span.Finish()
+
+			if tagValue := span.Tag(ti.tagName); ti.baggageItemValue != tagValue {
 				t.Error("couldn't set span tag from baggage item")
 			}
 		})
@@ -99,7 +102,8 @@ func TestFallbackToBaggageNameForTag(t *testing.T) {
 		t.Run(ti.msg, func(t *testing.T) {
 			req := &http.Request{Header: http.Header{}}
 
-			span := tracingtest.NewSpan("start_span")
+			tracer := tracingtest.NewTracer()
+			span := tracer.StartSpan("start_span").(*tracingtest.MockSpan)
 			span.SetBaggageItem(ti.baggageItemName, ti.baggageItemValue)
 			req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
 			ctx := &filtertest.Context{FRequest: req}
@@ -112,7 +116,9 @@ func TestFallbackToBaggageNameForTag(t *testing.T) {
 
 			f.Request(ctx)
 
-			if tagValue := span.Tags[ti.baggageItemName]; ti.baggageItemValue != tagValue {
+			span.Finish()
+
+			if tagValue := span.Tag(ti.baggageItemName); ti.baggageItemValue != tagValue {
 				t.Error("couldn't set span tag from baggage item")
 			}
 		})

--- a/filters/tracing/tag_test.go
+++ b/filters/tracing/tag_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/filtertest"
@@ -306,7 +305,7 @@ func TestTracingTag(t *testing.T) {
 	},
 	} {
 		t.Run(ti.name, func(t *testing.T) {
-			span := tracer.StartSpan("proxy").(*mocktracer.MockSpan)
+			span := tracer.StartSpan("proxy").(*tracingtest.MockSpan)
 			defer span.Finish()
 
 			requestContext := &filtertest.Context{

--- a/redis_test.go
+++ b/redis_test.go
@@ -126,7 +126,7 @@ spec:
 	rt := routing.New(ro)
 	defer rt.Close()
 	<-rt.FirstLoad()
-	tracer := &tracingtest.Tracer{}
+	tracer := tracingtest.NewTracer()
 	pr := proxy.WithParams(proxy.Params{
 		Routing:     rt,
 		OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
@@ -301,7 +301,7 @@ spec:
 	rt := routing.New(ro)
 	defer rt.Close()
 	<-rt.FirstLoad()
-	tracer := &tracingtest.Tracer{}
+	tracer := tracingtest.NewTracer()
 	pr := proxy.WithParams(proxy.Params{
 		Routing:     rt,
 		OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -132,7 +132,7 @@ func TestOptionsFilterRegistry(t *testing.T) {
 }
 
 func TestOptionsOpenTracingTracerInstanceOverridesOpenTracing(t *testing.T) {
-	tracer := &tracingtest.Tracer{}
+	tracer := tracingtest.NewTracer()
 	o := Options{
 		OpenTracingTracer: tracer,
 		OpenTracing:       []string{"noop"},
@@ -574,7 +574,7 @@ func TestDataClients(t *testing.T) {
 	rt := routing.New(ro)
 	defer rt.Close()
 	<-rt.FirstLoad()
-	tracer := &tracingtest.Tracer{}
+	tracer := tracingtest.NewTracer()
 	pr := proxy.WithParams(proxy.Params{
 		Routing:     rt,
 		OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},

--- a/tracing/tracingtest/mocktracer.go
+++ b/tracing/tracingtest/mocktracer.go
@@ -1,6 +1,7 @@
 package tracingtest
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -11,6 +12,11 @@ import (
 type MockTracer struct {
 	mockTracer *mocktracer.MockTracer
 	spans      atomic.Int32
+}
+
+type MockSpan struct {
+	*mocktracer.MockSpan
+	t *MockTracer
 }
 
 func NewTracer() *MockTracer {
@@ -24,24 +30,37 @@ func (t *MockTracer) Reset() {
 
 func (t *MockTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
 	t.spans.Add(1)
-	return t.mockTracer.StartSpan(operationName, opts...)
+	return &MockSpan{MockSpan: t.mockTracer.StartSpan(operationName, opts...).(*mocktracer.MockSpan), t: t}
 }
 
-func (t *MockTracer) FinishedSpans() []*mocktracer.MockSpan {
+func (t *MockTracer) FinishedSpans() []*MockSpan {
 	timeout := time.After(1 * time.Second)
 	retry := time.NewTicker(100 * time.Millisecond)
 	defer retry.Stop()
 	for {
 		finished := t.mockTracer.FinishedSpans()
 		if len(finished) == int(t.spans.Load()) {
-			return finished
+			result := make([]*MockSpan, len(finished))
+			for i, s := range finished {
+				result[i] = &MockSpan{MockSpan: s, t: t}
+			}
+			return result
 		}
 		select {
 		case <-retry.C:
 		case <-timeout:
-			return nil
+			panic(fmt.Sprintf("Timeout waiting for %d finished spans, got: %d", t.spans.Load(), len(finished)))
 		}
 	}
+}
+
+func (t *MockTracer) FindSpan(operationName string) *MockSpan {
+	for _, s := range t.FinishedSpans() {
+		if s.OperationName == operationName {
+			return s
+		}
+	}
+	return nil
 }
 
 func (t *MockTracer) Inject(sm opentracing.SpanContext, format any, carrier any) error {
@@ -50,4 +69,8 @@ func (t *MockTracer) Inject(sm opentracing.SpanContext, format any, carrier any)
 
 func (t *MockTracer) Extract(format any, carrier any) (opentracing.SpanContext, error) {
 	return t.mockTracer.Extract(format, carrier)
+}
+
+func (s *MockSpan) Tracer() opentracing.Tracer {
+	return s.t
 }

--- a/tracing/tracingtest/mocktracer_test.go
+++ b/tracing/tracingtest/mocktracer_test.go
@@ -1,0 +1,17 @@
+package tracingtest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zalando/skipper/tracing/tracingtest"
+)
+
+func TestMockTracerSpanTracer(t *testing.T) {
+	tracer := tracingtest.NewTracer()
+
+	span := tracer.StartSpan("test")
+	span.Finish()
+
+	assert.Same(t, tracer, span.Tracer())
+}

--- a/tracing/tracingtest/testtracer.go
+++ b/tracing/tracingtest/testtracer.go
@@ -13,6 +13,8 @@ import (
 
 // Tracer is an implementation of opentracing.Tracer for testing. It records
 // the defined spans during a series of operations.
+//
+// Deprecated: use [NewTracer] instead.
 type Tracer struct {
 
 	// TraceContent represents the tracing content passed along the wire.
@@ -44,6 +46,7 @@ type Span struct {
 	tracer        *Tracer
 }
 
+// Deprecated: use [NewTracer] and [MockTracer.StartSpan] instead.
 func NewSpan(operation string) *Span {
 	return &Span{
 		operationName: operation,


### PR DESCRIPTION
Follow up on https://github.com/zalando/skipper/pull/684 (https://github.com/zalando/skipper/pull/684#issuecomment-399030290) and
deprecate hand-rolled test tracer implementation in favour of
MockTracer added by https://github.com/zalando/skipper/pull/3322 that wraps github.com/opentracing/opentracing-go/mocktracer and waits for finished spans.

Fix MockTracer:
* return MockSpan that has proper Tracer() implementation
* return MockSpan wrappers from FinishedSpans
* panic on timeout waiting for finished spans

Closes https://github.com/zalando/skipper/issues/2084
Updates https://github.com/zalando/skipper/issues/2104