### PR TITLE
feature: allow to configure response body size bucket metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -188,6 +188,10 @@ type Options struct {
 	// histogram metrics.
 	HistogramBuckets []float64
 
+	// ResponseSizeBuckets defines buckets into which the observations are counted for
+	// response in bytes metrics.
+	ResponseSizeBuckets []float64
+
 	// The following options, for backwards compatibility, are true
 	// by default: EnableAllFiltersMetrics, EnableRouteResponseMetrics,
 	// EnableRouteBackendErrorsCounters, EnableRouteStreamingErrorsCounters,

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -39,8 +39,8 @@ const (
 //   - 8 KiB for [Spring Boot](https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.server.server.max-http-request-header-size)
 var headerSizeBuckets = []float64{4 * KiB, 8 * KiB, 16 * KiB, 64 * KiB}
 
-// responseSizeBuckets are chosen to cover 2^(10*n) sizes up to 1 GiB and halves of those.
-var responseSizeBuckets = []float64{1, 512, 1 * KiB, 512 * KiB, 1 * MiB, 512 * MiB, 1 * GiB}
+// DefaultResponseSizeBuckets are chosen to cover 2^(10*n) sizes up to 1 GiB and halves of those.
+var DefaultResponseSizeBuckets = []float64{1, 512, 1 * KiB, 512 * KiB, 1 * MiB, 512 * MiB, 1 * GiB}
 
 // Prometheus implements the prometheus metrics backend.
 type Prometheus struct {
@@ -95,6 +95,11 @@ func NewPrometheus(opts Options) *Prometheus {
 
 	if p.registry == nil {
 		p.registry = prometheus.NewRegistry()
+	}
+
+	responseSizeBuckets := DefaultResponseSizeBuckets
+	if len(opts.ResponseSizeBuckets) > 1 {
+		responseSizeBuckets = opts.ResponseSizeBuckets
 	}
 
 	namespace := promNamespace

--- a/skipper.go
+++ b/skipper.go
@@ -589,6 +589,9 @@ type Options struct {
 	// Use custom buckets for prometheus histograms.
 	HistogramMetricBuckets []float64
 
+	// Use custom buckets for prometheus response body size.
+	ResponseSizeBuckets []float64
+
 	// The following options, for backwards compatibility, are true
 	// by default: EnableAllFiltersMetrics, EnableRouteResponseMetrics,
 	// EnableRouteBackendErrorsCounters, EnableRouteStreamingErrorsCounters,
@@ -1626,6 +1629,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		EnableRouteBackendMetrics:          o.EnableRouteBackendMetrics,
 		UseExpDecaySample:                  o.MetricsUseExpDecaySample,
 		HistogramBuckets:                   o.HistogramMetricBuckets,
+		ResponseSizeBuckets:                o.ResponseSizeBuckets,
 		DisableCompatibilityDefaults:       o.DisableMetricsCompatibilityDefaults,
 		PrometheusRegistry:                 o.PrometheusRegistry,
 		EnablePrometheusStartLabel:         o.EnablePrometheusStartLabel,


### PR DESCRIPTION
feature: allow to configure response body size bucket metrics

```
./bin/skipper -inline-routes='r: * -> status(201) -> repeatContent("A", 2000) -> <shunt>' -address :9001 -metrics-flavour prometheus -response-size-buckets="1024,$((4 *1024)),$((8 *1024)),$((16 *1024))" 
```
After a couple of calls to this I get metrics:
```
# HELP skipper_response_size_bytes Size of response in bytes.
# TYPE skipper_response_size_bytes histogram
skipper_response_size_bytes_bucket{host="_unknownhost_",le="1024"} 0
skipper_response_size_bytes_bucket{host="_unknownhost_",le="4096"} 4
skipper_response_size_bytes_bucket{host="_unknownhost_",le="8192"} 4
skipper_response_size_bytes_bucket{host="_unknownhost_",le="16384"} 4
skipper_response_size_bytes_bucket{host="_unknownhost_",le="+Inf"} 4
skipper_response_size_bytes_sum{host="_unknownhost_"} 8000
skipper_response_size_bytes_count{host="_unknownhost_"} 4
```