### PR TITLE
change log level to debug

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1230,7 +1230,7 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 		// consume the body to prevent goroutine leaks
 		if ctx.request.Body != nil {
 			if _, err := io.Copy(io.Discard, ctx.request.Body); err != nil {
-				ctx.Logger().Errorf("error while discarding remainder request body: %v.", err)
+				ctx.Logger().Debugf("error while discarding remainder request body: %v.", err)
 			}
 		}
 		ctx.ensureDefaultResponse()


### PR DESCRIPTION
Changing the error level because it is not due to issues in skipper. This is due to client/user side issues. This is why suggesting to move the log to debug level. 