### PR TITLE
predicates/forwarded: use strings.Index to parse header

### DIFF
--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -130,11 +130,10 @@ type forwarded struct {
 }
 
 func parseForwarded(fh string) *forwarded {
-
 	f := &forwarded{}
 
-	for _, forwardedFull := range strings.Split(fh, ",") {
-		for _, forwardedPair := range strings.Split(strings.TrimSpace(forwardedFull), ";") {
+	for forwardedFull := range splitSeq(fh, ",") {
+		for forwardedPair := range splitSeq(strings.TrimSpace(forwardedFull), ";") {
 			token, value, found := strings.Cut(forwardedPair, "=")
 			value = strings.Trim(value, `"`)
 			if found && value != "" {
@@ -147,6 +146,23 @@ func parseForwarded(fh string) *forwarded {
 			}
 		}
 	}
-
 	return f
+}
+
+// TODO: use [strings.SplitSeq] added in go1.24 once go1.25 is released.
+func splitSeq(s string, sep string) func(yield func(string) bool) {
+	return func(yield func(string) bool) {
+		for {
+			i := strings.Index(s, sep)
+			if i < 0 {
+				break
+			}
+			frag := s[:i]
+			if !yield(frag) {
+				return
+			}
+			s = s[i+len(sep):]
+		}
+		yield(s)
+	}
 }


### PR DESCRIPTION
Use strings.Index instead of strings.Split to reduce memory allocations.

See #3403 for details.