### PR TITLE
proxy: skip TestPHC for short test

### DIFF
--- a/proxy/healthy_endpoints_test.go
+++ b/proxy/healthy_endpoints_test.go
@@ -174,6 +174,10 @@ func TestPHCForSingleHealthyEndpoint(t *testing.T) {
 }
 
 func TestPHC(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	rpsFactor := 0.0
 	for _, tt := range []struct {
 		name               string


### PR DESCRIPTION
Skip TestPHC that takes ~133.47s for short test so that short test finishes in a reasonable time (~80s).