### PR TITLE
fix: Copy headers from backend in upgrade proxy

### DIFF
--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -124,11 +125,7 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		log.Debugf("Got invalid status code from backend: %d", resp.StatusCode)
-		for key, values := range resp.Header {
-			for _, value := range values {
-				w.Header().Add(key, value)
-			}
-		}
+		maps.Copy(w.Header(), resp.Header)
 		w.WriteHeader(resp.StatusCode)
 		_, err := io.Copy(w, resp.Body)
 		if err != nil {

--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -124,6 +124,11 @@ func (p *upgradeProxy) serveHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		log.Debugf("Got invalid status code from backend: %d", resp.StatusCode)
+		for key, values := range resp.Header {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
 		w.WriteHeader(resp.StatusCode)
 		_, err := io.Copy(w, resp.Body)
 		if err != nil {

--- a/proxy/upgrade_test.go
+++ b/proxy/upgrade_test.go
@@ -133,7 +133,7 @@ func TestServeHTTP(t *testing.T) {
 			backendStatusCode:          http.StatusOK,
 			backendClosesConnection:    true,
 			expectedResponseStatusCode: http.StatusOK,
-			backendHeaders:             map[string][]string{"X-Header": []string{"value1", "value2"}, "Content-Type": []string{"application/json"}},
+			backendHeaders:             map[string][]string{"X-Header": {"value1", "value2"}, "Content-Type": {"application/json"}},
 			expectedResponseBody:       "{}",
 		},
 		{

--- a/proxy/upgrade_test.go
+++ b/proxy/upgrade_test.go
@@ -98,7 +98,7 @@ func TestServeHTTP(t *testing.T) {
 		backendStatusCode          int
 		expectedResponseStatusCode int
 		expectedResponseBody       string
-		backendHeaders             map[string]string
+		backendHeaders             map[string][]string
 	}{
 		{
 			msg:               "Load balanced route",
@@ -133,7 +133,7 @@ func TestServeHTTP(t *testing.T) {
 			backendStatusCode:          http.StatusOK,
 			backendClosesConnection:    true,
 			expectedResponseStatusCode: http.StatusOK,
-			backendHeaders:             map[string]string{"X-Header": "value", "Content-Type": "application/json"},
+			backendHeaders:             map[string][]string{"X-Header": []string{"value1", "value2"}, "Content-Type": []string{"application/json"}},
 			expectedResponseBody:       "{}",
 		},
 		{
@@ -175,8 +175,10 @@ func TestServeHTTP(t *testing.T) {
 
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if ti.backendHeaders != nil {
-					for k, v := range ti.backendHeaders {
-						w.Header().Set(k, v)
+					for k, vv := range ti.backendHeaders {
+						for _, v := range vv {
+							w.Header().Add(k, v)
+						}
 					}
 				}
 				if ti.backendClosesConnection {
@@ -289,7 +291,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 				if ti.backendHeaders != nil {
 					for k, v := range ti.backendHeaders {
-						assert.Equal(t, v, resp.Header.Get(k), "Should copy all headers from response")
+						assert.Equal(t, v, resp.Header.Values(k), "Should copy all headers from response")
 					}
 				}
 


### PR DESCRIPTION
When a backend server responded with a non-101 status code during WebSocket upgrade attempts, the response headers were not forwarded to the client. This fix ensures all headers from the backend response are copied to the client response before writing the status code.