### PR TITLE
chore: Update Go version to 1.24.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -207,4 +207,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-go 1.24.6
+go 1.24.9


### PR DESCRIPTION
1.24.6 has some vulnerabilities:

https://osv.dev/GO-2025-4006
https://osv.dev/GO-2025-4007
https://osv.dev/GO-2025-4008
https://osv.dev/GO-2025-4009
https://osv.dev/GO-2025-4010
https://osv.dev/GO-2025-4011
https://osv.dev/GO-2025-4012
https://osv.dev/GO-2025-4013
https://osv.dev/GO-2025-4014