### PR TITLE
fix: `TestPHCNoHealthyEndpoints` use roundRobin for load balancing

### DIFF
--- a/proxy/healthy_endpoints_test.go
+++ b/proxy/healthy_endpoints_test.go
@@ -275,7 +275,7 @@ func TestPHCNoHealthyEndpoints(t *testing.T) {
 	)
 
 	servicesString := setupServices(t, healthy, unhealthy)
-	mockMetrics, ps := setupProxy(t, fmt.Sprintf(`* -> backendTimeout("20ms") -> <random, %s>`,
+	mockMetrics, ps := setupProxy(t, fmt.Sprintf(`* -> backendTimeout("20ms") -> <roundRobin, %s>`,
 		servicesString))
 	va := fireVegeta(t, ps, 5000, 1*time.Second, 5*time.Second)
 


### PR DESCRIPTION
`TestPHCNoHealthyEndpoints` uses `random` for load balancing, and it's possible some endpoints are never visited. A never visited endpoint would have a drop probability of 0 (i.e., the endpoint is allowed to pass the request). If we use `roundRobin`, we remove the uncertainty in request distribution and we have a better exepectation on the metrics count.

The detailed reasoning can also be found in: https://github.com/zalando/skipper/issues/3189#issuecomment-3509302430

fix #3189 
