### PR TITLE
fix: threaded notifications

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -23,9 +23,9 @@ jobs:
       - run: make check-fmt
       - run: make vet
       - run: make staticcheck
-      - run: make check-race
       - run: make osv-scanner
       - run: make govulncheck
+      - run: make check-race
       - run: make capslock
       - run: make coverprofile
       - name: Convert coverage to lcov
@@ -53,10 +53,10 @@ jobs:
     - run: >-
         curl
         -H 'content-type:application/json'
-        "${{ secrets.INTERNAL_CHAT_WEBHOOK }}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
+        "${{ secrets.INTERNAL_CHAT_WEBHOOK }}"
         -d "{
           \"thread\": {
-              \"threadKey\": \"${{ steps.thread-key.KEY }}\"
+              \"threadKey\": \"${{ steps.thread-key.outputs.KEY }}\"
             },
           \"cardsV2\": [
             {


### PR DESCRIPTION
This commit fixes the reference to the output of the step. 
Also moving the check-race step further in pipeline, it is cheaper to fail earlier in case if vulnerability detected.
The query argument moved to the secret itself.

<img width="399" height="388" alt="Screenshot 2025-11-07 at 13 38 52" src="https://github.com/user-attachments/assets/eac34cd1-609a-46dc-9716-5e1b3d1c41f0" />
