### PR TITLE
Workaround OPA race condition in plugin status updates

### DIFF
--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -715,9 +715,11 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 	}
 
 	manager.RegisterCompilerTrigger(opa.compilerUpdated)
-	manager.RegisterPluginStatusListener("instance-health-check", func(status map[string]*plugins.Status) {
+	manager.RegisterPluginStatusListener("instance-health-check", func(_ map[string]*plugins.Status) {
+		// Get fresh status to workaround OPA issue https://github.com/open-policy-agent/opa/issues/8009
+		status := opa.manager.PluginStatus()
 		opa.healthy.Store(allPluginsReady(status, bundle.Name, discovery.Name))
-		opa.Logger().Info("OPA instance health updated: healthy=%t", opa.healthy.Load())
+		opa.Logger().Info("OPA instance health updated: healthy=%t status=%+v", opa.healthy.Load(), status)
 	})
 
 	return opa, nil


### PR DESCRIPTION
Addresses issue https://github.com/zalando/skipper/issues/3687 working around it, by directly using manager statuses.
cc: @mjungsbluth 

Enriched log messages with plugin statuses.
It will now print something similar to below when a plugin status changed and listener is notified. Expect less logs after the start up.

```
[APP]time="2025-11-03T22:39:00+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} discovery:{NOT_READY \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:00+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} decision_logs:{NOT_READY \"\"} discovery:{NOT_READY \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:00+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} decision_logs:{NOT_READY \"\"} discovery:{NOT_READY \"\"} status:{NOT_READY \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:00+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} decision_logs:{NOT_READY \"\"} discovery:{NOT_READY \"\"} envoy_ext_authz_grpc:{NOT_READY \"\"} status:{NOT_READY \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:00+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} decision_logs:{OK \"\"} discovery:{NOT_READY \"\"} envoy_ext_authz_grpc:{NOT_READY \"\"} status:{NOT_READY \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:00+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} decision_logs:{OK \"\"} discovery:{NOT_READY \"\"} envoy_ext_authz_grpc:{NOT_READY \"\"} status:{OK \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:00+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} decision_logs:{OK \"\"} discovery:{NOT_READY \"\"} envoy_ext_authz_grpc:{OK \"\"} status:{OK \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:06+01:00" level=info msg="OPA instance health updated: healthy=false status=map[bundle:{NOT_READY \"\"} decision_logs:{OK \"\"} discovery:{OK \"\"} envoy_ext_authz_grpc:{OK \"\"} status:{OK \"\"}]" bundle-name=bundles/discovery.tar.gz
[APP]time="2025-11-03T22:39:26+01:00" level=info msg="OPA instance health updated: healthy=true status=map[bundle:{OK \"\"} decision_logs:{OK \"\"} discovery:{OK \"\"} envoy_ext_authz_grpc:{OK \"\"} status:{OK \"\"}]" bundle-name=bundles/discovery.tar.gz
```