### PR TITLE
chore: update image versions in k8s manifests

### DIFF
--- a/docs/kubernetes/deploy/daemonset/daemonset.yaml
+++ b/docs/kubernetes/deploy/daemonset/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.12.0
+        image: registry.opensource.zalan.do/teapot/skipper:v0.22.170
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/docs/kubernetes/deploy/demo/deployment.yaml
+++ b/docs/kubernetes/deploy/demo/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: skipper-demo
-        image: registry.opensource.zalan.do/teapot/skipper:v0.12.0
+        image: registry.opensource.zalan.do/teapot/skipper:v0.22.170
         args:
           - "skipper"
           - "-inline-routes"

--- a/docs/kubernetes/deploy/deployment/deployment.yaml
+++ b/docs/kubernetes/deploy/deployment/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.12.0
+        image: registry.opensource.zalan.do/teapot/skipper:v0.22.170
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
v1beta1 is removed from k8s since some time. The
image version used in manifests are not working
out of the box anymore. At least v0.14.0 is
required to adopt to v1beta1 removal.