### PR TITLE
metrics: remove invalid routes deletion

### DIFF
--- a/metrics/all_kind.go
+++ b/metrics/all_kind.go
@@ -136,11 +136,6 @@ func (a *All) SetInvalidRoute(routeId, reason string) {
 	a.codaHale.SetInvalidRoute(routeId, reason)
 }
 
-func (a *All) DeleteInvalidRoute(routeId string) {
-	a.prometheus.DeleteInvalidRoute(routeId)
-	a.codaHale.DeleteInvalidRoute(routeId)
-}
-
 func (a *All) Close() {
 	a.codaHale.Close()
 	a.prometheus.Close()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -81,7 +81,6 @@ type Metrics interface {
 	RegisterHandler(path string, handler *http.ServeMux)
 	UpdateGauge(key string, value float64)
 	SetInvalidRoute(routeId, reason string)
-	DeleteInvalidRoute(routeId string)
 	Close()
 }
 

--- a/metrics/metricstest/metricsmock.go
+++ b/metrics/metricstest/metricsmock.go
@@ -5,7 +5,6 @@ package metricstest
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 )
@@ -228,17 +227,6 @@ func (m *MockMetrics) Gauge(key string) (v float64, ok bool) {
 func (m *MockMetrics) SetInvalidRoute(routeID, reason string) {
 	key := fmt.Sprintf("route.invalid.%s..%s", routeID, reason)
 	m.UpdateGauge(key, 1)
-}
-
-func (m *MockMetrics) DeleteInvalidRoute(routeID string) {
-	m.WithGauges(func(gauges map[string]float64) {
-		prefix := fmt.Sprintf("route.invalid.%s.", routeID)
-		for key := range gauges {
-			if strings.HasPrefix(key, prefix) {
-				gauges[key] = 0
-			}
-		}
-	})
 }
 
 func (*MockMetrics) Close() {}

--- a/metrics/metricstest/metricsmock_test.go
+++ b/metrics/metricstest/metricsmock_test.go
@@ -165,7 +165,7 @@ func TestMockMetrics(t *testing.T) {
 		}
 	})
 
-	t.Run("test-measure-backend-request-header", func(t *testing.T) {
+	t.Run("test-set-invalid-route", func(t *testing.T) {
 		routeID := "my-route"
 		reason := "foo"
 		key := fmt.Sprintf("route.invalid.%s..%s", routeID, reason)
@@ -175,13 +175,6 @@ func TestMockMetrics(t *testing.T) {
 		if f, ok := m.gauges[key]; !ok {
 			t.Fatalf("Failed to find value %q for routeID %q", key, routeID)
 		} else if f != 1 {
-			t.Fatalf("Failed to get the right value after inc: %0.2f", f)
-		}
-
-		m.DeleteInvalidRoute(routeID)
-		if f, ok := m.gauges[key]; !ok {
-			t.Fatalf("Failed to find value %q for routeID %q", key, routeID)
-		} else if f != 0 {
 			t.Fatalf("Failed to get the right value after inc: %0.2f", f)
 		}
 	})

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -531,9 +531,6 @@ func processRouteDefs(o *Options, defs []*eskip.Route) (routes []*Route, invalid
 		route, err := processRouteDef(o, cpm, def)
 		if err == nil {
 			routes = append(routes, route)
-			if o.Metrics != nil {
-				o.Metrics.DeleteInvalidRoute(def.Id)
-			}
 		} else {
 			invalidDefs = append(invalidDefs, def)
 			o.Log.Errorf("failed to process route %s: %v", def.Id, err)

--- a/routing/errors.go
+++ b/routing/errors.go
@@ -30,7 +30,6 @@ func WrapInvalidDefinitionReason(reason string, err error) error {
 
 func HandleValidationError(mtr metrics.Metrics, err error, routeId string) error {
 	if err == nil {
-		mtr.DeleteInvalidRoute(routeId)
 		return nil
 	}
 

--- a/routing/errors_test.go
+++ b/routing/errors_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -87,10 +88,9 @@ func TestValidationErrorsNoError(t *testing.T) {
 	}
 
 	mtr.WithGauges(func(g map[string]float64) {
-		for k, v := range g {
-			if strings.HasPrefix(k, "route.invalid") && v > 0 {
-				t.Fatalf("Failed to have no invalid routes %q -> %0.2f", k, v)
-			}
+		key := fmt.Sprintf("route.invalid.%s..%s", routeID, errInvalidPredicateParams)
+		if v := g[key]; v != 1 {
+			t.Fatalf("Invalid route metric should remain set, got %0.2f", v)
 		}
 	})
 }


### PR DESCRIPTION
When validation is enabled and a new invalid route is created, it gets rejected and a metric is emitted. But when the route is later fixed, the old metric is not removed. Once the route is fixed, there is no error, so the corrected route no longer matches the old metric key.