### PR TITLE
benchmarks: JWTPayloadAnyKV and JWTPayloadAnyKV

### DIFF
--- a/predicates/auth/jwt_test.go
+++ b/predicates/auth/jwt_test.go
@@ -619,6 +619,24 @@ s: JWTPayloadAnyKVRegexp("https://identity.zalando.com/managed-id", "^ssz") -> s
 
 }
 
+func BenchmarkJWTPayloadAnyKV(b *testing.B) {
+	sp := NewJWTPayloadAnyKV()
+	p, err := sp.Create([]interface{}{"https://identity.zalando.com/managed-id", "foo", "iss", "https://identity.zalando.com"})
+	if err != nil {
+		b.Fatalf("Failed to create predicate: %v", err)
+	}
+	benchPredicate(b, p)
+}
+
+func BenchmarkJWTPayloadAllKV(b *testing.B) {
+	sp := NewJWTPayloadAnyKV()
+	p, err := sp.Create([]interface{}{"https://identity.zalando.com/managed-id", "sszuecs", "iss", "https://identity.zalando.com"})
+	if err != nil {
+		b.Fatalf("Failed to create predicate: %v", err)
+	}
+	benchPredicate(b, p)
+}
+
 func BenchmarkJWTPayloadAnyKVRegexp(b *testing.B) {
 	sp := NewJWTPayloadAnyKVRegexp()
 	p, err := sp.Create([]interface{}{"https://identity.zalando.com/managed-id", "^ssz", "https://identity.zalando.com/token", "^Bear"})


### PR DESCRIPTION
benchmarks: JWTPayloadAnyKV and JWTPayloadAnyKV
We can see that caching the decision does not make it faster. I also created a change to use cache, no change.

```
% go test -bench='^BenchmarkJWTPayload' -benchmem ./predicates/auth -run='^$' -count 10 -cpu 1,2,4,8,16 goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/predicates/auth
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkJWTPayloadAnyKV                18273067                67.67 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKV                17120702                67.04 ns/op            0 B/op          0 allocs/op
..
BenchmarkJWTPayloadAnyKV-2              17518123                66.94 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKV-2              18698533                68.39 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAnyKV-8              16888083                66.80 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKV-8              17371408                65.71 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKV-16             17461327                66.93 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKV-16             17745558                67.81 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAllKV                17975056                66.29 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKV                17848806                65.96 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAllKV-2              17093637                67.88 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKV-2              17151800                66.02 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAllKV-8              18043434                69.36 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKV-8              16840196                69.06 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKV-16             16482150                76.50 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKV-16             16218813                86.82 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp          17859433                68.57 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp          17453676                76.89 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp-2        17191760                66.33 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-2        17997068                65.48 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-4        17705949                67.30 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-4        17178394                67.81 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp-8        17213996                69.79 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-8        17701802                69.19 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-16       16551988                66.29 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-16       17665833                70.56 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-16       17156443                70.93 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp          18188683                66.13 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp          17915355                66.55 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-2        17044281                67.50 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-2        17210587                67.64 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-2        17805511                68.00 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp-4        17059782                68.95 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-4        14563726                82.22 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-4        15201260                69.31 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-8        16844420                69.39 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-8        17253874                68.88 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-8        16975526                70.47 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-8        17230522                65.84 ns/op            0 B/op          0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp-16       16778550                68.83 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-16       16812842                69.98 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-16       16025841                70.98 ns/op            0 B/op          0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-16       17483354                68.56 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/zalando/skipper/predicates/auth      255.842s
```