### PR TITLE
predicates: fix JWTPayloadAllKV benchmark test

### DIFF
--- a/predicates/auth/jwt_test.go
+++ b/predicates/auth/jwt_test.go
@@ -629,7 +629,7 @@ func BenchmarkJWTPayloadAnyKV(b *testing.B) {
 }
 
 func BenchmarkJWTPayloadAllKV(b *testing.B) {
-	sp := NewJWTPayloadAnyKV()
+	sp := NewJWTPayloadAllKV()
 	p, err := sp.Create([]interface{}{"https://identity.zalando.com/managed-id", "sszuecs", "iss", "https://identity.zalando.com"})
 	if err != nil {
 		b.Fatalf("Failed to create predicate: %v", err)


### PR DESCRIPTION
```
❯ go test -bench='^BenchmarkJWTPayload' -benchmem ./predicates/auth -run='^$' -count 10 -cpu 1,2,4,8,16
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/predicates/auth
cpu: Apple M1
BenchmarkJWTPayloadAnyKV             	23994320	        48.99 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKV             	24675448	        49.00 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKV-2           	24562334	        49.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKV-2           	23767533	        49.09 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKV-4           	24673927	        49.16 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKV-4           	24414868	        49.26 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKV-8           	23866881	        49.36 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKV-8           	24417084	        49.02 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKV-16          	24570610	        49.17 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKV-16          	24405496	        48.92 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKV             	24545481	        49.05 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKV             	24441930	        48.93 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKV-2           	24547093	        49.10 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKV-2           	24441992	        49.95 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKV-4           	24554334	        49.19 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKV-4           	24392019	        48.90 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKV-8           	24514622	        49.07 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKV-8           	24407358	        48.84 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKV-16          	24532038	        49.35 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKV-16          	24377092	        48.85 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp       	24513246	        49.15 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp       	24383862	        49.03 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp-2     	23948172	        49.16 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-2     	24212361	        48.79 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp-4     	24508989	        49.10 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-4     	24398632	        49.66 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp-8     	24408309	        49.16 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-8     	24144058	        48.85 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAnyKVRegexp-16    	24552618	        49.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAnyKVRegexp-16    	24435397	        48.75 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp       	24556365	        49.21 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKVRegexp       	24433615	        49.51 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp-2     	19985052	        50.67 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-2     	22292419	        55.55 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp-4     	24413626	        50.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-4     	24340255	        48.83 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp-8     	20865724	        50.53 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-8     	24261088	        49.22 ns/op	       0 B/op	       0 allocs/op
...
BenchmarkJWTPayloadAllKVRegexp-16    	24410481	        49.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkJWTPayloadAllKVRegexp-16    	24367832	        48.94 ns/op	       0 B/op	       0 allocs/op
...
PASS
ok  	github.com/zalando/skipper/predicates/auth	251.718s
```