### PR TITLE
tracing: set OTel network.peer.address in proxy span

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1010,7 +1010,8 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 	u.RawQuery = ""
 	p.tracing.
 		setTag(ctx.proxySpan, HTTPUrlTag, u.String()).
-		setTag(ctx.proxySpan, SkipperRouteIDTag, ctx.route.Id)
+		setTag(ctx.proxySpan, SkipperRouteIDTag, ctx.route.Id).
+		setTag(ctx.proxySpan, NetworkPeerAddressTag, u.Host)
 	p.setCommonSpanInfo(u, req, ctx.proxySpan)
 
 	carrier := ot.HTTPHeadersCarrier(req.Header)

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -18,6 +18,7 @@ const (
 	HTTPRemoteIPTag       = "http.remote_ip"
 	HTTPPathTag           = "http.path"
 	HTTPUrlTag            = "http.url"
+	NetworkPeerAddressTag = "network.peer.address"
 	HTTPStatusCodeTag     = "http.status_code"
 	SkipperRouteIDTag     = "skipper.route_id"
 	SpanKindTag           = "span.kind"

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -326,6 +326,7 @@ func TestTracingProxySpan(t *testing.T) {
 	verifyTag(t, span, SkipperRouteIDTag, "hello")
 	verifyTag(t, span, ComponentTag, "skipper")
 	verifyTag(t, span, HTTPUrlTag, "http://"+backendAddr+"/bye") // proxy removes query
+	verifyTag(t, span, NetworkPeerAddressTag, backendAddr)
 	verifyTag(t, span, HTTPMethodTag, "GET")
 	verifyTag(t, span, HostnameTag, "proxy.tracing.test")
 	verifyTag(t, span, HTTPPathTag, "/bye")


### PR DESCRIPTION
To be able to find bad backend application instances we can use group_by network.peer.address queries.