### PR TITLE
Add access log formatter

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -44,7 +44,11 @@ type Options struct {
 
 	// AccessLogJsonFormatter, when set and JSON logging is enabled, is passed along to to the underlying
 	// Logrus logger for access logs. To enable structured logging, use AccessLogJSONEnabled.
+	// Deprecated: use [AccessLogFormatter].
 	AccessLogJsonFormatter *logrus.JSONFormatter
+
+	// AccessLogFormatter, when set is passed along to the underlying Logrus logger for access logs.
+	AccessLogFormatter logrus.Formatter
 }
 
 func (f *prefixFormatter) Format(e *logrus.Entry) ([]byte, error) {
@@ -74,7 +78,9 @@ func initApplicationLog(o Options) {
 
 func initAccessLog(o Options) {
 	l := logrus.New()
-	if o.AccessLogJSONEnabled {
+	if o.AccessLogFormatter != nil {
+		l.Formatter = o.AccessLogFormatter
+	} else if o.AccessLogJSONEnabled {
 		if o.AccessLogJsonFormatter != nil {
 			l.Formatter = o.AccessLogJsonFormatter
 		} else {

--- a/skipper.go
+++ b/skipper.go
@@ -619,9 +619,13 @@ type Options struct {
 	// from the request URI in the access logs.
 	AccessLogStripQuery bool
 
-	// AccessLogJsonFormatter, when set and JSON logging is enabled, is passed along to to the underlying
+	// AccessLogJsonFormatter, when set and JSON logging is enabled, is passed along to the underlying
 	// Logrus logger for access logs. To enable structured logging, use AccessLogJSONEnabled.
+	// Deprecated: use [AccessLogFormatter].
 	AccessLogJsonFormatter *log.JSONFormatter
+
+	// AccessLogFormatter, when set is passed along to the underlying Logrus logger for access logs.
+	AccessLogFormatter log.Formatter
 
 	DebugListener string
 
@@ -1177,6 +1181,7 @@ func initLog(o Options) error {
 		AccessLogJSONEnabled:        o.AccessLogJSONEnabled,
 		AccessLogStripQuery:         o.AccessLogStripQuery,
 		AccessLogJsonFormatter:      o.AccessLogJsonFormatter,
+		AccessLogFormatter:          o.AccessLogFormatter,
 	})
 
 	return nil


### PR DESCRIPTION
This PR adds the ability to use a custom access log formatter.

Currently, accessLogs can be configured in three ways:
- If `AccessLogJSONEnabled` is defined, you can either pass a JSONFormatter, or have Skipper initialize one.
- If `AccessLogJSONEnabled` is not defined, it uses a basic text formatter.

There are cases (for example, when configuring NewRelic logrus integration, [see here](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/nrlogrus), that a custom formatter is needed, but current logger can't be configured.

My initial approach was to change type on `AccessLogJsonFormatter` (typed parameter in Skipper options) to be able to pass any logrus.Formatter (interface), as it wouldn't break anything. But it would be weird to have something called `JSONFormatter` that may not be a JSON formatter.