### PR TITLE
fix: Add missing timing metrics in makeBackendRequest

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -971,6 +971,13 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 	requestStopWatch, responseStopWatch := newStopWatch(), newStopWatch()
 	requestStopWatch.Start()
 
+	defer func() {
+		requestStopWatch.Stop()
+		responseStopWatch.Stop()
+		ctx.proxyRequestElapsed = requestStopWatch.Elapsed()
+		ctx.proxyResponseElapsed = responseStopWatch.Elapsed()
+	}()
+
 	payloadProtocol := getUpgradeRequest(ctx.Request())
 
 	req, endpointMetrics, err := p.mapRequest(ctx, requestContext)


### PR DESCRIPTION
The request and response timing metrics weren't captured in makeBackendRequest. 
Added a defer block to ensure stopwatches are stopped and elapsed times are recorded in the context.
A follow up to https://github.com/zalando/skipper/pull/3603