### PR TITLE
Optimize: jwt regexp predicates

### DIFF
--- a/predicates/auth/jwt.go
+++ b/predicates/auth/jwt.go
@@ -174,15 +174,13 @@ func (s *spec) Create(args []interface{}) (routing.Predicate, error) {
 		kv[key] = append(kv[key], matcher)
 	}
 
-	if s.matchMode == matchModeRegexp {
-
-	}
-
 	p := &predicate{
 		kv:            kv,
 		matchBehavior: s.matchBehavior,
 	}
-	s.reg.predicates = append(s.reg.predicates, p)
+	if s.matchMode == matchModeRegexp {
+		s.reg.predicates = append(s.reg.predicates, p)
+	}
 
 	return p, nil
 }

--- a/predicates/auth/jwt_test.go
+++ b/predicates/auth/jwt_test.go
@@ -544,5 +544,40 @@ func Test_anyMatch(t *testing.T) {
 			}
 		})
 	}
+}
 
+func BenchmarkJWTPayloadAnyKVRegexp(b *testing.B) {
+	sp := NewJWTPayloadAnyKVRegexp()
+	p, err := sp.Create([]interface{}{"https://identity.zalando.com/managed-id", "^ssz", "https://identity.zalando.com/token", "^Bear"})
+	if err != nil {
+		b.Fatalf("Failed to create predicate: %v", err)
+	}
+	benchPredicate(b, p)
+}
+
+func BenchmarkJWTPayloadAllKVRegexp(b *testing.B) {
+	sp := NewJWTPayloadAllKVRegexp()
+	p, err := sp.Create([]interface{}{"https://identity.zalando.com/managed-id", "^ssz", "https://identity.zalando.com/token", "^Bear"})
+	if err != nil {
+		b.Fatalf("Failed to create predicate: %v", err)
+	}
+	benchPredicate(b, p)
+}
+
+func benchPredicate(b *testing.B, p routing.Predicate) {
+	token := "eyJraWQiOiJwbGF0Zm9ybS1pYW0tdmNlaHloajYiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJjNGRkZmU5ZC1hMGQzLTRhZmItYmYyNi0yNGI5NTg4NzMxYTAiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3JlYWxtIjoidXNlcnMiLCJodHRwczovL2lkZW50aXR5LnphbGFuZG8uY29tL3Rva2VuIjoiQmVhcmVyIiwiaHR0cHM6Ly9pZGVudGl0eS56YWxhbmRvLmNvbS9tYW5hZ2VkLWlkIjoic3N6dWVjcyIsImF6cCI6Inp0b2tlbiIsImh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20vYnAiOiI4MTBkMWQwMC00MzEyLTQzZTUtYmQzMS1kODM3M2ZkZDI0YzciLCJhdXRoX3RpbWUiOjE1MjMyNTk0NjgsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuemFsYW5kby5jb20iLCJleHAiOjE1MjUwMjQyODUsImlhdCI6MTUyNTAyMDY3NX0.uxHcC7DJrkP-_G81Jmiba5liVP0LJOmkpal4wsUr7CmtMlE23P1bptIMxnJLv5EMSN1NFn-BJe9hcEB2A3LarA"
+
+	r := &http.Request{
+		Header: http.Header{
+			authHeaderName: []string{"Bearer " + token},
+		},
+	}
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if !p.Match(r) {
+			b.Fatal("Failed to match but want a match")
+		}
+	}
 }


### PR DESCRIPTION
optimize: JWT regexp based predicates

Context:
Normally clients reuse their tokens so we can easily cache the matching result by token for each predicate.
This will speedup significantly FabricGateway matching lookups.

Adds a sync.Map that we use to perform a cache lookup of the wire string to the result.
A new type `registry` is used to cleanup all entries every hour. For simplicity we do not track timestamps. Tested by a benchmark to cleanup every Millisecond and the result does not change significantly, so we should not care about the recreation of the cache once in a while.

Benchmarks for benchstat comparision ran with count 20
```
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/predicates/auth
cpu: Apple M2
                        │    old.txt    │               new.txt               │
                        │    sec/op     │   sec/op     vs base                │
JWTPayloadAllKVRegexp     4079.00n ± 1%   45.59n ± 0%  -98.88% (p=0.000 n=20)
JWTPayloadAllKVRegexp-2   3600.00n ± 0%   45.57n ± 0%  -98.73% (p=0.000 n=20)
JWTPayloadAllKVRegexp-4   3607.00n ± 0%   45.59n ± 0%  -98.74% (p=0.000 n=20)
JWTPayloadAllKVRegexp-8   3603.00n ± 0%   45.70n ± 0%  -98.73% (p=0.000 n=20)
geomean                     3.717µ        45.61n       -98.77%

                        │   old.txt    │                  new.txt                  │
                        │     B/op     │     B/op      vs base                     │
JWTPayloadAllKVRegexp     2.250Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=20)
JWTPayloadAllKVRegexp-2   2.250Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=20)
JWTPayloadAllKVRegexp-4   2.250Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=20)
JWTPayloadAllKVRegexp-8   2.250Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=20)
geomean                   2.250Ki                      ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                        │  old.txt   │                new.txt                 │
                        │ allocs/op  │ allocs/op  vs base                     │
JWTPayloadAllKVRegexp     51.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=20)
JWTPayloadAllKVRegexp-2   51.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=20)
JWTPayloadAllKVRegexp-4   51.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=20)
JWTPayloadAllKVRegexp-8   51.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=20)
geomean                   51.00                   ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```


old:
```
% go test -run '^$' -benchmem -cpu 1,2,4,8 -bench BenchmarkJWTPayloadAnyKVRegexp ./predicates/auth -count 1
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/predicates/auth
cpu: Apple M2
BenchmarkJWTPayloadAnyKVRegexp            311738              3985 ns/op            2304 B/op         51 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-2          338103              3524 ns/op            2304 B/op         51 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-4          343358              3519 ns/op            2304 B/op         51 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-8          342327              3543 ns/op            2304 B/op         51 allocs/op
PASS
ok      github.com/zalando/skipper/predicates/auth      5.013s
```
new:
```
% go test -run '^$' -benchmem -cpu 1,2,4,8 -bench BenchmarkJWTPayloadAnyKVRegexp ./predicates/auth -count 1               
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/predicates/auth
cpu: Apple M2
BenchmarkJWTPayloadAnyKVRegexp          24621844                45.77 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-2        26927236                45.68 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-4        26123988                45.59 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-8        26365248                45.65 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/zalando/skipper/predicates/auth      4.952s
```