### PR TITLE
feature: letsencrypt http.Handler

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1337,9 +1337,10 @@ func (c *Config) ToOptions() skipper.Options {
 }
 
 func (c *Config) getLetsencryptCache() autocert.Cache {
+	dir := "/data/skipper/certs" // TODO(sszuecs): pass dir value via config
 	switch c.LetsencryptCache {
 	case "directory":
-		return autocert.DirCache(os.TempDir())
+		return net.NewDirCache(dir)
 	case "remote":
 		// postpone to skipper.go and use net.(*Letsencrypt).SetCache()
 		return nil

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/acme/autocert"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -271,6 +272,14 @@ type Config struct {
 	// TLS Config
 	KubernetesEnableTLS bool `yaml:"kubernetes-enable-tls"`
 
+	// Letsencrypt
+	EnableLetsencrypt       bool      `yaml:"enable-letsencrypt"`
+	LetsencryptCache        string    `yaml:"letsencrypt-cache"`
+	LetsencryptEmail        string    `yaml:"letsencrypt-email"`
+	LetsencryptDomains      *listFlag `yaml:"letsencrypt-domains"`
+	LetsencryptDirectoryURL string    `yaml:"letsencrypt-directory-url"`
+	LetsencryptUserAgent    string    `yaml:"letsencrypt-user-agent"`
+
 	// API Monitoring
 	ApiUsageMonitoringEnable                       bool   `yaml:"enable-api-usage-monitoring"`
 	ApiUsageMonitoringRealmKeys                    string `yaml:"api-usage-monitoring-realm-keys"`
@@ -405,6 +414,7 @@ func NewConfig() *Config {
 	cfg.ProxyDenyListCIDRs = commaListFlag()
 	cfg.ProxySkipListCIDRs = commaListFlag()
 	cfg.EnsureDataClients = commaListFlag()
+	cfg.LetsencryptDomains = commaListFlag()
 
 	flag := flag.NewFlagSet("", flag.ExitOnError)
 	flag.StringVar(&cfg.ConfigFile, "config-file", "", "if provided the flags will be loaded/overwritten by the values on the file (yaml)")
@@ -649,6 +659,14 @@ func NewConfig() *Config {
 
 	// Exclude insecure cipher suites
 	flag.BoolVar(&cfg.ExcludeInsecureCipherSuites, "exclude-insecure-cipher-suites", false, "excludes insecure cipher suites")
+
+	// Letsencrypt
+	flag.BoolVar(&cfg.EnableLetsencrypt, "enable-letsencrypt", false, "enables letsencrypt autocert handling on the proxy")
+	flag.StringVar(&cfg.LetsencryptCache, "letsencrypt-cache", "", "Configure the autocert cert cache <inmemory|remote|directory>")
+	flag.StringVar(&cfg.LetsencryptEmail, "letsencrypt-email", "", "Sets letsencrypt email address such that you can be reached by letsencrypt if something goes wrong")
+	flag.Var(cfg.LetsencryptDomains, "letsencrypt-domains", "An allow list of domains for autocert handling")
+	flag.StringVar(&cfg.LetsencryptDirectoryURL, "letsencrypt-directory-url", "", "Sets directory URL for testing")
+	flag.StringVar(&cfg.LetsencryptUserAgent, "letsencrypt-user-agent", "", "Sets httpclient useragent that calls letsencrypt that enables letsencrypt to limit you if something goes wrong")
 
 	// API Monitoring:
 	flag.BoolVar(&cfg.ApiUsageMonitoringEnable, "enable-api-usage-monitoring", false, "enables the apiUsageMonitoring filter")
@@ -1282,6 +1300,7 @@ func (c *Config) ToOptions() skipper.Options {
 			}
 		})
 	}
+
 	if c.ValidateQueryLog {
 		wrappers = append(wrappers, func(handler http.Handler) http.Handler {
 			return &net.ValidateQueryLogHandler{
@@ -1299,7 +1318,32 @@ func (c *Config) ToOptions() skipper.Options {
 		})
 	}
 
+	if c.EnableLetsencrypt {
+		wrappers = append(wrappers, func(handler http.Handler) http.Handler {
+			return net.NewLetsencrypt(
+				c.getLetsencryptCache(),
+				c.LetsencryptEmail,
+				c.LetsencryptDirectoryURL,
+				c.LetsencryptUserAgent,
+				c.LetsencryptDomains.values,
+			).Handler(handler)
+		})
+	}
+
 	return options
+}
+
+func (c *Config) getLetsencryptCache() autocert.Cache {
+	switch c.LetsencryptCache {
+	case "directory":
+		return autocert.DirCache(os.TempDir())
+	case "remote":
+		return &net.RemoteCache{
+			Client: &net.RedisRingClient{},
+		}
+	default:
+		return &net.InmemoryCache{}
+	}
 }
 
 func (c *Config) getMinTLSVersion() uint16 {

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/acme/autocert"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -955,11 +956,7 @@ func (c *Config) ToOptions() skipper.Options {
 		MaxMatcherBufferSize:             c.MaxMatcherBufferSize,
 		EnableBreakers:                   c.EnableBreakers,
 		BreakerSettings:                  c.Breakers,
-		EnableLetsencrypt:                c.EnableLetsencrypt,
-		LetsencryptEmail:                 c.LetsencryptEmail,
-		LetsencryptDirectoryURL:          c.LetsencryptDirectoryURL,
-		LetsencryptUserAgent:             c.LetsencryptUserAgent,
-		LetsencryptDomains:               c.LetsencryptDomains.values,
+		LetsencryptCache:                 c.LetsencryptCache,
 		EnableRatelimiters:               c.EnableRatelimiters,
 		RatelimitSettings:                c.Ratelimits,
 		EnableRouteFIFOMetrics:           c.EnableRouteFIFOMetrics,
@@ -1322,19 +1319,33 @@ func (c *Config) ToOptions() skipper.Options {
 		})
 	}
 
-	// if c.EnableLetsencrypt {
-	// 	wrappers = append(wrappers, func(handler http.Handler) http.Handler {
-	// 		return net.NewLetsencrypt(
-	// 			c.getLetsencryptCache(),
-	// 			c.LetsencryptEmail,
-	// 			c.LetsencryptDirectoryURL,
-	// 			c.LetsencryptUserAgent,
-	// 			c.LetsencryptDomains.values,
-	// 		).Handler(handler)
-	// 	})
-	// }
+	if c.EnableLetsencrypt {
+		options.Letsencrypt = net.NewLetsencrypt(
+			c.getLetsencryptCache(),
+			c.LetsencryptEmail,
+			c.LetsencryptDirectoryURL,
+			c.LetsencryptUserAgent,
+			c.LetsencryptDomains.values,
+		)
+
+		wrappers = append(wrappers, func(handler http.Handler) http.Handler {
+			return options.Letsencrypt.Handler(handler)
+		})
+	}
 
 	return options
+}
+
+func (c *Config) getLetsencryptCache() autocert.Cache {
+	switch c.LetsencryptCache {
+	case "directory":
+		return autocert.DirCache(os.TempDir())
+	case "remote":
+		// postpone to skipper.go and use net.(*Letsencrypt).SetCache()
+		return nil
+	default:
+		return &net.InmemoryCache{}
+	}
 }
 
 func (c *Config) getMinTLSVersion() uint16 {

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/acme/autocert"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -662,10 +661,10 @@ func NewConfig() *Config {
 
 	// Letsencrypt
 	flag.BoolVar(&cfg.EnableLetsencrypt, "enable-letsencrypt", false, "enables letsencrypt autocert handling on the proxy")
-	flag.StringVar(&cfg.LetsencryptCache, "letsencrypt-cache", "", "Configure the autocert cert cache <inmemory|remote|directory>")
+	flag.StringVar(&cfg.LetsencryptCache, "letsencrypt-cache", "directory", "Configure the autocert cert cache <inmemory|remote|directory>. If you use certbot, you need to use directory.")
 	flag.StringVar(&cfg.LetsencryptEmail, "letsencrypt-email", "", "Sets letsencrypt email address such that you can be reached by letsencrypt if something goes wrong")
 	flag.Var(cfg.LetsencryptDomains, "letsencrypt-domains", "An allow list of domains for autocert handling")
-	flag.StringVar(&cfg.LetsencryptDirectoryURL, "letsencrypt-directory-url", "", "Sets directory URL for testing")
+	flag.StringVar(&cfg.LetsencryptDirectoryURL, "letsencrypt-directory-url", "", "Sets directory URL for testing, defaults to autocert.DefaultACMEDirectory")
 	flag.StringVar(&cfg.LetsencryptUserAgent, "letsencrypt-user-agent", "", "Sets httpclient useragent that calls letsencrypt that enables letsencrypt to limit you if something goes wrong")
 
 	// API Monitoring:
@@ -956,6 +955,11 @@ func (c *Config) ToOptions() skipper.Options {
 		MaxMatcherBufferSize:             c.MaxMatcherBufferSize,
 		EnableBreakers:                   c.EnableBreakers,
 		BreakerSettings:                  c.Breakers,
+		EnableLetsencrypt:                c.EnableLetsencrypt,
+		LetsencryptEmail:                 c.LetsencryptEmail,
+		LetsencryptDirectoryURL:          c.LetsencryptDirectoryURL,
+		LetsencryptUserAgent:             c.LetsencryptUserAgent,
+		LetsencryptDomains:               c.LetsencryptDomains.values,
 		EnableRatelimiters:               c.EnableRatelimiters,
 		RatelimitSettings:                c.Ratelimits,
 		EnableRouteFIFOMetrics:           c.EnableRouteFIFOMetrics,
@@ -1318,32 +1322,19 @@ func (c *Config) ToOptions() skipper.Options {
 		})
 	}
 
-	if c.EnableLetsencrypt {
-		wrappers = append(wrappers, func(handler http.Handler) http.Handler {
-			return net.NewLetsencrypt(
-				c.getLetsencryptCache(),
-				c.LetsencryptEmail,
-				c.LetsencryptDirectoryURL,
-				c.LetsencryptUserAgent,
-				c.LetsencryptDomains.values,
-			).Handler(handler)
-		})
-	}
+	// if c.EnableLetsencrypt {
+	// 	wrappers = append(wrappers, func(handler http.Handler) http.Handler {
+	// 		return net.NewLetsencrypt(
+	// 			c.getLetsencryptCache(),
+	// 			c.LetsencryptEmail,
+	// 			c.LetsencryptDirectoryURL,
+	// 			c.LetsencryptUserAgent,
+	// 			c.LetsencryptDomains.values,
+	// 		).Handler(handler)
+	// 	})
+	// }
 
 	return options
-}
-
-func (c *Config) getLetsencryptCache() autocert.Cache {
-	switch c.LetsencryptCache {
-	case "directory":
-		return autocert.DirCache(os.TempDir())
-	case "remote":
-		return &net.RemoteCache{
-			Client: &net.RedisRingClient{},
-		}
-	default:
-		return &net.InmemoryCache{}
-	}
 }
 
 func (c *Config) getMinTLSVersion() uint16 {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/acme/autocert"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -284,6 +285,15 @@ type Config struct {
 	// TLS Config
 	KubernetesEnableTLS bool `yaml:"kubernetes-enable-tls"`
 
+	// Letsencrypt
+	EnableLetsencrypt       bool      `yaml:"enable-letsencrypt"`
+	LetsencryptCache        string    `yaml:"letsencrypt-cache"`
+	LetsencryptCacheDir     string    `yaml:"letsencrypt-cache-dir"`
+	LetsencryptEmail        string    `yaml:"letsencrypt-email"`
+	LetsencryptDomains      *listFlag `yaml:"letsencrypt-domains"`
+	LetsencryptDirectoryURL string    `yaml:"letsencrypt-directory-url"`
+	LetsencryptUserAgent    string    `yaml:"letsencrypt-user-agent"`
+
 	// API Monitoring
 	ApiUsageMonitoringEnable                       bool   `yaml:"enable-api-usage-monitoring"`
 	ApiUsageMonitoringRealmKeys                    string `yaml:"api-usage-monitoring-realm-keys"`
@@ -426,6 +436,7 @@ func NewConfig() *Config {
 	cfg.ProxyDenyListCIDRs = commaListFlag()
 	cfg.ProxySkipListCIDRs = commaListFlag()
 	cfg.EnsureDataClients = commaListFlag()
+	cfg.LetsencryptDomains = commaListFlag()
 
 	flag := flag.NewFlagSet("", flag.ExitOnError)
 	flag.StringVar(&cfg.ConfigFile, "config-file", "", "if provided the flags will be loaded/overwritten by the values on the file (yaml)")
@@ -677,6 +688,15 @@ func NewConfig() *Config {
 
 	// Exclude insecure cipher suites
 	flag.BoolVar(&cfg.ExcludeInsecureCipherSuites, "exclude-insecure-cipher-suites", false, "excludes insecure cipher suites")
+
+	// Letsencrypt
+	flag.BoolVar(&cfg.EnableLetsencrypt, "enable-letsencrypt", false, "enables letsencrypt autocert handling on the proxy")
+	flag.StringVar(&cfg.LetsencryptCache, "letsencrypt-cache", "directory", "Configure the autocert cert cache <inmemory|remote|directory>. If you use certbot, you need to use directory.")
+	flag.StringVar(&cfg.LetsencryptCacheDir, "letsencrypt-cache-dir", "/data/skipper/certs", `Configure the autocert cert cache directory for cache type "directory".`)
+	flag.StringVar(&cfg.LetsencryptEmail, "letsencrypt-email", "", "Sets letsencrypt email address such that you can be reached by letsencrypt if something goes wrong")
+	flag.Var(cfg.LetsencryptDomains, "letsencrypt-domains", "An allow list of domains for autocert handling")
+	flag.StringVar(&cfg.LetsencryptDirectoryURL, "letsencrypt-directory-url", "", "Sets directory URL for testing, defaults to autocert.DefaultACMEDirectory")
+	flag.StringVar(&cfg.LetsencryptUserAgent, "letsencrypt-user-agent", "", "Sets httpclient useragent that calls letsencrypt that enables letsencrypt to limit you if something goes wrong")
 
 	// API Monitoring:
 	flag.BoolVar(&cfg.ApiUsageMonitoringEnable, "enable-api-usage-monitoring", false, "enables the apiUsageMonitoring filter")
@@ -984,6 +1004,7 @@ func (c *Config) ToOptions() skipper.Options {
 		MaxMatcherBufferSize:                  c.MaxMatcherBufferSize,
 		EnableBreakers:                        c.EnableBreakers,
 		BreakerSettings:                       c.Breakers,
+		LetsencryptCache:                      c.LetsencryptCache,
 		EnableRatelimiters:                    c.EnableRatelimiters,
 		RatelimitSettings:                     c.Ratelimits,
 		EnableRouteFIFOMetrics:                c.EnableRouteFIFOMetrics,
@@ -1347,6 +1368,7 @@ func (c *Config) ToOptions() skipper.Options {
 			}
 		})
 	}
+
 	if c.ValidateQueryLog {
 		wrappers = append(wrappers, func(handler http.Handler) http.Handler {
 			return &net.ValidateQueryLogHandler{
@@ -1364,7 +1386,33 @@ func (c *Config) ToOptions() skipper.Options {
 		})
 	}
 
+	if c.EnableLetsencrypt {
+		options.Letsencrypt = net.NewLetsencrypt(
+			c.getLetsencryptCache(),
+			c.LetsencryptEmail,
+			c.LetsencryptDirectoryURL,
+			c.LetsencryptUserAgent,
+			c.LetsencryptDomains.values,
+		)
+
+		wrappers = append(wrappers, func(handler http.Handler) http.Handler {
+			return options.Letsencrypt.Handler(handler)
+		})
+	}
+
 	return options
+}
+
+func (c *Config) getLetsencryptCache() autocert.Cache {
+	switch c.LetsencryptCache {
+	case "directory":
+		return net.NewDirCache(c.LetsencryptCacheDir)
+	case "remote":
+		// postpone to skipper.go and use net.(*Letsencrypt).SetCache()
+		return nil
+	default:
+		return &net.InmemoryCache{}
+	}
 }
 
 func (c *Config) getMinTLSVersion() uint16 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -178,6 +178,7 @@ func defaultConfig(with func(*Config)) *Config {
 		ClusterRatelimitMaxGroupShards:          1,
 		ValidateQuery:                           true,
 		ValidateQueryLog:                        true,
+		LetsencryptDomains:                      commaListFlag(),
 		EnableLua:                               false,
 		LuaModules:                              commaListFlag(),
 		LuaSources:                              commaListFlag(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -183,6 +183,7 @@ func defaultConfig(with func(*Config)) *Config {
 		ClusterRatelimitMaxGroupShards:          1,
 		ValidateQuery:                           true,
 		ValidateQueryLog:                        true,
+		LetsencryptDomains:                      commaListFlag(),
 		EnableLua:                               false,
 		LuaModules:                              commaListFlag(),
 		LuaSources:                              commaListFlag(),

--- a/net/letsencrypt.go
+++ b/net/letsencrypt.go
@@ -1,0 +1,137 @@
+package net
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+type InmemoryCache struct {
+	m sync.Map
+}
+
+func (ic *InmemoryCache) Get(ctx context.Context, key string) ([]byte, error) {
+	if dat, ok := ic.m.Load(key); !ok {
+		return nil, fmt.Errorf("missing key %q", key)
+	} else {
+		if data, ok := dat.([]byte); !ok {
+			return nil, fmt.Errorf("failed to convert %q to []byte", dat)
+		} else {
+			return data, nil
+		}
+	}
+}
+
+func (ic *InmemoryCache) Put(ctx context.Context, key string, data []byte) error {
+	ic.m.Store(key, data)
+	return nil
+}
+
+func (ic *InmemoryCache) Delete(ctx context.Context, key string) error {
+	ic.m.Delete(key)
+	return nil
+}
+
+type RemoteCache struct {
+	Client *RedisRingClient
+}
+
+func (rc *RemoteCache) Get(ctx context.Context, key string) ([]byte, error) {
+	res, err := rc.Client.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(res), nil
+}
+
+func (rc *RemoteCache) Delete(ctx context.Context, key string) error {
+	return rc.Client.Del(ctx, key)
+}
+
+func (rc *RemoteCache) Put(ctx context.Context, key string, val []byte) error {
+	_, err := rc.Client.Set(ctx, key, val, 0)
+	return err
+}
+
+func (rc *RemoteCache) Close() {
+	rc.Client.Close()
+}
+
+type Letsencrypt struct {
+	manager *autocert.Manager
+}
+
+// NewLetsencrypt creates a letsencrypt handler to automatically handle CSR challenges.
+//
+// The cache argument can be either
+//
+//   - autocert.DirCache for a filesystem cache
+//   - inmemoryCache for in memory cache
+//   - remoteCache for redis based production cache to be shared between multiple skipper processes
+func NewLetsencrypt(cache autocert.Cache, email, directoryURL, userAgent string, proposedDomains []string) *Letsencrypt {
+	domains := make([]string, 0, len(proposedDomains))
+	for _, s := range proposedDomains {
+		if validateDomain(s) {
+			domains = append(domains, s)
+		}
+	}
+
+	manager := &autocert.Manager{
+		Cache:      cache,
+		Email:      email,
+		HostPolicy: autocert.HostWhitelist(domains...),
+		Prompt:     autocert.AcceptTOS,
+		Client: &acme.Client{
+			DirectoryURL: directoryURL,
+			UserAgent:    userAgent,
+			HTTPClient:   http.DefaultClient,
+		},
+	}
+
+	return &Letsencrypt{
+		manager: manager,
+	}
+}
+
+func (le *Letsencrypt) Handler(fallback http.Handler) http.Handler {
+	return le.manager.HTTPHandler(fallback)
+}
+
+func (le *Letsencrypt) TLSConfig() *tls.Config {
+	return le.manager.TLSConfig()
+}
+
+// Listener returns a net.Listener that need to be closed on exit or
+// you leak a goroutine
+func (le *Letsencrypt) Listener() net.Listener {
+	return le.manager.Listener()
+}
+
+func (le *Letsencrypt) Client() *acme.Client {
+	return le.manager.Client
+}
+
+func (le *Letsencrypt) Close() {
+	le.Listener().Close()
+}
+
+var domainRegex = regexp.MustCompile("^[a-z0-9]+$")
+
+func validateDomain(s string) bool {
+	i := 0
+	for w := range strings.SplitSeq(s, ".") {
+		if !domainRegex.MatchString(w) {
+			return false
+		}
+		i++
+	}
+	return i > 1
+}

--- a/net/letsencrypt.go
+++ b/net/letsencrypt.go
@@ -84,6 +84,10 @@ func NewLetsencrypt(cache autocert.Cache, email, directoryURL, userAgent string,
 		}
 	}
 
+	if directoryURL == "" {
+		directoryURL = autocert.DefaultACMEDirectory
+	}
+
 	manager := &autocert.Manager{
 		Cache:      cache,
 		Email:      email,
@@ -123,7 +127,7 @@ func (le *Letsencrypt) Close() {
 	le.Listener().Close()
 }
 
-var domainRegex = regexp.MustCompile("^[a-z0-9]+$")
+var domainRegex = regexp.MustCompile("^[a-z0-9-]+$")
 
 func validateDomain(s string) bool {
 	i := 0

--- a/net/letsencrypt.go
+++ b/net/letsencrypt.go
@@ -10,9 +10,39 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 )
+
+type DirCache struct {
+	dir   string
+	cache autocert.Cache
+}
+
+func NewDirCache(dir string) *DirCache {
+	return &DirCache{
+		cache: autocert.DirCache(dir),
+		dir:   dir,
+	}
+}
+
+func (d *DirCache) Get(ctx context.Context, key string) ([]byte, error) {
+	val, err := d.cache.Get(ctx, key)
+	if err != nil {
+		logrus.Errorf("Get %q -> %v", key, err)
+	}
+
+	return val, err
+}
+
+func (d *DirCache) Put(ctx context.Context, key string, val []byte) error {
+	return d.cache.Put(ctx, key, val)
+}
+
+func (d *DirCache) Delete(ctx context.Context, key string) error {
+	return d.cache.Delete(ctx, key)
+}
 
 type InmemoryCache struct {
 	m sync.Map

--- a/net/letsencrypt.go
+++ b/net/letsencrypt.go
@@ -40,8 +40,15 @@ func (ic *InmemoryCache) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
+type RemoteCacheClient interface {
+	Get(ctx context.Context, key string) (string, error)
+	Del(ctx context.Context, key string) error
+	Set(ctx context.Context, key string, val string) (string, error)
+	Close() error
+}
+
 type RemoteCache struct {
-	Client *RedisRingClient
+	Client RemoteCacheClient
 }
 
 func (rc *RemoteCache) Get(ctx context.Context, key string) ([]byte, error) {
@@ -57,12 +64,12 @@ func (rc *RemoteCache) Delete(ctx context.Context, key string) error {
 }
 
 func (rc *RemoteCache) Put(ctx context.Context, key string, val []byte) error {
-	_, err := rc.Client.Set(ctx, key, val, 0)
+	_, err := rc.Client.Set(ctx, key, string(val))
 	return err
 }
 
-func (rc *RemoteCache) Close() {
-	rc.Client.Close()
+func (rc *RemoteCache) Close() error {
+	return rc.Client.Close()
 }
 
 type Letsencrypt struct {
@@ -103,6 +110,10 @@ func NewLetsencrypt(cache autocert.Cache, email, directoryURL, userAgent string,
 	return &Letsencrypt{
 		manager: manager,
 	}
+}
+
+func (le *Letsencrypt) SetCache(cache autocert.Cache) {
+	le.manager.Cache = cache
 }
 
 func (le *Letsencrypt) Handler(fallback http.Handler) http.Handler {

--- a/net/letsencrypt.go
+++ b/net/letsencrypt.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"github.com/valkey-io/valkey-go"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 )
@@ -50,7 +51,7 @@ type InmemoryCache struct {
 
 func (ic *InmemoryCache) Get(ctx context.Context, key string) ([]byte, error) {
 	if dat, ok := ic.m.Load(key); !ok {
-		return nil, fmt.Errorf("missing key %q", key)
+		return nil, autocert.ErrCacheMiss
 	} else {
 		if data, ok := dat.([]byte); !ok {
 			return nil, fmt.Errorf("failed to convert %q to []byte", dat)
@@ -84,9 +85,15 @@ type RemoteCache struct {
 
 func (rc *RemoteCache) Get(ctx context.Context, key string) ([]byte, error) {
 	res, err := rc.Client.Get(ctx, key)
+
 	if err != nil {
+		// key not found
+		if valkey.IsValkeyNil(err) {
+			return nil, autocert.ErrCacheMiss
+		}
 		return nil, err
 	}
+
 	return []byte(res), nil
 }
 

--- a/net/letsencrypt.go
+++ b/net/letsencrypt.go
@@ -1,0 +1,184 @@
+package net
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+type DirCache struct {
+	dir   string
+	cache autocert.Cache
+}
+
+func NewDirCache(dir string) *DirCache {
+	return &DirCache{
+		cache: autocert.DirCache(dir),
+		dir:   dir,
+	}
+}
+
+func (d *DirCache) Get(ctx context.Context, key string) ([]byte, error) {
+	val, err := d.cache.Get(ctx, key)
+	if err != nil {
+		logrus.Errorf("Get %q -> %v", key, err)
+	}
+
+	return val, err
+}
+
+func (d *DirCache) Put(ctx context.Context, key string, val []byte) error {
+	return d.cache.Put(ctx, key, val)
+}
+
+func (d *DirCache) Delete(ctx context.Context, key string) error {
+	return d.cache.Delete(ctx, key)
+}
+
+type InmemoryCache struct {
+	m sync.Map
+}
+
+func (ic *InmemoryCache) Get(ctx context.Context, key string) ([]byte, error) {
+	if dat, ok := ic.m.Load(key); !ok {
+		return nil, fmt.Errorf("missing key %q", key)
+	} else {
+		if data, ok := dat.([]byte); !ok {
+			return nil, fmt.Errorf("failed to convert %q to []byte", dat)
+		} else {
+			return data, nil
+		}
+	}
+}
+
+func (ic *InmemoryCache) Put(ctx context.Context, key string, data []byte) error {
+	ic.m.Store(key, data)
+	return nil
+}
+
+func (ic *InmemoryCache) Delete(ctx context.Context, key string) error {
+	ic.m.Delete(key)
+	return nil
+}
+
+// RemoteCacheClient is used as Client for RemoteCache. The Interface for Get, Del, Set are driven by the autocert.Cache interface
+type RemoteCacheClient interface {
+	Get(ctx context.Context, key string) (string, error)
+	Del(ctx context.Context, key string) (int64, error)
+	Set(ctx context.Context, key string, val string) (string, error)
+	Close() error
+}
+
+type RemoteCache struct {
+	Client RemoteCacheClient
+}
+
+func (rc *RemoteCache) Get(ctx context.Context, key string) ([]byte, error) {
+	res, err := rc.Client.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(res), nil
+}
+
+func (rc *RemoteCache) Delete(ctx context.Context, key string) error {
+	_, err := rc.Client.Del(ctx, key)
+	return err
+}
+
+func (rc *RemoteCache) Put(ctx context.Context, key string, val []byte) error {
+	_, err := rc.Client.Set(ctx, key, string(val))
+	return err
+}
+
+func (rc *RemoteCache) Close() error {
+	return rc.Client.Close()
+}
+
+type Letsencrypt struct {
+	manager *autocert.Manager
+}
+
+// NewLetsencrypt creates a letsencrypt handler to automatically handle CSR challenges.
+//
+// The cache argument can be either
+//
+//   - autocert.DirCache for a filesystem cache
+//   - inmemoryCache for in memory cache
+//   - remoteCache for redis/valkey based production cache to be shared between multiple skipper processes
+func NewLetsencrypt(cache autocert.Cache, email, directoryURL, userAgent string, proposedDomains []string) *Letsencrypt {
+	domains := make([]string, 0, len(proposedDomains))
+	for _, s := range proposedDomains {
+		if validateDomain(s) {
+			domains = append(domains, s)
+		}
+	}
+
+	if directoryURL == "" {
+		directoryURL = autocert.DefaultACMEDirectory
+	}
+
+	manager := &autocert.Manager{
+		Cache:      cache,
+		Email:      email,
+		HostPolicy: autocert.HostWhitelist(domains...),
+		Prompt:     autocert.AcceptTOS,
+		Client: &acme.Client{
+			DirectoryURL: directoryURL,
+			UserAgent:    userAgent,
+			HTTPClient:   http.DefaultClient,
+		},
+	}
+
+	return &Letsencrypt{
+		manager: manager,
+	}
+}
+
+func (le *Letsencrypt) SetCache(cache autocert.Cache) {
+	le.manager.Cache = cache
+}
+
+func (le *Letsencrypt) Handler(fallback http.Handler) http.Handler {
+	return le.manager.HTTPHandler(fallback)
+}
+
+func (le *Letsencrypt) TLSConfig() *tls.Config {
+	return le.manager.TLSConfig()
+}
+
+// Listener returns a net.Listener that need to be closed on exit or
+// you leak a goroutine
+func (le *Letsencrypt) Listener() net.Listener {
+	return le.manager.Listener()
+}
+
+func (le *Letsencrypt) Client() *acme.Client {
+	return le.manager.Client
+}
+
+func (le *Letsencrypt) Close() {
+	le.Listener().Close()
+}
+
+var domainRegex = regexp.MustCompile("^[a-z0-9-]+$")
+
+func validateDomain(s string) bool {
+	i := 0
+	for w := range strings.SplitSeq(s, ".") {
+		if !domainRegex.MatchString(w) {
+			return false
+		}
+		i++
+	}
+	return i > 1
+}

--- a/net/letsencrypt_test.go
+++ b/net/letsencrypt_test.go
@@ -1,0 +1,116 @@
+package net
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/net/redistest"
+)
+
+func TestRemoteCache(t *testing.T) {
+	t.Logf("create redis..")
+	redisAddr, done := redistest.NewTestRedis(t)
+	defer done()
+	if redisAddr == "" {
+		t.Fatal("Failed to create redis 1")
+	}
+
+	redisAddr2, done2 := redistest.NewTestRedis(t)
+	defer done2()
+	if redisAddr2 == "" {
+		t.Fatal("Failed to create redis 2")
+	}
+
+	rc := RemoteCache{
+		Client: NewRedisRingClient(&RedisOptions{
+			Addrs: []string{redisAddr, redisAddr2},
+		}),
+	}
+	defer rc.Close()
+
+	if err := rc.Put(context.Background(), "foo", []byte("bar")); err != nil {
+		t.Fatalf("Failed to put: %v", err)
+	}
+
+	if v, err := rc.Get(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to get: %v", err)
+	} else {
+		t.Logf("%T %v %s", v, v, v)
+		if string(v) != "bar" {
+			t.Fatalf("Failed to get result, got: %q", string(v))
+		}
+	}
+
+	if err := rc.Delete(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to delete: %v", err)
+	}
+}
+
+func TestInmemoryCache(t *testing.T) {
+	rc := &InmemoryCache{}
+
+	if _, err := rc.Get(context.Background(), "foo"); err == nil {
+		t.Fatal(`Failed can not get "foo" on empty cache`)
+	}
+
+	if err := rc.Put(context.Background(), "foo", []byte("bar")); err != nil {
+		t.Fatalf("Failed to put: %v", err)
+	}
+
+	if v, err := rc.Get(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to get: %v", err)
+	} else {
+		t.Logf("%T %v %s", v, v, v)
+	}
+
+	if err := rc.Delete(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to delete: %v", err)
+	}
+
+	if err := rc.Put(context.Background(), "foo2", []byte("ü")); err != nil {
+		t.Fatalf("Failed to put: %v", err)
+	}
+
+	if v, err := rc.Get(context.Background(), "foo2"); err != nil {
+		t.Fatalf("Failed to get: %v", err)
+	} else {
+		t.Logf("%T %v %s", v, v, v)
+	}
+
+}
+
+func TestLetsencrypt(t *testing.T) {
+	invalidDomain := "s_.example.org"
+	if validateDomain(invalidDomain) {
+		t.Fatalf("Failed to validate invalid domain %q", invalidDomain)
+	}
+	validDomain := "example.org"
+	if !validateDomain(validDomain) {
+		t.Fatalf("Failed to validate valid domain %q", validDomain)
+	}
+
+	le := NewLetsencrypt(&InmemoryCache{}, "skipper@example.org", "https://acme-staging-v02.api.letsencrypt.org/directory", "skipper-test TestLetsencrypt", []string{validDomain})
+	defer le.Close()
+	if le.manager.Client != nil {
+		dir, err := le.manager.Client.Discover(context.TODO())
+		if err != nil {
+			t.Fatalf("Failed to discover: %v", err)
+		}
+		t.Logf("order: %s", dir.OrderURL)
+
+		defer func() {
+			if le.manager.Client.HTTPClient != nil {
+				le.manager.Client.HTTPClient.CloseIdleConnections()
+			}
+		}()
+	}
+
+	require.NotNil(t, le.Client(), "client should not be nil")
+	require.NotNil(t, le.TLSConfig(), "TLSConfig should not be nil")
+	require.NotNil(t, le.Handler(nil), "http.Handler should not be nil")
+
+	li := le.Listener()
+	defer li.Close()
+	t.Logf("listener %v", li.Addr())
+}

--- a/net/letsencrypt_test.go
+++ b/net/letsencrypt_test.go
@@ -1,0 +1,121 @@
+package net
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/net/valkeytest"
+)
+
+func TestRemoteCache(t *testing.T) {
+	t.Logf("create valkey..")
+	valkeyAddr, done := valkeytest.NewTestValkey(t)
+	defer done()
+	if valkeyAddr == "" {
+		t.Fatal("Failed to create valkey 1")
+	}
+
+	valkeyAddr2, done2 := valkeytest.NewTestValkey(t)
+	defer done2()
+	if valkeyAddr2 == "" {
+		t.Fatal("Failed to create valkey 2")
+	}
+
+	client, err := NewValkeyRingClient(&ValkeyOptions{
+		Addrs: []string{valkeyAddr, valkeyAddr2},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create remote cahce client: %v", err)
+	}
+
+	rc := RemoteCache{
+		Client: client,
+	}
+	defer rc.Close()
+
+	if err := rc.Put(context.Background(), "foo", []byte("bar")); err != nil {
+		t.Fatalf("Failed to put: %v", err)
+	}
+
+	if v, err := rc.Get(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to get: %v", err)
+	} else {
+		t.Logf("%T %v %s", v, v, v)
+		if string(v) != "bar" {
+			t.Fatalf("Failed to get result, got: %q", string(v))
+		}
+	}
+
+	if err := rc.Delete(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to delete: %v", err)
+	}
+}
+
+func TestInmemoryCache(t *testing.T) {
+	rc := &InmemoryCache{}
+
+	if _, err := rc.Get(context.Background(), "foo"); err == nil {
+		t.Fatal(`Failed can not get "foo" on empty cache`)
+	}
+
+	if err := rc.Put(context.Background(), "foo", []byte("bar")); err != nil {
+		t.Fatalf("Failed to put: %v", err)
+	}
+
+	if v, err := rc.Get(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to get: %v", err)
+	} else {
+		t.Logf("%T %v %s", v, v, v)
+	}
+
+	if err := rc.Delete(context.Background(), "foo"); err != nil {
+		t.Fatalf("Failed to delete: %v", err)
+	}
+
+	if err := rc.Put(context.Background(), "foo2", []byte("ü")); err != nil {
+		t.Fatalf("Failed to put: %v", err)
+	}
+
+	if v, err := rc.Get(context.Background(), "foo2"); err != nil {
+		t.Fatalf("Failed to get: %v", err)
+	} else {
+		t.Logf("%T %v %s", v, v, v)
+	}
+
+}
+
+func TestLetsencrypt(t *testing.T) {
+	invalidDomain := "s_.example.org"
+	if validateDomain(invalidDomain) {
+		t.Fatalf("Failed to validate invalid domain %q", invalidDomain)
+	}
+	validDomain := "example.org"
+	if !validateDomain(validDomain) {
+		t.Fatalf("Failed to validate valid domain %q", validDomain)
+	}
+
+	le := NewLetsencrypt(&InmemoryCache{}, "skipper@example.org", "https://acme-staging-v02.api.letsencrypt.org/directory", "skipper-test TestLetsencrypt", []string{validDomain})
+	defer le.Close()
+	if le.manager.Client != nil {
+		dir, err := le.manager.Client.Discover(context.TODO())
+		if err != nil {
+			t.Fatalf("Failed to discover: %v", err)
+		}
+		t.Logf("order: %s", dir.OrderURL)
+
+		defer func() {
+			if le.manager.Client.HTTPClient != nil {
+				le.manager.Client.HTTPClient.CloseIdleConnections()
+			}
+		}()
+	}
+
+	require.NotNil(t, le.Client(), "client should not be nil")
+	require.NotNil(t, le.TLSConfig(), "TLSConfig should not be nil")
+	require.NotNil(t, le.Handler(nil), "http.Handler should not be nil")
+
+	li := le.Listener()
+	defer li.Close()
+	t.Logf("listener %v", li.Addr())
+}

--- a/net/letsencrypt_test.go
+++ b/net/letsencrypt_test.go
@@ -5,27 +5,32 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/zalando/skipper/net/redistest"
+	"github.com/zalando/skipper/net/valkeytest"
 )
 
 func TestRemoteCache(t *testing.T) {
-	t.Logf("create redis..")
-	redisAddr, done := redistest.NewTestRedis(t)
+	t.Logf("create valkey..")
+	valkeyAddr, done := valkeytest.NewTestValkey(t)
 	defer done()
-	if redisAddr == "" {
-		t.Fatal("Failed to create redis 1")
+	if valkeyAddr == "" {
+		t.Fatal("Failed to create valkey 1")
 	}
 
-	redisAddr2, done2 := redistest.NewTestRedis(t)
+	valkeyAddr2, done2 := valkeytest.NewTestValkey(t)
 	defer done2()
-	if redisAddr2 == "" {
-		t.Fatal("Failed to create redis 2")
+	if valkeyAddr2 == "" {
+		t.Fatal("Failed to create valkey 2")
+	}
+
+	client, err := NewValkeyRingClient(&ValkeyOptions{
+		Addrs: []string{valkeyAddr, valkeyAddr2},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create remote cahce client: %v", err)
 	}
 
 	rc := RemoteCache{
-		Client: NewRedisRingClient(&RedisOptions{
-			Addrs: []string{redisAddr, redisAddr2},
-		}),
+		Client: client,
 	}
 	defer rc.Close()
 

--- a/net/letsencrypt_test.go
+++ b/net/letsencrypt_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/net/valkeytest"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 func TestRemoteCache(t *testing.T) {
@@ -34,6 +35,14 @@ func TestRemoteCache(t *testing.T) {
 	}
 	defer rc.Close()
 
+	if v, err := rc.Get(context.Background(), "not-exist"); err != nil {
+		if err != autocert.ErrCacheMiss {
+			t.Fatalf("Failed to get cache miss error on not existing key: %v err: %v", v, err)
+		}
+	} else {
+		t.Fatalf("Want error %q but got %q", autocert.ErrCacheMiss, v)
+	}
+
 	if err := rc.Put(context.Background(), "foo", []byte("bar")); err != nil {
 		t.Fatalf("Failed to put: %v", err)
 	}
@@ -55,8 +64,8 @@ func TestRemoteCache(t *testing.T) {
 func TestInmemoryCache(t *testing.T) {
 	rc := &InmemoryCache{}
 
-	if _, err := rc.Get(context.Background(), "foo"); err == nil {
-		t.Fatal(`Failed can not get "foo" on empty cache`)
+	if _, err := rc.Get(context.Background(), "foo"); err != autocert.ErrCacheMiss {
+		t.Fatal(`Failed can not get cache miss on empty cache`)
 	}
 
 	if err := rc.Put(context.Background(), "foo", []byte("bar")); err != nil {

--- a/net/redisclient.go
+++ b/net/redisclient.go
@@ -409,6 +409,11 @@ func (r *RedisRingClient) SetAddrs(ctx context.Context, addrs []string) {
 	r.ring.SetAddrs(createAddressMap(addrs))
 }
 
+func (r *RedisRingClient) Del(ctx context.Context, key string) error {
+	res := r.ring.Del(ctx, key)
+	return res.Err()
+}
+
 func (r *RedisRingClient) Get(ctx context.Context, key string) (string, error) {
 	res := r.ring.Get(ctx, key)
 	return res.Val(), res.Err()

--- a/net/redisclient.go
+++ b/net/redisclient.go
@@ -392,14 +392,16 @@ func (r *RedisRingClient) StartSpan(operationName string, opts ...opentracing.St
 	return r.tracer.StartSpan(operationName, opts...)
 }
 
-func (r *RedisRingClient) Close() {
+func (r *RedisRingClient) Close() error {
+	var err error
 	r.once.Do(func() {
 		r.closed = true
 		close(r.quit)
 		if r.ring != nil {
-			r.ring.Close()
+			err = r.ring.Close()
 		}
 	})
+	return err
 }
 
 func (r *RedisRingClient) SetAddrs(ctx context.Context, addrs []string) {
@@ -409,13 +411,17 @@ func (r *RedisRingClient) SetAddrs(ctx context.Context, addrs []string) {
 	r.ring.SetAddrs(createAddressMap(addrs))
 }
 
+// make sure we can use *RedisRingClient as autocert.Cache
+var _ RemoteCacheClient = &RedisRingClient{}
+
 func (r *RedisRingClient) Get(ctx context.Context, key string) (string, error) {
 	res := r.ring.Get(ctx, key)
 	return res.Val(), res.Err()
 }
 
-func (r *RedisRingClient) Set(ctx context.Context, key string, value any, expiration time.Duration) (string, error) {
-	res := r.ring.Set(ctx, key, value, expiration)
+func (r *RedisRingClient) Set(ctx context.Context, key, value string) (string, error) {
+	var v interface{} = value
+	res := r.ring.Set(ctx, key, v, 0)
 	return res.Result()
 }
 

--- a/net/redisclient_test.go
+++ b/net/redisclient_test.go
@@ -201,7 +201,7 @@ func TestRedisClientGetSet(t *testing.T) {
 		name    string
 		options *RedisOptions
 		key     string
-		value   any
+		value   string
 		expire  time.Duration
 		wait    time.Duration
 		expect  any
@@ -300,7 +300,7 @@ func TestRedisClientGetSet(t *testing.T) {
 			defer cli.Close()
 			ctx := context.Background()
 
-			_, err := cli.Set(ctx, tt.key, tt.value, tt.expire)
+			err := cli.SetWithExpire(ctx, tt.key, tt.value, tt.expire)
 			if err != nil && !tt.wantErr {
 				t.Errorf("Failed to do Set error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1092,7 +1092,7 @@ func TestRedisClientSetAddr(t *testing.T) {
 			r := NewRedisRingClient(tt.options)
 			defer r.Close()
 			for i := 0; i < len(tt.keys); i++ {
-				r.Set(context.Background(), tt.keys[i], tt.vals[i], time.Second)
+				r.SetWithExpire(context.Background(), tt.keys[i], tt.vals[i], time.Second)
 			}
 			if len(tt.redisUpdate) != len(tt.options.Addrs) {
 				r.SetAddrs(context.Background(), tt.redisUpdate)

--- a/net/valkey.go
+++ b/net/valkey.go
@@ -277,6 +277,11 @@ func (vr *valkeyRing) Expire(ctx context.Context, key string, expire time.Durati
 	return shard.Do(ctx, shard.B().Expire().Key(key).Seconds(int64(expire.Seconds())).Build())
 }
 
+func (vr *valkeyRing) Del(ctx context.Context, key string) valkey.ValkeyResult {
+	shard := vr.shardForKey(key)
+	return shard.Do(ctx, shard.B().Del().Key(key).Build())
+}
+
 func (vr *valkeyRing) Get(ctx context.Context, key string) valkey.ValkeyResult {
 	shard := vr.shardForKey(key)
 	return shard.Do(ctx, shard.B().Get().Key(key).Build())
@@ -518,6 +523,10 @@ func (vrc *ValkeyRingClient) Ping(ctx context.Context, shard string) error {
 func (vrc *ValkeyRingClient) Expire(ctx context.Context, key string, d time.Duration) (int64, error) {
 	res := vrc.ring.Expire(ctx, key, d)
 	return res.ToInt64()
+}
+
+func (vrc *ValkeyRingClient) Del(ctx context.Context, key string) error {
+	return vrc.ring.Del(ctx, key).Error()
 }
 
 func (vrc *ValkeyRingClient) Get(ctx context.Context, key string) (string, error) {

--- a/net/valkey.go
+++ b/net/valkey.go
@@ -414,9 +414,6 @@ func NewValkeyRingClient(opt *ValkeyOptions) (*ValkeyRingClient, error) {
 }
 
 func (vrc *ValkeyRingClient) Close() error {
-	if vrc.closed {
-		return nil
-	}
 	vrc.once.Do(func() {
 		vrc.closed = true
 		close(vrc.quit)
@@ -525,6 +522,9 @@ func (vrc *ValkeyRingClient) Expire(ctx context.Context, key string, d time.Dura
 	res := vrc.ring.Expire(ctx, key, d)
 	return res.ToInt64()
 }
+
+// make sure we can use *ValkeyRingClient as autocert.Cache
+var _ RemoteCacheClient = &ValkeyRingClient{}
 
 func (vrc *ValkeyRingClient) Del(ctx context.Context, key string) (int64, error) {
 	res := vrc.ring.Del(ctx, key)

--- a/ratelimit/leakybucket_test.go
+++ b/ratelimit/leakybucket_test.go
@@ -79,7 +79,7 @@ func verifyAttempts(t *testing.T, capacity int, emission time.Duration, incremen
 				redisAddr, done := redistest.NewTestRedis(t)
 				t.Cleanup(done)
 				ringClient := net.NewRedisRingClient(&net.RedisOptions{Addrs: []string{redisAddr}})
-				t.Cleanup(ringClient.Close)
+				t.Cleanup(func() { ringClient.Close() })
 				return newClusterLeakyBucketRedis(ringClient, capacity, emission, now)
 			},
 		},

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -154,7 +154,7 @@ func New(opts skipper.Options) (*RouteServer, error) {
 	var tlsConfig *tls.Config
 	if opts.EnableMTLS {
 		cr := certregistry.NewCertRegistry()
-		tlsConfig, err = opts.TLSConfig(cr)
+		tlsConfig, err = opts.TlsConfig(cr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tls config: %w", err)
 		}

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -154,7 +154,7 @@ func New(opts skipper.Options) (*RouteServer, error) {
 	var tlsConfig *tls.Config
 	if opts.EnableMTLS {
 		cr := certregistry.NewCertRegistry()
-		tlsConfig, err = opts.TlsConfig(cr)
+		tlsConfig, err = opts.TLSConfig(cr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tls config: %w", err)
 		}

--- a/skipper.go
+++ b/skipper.go
@@ -776,13 +776,10 @@ type Options struct {
 	// BreakerSettings contain global and host specific settings for the circuit breakers.
 	BreakerSettings []circuit.BreakerSettings
 
-	// EnableLetsencrypt
-	EnableLetsencrypt bool
-
-	LetsencryptEmail        string
-	LetsencryptDirectoryURL string
-	LetsencryptUserAgent    string
-	LetsencryptDomains      []string
+	// Letsencrypt if not nil you can use a remote cache config.
+	Letsencrypt *skpnet.Letsencrypt
+	// LetsencryptCache
+	LetsencryptCache string
 
 	// EnableRatelimiters enables the usage of the ratelimiter in the route definitions without initializing any
 	// by default. It is a shortcut for setting the RatelimitSettings to:
@@ -2034,7 +2031,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	var (
 		swarmer       ratelimit.Swarmer
 		redisOptions  *skpnet.RedisOptions
-		redisClient   *skpnet.RedisRingClient
 		valkeyOptions *skpnet.ValkeyOptions
 		valkeyClient  *skpnet.ValkeyRingClient
 	)
@@ -2192,9 +2188,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		}
 	}
 
-	if redisOptions != nil {
-		redisClient = skpnet.NewRedisRingClient(redisOptions)
-	}
 	if valkeyOptions != nil {
 		valkeyClient, err = skpnet.NewValkeyRingClient(valkeyOptions)
 		if err != nil {
@@ -2202,32 +2195,22 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		}
 	}
 
-	if o.EnableLetsencrypt {
-		var cache autocert.Cache
+	if o.Letsencrypt != nil {
 		switch o.LetsencryptCache {
-		case "directory":
-			cache = autocert.DirCache(os.TempDir())
 		case "remote":
-			cache = &net.RemoteCache{
-				Client: redisClient,
+			var cache autocert.Cache
+			switch {
+			case valkeyClient != nil:
+				cache = &skpnet.RemoteCache{
+					Client: valkeyClient,
+				}
 			}
-
-		case "inmemory":
-			cache = &skpnet.InmemoryCache{}
+			if cache != nil {
+				o.Letsencrypt.SetCache(cache)
+			}
 		default:
-
+			// nothing to do, see config/config.go
 		}
-
-		le := skpnet.NewLetsencrypt(
-			cache,
-			o.LetsencryptEmail,
-			o.LetsencryptDirectoryURL,
-			o.LetsencryptUserAgent,
-			o.LetsencryptDomains,
-		)
-		_ = le
-		// le.Handler(o.CustomHttpHandlerWrap)
-		// o.CustomHttpHandlerWrap = leHandler()
 	}
 
 	var ratelimitRegistry *ratelimit.Registry

--- a/skipper.go
+++ b/skipper.go
@@ -778,6 +778,7 @@ type Options struct {
 
 	// Letsencrypt if not nil you can use a remote cache config.
 	Letsencrypt *skpnet.Letsencrypt
+
 	// LetsencryptCache
 	LetsencryptCache string
 
@@ -1428,6 +1429,11 @@ func (o *Options) filterRegistry() filters.Registry {
 
 func (o *Options) tlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) {
 
+	// TODO(sszuecs): does it make sense or do we want to chain TLSConfigs?
+	if o.Letsencrypt != nil {
+		return o.Letsencrypt.TLSConfig(), nil
+	}
+
 	if o.ProxyTLS != nil {
 		return o.ProxyTLS, nil
 	}
@@ -1460,7 +1466,7 @@ func (o *Options) tlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 		return nil, fmt.Errorf("number of certificates does not match number of keys")
 	}
 
-	for i := 0; i < len(crts); i++ {
+	for i := range crts {
 		crt, key := crts[i], keys[i]
 		keypair, err := tls.LoadX509KeyPair(crt, key)
 		if err != nil {
@@ -2196,6 +2202,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	}
 
 	if o.Letsencrypt != nil {
+		println("running Letsencrypt")
 		switch o.LetsencryptCache {
 		case "remote":
 			var cache autocert.Cache

--- a/skipper.go
+++ b/skipper.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel"
 	otBridge "go.opentelemetry.io/otel/bridge/opentracing"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/zalando/skipper/circuit"
 	"github.com/zalando/skipper/dataclients/kubernetes"
@@ -774,6 +775,14 @@ type Options struct {
 
 	// BreakerSettings contain global and host specific settings for the circuit breakers.
 	BreakerSettings []circuit.BreakerSettings
+
+	// EnableLetsencrypt
+	EnableLetsencrypt bool
+
+	LetsencryptEmail        string
+	LetsencryptDirectoryURL string
+	LetsencryptUserAgent    string
+	LetsencryptDomains      []string
 
 	// EnableRatelimiters enables the usage of the ratelimiter in the route definitions without initializing any
 	// by default. It is a shortcut for setting the RatelimitSettings to:
@@ -2025,7 +2034,9 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	var (
 		swarmer       ratelimit.Swarmer
 		redisOptions  *skpnet.RedisOptions
+		redisClient   *skpnet.RedisRingClient
 		valkeyOptions *skpnet.ValkeyOptions
+		valkeyClient  *skpnet.ValkeyRingClient
 	)
 	log.Infof("enable swarm: %v", o.EnableSwarm)
 	if o.EnableSwarm {
@@ -2179,6 +2190,44 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 				return err
 			}
 		}
+	}
+
+	if redisOptions != nil {
+		redisClient = skpnet.NewRedisRingClient(redisOptions)
+	}
+	if valkeyOptions != nil {
+		valkeyClient, err = skpnet.NewValkeyRingClient(valkeyOptions)
+		if err != nil {
+			return err
+		}
+	}
+
+	if o.EnableLetsencrypt {
+		var cache autocert.Cache
+		switch o.LetsencryptCache {
+		case "directory":
+			cache = autocert.DirCache(os.TempDir())
+		case "remote":
+			cache = &net.RemoteCache{
+				Client: redisClient,
+			}
+
+		case "inmemory":
+			cache = &skpnet.InmemoryCache{}
+		default:
+
+		}
+
+		le := skpnet.NewLetsencrypt(
+			cache,
+			o.LetsencryptEmail,
+			o.LetsencryptDirectoryURL,
+			o.LetsencryptUserAgent,
+			o.LetsencryptDomains,
+		)
+		_ = le
+		// le.Handler(o.CustomHttpHandlerWrap)
+		// o.CustomHttpHandlerWrap = leHandler()
 	}
 
 	var ratelimitRegistry *ratelimit.Registry

--- a/skipper.go
+++ b/skipper.go
@@ -2322,10 +2322,12 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 				o.Letsencrypt.SetCache(&skpnet.RemoteCache{
 					Client: redisRing,
 				})
-
 			default:
-				// nothing to do, see config/config.go for other autocert.Cache implementations
+				log.Fatal("Failed to set letsencrypt remote cache: no valkey nor redis ring")
 			}
+
+		default:
+			// nothing to do, see config/config.go for other autocert.Cache implementations
 		}
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -1522,6 +1522,10 @@ func (o *Options) TlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 		return o.ProxyTLS, nil
 	}
 
+	if o.CertPathTLS == "" && o.KeyPathTLS == "" && cr == nil && o.Letsencrypt == nil {
+		return nil, nil
+	}
+
 	if o.Letsencrypt != nil {
 		// sets:
 		// - GetCertificate
@@ -1533,10 +1537,6 @@ func (o *Options) TlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 			GetCertificate: cr.GetCertFromHello,
 		}
 	} else {
-		if o.CertPathTLS == "" && o.KeyPathTLS == "" {
-			return nil, nil
-		}
-
 		config = &tls.Config{}
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -834,6 +834,12 @@ type Options struct {
 	// BreakerSettings contain global and host specific settings for the circuit breakers.
 	BreakerSettings []circuit.BreakerSettings
 
+	// Letsencrypt if not nil you can use a remote cache config.
+	Letsencrypt *skpnet.Letsencrypt
+
+	// LetsencryptCache
+	LetsencryptCache string
+
 	// EnableRatelimiters enables the usage of the ratelimiter in the route definitions without initializing any
 	// by default. It is a shortcut for setting the RatelimitSettings to:
 	//
@@ -1511,6 +1517,11 @@ func (o *Options) filterRegistry() filters.Registry {
 
 func (o *Options) TlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) {
 
+	// TODO(sszuecs): does it make sense or do we want to chain TLSConfigs?
+	if o.Letsencrypt != nil {
+		return o.Letsencrypt.TLSConfig(), nil
+	}
+
 	if o.ProxyTLS != nil {
 		return o.ProxyTLS, nil
 	}
@@ -2120,7 +2131,9 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	var (
 		swarmer       ratelimit.Swarmer
 		redisOptions  *skpnet.RedisOptions
+		redisRing     *skpnet.RedisRingClient
 		valkeyOptions *skpnet.ValkeyOptions
+		valkeyRing    *skpnet.ValkeyRingClient
 	)
 	log.Infof("enable swarm: %v", o.EnableSwarm)
 	if o.EnableSwarm {
@@ -2272,7 +2285,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		}
 	}
 
-	var valkeyRing *skpnet.ValkeyRingClient
 	if valkeyOptions != nil {
 		if valkeyOptions.MetricsPrefix == "" {
 			valkeyOptions.MetricsPrefix = ratelimit.ValkeyMetricsPrefix
@@ -2284,13 +2296,33 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		defer valkeyRing.Close()
 	}
 
-	var redisRing *skpnet.RedisRingClient
 	if redisOptions != nil {
 		if redisOptions.MetricsPrefix == "" {
 			redisOptions.MetricsPrefix = ratelimit.RedisMetricsPrefix
 		}
 		redisRing = skpnet.NewRedisRingClient(redisOptions)
 		defer redisRing.Close()
+	}
+
+	if o.Letsencrypt != nil {
+		switch o.LetsencryptCache {
+		case "remote":
+			// we need this here because of the remote cache client init
+			switch {
+			case valkeyRing != nil:
+				o.Letsencrypt.SetCache(&skpnet.RemoteCache{
+					Client: valkeyRing,
+				})
+
+			case redisRing != nil:
+				o.Letsencrypt.SetCache(&skpnet.RemoteCache{
+					Client: redisRing,
+				})
+
+			default:
+				// nothing to do, see config/config.go for other autocert.Cache implementations
+			}
+		}
 	}
 
 	var (

--- a/skipper.go
+++ b/skipper.go
@@ -1527,15 +1527,17 @@ func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 		// - GetCertificate
 		// - NextProtos
 		tlsConfig = o.Letsencrypt.TLSConfig()
-	}
-
-	if o.Letsencrypt == nil && cr != nil {
+	} else if cr != nil {
 		tlsConfig = &tls.Config{
 			// sets GetCertificate which was already set by Letsencrypt.TLSConfig()
 			GetCertificate: cr.GetCertFromHello,
 		}
-	} else if tlsConfig == nil {
-		return nil, nil
+	} else {
+		if o.CertPathTLS == "" && o.KeyPathTLS == "" {
+			return nil, nil
+		}
+
+		tlsConfig = &tls.Config{}
 	}
 
 	tlsConfig.MinVersion = o.TLSMinVersion

--- a/skipper.go
+++ b/skipper.go
@@ -1516,7 +1516,7 @@ func (o *Options) filterRegistry() filters.Registry {
 }
 
 func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) {
-	var tlsConfig *tls.Config
+	var config *tls.Config
 
 	if o.ProxyTLS != nil {
 		return o.ProxyTLS, nil
@@ -1526,9 +1526,9 @@ func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 		// sets:
 		// - GetCertificate
 		// - NextProtos
-		tlsConfig = o.Letsencrypt.TLSConfig()
+		config = o.Letsencrypt.TLSConfig()
 	} else if cr != nil {
-		tlsConfig = &tls.Config{
+		config = &tls.Config{
 			// sets GetCertificate which was already set by Letsencrypt.TLSConfig()
 			GetCertificate: cr.GetCertFromHello,
 		}
@@ -1537,20 +1537,20 @@ func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 			return nil, nil
 		}
 
-		tlsConfig = &tls.Config{}
+		config = &tls.Config{}
 	}
 
-	tlsConfig.MinVersion = o.TLSMinVersion
-	tlsConfig.ClientAuth = o.TLSClientAuth
-	tlsConfig.KeyLogWriter = o.KeyLogWriter
-	tlsConfig.VerifyConnection = o.VerifyConnection
+	config.MinVersion = o.TLSMinVersion
+	config.ClientAuth = o.TLSClientAuth
+	config.KeyLogWriter = o.KeyLogWriter
+	config.VerifyConnection = o.VerifyConnection
 
 	if o.CipherSuites != nil {
-		tlsConfig.CipherSuites = o.CipherSuites
+		config.CipherSuites = o.CipherSuites
 	}
 
 	if o.CertPathTLS == "" && o.KeyPathTLS == "" {
-		return tlsConfig, nil
+		return config, nil
 	}
 
 	crts := strings.Split(o.CertPathTLS, ",")
@@ -1566,9 +1566,9 @@ func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to load X509 keypair from %s and %s: %w", crt, key, err)
 		}
-		tlsConfig.Certificates = append(tlsConfig.Certificates, keypair)
+		config.Certificates = append(config.Certificates, keypair)
 	}
-	return tlsConfig, nil
+	return config, nil
 }
 
 func (o *Options) openTracingTracerInstance() (ot.Tracer, error) {

--- a/skipper.go
+++ b/skipper.go
@@ -1515,7 +1515,7 @@ func (o *Options) filterRegistry() filters.Registry {
 	return registry
 }
 
-func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) {
+func (o *Options) TlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) {
 	var config *tls.Config
 
 	if o.ProxyTLS != nil {
@@ -1639,7 +1639,7 @@ func listenAndServeQuit(
 	mtr metrics.Metrics,
 	cr *certregistry.CertRegistry,
 ) error {
-	tlsConfig, err := o.TLSConfig(cr)
+	tlsConfig, err := o.TlsConfig(cr)
 	if err != nil {
 		return err
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -1515,38 +1515,45 @@ func (o *Options) filterRegistry() filters.Registry {
 	return registry
 }
 
-func (o *Options) TlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) {
-
-	// TODO(sszuecs): does it make sense or do we want to chain TLSConfigs?
-	if o.Letsencrypt != nil {
-		return o.Letsencrypt.TLSConfig(), nil
-	}
+func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) {
+	var tlsConfig *tls.Config
 
 	if o.ProxyTLS != nil {
-		return o.ProxyTLS, nil
+		tlsConfig = o.ProxyTLS
 	}
 
-	if o.CertPathTLS == "" && o.KeyPathTLS == "" && cr == nil {
-		return nil, nil
+	if o.Letsencrypt != nil {
+		// sets:
+		// - GetCertificate
+		// - NextProtos
+		tlsConfig = o.Letsencrypt.TLSConfig()
 	}
 
-	config := &tls.Config{
-		MinVersion:       o.TLSMinVersion,
-		ClientAuth:       o.TLSClientAuth,
-		KeyLogWriter:     o.KeyLogWriter,
-		VerifyConnection: o.VerifyConnection,
+	if tlsConfig != nil {
+		tlsConfig.MinVersion = o.TLSMinVersion
+		tlsConfig.ClientAuth = o.TLSClientAuth
+		tlsConfig.KeyLogWriter = o.KeyLogWriter
+		tlsConfig.VerifyConnection = o.VerifyConnection
+	} else {
+		tlsConfig = &tls.Config{
+			MinVersion:       o.TLSMinVersion,
+			ClientAuth:       o.TLSClientAuth,
+			KeyLogWriter:     o.KeyLogWriter,
+			VerifyConnection: o.VerifyConnection,
+		}
 	}
 
 	if o.CipherSuites != nil {
-		config.CipherSuites = o.CipherSuites
+		tlsConfig.CipherSuites = o.CipherSuites
 	}
 
-	if cr != nil {
-		config.GetCertificate = cr.GetCertFromHello
+	if o.Letsencrypt == nil && cr != nil {
+		// sets GetCertificate which was already set by Letsencrypt.TLSConfig()
+		tlsConfig.GetCertificate = cr.GetCertFromHello
 	}
 
 	if o.CertPathTLS == "" && o.KeyPathTLS == "" {
-		return config, nil
+		return tlsConfig, nil
 	}
 
 	crts := strings.Split(o.CertPathTLS, ",")
@@ -1562,9 +1569,9 @@ func (o *Options) TlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to load X509 keypair from %s and %s: %w", crt, key, err)
 		}
-		config.Certificates = append(config.Certificates, keypair)
+		tlsConfig.Certificates = append(tlsConfig.Certificates, keypair)
 	}
-	return config, nil
+	return tlsConfig, nil
 }
 
 func (o *Options) openTracingTracerInstance() (ot.Tracer, error) {
@@ -1635,7 +1642,7 @@ func listenAndServeQuit(
 	mtr metrics.Metrics,
 	cr *certregistry.CertRegistry,
 ) error {
-	tlsConfig, err := o.TlsConfig(cr)
+	tlsConfig, err := o.TLSConfig(cr)
 	if err != nil {
 		return err
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -1519,7 +1519,7 @@ func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 	var tlsConfig *tls.Config
 
 	if o.ProxyTLS != nil {
-		tlsConfig = o.ProxyTLS
+		return o.ProxyTLS, nil
 	}
 
 	if o.Letsencrypt != nil {
@@ -1529,27 +1529,22 @@ func (o *Options) TLSConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 		tlsConfig = o.Letsencrypt.TLSConfig()
 	}
 
-	if tlsConfig != nil {
-		tlsConfig.MinVersion = o.TLSMinVersion
-		tlsConfig.ClientAuth = o.TLSClientAuth
-		tlsConfig.KeyLogWriter = o.KeyLogWriter
-		tlsConfig.VerifyConnection = o.VerifyConnection
-	} else {
+	if o.Letsencrypt == nil && cr != nil {
 		tlsConfig = &tls.Config{
-			MinVersion:       o.TLSMinVersion,
-			ClientAuth:       o.TLSClientAuth,
-			KeyLogWriter:     o.KeyLogWriter,
-			VerifyConnection: o.VerifyConnection,
+			// sets GetCertificate which was already set by Letsencrypt.TLSConfig()
+			GetCertificate: cr.GetCertFromHello,
 		}
+	} else if tlsConfig == nil {
+		return nil, nil
 	}
+
+	tlsConfig.MinVersion = o.TLSMinVersion
+	tlsConfig.ClientAuth = o.TLSClientAuth
+	tlsConfig.KeyLogWriter = o.KeyLogWriter
+	tlsConfig.VerifyConnection = o.VerifyConnection
 
 	if o.CipherSuites != nil {
 		tlsConfig.CipherSuites = o.CipherSuites
-	}
-
-	if o.Letsencrypt == nil && cr != nil {
-		// sets GetCertificate which was already set by Letsencrypt.TLSConfig()
-		tlsConfig.GetCertificate = cr.GetCertFromHello
 	}
 
 	if o.CertPathTLS == "" && o.KeyPathTLS == "" {

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -239,45 +239,45 @@ func TestOptionsTLSConfig(t *testing.T) {
 
 	// empty without registry
 	o := &Options{}
-	c, err := o.TLSConfig(nil)
+	c, err := o.TlsConfig(nil)
 	require.NoError(t, err)
 	require.Nil(t, c)
 
 	// empty with registry
 	o = &Options{}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	require.NotNil(t, c.GetCertificate)
 
 	// proxy tls config
 	o = &Options{ProxyTLS: proxyTLS}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	require.Same(t, proxyTLS, c)
 
 	// proxy tls config priority
 	o = &Options{ProxyTLS: proxyTLS, CertPathTLS: "fixtures/test.crt", KeyPathTLS: "fixtures/test.key"}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	require.Same(t, proxyTLS, c)
 
 	// cert key path
 	o = &Options{TLSMinVersion: tls.VersionTLS12, CertPathTLS: "fixtures/test.crt", KeyPathTLS: "fixtures/test.key"}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	require.Equal(t, uint16(tls.VersionTLS12), c.MinVersion)
 	require.Equal(t, []tls.Certificate{cert}, c.Certificates)
 
 	// multiple cert key paths
 	o = &Options{TLSMinVersion: tls.VersionTLS13, CertPathTLS: "fixtures/test.crt,fixtures/test2.crt", KeyPathTLS: "fixtures/test.key,fixtures/test2.key"}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	require.Equal(t, uint16(tls.VersionTLS13), c.MinVersion)
 	require.Equal(t, []tls.Certificate{cert, cert2}, c.Certificates)
 
 	// TLS Cipher Suites
 	o = &Options{CipherSuites: []uint16{1}}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	assert.Equal(t, len(c.CipherSuites), 1)
 
@@ -291,7 +291,7 @@ func TestOptionsTLSConfig(t *testing.T) {
 		KeyLogWriter:     keyLogWriter,
 		VerifyConnection: verifyConnection,
 	}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.Same(t, keyLogWriter, c.KeyLogWriter)
@@ -302,7 +302,7 @@ func TestOptionsTLSConfig(t *testing.T) {
 		Letsencrypt:   skpnet.NewLetsencrypt(&skpnet.InmemoryCache{}, "email@example", "http://dir.example/url", "UA", []string{"example.test"}),
 		TLSMinVersion: tls.VersionTLS12,
 	}
-	c, err = o.TLSConfig(cr)
+	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	require.Equal(t, uint16(tls.VersionTLS12), c.MinVersion)
 	assert.NotNil(t, c.GetCertificate)
@@ -325,7 +325,7 @@ func TestOptionsTLSConfigInvalidPaths(t *testing.T) {
 		{"multiple cert key mismatch", &Options{CertPathTLS: "fixtures/test.crt,fixtures/test2.crt", KeyPathTLS: "fixtures/test2.key,fixtures/test.key"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.options.TLSConfig(cr)
+			_, err := tt.options.TlsConfig(cr)
 			t.Logf("tlsConfig error: %v", err)
 			require.Error(t, err)
 		})

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -239,45 +239,45 @@ func TestOptionsTLSConfig(t *testing.T) {
 
 	// empty without registry
 	o := &Options{}
-	c, err := o.TlsConfig(nil)
+	c, err := o.TLSConfig(nil)
 	require.NoError(t, err)
 	require.Nil(t, c)
 
 	// empty with registry
 	o = &Options{}
-	c, err = o.TlsConfig(cr)
+	c, err = o.TLSConfig(cr)
 	require.NoError(t, err)
 	require.NotNil(t, c.GetCertificate)
 
 	// proxy tls config
 	o = &Options{ProxyTLS: proxyTLS}
-	c, err = o.TlsConfig(cr)
+	c, err = o.TLSConfig(cr)
 	require.NoError(t, err)
 	require.Same(t, proxyTLS, c)
 
 	// proxy tls config priority
 	o = &Options{ProxyTLS: proxyTLS, CertPathTLS: "fixtures/test.crt", KeyPathTLS: "fixtures/test.key"}
-	c, err = o.TlsConfig(cr)
+	c, err = o.TLSConfig(cr)
 	require.NoError(t, err)
 	require.Same(t, proxyTLS, c)
 
 	// cert key path
 	o = &Options{TLSMinVersion: tls.VersionTLS12, CertPathTLS: "fixtures/test.crt", KeyPathTLS: "fixtures/test.key"}
-	c, err = o.TlsConfig(cr)
+	c, err = o.TLSConfig(cr)
 	require.NoError(t, err)
 	require.Equal(t, uint16(tls.VersionTLS12), c.MinVersion)
 	require.Equal(t, []tls.Certificate{cert}, c.Certificates)
 
 	// multiple cert key paths
 	o = &Options{TLSMinVersion: tls.VersionTLS13, CertPathTLS: "fixtures/test.crt,fixtures/test2.crt", KeyPathTLS: "fixtures/test.key,fixtures/test2.key"}
-	c, err = o.TlsConfig(cr)
+	c, err = o.TLSConfig(cr)
 	require.NoError(t, err)
 	require.Equal(t, uint16(tls.VersionTLS13), c.MinVersion)
 	require.Equal(t, []tls.Certificate{cert, cert2}, c.Certificates)
 
 	// TLS Cipher Suites
 	o = &Options{CipherSuites: []uint16{1}}
-	c, err = o.TlsConfig(cr)
+	c, err = o.TLSConfig(cr)
 	require.NoError(t, err)
 	assert.Equal(t, len(c.CipherSuites), 1)
 
@@ -291,7 +291,7 @@ func TestOptionsTLSConfig(t *testing.T) {
 		KeyLogWriter:     keyLogWriter,
 		VerifyConnection: verifyConnection,
 	}
-	c, err = o.TlsConfig(cr)
+	c, err = o.TLSConfig(cr)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.Same(t, keyLogWriter, c.KeyLogWriter)
@@ -315,7 +315,7 @@ func TestOptionsTLSConfigInvalidPaths(t *testing.T) {
 		{"multiple cert key mismatch", &Options{CertPathTLS: "fixtures/test.crt,fixtures/test2.crt", KeyPathTLS: "fixtures/test2.key,fixtures/test.key"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.options.TlsConfig(cr)
+			_, err := tt.options.TLSConfig(cr)
 			t.Logf("tlsConfig error: %v", err)
 			require.Error(t, err)
 		})

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -297,6 +297,16 @@ func TestOptionsTLSConfig(t *testing.T) {
 	assert.Same(t, keyLogWriter, c.KeyLogWriter)
 	assert.NotNil(t, c.VerifyConnection)
 
+	// Letsencrypt
+	o = &Options{
+		Letsencrypt:   skpnet.NewLetsencrypt(&skpnet.InmemoryCache{}, "email@example", "http://dir.example/url", "UA", []string{"example.test"}),
+		TLSMinVersion: tls.VersionTLS12,
+	}
+	c, err = o.TLSConfig(cr)
+	require.NoError(t, err)
+	require.Equal(t, uint16(tls.VersionTLS12), c.MinVersion)
+	assert.NotNil(t, c.GetCertificate)
+	assert.NotNil(t, c.NextProtos)
 }
 
 func TestOptionsTLSConfigInvalidPaths(t *testing.T) {


### PR DESCRIPTION
feature: letsencrypt http.Handler integration via autocert with different storage/cache systems to be used by different deployments

Test:
I am running this now since a while on my personal websites and completely replaced certbot+apache+cron to automate certs via skipper+curl+cron.

ref: closes https://github.com/zalando/skipper/issues/1786