### PR TITLE
chore(deps): optimize dependabot configuration for OPA dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,15 @@ updates:
       - dependency-name: "github.com/open-policy-agent/opa"
       - dependency-name: "github.com/open-policy-agent/opa-envoy-plugin"
       - dependency-name: "github.com/envoyproxy/go-control-plane"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      opa:
+        patterns:
+          - "github.com/open-policy-agent/opa"
+          - "github.com/open-policy-agent/opa-envoy-plugin"
   - package-ecosystem: "github-actions"
     directory: "/" # For GitHub Actions, set the directory to / to check for workflow files in .github/workflows
     schedule:


### PR DESCRIPTION
- Add dedicated gomod group for OPA-related dependencies
- Keep existing configuration for other dependencies

This change helps manage OPA dependency updates more effectively by grouping them separately from other Go dependencies.