### PR TITLE
all: remove unused fields

### DIFF
--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -30,7 +30,6 @@ type Client struct {
 	once   sync.Once
 	client http.Client
 	tr     *Transport
-	log    logging.Logger
 	sr     secrets.SecretsReader
 }
 
@@ -67,9 +66,8 @@ func NewClient(o Options) *Client {
 			Transport:     tr,
 			CheckRedirect: o.CheckRedirect,
 		},
-		tr:  tr,
-		log: o.Log,
-		sr:  sr,
+		tr: tr,
+		sr: sr,
 	}
 
 	return c

--- a/net/redisclient.go
+++ b/net/redisclient.go
@@ -137,15 +137,13 @@ func (j *jumpHash) Get(k string) string {
 // Multi-probe consistent hashing - mpchash
 // https://arxiv.org/pdf/1505.00062.pdf
 type multiprobe struct {
-	hash   *mpchash.Multi
-	shards []string
+	hash *mpchash.Multi
 }
 
 func NewMultiprobe(shards []string) redis.ConsistentHash {
 	return &multiprobe{
 		// 2 seeds and k=21 got from library
-		hash:   mpchash.New(shards, siphash64seed, [2]uint64{1, 2}, 21),
-		shards: shards,
+		hash: mpchash.New(shards, siphash64seed, [2]uint64{1, 2}, 21),
 	}
 }
 

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -22,8 +22,6 @@ const (
 type Registry struct {
 	sync.Mutex
 	once      sync.Once
-	closed    bool
-	defaults  Settings
 	global    Settings
 	lookup    map[Settings]*Ratelimit
 	swarm     Swarmer
@@ -52,7 +50,6 @@ func NewSwarmRegistry(swarm Swarmer, ro *net.RedisOptions, settings ...Settings)
 
 	r := &Registry{
 		once:      sync.Once{},
-		defaults:  defaults,
 		global:    defaults,
 		lookup:    make(map[Settings]*Ratelimit),
 		swarm:     swarm,
@@ -72,7 +69,6 @@ func NewSwarmRegistry(swarm Swarmer, ro *net.RedisOptions, settings ...Settings)
 // Close teardown Registry and dependent resources
 func (r *Registry) Close() {
 	r.once.Do(func() {
-		r.closed = true
 		r.redisRing.Close()
 		for _, rl := range r.lookup {
 			rl.Close()

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -23,7 +23,6 @@ import (
 // RouteServer is used to serve eskip-formatted routes,
 // that originate from the polled data source.
 type RouteServer struct {
-	metrics       metrics.Metrics
 	server        *http.Server
 	supportServer *http.Server
 	poller        *poller
@@ -53,9 +52,7 @@ func New(opts skipper.Options) (*RouteServer, error) {
 	m := metrics.NewMetrics(mopt)
 	metricsHandler := metrics.NewHandler(mopt, m)
 
-	rs := &RouteServer{
-		metrics: m,
-	}
+	rs := &RouteServer{}
 
 	opentracingOpts := opts.OpenTracing
 	if len(opentracingOpts) == 0 {

--- a/secrets/secrettest/secrettest.go
+++ b/secrets/secrettest/secrettest.go
@@ -42,11 +42,9 @@ func (tr *TestRegistry) GetEncrypter(refreshInterval time.Duration, s string) (s
 }
 
 type TestingSecretSource struct {
-	getCount  int
 	secretKey string
 }
 
 func (s *TestingSecretSource) GetSecret() ([][]byte, error) {
-	s.getCount++
 	return [][]byte{[]byte(s.secretKey)}, nil
 }


### PR DESCRIPTION
Remove (some) unused fields detected via:
```
$ go install honnef.co/go/tools/internal/cmd/unused@latest
$ unused -field-writes-are-uses=false ./... 2>/dev/null
```