### PR TITLE
OPA JWT token cache configuration

### DIFF
--- a/filters/openpolicyagent/opaauthorizerequest/benchmark_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -125,6 +126,7 @@ func BenchmarkMinimalPolicyWithDecisionLogs(b *testing.B) {
 		BundleNames:         []string{testBundleName},
 		DecisionLogging:     true,
 		ContextExtensions:   "",
+		JwtCache:            false,
 	}
 	f, err := createOpaFilter(filterOpts)
 	require.NoError(b, err)
@@ -199,7 +201,119 @@ func BenchmarkAllowWithReqBody(b *testing.B) {
 
 }
 
+// BenchmarkJwtValidation measures the performance of the OPA authorization filter with a JWT validation
+// with and without JWT cache configuration enabled.
 func BenchmarkJwtValidation(b *testing.B) {
+	type benchmarkCase struct {
+		name     string
+		jwtCache bool
+	}
+
+	cases := []benchmarkCase{
+		{
+			name:     "without_jwt_cache",
+			jwtCache: false,
+		},
+		{
+			name:     "with_jwt_cache",
+			jwtCache: true,
+		},
+	}
+
+	for _, bc := range cases {
+		opaControlPlane := opasdktest.MustNewServer(
+			opasdktest.MockBundle(testBundleEndpoint, map[string]string{
+				"main.rego": fmt.Sprintf(`
+					package envoy.authz
+
+					import rego.v1
+
+					default allow = false
+
+					public_key_cert := %q
+
+					bearer_token := t if {
+						v := input.attributes.request.http.headers.authorization
+						startswith(v, "Bearer ")
+						t := substring(v, count("Bearer "), -1)
+					}
+
+					allow if {
+						[valid, _, payload] :=  io.jwt.decode_verify(bearer_token, {
+							"cert": public_key_cert,
+							"aud": "nqz3xhorr5"
+						})
+					
+						valid
+						
+						payload.sub == "5974934733"
+					}				
+				`, publicKey),
+			}),
+		)
+		defer opaControlPlane.Stop()
+
+		filterOpts := FilterOptions{
+			OpaControlPlaneUrl:  opaControlPlane.URL(),
+			DecisionConsumerUrl: "",
+			DecisionPath:        testDecisionPath,
+			BundleNames:         []string{testBundleName},
+			DecisionLogging:     false,
+			ContextExtensions:   "",
+			JwtCache:            bc.jwtCache,
+		}
+
+		f, err := createOpaFilter(filterOpts)
+		require.NoError(b, err)
+
+		reqUrl, err := url.Parse("http://opa-authorized.test/somepath")
+		require.NoError(b, err)
+
+		claims := jwt.MapClaims{
+			"iss":   "https://some.identity.acme.com",
+			"sub":   "5974934733",
+			"aud":   "nqz3xhorr5",
+			"iat":   time.Now().Add(-time.Minute).UTC().Unix(),
+			"exp":   time.Now().Add(tokenExp).UTC().Unix(),
+			"email": "someone@example.org",
+		}
+
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+
+		key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
+		require.NoError(b, err, "Failed to parse RSA PEM")
+
+		// Sign and get the complete encoded token as a string using the secret
+		signedToken, err := token.SignedString(key)
+		require.NoError(b, err, "Failed to sign token")
+
+		b.Run(bc.name, func(b *testing.B) {
+			ctx := &filtertest.Context{
+				FStateBag: map[string]interface{}{},
+				FResponse: &http.Response{},
+				FRequest: &http.Request{
+					Header: map[string][]string{
+						"Authorization": {fmt.Sprintf("Bearer %s", signedToken)},
+					},
+					URL: reqUrl,
+				},
+				FMetrics: &metricstest.MockMetrics{},
+			}
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					f.Request(ctx)
+					assert.False(b, ctx.FServed)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkJwtValidationWithVaryingTokenCounts measures the performance of the OPA authorization filter with a JWT validation
+// with JWT cache configured to keep 5 entries and with varying number of tokens.
+func BenchmarkJwtValidationWithVaryingTokenCounts(b *testing.B) {
 	opaControlPlane := opasdktest.MustNewServer(
 		opasdktest.MockBundle(testBundleEndpoint, map[string]string{
 			"main.rego": fmt.Sprintf(`
@@ -232,50 +346,72 @@ func BenchmarkJwtValidation(b *testing.B) {
 	)
 	defer opaControlPlane.Stop()
 
-	filterOpts := NewFilterOptionsWithDefaults(opaControlPlane.URL())
+	filterOpts := FilterOptions{
+		OpaControlPlaneUrl:  opaControlPlane.URL(),
+		DecisionConsumerUrl: "",
+		DecisionPath:        testDecisionPath,
+		BundleNames:         []string{testBundleName},
+		DecisionLogging:     false,
+		ContextExtensions:   "",
+		JwtCache:            true,
+	}
+
 	f, err := createOpaFilter(filterOpts)
+
 	require.NoError(b, err)
 
 	reqUrl, err := url.Parse("http://opa-authorized.test/somepath")
 	require.NoError(b, err)
 
-	claims := jwt.MapClaims{
-		"iss":   "https://some.identity.acme.com",
-		"sub":   "5974934733",
-		"aud":   "nqz3xhorr5",
-		"iat":   time.Now().Add(-time.Minute).UTC().Unix(),
-		"exp":   time.Now().Add(tokenExp).UTC().Unix(),
-		"email": "someone@example.org",
-	}
+	tokenCounts := []int{1, 5, 6, 10, 100}
+	for _, tokenCount := range tokenCounts {
+		tokens := make([]string, tokenCount)
+		for i := 0; i < tokenCount; i++ {
+			claims := jwt.MapClaims{
+				"iss":   "https://some.identity.acme.com",
+				"sub":   "5974934733",
+				"aud":   "nqz3xhorr5",
+				"iat":   time.Now().Add(-time.Minute).UTC().Unix(),
+				"exp":   time.Now().Add(tokenExp).UTC().Unix(),
+				"email": "someone@example.org",
+				"jti":   fmt.Sprintf("token-%d", i),
+			}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+			token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
 
-	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
-	require.NoError(b, err, "Failed to parse RSA PEM")
+			key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
+			require.NoError(b, err, "Failed to parse RSA PEM")
 
-	// Sign and get the complete encoded token as a string using the secret
-	signedToken, err := token.SignedString(key)
-	require.NoError(b, err, "Failed to sign token")
-
-	ctx := &filtertest.Context{
-		FStateBag: map[string]interface{}{},
-		FResponse: &http.Response{},
-		FRequest: &http.Request{
-			Header: map[string][]string{
-				"Authorization": {fmt.Sprintf("Bearer %s", signedToken)},
-			},
-			URL: reqUrl,
-		},
-		FMetrics: &metricstest.MockMetrics{},
-	}
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			f.Request(ctx)
-			assert.False(b, ctx.FServed)
+			// Sign and get the complete encoded token as a string using the secret
+			signedToken, err := token.SignedString(key)
+			require.NoError(b, err, "Failed to sign token")
+			tokens[i] = signedToken
 		}
-	})
+
+		b.Run(fmt.Sprintf("tokens_count_%d", tokenCount), func(b *testing.B) {
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rnd := rand.New(rand.NewSource(time.Now().UnixNano() + int64(rand.Int())))
+					token := tokens[rnd.Intn(tokenCount)]
+					ctx := &filtertest.Context{
+						FStateBag: map[string]interface{}{},
+						FResponse: &http.Response{},
+						FRequest: &http.Request{
+							Header: map[string][]string{
+								"Authorization": {fmt.Sprintf("Bearer %s", token)},
+							},
+							URL: reqUrl,
+						},
+						FMetrics: &metricstest.MockMetrics{},
+					}
+					f.Request(ctx)
+					assert.False(b, ctx.FServed)
+				}
+			})
+		})
+	}
 }
 
 // BenchmarkPolicyBundle measures the performance of the OPA authorization filter
@@ -465,7 +601,7 @@ func newDecisionConsumer() *httptest.Server {
 }
 
 func createOpaFilter(opts FilterOptions) (filters.Filter, error) {
-	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
+	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging, opts.JwtCache)
 
 	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
 	if err != nil {
@@ -477,7 +613,7 @@ func createOpaFilter(opts FilterOptions) (filters.Filter, error) {
 }
 
 func createBodyBasedOpaFilter(opts FilterOptions) (filters.Filter, error) {
-	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging)
+	config := generateConfig(opts.OpaControlPlaneUrl, opts.DecisionConsumerUrl, opts.DecisionPath, opts.DecisionLogging, opts.JwtCache)
 
 	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)))
 	if err != nil {
@@ -488,7 +624,7 @@ func createBodyBasedOpaFilter(opts FilterOptions) (filters.Filter, error) {
 	return spec.CreateFilter([]interface{}{opts.BundleNames[0], opts.ContextExtensions})
 }
 
-func generateConfig(opaControlPlane string, decisionLogConsumer string, decisionPath string, decisionLogging bool) []byte {
+func generateConfig(opaControlPlane string, decisionLogConsumer string, decisionPath string, decisionLogging bool, jwtCache bool) []byte {
 	var decisionPlugin string
 	if decisionLogging {
 		decisionPlugin = `
@@ -498,6 +634,21 @@ func generateConfig(opaControlPlane string, decisionLogConsumer string, decision
   				"reporting": {
 					"min_delay_seconds": 300,
 					"max_delay_seconds": 600				
+				}
+			},
+		`
+	}
+
+	var jwtCacheConfig string
+	if jwtCache {
+		jwtCacheConfig = `
+			"caching": {
+				"inter_query_builtin_value_cache": {
+					"named": {
+						"io_jwt": {
+							"max_num_entries": 5
+						}
+					}
 				}
 			},
 		`
@@ -531,8 +682,9 @@ func generateConfig(opaControlPlane string, decisionLogConsumer string, decision
 				"path": %q,
 				"dry-run": false    
 			}
-		}
-	}`, opaControlPlane, decisionLogConsumer, decisionPlugin, decisionPath))
+		},
+		%s
+	}`, opaControlPlane, decisionLogConsumer, decisionPlugin, decisionPath, jwtCacheConfig))
 }
 
 func createOpaFilterForMultipleBundles(opts FilterOptions) (filters.Filter, error) {
@@ -620,6 +772,7 @@ type FilterOptions struct {
 	BundleNames         []string
 	DecisionLogging     bool
 	ContextExtensions   string
+	JwtCache            bool
 }
 
 func NewFilterOptionsWithDefaults(opaControlPlaneURL string) FilterOptions {
@@ -630,5 +783,6 @@ func NewFilterOptionsWithDefaults(opaControlPlaneURL string) FilterOptions {
 		BundleNames:         []string{testBundleName},
 		DecisionLogging:     false,
 		ContextExtensions:   "",
+		JwtCache:            false,
 	}
 }


### PR DESCRIPTION
### Context
With https://github.com/open-policy-agent/opa/pull/7274 Open Policy Agent added configurable token cache to io.jwt token verification built-in functions to improve performance. See [changelog](https://github.com/open-policy-agent/opa/releases/tag/v1.1.0). 

### Changes
With this pull request JWT cache reading and writing is enabled and benchmark tests are added to measure JWT validation performance with cache configuration. 

**Fix in opa-envoy-plugin**
After initial round of benchmark tests that showed no impact on perfomence the bug was found in opa-envoy-plugin and [contribution with the fix was made](https://github.com/open-policy-agent/opa-envoy-plugin/pull/748). 

### Benchmark tests result after fix

- results for test with vs without cache configuration

for 10 runs, each 20 s:
attached: [jwt-validation-cache-benchmark-results-10runs-20s.txt](https://github.com/user-attachments/files/21157031/jwt-validation-cache-benchmark-results-10runs-20s.txt)
```goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/filters/openpolicyagent/opaauthorizerequest
cpu: Apple M1
                                  │       sec/op       │
JwtValidation/without_jwt_cache-8       20.10µ ± 4%
JwtValidation/with_jwt_cache-8          10.65µ ± 3%
geomean                                 14.63µ

                                  │        B/op        │
JwtValidation/without_jwt_cache-8      38.11Ki ± 0%
JwtValidation/with_jwt_cache-8         29.89Ki ± 0%
geomean                                33.75Ki

                                  │     allocs/op      │
JwtValidation/without_jwt_cache-8        621.0 ± 0%
JwtValidation/with_jwt_cache-8           512.0 ± 0%
geomean                                  563.9
```


- results for test with cache set for max number of 5 tokens in the cache and varying number of tokens in the test (1, 5, 6, 10, 100)


```goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/filters/openpolicyagent/opaauthorizerequest
cpu: Apple M1
                                                       │        B/op        │
JwtValidationWithVaryingTokenCounts/tokens_count_1-8           9.892µ ± 14%
JwtValidationWithVaryingTokenCounts/tokens_count_5-8           10.38µ ±  9%
JwtValidationWithVaryingTokenCounts/tokens_count_6-8           13.38µ ±  3%
JwtValidationWithVaryingTokenCounts/tokens_count_10-8          16.23µ ±  7%
JwtValidationWithVaryingTokenCounts/tokens_count_100-8         22.25µ ± 14%

                                                       
                                                       │        B/op        │
JwtValidationWithVaryingTokenCounts/tokens_count_1-8           29.89Ki ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_5-8           29.90Ki ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_6-8           31.78Ki ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_10-8          34.57Ki ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_100-8         38.27Ki ± 0%
geomean                                                        32.73Ki

                                
                                                       │     allocs/op      │
JwtValidationWithVaryingTokenCounts/tokens_count_1-8             512.0 ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_5-8             512.0 ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_6-8             538.0 ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_10-8            577.0 ± 0%
JwtValidationWithVaryingTokenCounts/tokens_count_100-8           631.5 ± 0%
```

