### PR TITLE
build(deps): bump oss-fuzz-base/base-builder-go in /.clusterfuzzlite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:9e293085f163de4a9d9c02f0c17663b3d1e082db3355c142144bc2483d69b5ef
+FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:9e76082f0d5e86f349c9f87f4e9bc994f905ba865160886ed121fe661e59d4aa
 
 COPY . $SRC/skipper
 COPY ./.clusterfuzzlite/build.sh $SRC/


### PR DESCRIPTION
replaces https://github.com/zalando/skipper/pull/3710

Bumps oss-fuzz-base/base-builder-go from `9e29308` to `9e76082`.

---
updated-dependencies:
- dependency-name: oss-fuzz-base/base-builder-go dependency-version: 9e76082f0d5e86f349c9f87f4e9bc994f905ba865160886ed121fe661e59d4aa dependency-type: direct:production ...