### PR TITLE
doc: metrics-flavour args were not clear how to set "both"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -380,7 +380,7 @@ func NewConfig() *Config {
 	flag.Var(&cfg.Ratelimits, "ratelimits", ratelimitsUsage)
 	flag.BoolVar(&cfg.EnableRouteFIFOMetrics, "enable-route-fifo-metrics", false, "enable metrics for the individual route FIFO queues")
 	flag.BoolVar(&cfg.EnableRouteLIFOMetrics, "enable-route-lifo-metrics", false, "enable metrics for the individual route LIFO queues")
-	flag.Var(cfg.MetricsFlavour, "metrics-flavour", "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale' and 'prometheus', you can select both of them")
+	flag.Var(cfg.MetricsFlavour, "metrics-flavour", "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale' and 'prometheus', you can select both of them by using one option with ',' separated values")
 	flag.Var(cfg.FilterPlugins, "filter-plugin", "set a custom filter plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.PredicatePlugins, "predicate-plugin", "set a custom predicate plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.DataclientPlugins, "dataclient-plugin", "set a custom dataclient plugins to load, a comma separated list of name and arguments")


### PR DESCRIPTION
We can not set  `skipper -metrics-flavour codahale -metrics-flavour prometheus` as I would expect from the args doc.

We have to set `skipper -metrics-flavour codahale,prometheus`