### PR TITLE
metrics: Enhanced gauge metrics to track individual invalid routes

### DIFF
--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -131,9 +131,14 @@ func (a *All) IncErrorsStreaming(routeId string) {
 
 }
 
-func (a *All) UpdateInvalidRoute(reasonCounts map[string]int) {
-	a.prometheus.UpdateInvalidRoute(reasonCounts)
-	a.codaHale.UpdateInvalidRoute(reasonCounts)
+func (a *All) SetInvalidRoute(routeId, reason string) {
+	a.prometheus.SetInvalidRoute(routeId, reason)
+	a.codaHale.SetInvalidRoute(routeId, reason)
+}
+
+func (a *All) DeleteInvalidRoute(routeId string) {
+	a.prometheus.DeleteInvalidRoute(routeId)
+	a.codaHale.DeleteInvalidRoute(routeId)
 }
 
 func (a *All) Close() {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -80,7 +80,8 @@ type Metrics interface {
 	IncErrorsStreaming(routeId string)
 	RegisterHandler(path string, handler *http.ServeMux)
 	UpdateGauge(key string, value float64)
-	UpdateInvalidRoute(reasonCounts map[string]int)
+	SetInvalidRoute(routeId, reason string)
+	DeleteInvalidRoute(routeId string)
 	Close()
 }
 

--- a/metrics/metricstest/metricsmock.go
+++ b/metrics/metricstest/metricsmock.go
@@ -3,6 +3,7 @@ package metricstest
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -225,10 +226,20 @@ func (m *MockMetrics) Gauge(key string) (v float64, ok bool) {
 	return
 }
 
-func (m *MockMetrics) UpdateInvalidRoute(reasonCounts map[string]int) {
-	for reason, count := range reasonCounts {
-		m.UpdateGauge("route.invalid."+reason, float64(count))
-	}
+func (m *MockMetrics) SetInvalidRoute(routeId, reason string) {
+	key := fmt.Sprintf("route.invalid.%s..%s", routeId, reason)
+	m.UpdateGauge(key, 1)
+}
+
+func (m *MockMetrics) DeleteInvalidRoute(routeId string) {
+	m.WithGauges(func(gauges map[string]float64) {
+		prefix := fmt.Sprintf("route.invalid.%s.", routeId)
+		for key := range gauges {
+			if strings.HasPrefix(key, prefix) {
+				gauges[key] = 0
+			}
+		}
+	})
 }
 
 func (m *MockMetrics) Close() {}


### PR DESCRIPTION
- Enhanced `skipper_route_invalid` metric to include route ID, name, and reason in labels.
- Adjusted test cases to validate per-route invalid metric behavior.

Signed-off-by: Veronika Volokitina <v.volokitinaa@gmail.com>
