### PR TITLE
feat/metric: add new metric for skipper latency

### DIFF
--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -89,6 +89,11 @@ func (a *All) MeasureResponse(code int, method string, routeId string, start tim
 	a.codaHale.MeasureResponse(code, method, routeId, start)
 }
 
+func (a *All) MeasureRequest(code int, method string, routeId string, start time.Time, backendDuration time.Duration) {
+	a.prometheus.MeasureRequest(code, method, routeId, start, backendDuration)
+	a.codaHale.MeasureRequest(code, method, routeId, start, backendDuration)
+}
+
 func (a *All) MeasureServe(routeId, host, method string, code int, start time.Time) {
 	a.prometheus.MeasureServe(routeId, host, method, code, start)
 	a.codaHale.MeasureServe(routeId, host, method, code, start)

--- a/metrics/codahale.go
+++ b/metrics/codahale.go
@@ -26,6 +26,8 @@ const (
 	KeyAllFiltersResponseCombined = "allfilters.combined.response"
 	KeyResponse                   = "response.%d.%s.skipper.%s"
 	KeyResponseCombined           = "all.response.%d.%s.skipper"
+	KeyRequest                    = "request.%d.%s.skipper.%s"
+	KeyRequestCombined            = "all.request.%d.%s.skipper"
 	Key5xxsBackend                = "all.backend.5xx"
 
 	KeyErrorsBackend   = "errors.backend.%s"
@@ -169,6 +171,12 @@ func (c *CodaHale) MeasureAllFiltersResponse(routeId string, start time.Time) {
 	if c.options.EnableAllFiltersMetrics {
 		c.measureSince(fmt.Sprintf(KeyFiltersResponse, routeId), start)
 	}
+}
+
+func (c *CodaHale) MeasureRequest(code int, method string, routeId string, start time.Time, backendDuration time.Duration) {
+	method = measuredMethod(method)
+	c.updateTimer(fmt.Sprintf(KeyRequest, code, method, routeId), time.Since(start)-backendDuration)
+	c.updateTimer(fmt.Sprintf(KeyRequestCombined, code, method), time.Since(start)-backendDuration)
 }
 
 func (c *CodaHale) MeasureResponse(code int, method string, routeId string, start time.Time) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -69,6 +69,7 @@ type Metrics interface {
 	MeasureBackendHost(routeBackendHost string, start time.Time)
 	MeasureFilterResponse(filterName string, start time.Time)
 	MeasureAllFiltersResponse(routeId string, start time.Time)
+	MeasureRequest(code int, method string, routeId string, start time.Time, backendDuration time.Duration)
 	MeasureResponse(code int, method string, routeId string, start time.Time)
 	MeasureServe(routeId, host, method string, code int, start time.Time)
 	IncRoutingFailures()

--- a/metrics/metricstest/metricsmock.go
+++ b/metrics/metricstest/metricsmock.go
@@ -148,6 +148,10 @@ func (m *MockMetrics) MeasureResponse(code int, method string, routeId string, s
 	// implement me
 }
 
+func (m *MockMetrics) MeasureRequest(code int, method string, routeId string, start time.Time, backendDuration time.Duration) {
+	// implement me
+}
+
 func (m *MockMetrics) MeasureServe(routeId, host, method string, code int, start time.Time) {
 	// implement me
 }

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -51,6 +51,7 @@ type context struct {
 	routeLookup          *routing.RouteLookup
 	cancelBackendContext stdlibcontext.CancelFunc
 	logger               filters.FilterContextLogger
+	backendTime          time.Duration
 }
 
 type filterMetrics struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1335,6 +1335,7 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 		}
 
 		ctx.setResponse(rsp, p.flags.PreserveOriginal())
+		ctx.backendTime = time.Since(backendStart)
 		p.metrics.MeasureBackend(ctx.route.Id, backendStart)
 		p.metrics.MeasureBackendHost(ctx.route.Host, backendStart)
 	}
@@ -1623,6 +1624,8 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ctx.Logger().Errorf("Failed to set write deadline: %v", e)
 		}
 	}
+
+	p.metrics.MeasureRequest(ctx.response.StatusCode, ctx.request.Method, ctx.route.Id, ctx.startServe, ctx.backendTime)
 
 	// stream response body to client
 	if err != nil {


### PR DESCRIPTION
feat/metric: add new metric for skipper latency

This change involves adding a new metric to measure the overall skipper latency of a request. i.e., the time taken by a request in skipper itself, so this does not include time taken for serving for the response to client and the time taken for the backend round trip.