### PR TITLE
Move OPA instance configuration to registry level

### DIFF
--- a/filters/openpolicyagent/opaauthorizerequest/benchmark_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/benchmark_test.go
@@ -467,7 +467,11 @@ func newDecisionConsumer() *httptest.Server {
 func createOpaFilter(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
 
-	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	if err != nil {
+		return nil, err
+	}
+
 	spec := NewOpaAuthorizeRequestSpec(opaFactory)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }
@@ -475,7 +479,11 @@ func createOpaFilter(opts FilterOptions) (filters.Filter, error) {
 func createBodyBasedOpaFilter(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
 
-	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	if err != nil {
+		return nil, err
+	}
+
 	spec := NewOpaAuthorizeRequestWithBodySpec(opaFactory)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }
@@ -529,7 +537,11 @@ func generateConfig(opaControlPlane string, decisionLogConsumer string, decision
 
 func createOpaFilterForMultipleBundles(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfigForMultipleBundles(opts.BundleNames, opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
-	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	if err != nil {
+		return nil, err
+	}
+
 	// Enable data pre-processing optimization by default for multiple bundles
 	spec := NewOpaAuthorizeRequestSpec(opaFactory)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
@@ -537,7 +549,11 @@ func createOpaFilterForMultipleBundles(opts FilterOptions) (filters.Filter, erro
 
 func createOpaFilterWithDataProcessingOptimization(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfigForMultipleBundles(opts.BundleNames, opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
-	registry := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithEnableDataPreProcessingOptimization(true), openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	registry, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithEnableDataPreProcessingOptimization(true), openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	if err != nil {
+		return nil, err
+	}
+
 	spec := NewOpaAuthorizeRequestSpec(registry)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }

--- a/filters/openpolicyagent/opaauthorizerequest/benchmark_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/benchmark_test.go
@@ -3,14 +3,6 @@ package opaauthorizerequest
 import (
 	_ "embed"
 	"fmt"
-	"github.com/golang-jwt/jwt/v4"
-	opasdktest "github.com/open-policy-agent/opa/v1/sdk/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/zalando/skipper/filters"
-	"github.com/zalando/skipper/filters/filtertest"
-	"github.com/zalando/skipper/filters/openpolicyagent"
-	"github.com/zalando/skipper/metrics/metricstest"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +11,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	opasdktest "github.com/open-policy-agent/opa/v1/sdk/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/filters/openpolicyagent"
+	"github.com/zalando/skipper/metrics/metricstest"
 )
 
 const (
@@ -465,15 +466,17 @@ func newDecisionConsumer() *httptest.Server {
 
 func createOpaFilter(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
-	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry()
-	spec := NewOpaAuthorizeRequestSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+
+	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	spec := NewOpaAuthorizeRequestSpec(opaFactory)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }
 
 func createBodyBasedOpaFilter(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
-	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry()
-	spec := NewOpaAuthorizeRequestWithBodySpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+
+	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	spec := NewOpaAuthorizeRequestWithBodySpec(opaFactory)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }
 
@@ -526,15 +529,16 @@ func generateConfig(opaControlPlane string, decisionLogConsumer string, decision
 
 func createOpaFilterForMultipleBundles(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfigForMultipleBundles(opts.BundleNames, opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
-	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry()
-	spec := NewOpaAuthorizeRequestSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+	opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	// Enable data pre-processing optimization by default for multiple bundles
+	spec := NewOpaAuthorizeRequestSpec(opaFactory)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }
 
 func createOpaFilterWithDataProcessingOptimization(opts FilterOptions) (filters.Filter, error) {
 	config := generateConfigForMultipleBundles(opts.BundleNames, opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
-	registry := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithEnableDataPreProcessingOptimization(true))
-	spec := NewOpaAuthorizeRequestSpec(registry, openpolicyagent.WithConfigTemplate(config))
+	registry := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithEnableDataPreProcessingOptimization(true), openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+	spec := NewOpaAuthorizeRequestSpec(registry)
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }
 

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest.go
@@ -20,23 +20,20 @@ const responseHeadersKey = "open-policy-agent:decision-response-headers"
 
 type spec struct {
 	registry    *openpolicyagent.OpenPolicyAgentRegistry
-	opts        []func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error
 	name        string
 	bodyParsing bool
 }
 
-func NewOpaAuthorizeRequestSpec(registry *openpolicyagent.OpenPolicyAgentRegistry, opts ...func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error) filters.Spec {
+func NewOpaAuthorizeRequestSpec(registry *openpolicyagent.OpenPolicyAgentRegistry) filters.Spec {
 	return &spec{
 		registry: registry,
-		opts:     opts,
 		name:     filters.OpaAuthorizeRequestName,
 	}
 }
 
-func NewOpaAuthorizeRequestWithBodySpec(registry *openpolicyagent.OpenPolicyAgentRegistry, opts ...func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error) filters.Spec {
+func NewOpaAuthorizeRequestWithBodySpec(registry *openpolicyagent.OpenPolicyAgentRegistry) filters.Spec {
 	return &spec{
 		registry:    registry,
-		opts:        opts,
 		name:        filters.OpaAuthorizeRequestWithBodyName,
 		bodyParsing: true,
 	}
@@ -74,15 +71,7 @@ func (s *spec) CreateFilter(args []interface{}) (filters.Filter, error) {
 		}
 	}
 
-	configOptions := s.opts
-
-	opaConfig, err := openpolicyagent.NewOpenPolicyAgentConfig(configOptions...)
-	if err != nil {
-		return nil, err
-	}
-
-	opa, err := s.registry.NewOpenPolicyAgentInstance(bundleName, *opaConfig, s.Name())
-
+	opa, err := s.registry.NewOpenPolicyAgentInstance(bundleName, s.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -2,6 +2,12 @@ package opaauthorizerequest
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	opasdktest "github.com/open-policy-agent/opa/v1/sdk/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,11 +16,6 @@ import (
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/proxy/proxytest"
 	"github.com/zalando/skipper/tracing/tracingtest"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
 
 	"github.com/zalando/skipper/filters/openpolicyagent"
 )
@@ -554,12 +555,14 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 			opts := make([]func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error, 0)
 			opts = append(opts,
 				openpolicyagent.WithConfigTemplate(config),
-				openpolicyagent.WithEnvoyMetadataBytes(envoyMetaDataConfig))
+				openpolicyagent.WithEnvoyMetadataBytes(envoyMetaDataConfig),
+			)
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()))
-			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory, opts...)
+			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
+				openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...))
+			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory)
 			fr.Register(ftSpec)
-			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, opts...)
+			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory)
 			fr.Register(ftSpec)
 			fr.Register(builtin.NewSetPath())
 
@@ -602,8 +605,9 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 }
 
 func TestCreateFilterArguments(t *testing.T) {
-	opaRegistry := openpolicyagent.NewOpenPolicyAgentRegistry()
-	ftSpec := NewOpaAuthorizeRequestSpec(opaRegistry, openpolicyagent.WithConfigTemplate([]byte("")))
+	opaRegistry := openpolicyagent.NewOpenPolicyAgentRegistry(
+		openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate([]byte(""))))
+	ftSpec := NewOpaAuthorizeRequestSpec(opaRegistry)
 
 	_, err := ftSpec.CreateFilter([]interface{}{})
 	assert.ErrorIs(t, err, filters.ErrInvalidFilterParameters)
@@ -722,10 +726,11 @@ func TestAuthorizeRequestInputContract(t *testing.T) {
 				openpolicyagent.WithConfigTemplate(config),
 				openpolicyagent.WithEnvoyMetadataBytes(envoyMetaDataConfig))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()))
-			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory, opts...)
+			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
+				openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...))
+			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory)
 			fr.Register(ftSpec)
-			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory, opts...)
+			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory)
 			fr.Register(ftSpec)
 			fr.Register(builtin.NewSetPath())
 

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -558,8 +558,10 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 				openpolicyagent.WithEnvoyMetadataBytes(envoyMetaDataConfig),
 			)
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
+			opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
 				openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...))
+			assert.NoError(t, err)
+
 			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory)
 			fr.Register(ftSpec)
 			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory)
@@ -605,11 +607,13 @@ func TestAuthorizeRequestFilter(t *testing.T) {
 }
 
 func TestCreateFilterArguments(t *testing.T) {
-	opaRegistry := openpolicyagent.NewOpenPolicyAgentRegistry(
+	opaRegistry, err := openpolicyagent.NewOpenPolicyAgentRegistry(
 		openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate([]byte(""))))
+	assert.NoError(t, err)
+
 	ftSpec := NewOpaAuthorizeRequestSpec(opaRegistry)
 
-	_, err := ftSpec.CreateFilter([]interface{}{})
+	_, err = ftSpec.CreateFilter([]interface{}{})
 	assert.ErrorIs(t, err, filters.ErrInvalidFilterParameters)
 
 	_, err = ftSpec.CreateFilter([]interface{}{"a bundle", "extra: value", "superfluous argument"})
@@ -726,8 +730,10 @@ func TestAuthorizeRequestInputContract(t *testing.T) {
 				openpolicyagent.WithConfigTemplate(config),
 				openpolicyagent.WithEnvoyMetadataBytes(envoyMetaDataConfig))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
+			opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
 				openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...))
+			assert.NoError(t, err)
+
 			ftSpec := NewOpaAuthorizeRequestSpec(opaFactory)
 			fr.Register(ftSpec)
 			ftSpec = NewOpaAuthorizeRequestWithBodySpec(opaFactory)

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse.go
@@ -14,24 +14,21 @@ import (
 
 type spec struct {
 	registry    *openpolicyagent.OpenPolicyAgentRegistry
-	opts        []func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error
 	name        string
 	bodyParsing bool
 }
 
-func NewOpaServeResponseSpec(registry *openpolicyagent.OpenPolicyAgentRegistry, opts ...func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error) filters.Spec {
+func NewOpaServeResponseSpec(registry *openpolicyagent.OpenPolicyAgentRegistry) filters.Spec {
 	return &spec{
 		registry:    registry,
-		opts:        opts,
 		name:        filters.OpaServeResponseName,
 		bodyParsing: false,
 	}
 }
 
-func NewOpaServeResponseWithReqBodySpec(registry *openpolicyagent.OpenPolicyAgentRegistry, opts ...func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error) filters.Spec {
+func NewOpaServeResponseWithReqBodySpec(registry *openpolicyagent.OpenPolicyAgentRegistry) filters.Spec {
 	return &spec{
 		registry:    registry,
-		opts:        opts,
 		name:        filters.OpaServeResponseWithReqBodyName,
 		bodyParsing: true,
 	}
@@ -69,14 +66,7 @@ func (s *spec) CreateFilter(args []interface{}) (filters.Filter, error) {
 		}
 	}
 
-	configOptions := s.opts
-
-	opaConfig, err := openpolicyagent.NewOpenPolicyAgentConfig(configOptions...)
-	if err != nil {
-		return nil, err
-	}
-
-	opa, err := s.registry.NewOpenPolicyAgentInstance(bundleName, *opaConfig, s.Name())
+	opa, err := s.registry.NewOpenPolicyAgentInstance(bundleName, s.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -302,8 +302,10 @@ func TestServerResponseFilter(t *testing.T) {
 				}
 			}`, opaControlPlane.URL(), ti.regoQuery))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
+			opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
 				openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+			assert.NoError(t, err)
+
 			ftSpec := NewOpaServeResponseSpec(opaFactory)
 			fr.Register(ftSpec)
 			ftSpec = NewOpaServeResponseWithReqBodySpec(opaFactory)
@@ -314,7 +316,7 @@ func TestServerResponseFilter(t *testing.T) {
 				filterArgs = append(filterArgs, ti.contextExtensions)
 			}
 
-			_, err := ftSpec.CreateFilter(filterArgs)
+			_, err = ftSpec.CreateFilter(filterArgs)
 			assert.NoErrorf(t, err, "error in creating filter: %v", err)
 
 			r := eskip.MustParse(fmt.Sprintf(`* -> %s("%s", "%s") -> <shunt>`, ti.filterName, ti.bundleName, ti.contextExtensions))
@@ -350,10 +352,12 @@ func TestServerResponseFilter(t *testing.T) {
 }
 
 func TestCreateFilterArguments(t *testing.T) {
-	opaRegistry := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate([]byte(""))))
+	opaRegistry, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate([]byte(""))))
+	assert.NoError(t, err)
+
 	ftSpec := NewOpaServeResponseSpec(opaRegistry)
 
-	_, err := ftSpec.CreateFilter([]interface{}{})
+	_, err = ftSpec.CreateFilter([]interface{}{})
 	assert.ErrorIs(t, err, filters.ErrInvalidFilterParameters)
 
 	_, err = ftSpec.CreateFilter([]interface{}{42})

--- a/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
+++ b/filters/openpolicyagent/opaserveresponse/opaserveresponse_test.go
@@ -302,10 +302,11 @@ func TestServerResponseFilter(t *testing.T) {
 				}
 			}`, opaControlPlane.URL(), ti.regoQuery))
 
-			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()))
-			ftSpec := NewOpaServeResponseSpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+			opaFactory := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithTracer(tracingtest.NewTracer()),
+				openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
+			ftSpec := NewOpaServeResponseSpec(opaFactory)
 			fr.Register(ftSpec)
-			ftSpec = NewOpaServeResponseWithReqBodySpec(opaFactory, openpolicyagent.WithConfigTemplate(config))
+			ftSpec = NewOpaServeResponseWithReqBodySpec(opaFactory)
 			fr.Register(ftSpec)
 
 			filterArgs := []interface{}{ti.bundleName}
@@ -349,8 +350,8 @@ func TestServerResponseFilter(t *testing.T) {
 }
 
 func TestCreateFilterArguments(t *testing.T) {
-	opaRegistry := openpolicyagent.NewOpenPolicyAgentRegistry()
-	ftSpec := NewOpaServeResponseSpec(opaRegistry, openpolicyagent.WithConfigTemplate([]byte("")))
+	opaRegistry := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate([]byte(""))))
+	ftSpec := NewOpaServeResponseSpec(opaRegistry)
 
 	_, err := ftSpec.CreateFilter([]interface{}{})
 	assert.ErrorIs(t, err, filters.ErrInvalidFilterParameters)

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -187,7 +187,7 @@ func WithControlLoopMaxJitter(maxJitter time.Duration) func(*OpenPolicyAgentRegi
 	}
 }
 
-func NewOpenPolicyAgentRegistry(opts ...func(*OpenPolicyAgentRegistry) error) *OpenPolicyAgentRegistry {
+func NewOpenPolicyAgentRegistry(opts ...func(*OpenPolicyAgentRegistry) error) (*OpenPolicyAgentRegistry, error) {
 	registry := &OpenPolicyAgentRegistry{
 		reuseDuration:          defaultReuseDuration,
 		cleanInterval:          DefaultCleanIdlePeriod,
@@ -205,6 +205,16 @@ func NewOpenPolicyAgentRegistry(opts ...func(*OpenPolicyAgentRegistry) error) *O
 		opt(registry)
 	}
 
+	if registry.configTemplate == nil {
+		config, err := NewOpenPolicyAgentConfig()
+
+		if err != nil {
+			return nil, err
+		}
+
+		registry.configTemplate = config
+	}
+
 	if registry.maxMemoryBodyParsingSem == nil {
 		registry.maxMemoryBodyParsingSem = semaphore.NewWeighted(DefaultMaxMemoryBodyParsing)
 	}
@@ -215,7 +225,7 @@ func NewOpenPolicyAgentRegistry(opts ...func(*OpenPolicyAgentRegistry) error) *O
 		go registry.startCustomControlLoopDaemon()
 	}
 
-	return registry
+	return registry, nil
 }
 
 type OpenPolicyAgentInstanceConfig struct {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -79,7 +79,7 @@ type OpenPolicyAgentRegistry struct {
 	reuseDuration          time.Duration
 	cleanInterval          time.Duration
 	instanceStartupTimeout time.Duration
-	config                 *OpenPolicyAgentInstanceConfig
+	configTemplate         *OpenPolicyAgentInstanceConfig
 
 	maxMemoryBodyParsingSem *semaphore.Weighted
 	maxRequestBodyBytes     int64
@@ -147,7 +147,7 @@ func WithOpenPolicyAgentInstanceConfig(opts ...func(*OpenPolicyAgentInstanceConf
 		if err != nil {
 			return err
 		}
-		cfg.config = config
+		cfg.configTemplate = config
 		return nil
 	}
 }
@@ -269,9 +269,9 @@ func WithEnvoyMetadataFile(file string) func(*OpenPolicyAgentInstanceConfig) err
 	}
 }
 
-func (cfg *OpenPolicyAgentInstanceConfig) GetEnvoyMetadata() *ext_authz_v3_core.Metadata {
-	if cfg.envoyMetadata != nil {
-		return proto.Clone(cfg.envoyMetadata).(*ext_authz_v3_core.Metadata)
+func (config *OpenPolicyAgentInstanceConfig) GetEnvoyMetadata() *ext_authz_v3_core.Metadata {
+	if config.envoyMetadata != nil {
+		return proto.Clone(config.envoyMetadata).(*ext_authz_v3_core.Metadata)
 	}
 	return nil
 }
@@ -418,7 +418,7 @@ func (registry *OpenPolicyAgentRegistry) NewOpenPolicyAgentInstance(bundleName s
 		return instance, nil
 	}
 
-	instance, err := registry.newOpenPolicyAgentInstance(bundleName, *registry.config, filterName)
+	instance, err := registry.newOpenPolicyAgentInstance(bundleName, filterName)
 	if err != nil {
 		return nil, err
 	}
@@ -438,15 +438,10 @@ func (registry *OpenPolicyAgentRegistry) markUnused(inUse map[*OpenPolicyAgentIn
 	}
 }
 
-func (registry *OpenPolicyAgentRegistry) newOpenPolicyAgentInstance(bundleName string, config OpenPolicyAgentInstanceConfig, filterName string) (*OpenPolicyAgentInstance, error) {
+func (registry *OpenPolicyAgentRegistry) newOpenPolicyAgentInstance(bundleName string, filterName string) (*OpenPolicyAgentInstance, error) {
 	runtime.RegisterPlugin(envoy.PluginName, envoy.Factory{})
 
-	configBytes, err := interpolateConfigTemplate(config.configTemplate, bundleName)
-	if err != nil {
-		return nil, err
-	}
-
-	engine, err := registry.new(inmem.NewWithOpts(inmem.OptReturnASTValuesOnRead(registry.enableDataPreProcessingOptimization)), configBytes, config, filterName, bundleName,
+	engine, err := registry.new(inmem.NewWithOpts(inmem.OptReturnASTValuesOnRead(registry.enableDataPreProcessingOptimization)), filterName, bundleName,
 		registry.maxRequestBodyBytes, registry.bodyReadBufferSize)
 	if err != nil {
 		return nil, err
@@ -500,10 +495,10 @@ func envVariablesMap() map[string]string {
 }
 
 // Config sets the configuration file to use on the OPA instance.
-func interpolateConfigTemplate(configTemplate []byte, bundleName string) ([]byte, error) {
+func (config *OpenPolicyAgentInstanceConfig) interpolateConfigTemplate(bundleName string) ([]byte, error) {
 	var buf bytes.Buffer
 
-	tpl := template.Must(template.New("opa-config").Parse(string(configTemplate)))
+	tpl := template.Must(template.New("opa-config").Parse(string(config.configTemplate)))
 
 	binding := make(map[string]interface{})
 	binding["bundlename"] = bundleName
@@ -534,9 +529,14 @@ func (registry *OpenPolicyAgentRegistry) withTracingOptions(bundleName string) f
 }
 
 // new returns a new OPA object.
-func (registry *OpenPolicyAgentRegistry) new(store storage.Store, configBytes []byte, instanceConfig OpenPolicyAgentInstanceConfig, filterName string, bundleName string, maxBodyBytes int64, bodyReadBufferSize int64) (*OpenPolicyAgentInstance, error) {
+func (registry *OpenPolicyAgentRegistry) new(store storage.Store, filterName string, bundleName string, maxBodyBytes int64, bodyReadBufferSize int64) (*OpenPolicyAgentInstance, error) {
 	id := uuid.New().String()
 	uniqueIDGenerator, err := flowid.NewStandardGenerator(32)
+	if err != nil {
+		return nil, err
+	}
+
+	configBytes, err := registry.configTemplate.interpolateConfigTemplate(bundleName)
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +571,7 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, configBytes []
 
 	opa := &OpenPolicyAgentInstance{
 		registry:       registry,
-		instanceConfig: instanceConfig,
+		instanceConfig: *registry.configTemplate,
 		manager:        manager,
 		opaConfig:      opaConfig,
 		bundleName:     bundleName,

--- a/skipper.go
+++ b/skipper.go
@@ -1927,6 +1927,13 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	var opaRegistry *openpolicyagent.OpenPolicyAgentRegistry
 	if o.EnableOpenPolicyAgent {
+		opts := make([]func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error, 0)
+		opts = append(opts,
+			openpolicyagent.WithConfigTemplateFile(o.OpenPolicyAgentConfigTemplate))
+		if o.OpenPolicyAgentEnvoyMetadata != "" {
+			opts = append(opts, openpolicyagent.WithEnvoyMetadataFile(o.OpenPolicyAgentEnvoyMetadata))
+		}
+
 		opaRegistry = openpolicyagent.NewOpenPolicyAgentRegistry(
 			openpolicyagent.WithMaxRequestBodyBytes(o.OpenPolicyAgentMaxRequestBodySize),
 			openpolicyagent.WithMaxMemoryBodyParsing(o.OpenPolicyAgentMaxMemoryBodyParsing),
@@ -1937,21 +1944,16 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			openpolicyagent.WithEnableCustomControlLoop(o.EnableOpenPolicyAgentCustomControlLoop),
 			openpolicyagent.WithControlLoopInterval(o.OpenPolicyAgentControlLoopInterval),
 			openpolicyagent.WithControlLoopMaxJitter(o.OpenPolicyAgentControlLoopMaxJitter),
-			openpolicyagent.WithEnableDataPreProcessingOptimization(o.EnableOpenPolicyAgentDataPreProcessingOptimization))
+			openpolicyagent.WithEnableDataPreProcessingOptimization(o.EnableOpenPolicyAgentDataPreProcessingOptimization),
+			openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...),
+		)
 		defer opaRegistry.Close()
 
-		opts := make([]func(*openpolicyagent.OpenPolicyAgentInstanceConfig) error, 0)
-		opts = append(opts,
-			openpolicyagent.WithConfigTemplateFile(o.OpenPolicyAgentConfigTemplate))
-		if o.OpenPolicyAgentEnvoyMetadata != "" {
-			opts = append(opts, openpolicyagent.WithEnvoyMetadataFile(o.OpenPolicyAgentEnvoyMetadata))
-		}
-
 		o.CustomFilters = append(o.CustomFilters,
-			opaauthorizerequest.NewOpaAuthorizeRequestSpec(opaRegistry, opts...),
-			opaauthorizerequest.NewOpaAuthorizeRequestWithBodySpec(opaRegistry, opts...),
-			opaserveresponse.NewOpaServeResponseSpec(opaRegistry, opts...),
-			opaserveresponse.NewOpaServeResponseWithReqBodySpec(opaRegistry, opts...),
+			opaauthorizerequest.NewOpaAuthorizeRequestSpec(opaRegistry),
+			opaauthorizerequest.NewOpaAuthorizeRequestWithBodySpec(opaRegistry),
+			opaserveresponse.NewOpaServeResponseSpec(opaRegistry),
+			opaserveresponse.NewOpaServeResponseWithReqBodySpec(opaRegistry),
 		)
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -1934,7 +1934,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			opts = append(opts, openpolicyagent.WithEnvoyMetadataFile(o.OpenPolicyAgentEnvoyMetadata))
 		}
 
-		opaRegistry = openpolicyagent.NewOpenPolicyAgentRegistry(
+		opaRegistry, err = openpolicyagent.NewOpenPolicyAgentRegistry(
 			openpolicyagent.WithMaxRequestBodyBytes(o.OpenPolicyAgentMaxRequestBodySize),
 			openpolicyagent.WithMaxMemoryBodyParsing(o.OpenPolicyAgentMaxMemoryBodyParsing),
 			openpolicyagent.WithReadBodyBufferSize(o.OpenPolicyAgentRequestBodyBufferSize),
@@ -1947,6 +1947,11 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			openpolicyagent.WithEnableDataPreProcessingOptimization(o.EnableOpenPolicyAgentDataPreProcessingOptimization),
 			openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...),
 		)
+
+		if err != nil {
+			log.Errorf("failed to create Open Policy Agent registry: %v.", err)
+			return err
+		}
 		defer opaRegistry.Close()
 
 		o.CustomFilters = append(o.CustomFilters,


### PR DESCRIPTION
This PR is a no-op refactoring from a user perspective that moves the Open Policy Agent configuration to the registry. 

Originally it was designed to have a per filter configuration but practically it is always the same.

This is the precondition to allow instance pre-loading #3526 and will also to re-use config across filters. 