### PR TITLE
go.mod: Upgrade to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,6 +184,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-go 1.23.6
+go 1.23.8
 
 toolchain go1.24.1


### PR DESCRIPTION
The [master pipeline](https://github.com/zalando/skipper/actions/runs/14443139827/job/40497621133) is currently failing due to a [security vulnerability](https://osv.dev/GO-2025-3563) in Go 1.23.6.

This PR upgrades Go to v1.23.8.