### PR TITLE
Fix: flakytest admission control

### DIFF
--- a/filters/shedder/admission.go
+++ b/filters/shedder/admission.go
@@ -335,7 +335,6 @@ func (spec *AdmissionControlSpec) CreateFilter(args []interface{}) (filters.Filt
 		counter:          new(atomic.Int64),
 		successCounter:   new(atomic.Int64),
 		rand:             r,
-		//rand:             randWithSeed(), // flakytest
 	}
 	go ac.tickWindows(d)
 	return ac, nil

--- a/filters/shedder/admission_test.go
+++ b/filters/shedder/admission_test.go
@@ -27,24 +27,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func TestRand(t *testing.T) {
-	r := randWithSeed()
-
-	for _, ti := range []struct {
-		msg string
-	}{
-		{msg: "1"},
-		{msg: "2"},
-	} {
-		t.Run(ti.msg, func(t *testing.T) {
-			for range 10 {
-				t.Logf("%0.2f", r())
-			}
-		})
-	}
-
-}
-
 func TestAdmissionControl(t *testing.T) {
 	for _, ti := range []struct {
 		msg                        string


### PR DESCRIPTION
Fix: flakytest admission control

The core problem was that we have had a non-seeded global random source that generated every time different random numbers so it's easy to have bad luck. Another issue was that if you have a global random source is that the different test cases interfere with each other. The third problem was that we used the same global random to have randomized response codes on the server side in the httptest.Server.
All of it is now fixed. 

We have an option to use a static seeded random source by filter that we use for tests.
In general we use the global random source that we have to guard by a mutex at least `test -race` says so.
Maybe we should also create filter local random source for the production build but I think it's fine like this.