### PR TITLE
net: use strings.LastIndex to parse header

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -90,8 +90,10 @@ func RemoteAddrFromLast(r *http.Request) netip.Addr {
 // RemoteHostFromLast is *deprecated* use RemoteAddrFromLast instead
 func RemoteHostFromLast(r *http.Request) net.IP {
 	ffs := r.Header.Get("X-Forwarded-For")
-	ffa := strings.Split(ffs, ",")
-	ff := ffa[len(ffa)-1]
+	ff := ffs
+	if i := strings.LastIndex(ffs, ","); i != -1 {
+		ff = ffs[i+1:]
+	}
 	if ff != "" {
 		if ip := parse(strings.TrimSpace(ff)); ip != nil {
 			return ip


### PR DESCRIPTION
Use strings.LastIndex instead of strings.Split to reduce memory allocations.

See #3403 for details.

```
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/net
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                                  │    HEAD~1    │                HEAD                 │
                                  │    sec/op    │   sec/op     vs base                │
RemoteHostFromLast/no_header-8      144.10n ± 7%   99.73n ± 6%  -30.79% (p=0.000 n=10)
RemoteHostFromLast/single_value-8    210.8n ± 5%   163.6n ± 5%  -22.39% (p=0.000 n=10)
RemoteHostFromLast/many_values-8     374.3n ± 4%   166.0n ± 3%  -55.66% (p=0.000 n=10)
geomean                              224.9n        139.4n       -38.01%

                                  │   HEAD~1    │                HEAD                │
                                  │    B/op     │    B/op     vs base                │
RemoteHostFromLast/no_header-8       64.00 ± 0%   48.00 ± 0%  -25.00% (p=0.000 n=10)
RemoteHostFromLast/single_value-8    64.00 ± 0%   48.00 ± 0%  -25.00% (p=0.000 n=10)
RemoteHostFromLast/many_values-8    224.00 ± 0%   48.00 ± 0%  -78.57% (p=0.000 n=10)
geomean                              97.17        48.00       -50.60%

                                  │   HEAD~1   │                HEAD                │
                                  │ allocs/op  │ allocs/op   vs base                │
RemoteHostFromLast/no_header-8      3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
RemoteHostFromLast/single_value-8   3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
RemoteHostFromLast/many_values-8    3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
geomean                             3.000        2.000       -33.33%
```