### PR TITLE
jwt: reduce heap allocations in jwt.Parse

### DIFF
--- a/jwt/token.go
+++ b/jwt/token.go
@@ -16,7 +16,7 @@ type Token struct {
 }
 
 func Parse(value string) (*Token, error) {
-	parts := strings.Split(value, ".")
+	parts := strings.SplitN(value, ".", 4)
 	if len(parts) != 3 {
 		return nil, errInvalidToken
 	}


### PR DESCRIPTION
Function `jwt.Parse` currently splits (via a call to [strings.Split](https://pkg.go.dev/strings#Split)) its argument (which is untrusted data) on periods.

As a result, in the face of a malicious request whose _Authorization_ header consists of `Bearer ` followed by many period characters, a call to that function incurs allocations to the tune of O(n) bytes (where n stands for the length of the function's argument), with a constant factor of about 16. Relevant weakness: [CWE-405: Asymmetric Resource Consumption (Amplification)](https://cwe.mitre.org/data/definitions/405.html)

With this change, `jwt.Parse` allocates O(1) bytes even in the face of such malicious requests.

---

Some benchmark results:

```
goos: darwin
goarch: amd64
pkg: github.com/zalando/skipper/jwt
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                                       │        old        │                  new                  │
                                       │      sec/op       │    sec/op     vs base                 │
Parse_malicious/all_periods-8            13681180.50n ± 2%   97.85n ± 47%  -100.00% (p=0.000 n=10)
Parse_malicious/two_trailing_periods-8         60.78µ ± 1%   35.41µ ± 11%   -41.74% (p=0.000 n=10)
geomean                                        911.9µ        1.861µ         -99.80%

                                       │       old        │                 new                 │
                                       │       B/op       │    B/op     vs base                 │
Parse_malicious/all_periods-8            16785409.00 ± 0%   64.00 ± 0%  -100.00% (p=0.000 n=10)
Parse_malicious/two_trailing_periods-8         224.0 ± 0%   240.0 ± 0%    +7.14% (p=0.000 n=10)
geomean                                      59.88Ki        123.9        -99.80%

                                       │    old     │                 new                 │
                                       │ allocs/op  │ allocs/op   vs base                 │
Parse_malicious/all_periods-8            1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Parse_malicious/two_trailing_periods-8   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                  2.000        2.000       +0.00%
¹ all samples are equal
```