### PR TITLE
Avoid duplicate start tasks from getting into the queue.

### DIFF
--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -599,6 +599,7 @@ type OpenPolicyAgentInstance struct {
 	startedOnce                 sync.Once
 	startingErr                 error
 	started                     atomic.Bool
+	startScheduled              atomic.Bool
 	registry                    *OpenPolicyAgentRegistry
 	healthy                     atomic.Bool
 	logger                      logging.Logger
@@ -799,6 +800,14 @@ func (opa *OpenPolicyAgentInstance) Healthy() bool {
 
 func (opa *OpenPolicyAgentInstance) Started() bool {
 	return opa.started.Load()
+}
+
+func (opa *OpenPolicyAgentInstance) StartScheduled() bool {
+	return opa.startScheduled.Load()
+}
+
+func (opa *OpenPolicyAgentInstance) MarkStartScheduled() {
+	opa.startScheduled.Store(true)
 }
 
 // StartAndTriggerPlugins Start starts the policy engine's plugin manager and triggers the plugins to download policies etc.

--- a/filters/openpolicyagent/preprocessor.go
+++ b/filters/openpolicyagent/preprocessor.go
@@ -123,7 +123,7 @@ func (p *opaPreProcessor) enqueueInstancesSequential(bundles []string) {
 		}
 
 		if inst != nil {
-			if !inst.Started() {
+			if !inst.StartScheduled() {
 				p.log.Info("Scheduling background task to start existing OPA instance for bundle: ", bundle)
 				if _, err := p.registry.ScheduleBackgroundTask(inst.Start); err != nil {
 					p.log.Errorf("Failed to reschedule OPA instance for bundle %q: %v", bundle, err)
@@ -144,6 +144,8 @@ func (p *opaPreProcessor) enqueueInstancesSequential(bundles []string) {
 
 		if err != nil {
 			p.log.Errorf("Failed to schedule OPA instance for bundle %q: %v", bundle, err)
+		} else {
+			inst.MarkStartScheduled()
 		}
 	}
 }


### PR DESCRIPTION
Avoid the same bundle start tasks been added to the queue twice.
co-author: @mjungsbluth 