### PR TITLE
Optimize: apiusagemonitoring jwt parsing

### DIFF
--- a/filters/apiusagemonitoring/jwt_test.go
+++ b/filters/apiusagemonitoring/jwt_test.go
@@ -1,9 +1,10 @@
 package apiusagemonitoring
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_parseJwtBody_NoHeader(t *testing.T) {
@@ -79,4 +80,17 @@ func Test_parseJwtBody_AuthorizationHeaderWithValidJwtBody(t *testing.T) {
 
 	body := parseJwtBody(req)
 	assert.Equal(t, jwtTokenPayload{"foo": "bar"}, body)
+}
+
+func BenchmarkParseJwtBody(b *testing.B) {
+	req, err := http.NewRequest(http.MethodGet, "", nil)
+	assert.NoError(b, err)
+	req.Header = http.Header{
+		authorizationHeaderName: []string{"Bearer Zm9v.eyJmb28iOiJiYXIifQ.bW9v"},
+	}
+
+	for b.Loop() {
+		body := parseJwtBody(req)
+		assert.Equal(b, jwtTokenPayload{"foo": "bar"}, body)
+	}
 }


### PR DESCRIPTION
```
% benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/filters/apiusagemonitoring
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
               │   old.txt    │               new.txt               │
               │    sec/op    │   sec/op     vs base                │
ParseJwtBody     2046.5n ± 1%   974.4n ± 1%  -52.39% (p=0.000 n=10)
ParseJwtBody-2    2.223µ ± 5%   1.004µ ± 3%  -54.86% (p=0.000 n=10)
ParseJwtBody-4    2.271µ ± 2%   1.042µ ± 1%  -54.14% (p=0.000 n=10)
ParseJwtBody-8    2.300µ ± 2%   1.071µ ± 5%  -53.45% (p=0.000 n=10)
geomean           2.208µ        1.022µ       -53.72%

               │   old.txt   │              new.txt               │
               │    B/op     │    B/op     vs base                │
ParseJwtBody     1016.0 ± 0%   384.0 ± 0%  -62.20% (p=0.000 n=10)
ParseJwtBody-2   1016.0 ± 0%   384.0 ± 0%  -62.20% (p=0.000 n=10)
ParseJwtBody-4   1016.0 ± 0%   384.0 ± 0%  -62.20% (p=0.000 n=10)
ParseJwtBody-8   1016.0 ± 0%   384.0 ± 0%  -62.20% (p=0.000 n=10)
geomean          1016.0        384.0       -62.20%

               │   old.txt   │              new.txt               │
               │  allocs/op  │ allocs/op   vs base                │
ParseJwtBody     17.000 ± 0%   5.000 ± 0%  -70.59% (p=0.000 n=10)
ParseJwtBody-2   17.000 ± 0%   5.000 ± 0%  -70.59% (p=0.000 n=10)
ParseJwtBody-4   17.000 ± 0%   5.000 ± 0%  -70.59% (p=0.000 n=10)
ParseJwtBody-8   17.000 ± 0%   5.000 ± 0%  -70.59% (p=0.000 n=10)
geomean           17.00        5.000       -70.59%
```