### PR TITLE
fix: forward backend in routegroups

### DIFF
--- a/dataclients/kubernetes/definitions/routegroups.go
+++ b/dataclients/kubernetes/definitions/routegroups.go
@@ -17,7 +17,7 @@ import (
 // contain the pod endpoints, and ignore the global option for skipper?
 // --> As CRD we have to lookup endpoints ourselves, maybe via kube.go
 const (
-	ServiceBackend = eskip.LBBackend + 1 + iota
+	ServiceBackend = -1
 )
 
 var (


### PR DESCRIPTION
fix: forward backend in routegroups

The validation webhook creates a ServiceBackend by adding +1 to eskip.LBBackend, which was ForwardBackend. 
It failed then by wanting to have a service_name which is not required nor makes sense in ForwardBackend. 

follow up ref https://github.com/zalando/skipper/issues/3649 
commit dd70bd65e7f99cfb5dd6b6f71885d9fe3b2707f6 broke the append for eskip backends.