### PR TITLE
Bump Go version to 1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -207,4 +207,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-go 1.24.9
+go 1.24.11


### PR DESCRIPTION
https://osv.dev/vulnerability/GO-2025-4155