### PR TITLE
Revert "chore(deps): optimize dependabot configuration for OPA dependencies (#3568)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,16 +17,6 @@ updates:
       - dependency-name: "github.com/open-policy-agent/opa"
       - dependency-name: "github.com/open-policy-agent/opa-envoy-plugin"
       - dependency-name: "github.com/envoyproxy/go-control-plane"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      opa:
-        patterns:
-          - "github.com/open-policy-agent/opa"
-          - "github.com/open-policy-agent/opa-envoy-plugin"
-        update-types: ["minor"]
   - package-ecosystem: "github-actions"
     directory: "/" # For GitHub Actions, set the directory to / to check for workflow files in .github/workflows
     schedule:


### PR DESCRIPTION
This reverts commit 342103181a61ff9ac82b06a6f18c534ce3829e41.