### PR TITLE
fix: thread-key step reference in workflow

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -56,7 +56,7 @@ jobs:
         "${{ secrets.INTERNAL_CHAT_WEBHOOK }}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
         -d "{
           \"thread\": {
-              \"threadKey\": \"${{ step.thread-key.KEY }}\"
+              \"threadKey\": \"${{ steps.thread-key.KEY }}\"
             },
           \"cardsV2\": [
             {


### PR DESCRIPTION
The workflow was incorrectly referencing 'step.thread-key.KEY' instead of 'steps.thread-key.KEY' (missing the 's' in 'steps').