### PR TITLE
Add context to log entry

### DIFF
--- a/logging/access.go
+++ b/logging/access.go
@@ -170,5 +170,9 @@ func LogAccess(entry *AccessEntry, additional map[string]interface{}) {
 		logData[k] = v
 	}
 
-	accessLog.WithFields(logData).Infoln()
+	logEntry := accessLog.WithFields(logData)
+	if entry.Request != nil {
+		logEntry = logEntry.WithContext(entry.Request.Context())
+	}
+	logEntry.Infoln()
 }


### PR DESCRIPTION
This change allows accesslog entries to be enriched with requests' context, if a custom formatter uses that context.