### PR TITLE
routing: ignore duplicate dataclients

### DIFF
--- a/routing/export_test.go
+++ b/routing/export_test.go
@@ -22,3 +22,7 @@ func SetNow(r *EndpointRegistry, now func() time.Time) {
 func (rl *RouteLookup) ValidRoutes() []*eskip.Route {
 	return rl.rt.validRoutes
 }
+
+func (rl *RouteLookup) DataClients() map[DataClient]struct{} {
+	return rl.rt.clients
+}


### PR DESCRIPTION
Ignore duplicate dataclients since this is likely a misconfiguration. 

Note that datasource still allows multiple pointer dataclients of the same type or non-equal value-type dataclients.

Routing constructor does not return error and we generally do not use panic therefore ignoring and logging an error is the only simple option.

This is also needed because datasource manages routes keyed by DataClient and to correctly signal first route load.

Follow up on #3447