### PR TITLE
proxy: trace response body size and request header length

### DIFF
--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"math"
+
 	ot "github.com/opentracing/opentracing-go"
 
 	"github.com/zalando/skipper/tracing"
@@ -19,6 +21,8 @@ const (
 	HTTPPathTag           = "http.path"
 	HTTPUrlTag            = "http.url"
 	HTTPStatusCodeTag     = "http.status_code"
+	HTTPResponseBodyCeil  = "http.response.body_ceil"
+	HTTPRequestHeaderCeil = "http.request.header_ceil"
 	SkipperRouteIDTag     = "skipper.route_id"
 	SpanKindTag           = "span.kind"
 
@@ -134,4 +138,8 @@ func (t *filterTracing) logEnd(filterName string) {
 	if t != nil && t.logEvents {
 		t.span.LogKV(filterName, EndEvent)
 	}
+}
+
+func ceilPow2(n int64) int64 {
+	return int64(math.Pow(2, math.Ceil(math.Log2(float64(n)))))
 }


### PR DESCRIPTION
Add response body size and request headers length rounded to the next power of two as proxy span tags.

The rounding is done to reduce cardinality of the tags and avoid introducing a new configuration parameter.

Since it is tricky to measure request header length in bytes it is calculated as the sum of lengths of header names and values.

Note that OpenTelemetry [Semantic Conventions for HTTP Spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) define the following related attributes:
* experimental [`http.response.body.size`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-response-body-size) for body size in bytes
* stable [`http.request.header.<key>`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-request-header) for header value