### PR TITLE
fix: Websocket requests fail if case of value in Connection header and case of key in Upgrade header do not match

### DIFF
--- a/proxy/upgrade.go
+++ b/proxy/upgrade.go
@@ -32,7 +32,7 @@ func isUpgradeRequest(req *http.Request) bool {
 func getUpgradeRequest(req *http.Request) string {
 	for _, h := range req.Header[http.CanonicalHeaderKey("Connection")] {
 		if strings.Contains(strings.ToLower(h), "upgrade") {
-			return strings.Join(req.Header[h], " ")
+			return strings.Join(req.Header.Values(h), " ")
 		}
 	}
 	return ""

--- a/proxy/upgrade_test.go
+++ b/proxy/upgrade_test.go
@@ -87,6 +87,19 @@ func TestValidGetUpgradeRequest(t *testing.T) {
 
 }
 
+func TestValidGetUpgradeRequestCaseInsensitivity(t *testing.T) {
+	req, prot := getValidUpgradeRequest()
+	req.Header.Set("Connection", "uPgRaDe")
+	if !isUpgradeRequest(req) {
+		t.Errorf("Request has an upgrade header, but isUpgradeRequest returned false for %+v", req)
+	}
+	gotProt := getUpgradeRequest(req)
+	if gotProt != prot {
+		t.Errorf("%s != %s for %+v", gotProt, prot, req)
+	}
+
+}
+
 func TestServeHTTP(t *testing.T) {
 	for _, ti := range []struct {
 		msg                        string


### PR DESCRIPTION
When a client sends a request to upgrade to a Websocket connection
and presents the value of the header `Connection` in lower-case
then Skipper fails to upgrade the request.

This change fixes the issue by using a function to read the header that is case insensitive.

The bug was likely introduced in #3553.