### PR TITLE
fix: outdated env syntax in dockerfiles

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -23,7 +23,7 @@ ADD ${BUILD_FOLDER}/${TARGETPLATFORM}/skipper \
     ${BUILD_FOLDER}/${TARGETPLATFORM}/eskip \
     ${BUILD_FOLDER}/${TARGETPLATFORM}/webhook \
     ${BUILD_FOLDER}/${TARGETPLATFORM}/routesrv /usr/bin/
-ENV PATH $PATH:/usr/bin
+ENV PATH=$PATH:/usr/bin
 
 EXPOSE 9090 9911
 

--- a/packaging/Dockerfile.arm64
+++ b/packaging/Dockerfile.arm64
@@ -5,7 +5,7 @@ ADD build/linux/arm64/skipper \
     build/linux/arm64/eskip \
     build/linux/arm64/webhook \
     build/linux/arm64/routesrv /usr/bin/
-ENV PATH $PATH:/usr/bin
+ENV PATH=$PATH:/usr/bin
 
 EXPOSE 9090 9911
 

--- a/packaging/Dockerfile.armv7
+++ b/packaging/Dockerfile.armv7
@@ -5,7 +5,7 @@ ADD build/linux/arm/v7/skipper \
     build/linux/arm/v7/eskip \
     build/linux/arm/v7/webhook \
     build/linux/arm/v7/routesrv /usr/bin/
-ENV PATH $PATH:/usr/bin
+ENV PATH=$PATH:/usr/bin
 
 EXPOSE 9090 9911
 


### PR DESCRIPTION
We have `#  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)` in build logs.
See https://docs.docker.com/reference/dockerfile/#env