### PR TITLE
Drop skipperOauthOidc cookies in oauthOidc filter

### DIFF
--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -788,9 +788,14 @@ func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
 	)
 	r := ctx.Request()
 
-	for _, cookie := range r.Cookies() {
+	// Retrieve skipperOauthOidc cookie for processing and remove it from downstream request
+	rCookies := r.Cookies()
+	r.Header.Del("Cookie")
+	for _, cookie := range rCookies {
 		if strings.HasPrefix(cookie.Name, f.cookiename) {
 			cookies = append(cookies, cookie)
+		} else {
+			r.AddCookie(cookie)
 		}
 	}
 	sessionCookie := mergerCookies(cookies)


### PR DESCRIPTION
The `skipperOauthOidc` cookies are only intended for Skipper, so they don't need to be forwarded to the application.

With this PR we simply drop those cookies before forwarding the request. This will reduce the overall header size of requests.
The implementation is inspired by the [`oauthGrant` filter](https://github.com/zalando/skipper/blob/6b448b1fe90cc113e365be8fba7cd6d122ad7a6d/filters/auth/grantcookie.go#L93-L100)

Closes https://github.com/zalando/skipper/issues/3459