### PR TITLE
Gh action/labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,11 @@
+# Add 'docs' to any changes within 'docs' folder or any subfolders
+documentation:
+  - docs/**/*
+
 # Add 'enhancement' label to any PR where the head branch name starts with `feature/` in the name
 enhancement:
- - head-branch: ['^feature/']
+  - head-branch: ['^feature/']
 
 # Add 'codefreeze' label to any PR that is opened against the `cw2025` branch
 codefreeze:
- - base-branch: 'cw2025'
+  - base-branch: 'cw2025'


### PR DESCRIPTION
Use commits from cw2025 such that the labeler works during code freeze


````
% git cherry-pick e23559c73e029040a3909906fde3a683e0967daa
[gh-action/labeler c4dc064f] automate: pr label cw2025 for convenience (#3724)
 Date: Mon Nov 10 22:28:21 2025 +0100
 1 file changed, 7 insertions(+)
 create mode 100644 .github/labeler.yml
% git cherry-pick 5192763ca9f626de5689cf47aacfe9699ed6f1a7
[gh-action/labeler fdba8134] fix: yaml indentation in labeler.yml (#3732)
 Date: Fri Nov 14 19:54:55 2025 +0100
 1 file changed, 6 insertions(+), 2 deletions(-)
````