### PR TITLE
proxy/tracing: loopback spans bugfix

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1255,6 +1255,10 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 		p.setCommonSpanInfo(ctx.Request().URL, ctx.Request(), loopSpan)
 		ctx.parentSpan = loopSpan
 
+		r := loopCTX.Request()
+		r = r.WithContext(ot.ContextWithSpan(r.Context(), loopSpan))
+		loopCTX.request = r
+
 		defer loopSpan.Finish()
 
 		if err := p.do(loopCTX, loopSpan); err != nil {

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -148,10 +148,10 @@ func TestTracingIngressSpanLoopback(t *testing.T) {
 	}
 
 	doc := fmt.Sprintf(`
-%s: Path("/shunt") -> setPath("/bye") -> setQuery("void") -> status(204) -> <shunt>;
-%s: Path("/loop1") -> setPath("/shunt") -> <loopback>;
-%s: Path("/loop2") -> setPath("/loop1") -> <loopback>;
-`, shuntRouteID, loop1RouteID, loop2RouteID)
+%s: Path("/shunt") -> setPath("/bye") -> setQuery("void") -> tracingTag("tracing-tag", "%s") -> status(204) -> <shunt>;
+%s: Path("/loop1") -> setPath("/shunt") -> tracingTag("tracing-tag", "%s") -> <loopback>;
+%s: Path("/loop2") -> setPath("/loop1") -> tracingTag("tracing-tag", "%s") -> <loopback>;
+`, shuntRouteID, shuntRouteID, loop1RouteID, loop1RouteID, loop2RouteID, loop2RouteID)
 
 	tracer := tracingtest.NewTracer()
 	params := Params{
@@ -205,6 +205,7 @@ func TestTracingIngressSpanLoopback(t *testing.T) {
 		verifyTag(t, span, HTTPPathTag, paths[rid])
 		verifyTag(t, span, HTTPHostTag, ps.Listener.Addr().String())
 		verifyTag(t, span, FlowIDTag, "test-flow-id")
+		verifyTag(t, span, "tracing-tag", rid)
 	}
 }
 


### PR DESCRIPTION
  When a request is looped back, all tracing operations (such as tagging and creating new spans) are performed on the original request's span rather than on the loopback span. This results in inaccurate tracing data: tags are overwritten, and the ingress span incorrectly appears to have child spans that actually belong to the inner loopback spans.

This PR adds a test case to illustrate the issue, along with a potential bug fix.

The trace produced by the request to the routegroup below

<img width="1045" alt="Screenshot 2025-07-09 at 09 17 24" src="https://github.com/user-attachments/assets/a51d03cd-b40e-4e00-8466-a5f13d8672b7" />
Both loopbacks are children of the ingress span
<details>
<summary>routegroup definition</summary>

```yaml
---
apiVersion: zalando.org/v1
kind: RouteGroup
metadata:
  name: loopback-test
spec:
  hosts:
  - loopback-test.playground.zalan.do
  backends:
  - name: loopback
    type: loopback
  - name: shunt
    type: shunt
  routes:
  - pathSubtree: /
    filters:
    - appendRequestHeader("A", "B")
    backends:
    - backendName: loopback
  - pathSubtree: /
    predicates:
    - Header("A","B")
    filters:
    - setRequestHeader("A", "C")
    - tracingTag("loop", "first")
    backends:
    - backendName: loopback
  - pathSubtree: /
    predicates:
    - Header("A","C")
    filters:
    - tracingTag("loop", "second")
    - inlineContent("boo")
    - status(200)
    backends:
    - backendName: shunt
```

</details>

The trace after the bugfix
![image](https://github.com/user-attachments/assets/058b02a6-351c-46e4-9db9-c3aea0fec334)
