### PR TITLE
proxy: fix timings calculation

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -51,8 +51,8 @@ type context struct {
 	routeLookup          *routing.RouteLookup
 	cancelBackendContext stdlibcontext.CancelFunc
 	logger               filters.FilterContextLogger
-	proxyWatch           stopWatch
-	proxyRequestLatency  time.Duration
+	proxyRequestElapsed  time.Duration
+	proxyResponseElapsed time.Duration
 }
 
 type filterMetrics struct {
@@ -138,7 +138,6 @@ func newContext(
 	w flushedResponseWriter,
 	r *http.Request,
 	p *Proxy,
-	watch *stopWatch,
 ) *context {
 	c := &context{
 		responseWriter: w,
@@ -148,7 +147,6 @@ func newContext(
 		metrics:        &filterMetrics{impl: p.metrics},
 		proxy:          p,
 		routeLookup:    p.routing.Get(),
-		proxyWatch:     *watch,
 	}
 
 	if p.flags.PreserveOriginal() {

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -73,8 +73,58 @@ func TestMeasureProxyWatch(t *testing.T) {
 	m := &metricstest.MockMetrics{}
 	defer m.Close()
 
+	backendLatency := 10 * time.Millisecond
+	filterLatency := 20 * time.Millisecond
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(backendLatency)
+		w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
 	tp := proxytest.Config{
-		Routes: eskip.MustParse(`test: * -> latency("10ms") -> backendLatency("20ms") -> status(200) -> <shunt>`),
+		Routes: eskip.MustParse(fmt.Sprintf(`test: * -> latency(%d)  -> status(200) -> "%s"`, filterLatency.Milliseconds(), backend.URL)),
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+		},
+		ProxyParams: proxy.Params{
+			Metrics: m,
+		},
+	}.Create()
+	defer tp.Close()
+
+	client := tp.Client()
+	rsp, body, err := client.GetBody(tp.URL + "/hello")
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	require.Equal(t, []byte("ok"), body)
+
+	m.WithMeasures(func(measures map[string][]time.Duration) {
+		assert.Equal(t, len(measures), 3)
+		assert.Len(t, measures["proxy.total.duration"], 1)
+		assert.Len(t, measures["proxy.request.duration"], 1)
+		assert.Len(t, measures["proxy.response.duration"], 1)
+
+		assert.Greater(t, measures["proxy.total.duration"][0].Seconds(), 0.0)
+		assert.Greater(t, measures["proxy.request.duration"][0].Seconds(), 0.0)
+		assert.Greater(t, measures["proxy.response.duration"][0].Seconds(), 0.0)
+
+		assert.Less(t, measures["proxy.total.duration"][0].Seconds(), filterLatency.Seconds())
+		assert.Less(t, measures["proxy.total.duration"][0].Seconds(), backendLatency.Seconds())
+
+		assert.InDelta(t, measures["proxy.total.duration"][0].Seconds(), measures["proxy.request.duration"][0].Seconds()+measures["proxy.response.duration"][0].Seconds(), 1e-20, "total should be sum of request and response")
+	})
+}
+
+func TestMeasureProxyWatchShunt(t *testing.T) {
+	m := &metricstest.MockMetrics{}
+	defer m.Close()
+
+	backendLatency := 200 * time.Millisecond
+	filterLatency := 20 * time.Millisecond
+
+	tp := proxytest.Config{
+		Routes: eskip.MustParse(fmt.Sprintf(`test: * -> latency(%d) -> backendLatency(%d) -> status(200) -> <shunt>`, filterLatency.Milliseconds(), backendLatency.Milliseconds())),
 		RoutingOptions: routing.Options{
 			FilterRegistry: builtin.MakeRegistry(),
 		},
@@ -95,9 +145,59 @@ func TestMeasureProxyWatch(t *testing.T) {
 		assert.Len(t, measures["proxy.total.duration"], 1)
 		assert.Len(t, measures["proxy.request.duration"], 1)
 		assert.Len(t, measures["proxy.response.duration"], 1)
-		assert.InDelta(t, measures["proxy.total.duration"][0].Seconds(), 0.001, 0.001)
-		assert.InDelta(t, measures["proxy.request.duration"][0].Seconds(), 0.001, 0.001)
-		assert.InDelta(t, measures["proxy.response.duration"][0].Seconds(), 0.001, 0.001)
+
+		assert.Greater(t, measures["proxy.total.duration"][0].Seconds(), 0.0)
+		assert.Greater(t, measures["proxy.request.duration"][0].Seconds(), 0.0)
+		assert.Greater(t, measures["proxy.response.duration"][0].Seconds(), 0.0)
+
+		assert.Less(t, measures["proxy.total.duration"][0].Seconds(), filterLatency.Seconds())
+		assert.Less(t, measures["proxy.total.duration"][0].Seconds(), backendLatency.Seconds())
+
+		assert.InDelta(t, measures["proxy.total.duration"][0].Seconds(), measures["proxy.request.duration"][0].Seconds()+measures["proxy.response.duration"][0].Seconds(), 1e-20, "total should be sum of request and response")
+	})
+}
+
+func TestMeasureProxyWatchWithLoopback(t *testing.T) {
+	m := &metricstest.MockMetrics{}
+	defer m.Close()
+
+	backendLatency := 200 * time.Millisecond
+	filterLatency := 20 * time.Millisecond
+
+	tp := proxytest.Config{
+		Routes: eskip.MustParse(fmt.Sprintf(`
+                        loopback: * -> setRequestHeader("a", "b") -> <loopback>;
+                        real:  Header("a", "b") -> latency(%d) -> backendLatency(%d) -> status(200) -> inlineContent("x") -> <shunt>;
+                `, filterLatency.Milliseconds(), backendLatency.Milliseconds())),
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+		},
+		ProxyParams: proxy.Params{
+			Metrics: m,
+		},
+	}.Create()
+	defer tp.Close()
+
+	client := tp.Client()
+	rsp, body, err := client.GetBody(tp.URL + "/hello")
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	require.Equal(t, []byte("x"), body)
+
+	m.WithMeasures(func(measures map[string][]time.Duration) {
+		assert.Equal(t, len(measures), 3)
+		assert.Len(t, measures["proxy.total.duration"], 1)
+		assert.Len(t, measures["proxy.request.duration"], 1)
+		assert.Len(t, measures["proxy.response.duration"], 1)
+
+		assert.Greater(t, measures["proxy.total.duration"][0].Seconds(), 0.0)
+		assert.Greater(t, measures["proxy.request.duration"][0].Seconds(), 0.0)
+		assert.Greater(t, measures["proxy.response.duration"][0].Seconds(), 0.0)
+
+		assert.Less(t, measures["proxy.total.duration"][0].Seconds(), filterLatency.Seconds())
+		assert.Less(t, measures["proxy.total.duration"][0].Seconds(), backendLatency.Seconds())
+
+		assert.InDelta(t, measures["proxy.total.duration"][0].Seconds(), measures["proxy.request.duration"][0].Seconds()+measures["proxy.response.duration"][0].Seconds(), 1e-20, "total should be sum of request and response")
 	})
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -967,6 +967,9 @@ func (p *Proxy) makeUpgradeRequest(ctx *context, req *http.Request) {
 }
 
 func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Context) (*http.Response, *proxyError) {
+	requestStopWatch, responseStopWatch := newStopWatch(), newStopWatch()
+	requestStopWatch.Start()
+
 	payloadProtocol := getUpgradeRequest(ctx.Request())
 
 	req, endpointMetrics, err := p.mapRequest(ctx, requestContext)
@@ -1031,11 +1034,11 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 
 	p.metrics.MeasureBackendRequestHeader(ctx.metricsHost(), snet.SizeOfRequestHeader(req))
 
-	ctx.proxyWatch.Stop()
-	ctx.proxyRequestLatency = ctx.proxyWatch.Elapsed()
+	requestStopWatch.Stop()
+
 	response, err := roundTripper.RoundTrip(req)
-	ctx.proxyWatch.Reset()
-	ctx.proxyWatch.Start()
+
+	responseStopWatch.Start()
 
 	if endpointMetrics != nil {
 		endpointMetrics.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: err != nil})
@@ -1187,6 +1190,11 @@ func stack() []byte {
 }
 
 func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
+	var requestElapsed, responseElapsed time.Duration
+
+	requestStopWatch, responseStopWatch := newStopWatch(), newStopWatch()
+	requestStopWatch.Start()
+
 	defer func() {
 		if r := recover(); r != nil {
 			p.onPanicSometimes.Do(func() {
@@ -1199,6 +1207,10 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 			p.makeErrorResponse(ctx, perr)
 			err = perr
 		}
+		requestStopWatch.Stop()
+		responseStopWatch.Stop()
+		ctx.proxyRequestElapsed = requestElapsed + requestStopWatch.Elapsed()
+		ctx.proxyResponseElapsed = responseElapsed + responseStopWatch.Elapsed()
 	}()
 
 	if ctx.executionCounter > p.maxLoops {
@@ -1234,22 +1246,27 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 
 	ctx.applyRoute(route, params, p.flags.PreserveHost())
 
-	ctx.proxyWatch.Stop()
+	requestStopWatch.Stop()
 	processedFilters := p.applyFiltersToRequest(ctx.route.Filters, ctx)
-	ctx.proxyWatch.Start()
+	requestStopWatch.Start()
 
+	// not every of these branches could endup in a response to the client
 	if ctx.deprecatedShunted() {
 		ctx.Logger().Debugf("deprecated shunting detected in route: %s", ctx.route.Id)
 		return &proxyError{handled: true}
 	} else if ctx.shunted() || ctx.route.Shunt || ctx.route.BackendType == eskip.ShuntBackend {
+		requestStopWatch.Stop()
 		// consume the body to prevent goroutine leaks
 		if ctx.request.Body != nil {
 			if _, err := io.Copy(io.Discard, ctx.request.Body); err != nil {
 				ctx.Logger().Debugf("error while discarding remainder request body: %v.", err)
 			}
 		}
+
+		responseStopWatch.Start()
 		ctx.ensureDefaultResponse()
 	} else if ctx.route.BackendType == eskip.LoopBackend {
+
 		loopCTX := ctx.clone()
 
 		loopSpanOpts := []ot.StartSpanOption{ot.Tags{
@@ -1270,18 +1287,30 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 		r := loopCTX.Request()
 		r = r.WithContext(ot.ContextWithSpan(r.Context(), loopSpan))
 		loopCTX.request = r
-		if err := p.do(loopCTX, loopSpan); err != nil {
+
+		requestStopWatch.Stop()
+
+		err := p.do(loopCTX, loopSpan)
+
+		loopSpan.Finish()
+		responseStopWatch.Start()
+
+		if err != nil {
 			// in case of error we have to copy the response in this recursion unwinding
 			ctx.response = loopCTX.response
 			p.applyFiltersOnError(ctx, processedFilters)
-			loopSpan.Finish()
 			return err
 		}
-		loopSpan.Finish()
+
+		requestElapsed += loopCTX.proxyRequestElapsed
+		responseElapsed += loopCTX.proxyResponseElapsed
+
 		ctx.setResponse(loopCTX.response, p.flags.PreserveOriginal())
 		ctx.proxySpan = loopCTX.proxySpan
 	} else if p.flags.Debug() {
+		requestStopWatch.Stop()
 		debugReq, _, err := p.mapRequest(ctx, ctx.request.Context())
+		responseStopWatch.Start()
 		if err != nil {
 			perr := &proxyError{err: err}
 			p.makeErrorResponse(ctx, perr)
@@ -1313,8 +1342,13 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 				ctx.Logger().Errorf("Failed to set read deadline: %v", e)
 			}
 		}
+
+		requestStopWatch.Stop()
 		rsp, perr := p.makeBackendRequest(ctx, backendContext)
+		requestElapsed += ctx.proxyRequestElapsed
+		responseElapsed += ctx.proxyRequestElapsed
 		if perr != nil {
+			requestStopWatch.Start()
 			if done != nil {
 				done(false)
 			}
@@ -1331,23 +1365,31 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 
 				perr = nil
 				var perr2 *proxyError
+				requestStopWatch.Stop()
 				rsp, perr2 = p.makeBackendRequest(ctx, backendContext)
+				requestElapsed += ctx.proxyRequestElapsed
+				requestElapsed += ctx.proxyRequestElapsed
+				responseStopWatch.Start()
 				if perr2 != nil {
 					ctx.Logger().Errorf("Failed to retry backend request: %v", perr2)
 					if perr2.code >= http.StatusInternalServerError {
 						p.metrics.MeasureBackend5xx(backendStart)
 					}
+
 					p.makeErrorResponse(ctx, perr2)
 					p.applyFiltersOnError(ctx, processedFilters)
 					return perr2
 				}
 			} else {
+				requestStopWatch.Stop()
+				responseStopWatch.Start()
 				p.makeErrorResponse(ctx, perr)
 				p.applyFiltersOnError(ctx, processedFilters)
 				return perr
 			}
+		} else {
+			responseStopWatch.Start()
 		}
-
 		if rsp.StatusCode >= http.StatusInternalServerError {
 			p.metrics.MeasureBackend5xx(backendStart)
 		}
@@ -1362,9 +1404,9 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 	}
 
 	addBranding(ctx.response.Header)
-	ctx.proxyWatch.Stop()
+	responseStopWatch.Stop()
 	p.applyFiltersToResponse(processedFilters, ctx)
-	ctx.proxyWatch.Start()
+	responseStopWatch.Start()
 	return nil
 }
 
@@ -1376,6 +1418,15 @@ func retryable(ctx *context, perr *proxyError) bool {
 }
 
 func (p *Proxy) serveResponse(ctx *context) {
+
+	responseStopWatch := newStopWatch()
+	responseStopWatch.Start()
+	defer func() {
+		responseStopWatch.Stop()
+		ctx.proxyRequestElapsed = 0
+		ctx.proxyResponseElapsed = responseStopWatch.Elapsed()
+	}()
+
 	if p.flags.Debug() {
 		dbgResponse(ctx.responseWriter, &debugInfo{
 			route:    &ctx.route.Route,
@@ -1405,9 +1456,11 @@ func (p *Proxy) serveResponse(ctx *context) {
 	ctx.responseWriter.Flush()
 	p.tracing.logStreamEvent(ctx.proxySpan, StreamHeadersEvent, EndEvent)
 
-	ctx.proxyWatch.Stop()
+	responseStopWatch.Stop()
+
 	n, err := copyStream(ctx.responseWriter, ctx.response.Body)
-	ctx.proxyWatch.Start()
+
+	responseStopWatch.Start()
 
 	p.tracing.logStreamEvent(ctx.proxySpan, StreamBodyEvent, strconv.FormatInt(n, 10))
 	if err != nil {
@@ -1424,6 +1477,14 @@ func (p *Proxy) serveResponse(ctx *context) {
 }
 
 func (p *Proxy) errorResponse(ctx *context, err error) {
+	responseStopWatch := newStopWatch()
+	responseStopWatch.Start()
+	defer func() {
+		responseStopWatch.Stop()
+		ctx.proxyRequestElapsed = 0
+		ctx.proxyResponseElapsed = responseStopWatch.Elapsed()
+	}()
+
 	perr, ok := err.(*proxyError)
 	if ok && perr.handled {
 		return
@@ -1505,9 +1566,9 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 	ctx.responseWriter.WriteHeader(ctx.response.StatusCode)
 	ctx.responseWriter.Flush()
 
-	ctx.proxyWatch.Stop()
+	responseStopWatch.Stop()
 	_, _ = copyStream(ctx.responseWriter, ctx.response.Body)
-	ctx.proxyWatch.Start()
+	responseStopWatch.Start()
 
 	p.metrics.MeasureServe(
 		id,
@@ -1566,8 +1627,10 @@ func shouldLog(statusCode int, filter *al.AccessLogFilter) bool {
 
 // http.Handler implementation
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	proxyStopWatch := newStopWatch()
-	proxyStopWatch.Start()
+
+	var requestElapsed, responseElapsed time.Duration
+	requestStopWatch, responseStopWatch := newStopWatch(), newStopWatch()
+	requestStopWatch.Start()
 
 	lw := logging.NewLoggingWriter(w)
 
@@ -1587,9 +1650,10 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ctx.proxySpan.Finish()
 		}
 		span.Finish()
-		ctx.proxyWatch.Stop()
-		skipperResponseLatency := ctx.proxyWatch.Elapsed()
-		p.metrics.MeasureProxy(ctx.proxyRequestLatency, skipperResponseLatency)
+		requestStopWatch.Stop()
+		responseStopWatch.Stop()
+
+		p.metrics.MeasureProxy(requestElapsed+requestStopWatch.Elapsed(), responseElapsed+responseStopWatch.Elapsed())
 	}()
 
 	defer func() {
@@ -1636,7 +1700,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ot.ContextWithSpan(r.Context(), span))
 	r = r.WithContext(routing.NewContext(r.Context()))
 
-	ctx = newContext(lw, r, p, proxyStopWatch)
+	ctx = newContext(lw, r, p)
 	ctx.startServe = time.Now()
 	ctx.tracer = p.tracing.tracer
 	ctx.initialSpan = span
@@ -1651,7 +1715,14 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	requestStopWatch.Stop()
+
 	err := p.do(ctx, span)
+
+	requestElapsed += ctx.proxyRequestElapsed
+	responseElapsed += ctx.proxyResponseElapsed
+
+	responseStopWatch.Start()
 
 	// writeTimeout() filter
 	if d, ok := ctx.StateBag()[filters.WriteTimeout].(time.Duration); ok {
@@ -1661,13 +1732,17 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	responseStopWatch.Stop()
 	// stream response body to client
 	if err != nil {
 		p.errorResponse(ctx, err)
+		responseElapsed += ctx.proxyResponseElapsed
 	} else {
 		p.serveResponse(ctx)
+		responseElapsed += ctx.proxyResponseElapsed
 	}
 
+	responseStopWatch.Start()
 	// fifoWtihBody() filter
 	if sbf, ok := ctx.StateBag()[filters.FifoWithBodyName]; ok {
 		if fs, ok := sbf.([]func()); ok {


### PR DESCRIPTION
Refactored proxy timing measurement to track request and response phases separately.

The previous implementation used a single stopwatch that failed to
properly handle shunt and loopback scenarios. For loopback routes,
the entire duration of subsequent loopbacks was incorrectly attributed
to response time since each loopback creates its own context.
Additionally, shunt routes never triggered the request-to-response
timer transition, which was located in makeBackendRequest and
therefore unreachable for shunt routes.

Additonally fixing another bug:
The defer statement for finishing the loopSpan was causing response
filter processing time to be incorrectly included in the loopback span
timings. This change moves the loopSpan.Finish() calls to execute
immediately after the recursive do() call completes.