### PR TITLE
optimize: routesrv eskip route creation

### DIFF
--- a/routesrv/polling.go
+++ b/routesrv/polling.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ const (
 	LogRoutesEmpty          = "received empty routes; ignoring"
 	LogRoutesInitialized    = "routes initialized"
 	LogRoutesUpdated        = "routes updated"
+	LogRoutesNoChange       = "routes did not change"
 )
 
 type poller struct {
@@ -50,16 +52,16 @@ func (p *poller) poll(wg *sync.WaitGroup) {
 	defer ticker.Stop()
 	p.setGaugeToCurrentTime("polling_started_timestamp")
 
-	var lastRoutesByID map[string]string
+	var (
+		lastRoutesByID map[string]string
+		lastRoutes     []*eskip.Route
+	)
+
 	for {
 		span := tracing.CreateSpan("poll_routes", context.TODO(), p.tracer)
 
 		routes, err := p.client.LoadAll()
-		routes = p.process(routes)
-		routesCount := len(routes)
-
-		switch {
-		case err != nil:
+		if err != nil {
 			log.WithError(err).Error(LogRoutesFetchingFailed)
 			p.metrics.IncCounter("routes.fetch_errors")
 
@@ -68,33 +70,47 @@ func (p *poller) poll(wg *sync.WaitGroup) {
 				"event", "error",
 				"message", fmt.Sprintf("%s: %s", LogRoutesFetchingFailed, err),
 			)
-		case routesCount == 0:
-			log.Info(LogRoutesEmpty)
-			p.metrics.IncCounter("routes.empty")
-			span.SetTag("routes.count", routesCount)
-		case routesCount > 0:
-			routesBytes, routesHash, initialized, updated := p.b.formatAndSet(routes)
-			logger := log.WithFields(log.Fields{"count": routesCount, "bytes": routesBytes, "hash": routesHash})
-			if initialized {
-				logger.Info(LogRoutesInitialized)
-				span.SetTag("routes.initialized", true)
-				p.setGaugeToCurrentTime("routes.initialized_timestamp")
-			}
-			if updated {
-				logger.Info(LogRoutesUpdated)
-				span.SetTag("routes.updated", true)
-				p.setGaugeToCurrentTime("routes.updated_timestamp")
-				p.metrics.UpdateGauge("routes.total", float64(routesCount))
-				p.metrics.UpdateGauge("routes.byte", float64(routesBytes))
-			}
-			span.SetTag("routes.count", routesCount)
-			span.SetTag("routes.bytes", routesBytes)
-			span.SetTag("routes.hash", routesHash)
 
-			if updated && log.IsLevelEnabled(log.DebugLevel) {
-				routesByID := mapRoutes(routes)
-				logChanges(routesByID, lastRoutesByID)
-				lastRoutesByID = routesByID
+		} else if hasChanged(lastRoutes, routes) {
+			lastRoutes = routes
+
+			routes = p.process(routes)
+			routesCount := len(routes)
+			span.SetTag("routes.count", routesCount)
+
+			switch {
+			case routesCount == 0:
+				p.handleEmptyRoutes()
+			case routesCount > 0:
+				routesBytes, routesHash, initialized, updated := p.b.formatAndSet(routes)
+				logger := log.WithFields(log.Fields{"count": routesCount, "bytes": routesBytes, "hash": routesHash})
+				if initialized {
+					logger.Info(LogRoutesInitialized)
+					span.SetTag("routes.initialized", true)
+					p.setGaugeToCurrentTime("routes.initialized_timestamp")
+				}
+				if updated {
+					logger.Info(LogRoutesUpdated)
+					span.SetTag("routes.updated", true)
+					p.setGaugeToCurrentTime("routes.updated_timestamp")
+					p.metrics.UpdateGauge("routes.total", float64(routesCount))
+					p.metrics.UpdateGauge("routes.byte", float64(routesBytes))
+				}
+				span.SetTag("routes.bytes", routesBytes)
+				span.SetTag("routes.hash", routesHash)
+
+				if updated && log.IsLevelEnabled(log.DebugLevel) {
+					routesByID := mapRoutes(routes)
+					logChanges(routesByID, lastRoutesByID)
+					lastRoutesByID = routesByID
+				}
+			}
+		} else {
+			log.Info(LogRoutesNoChange)
+			span.SetTag("routes.updated", false)
+			span.SetTag("routes.count", len(lastRoutes))
+			if len(routes) == 0 {
+				p.handleEmptyRoutes()
 			}
 		}
 
@@ -107,6 +123,11 @@ func (p *poller) poll(wg *sync.WaitGroup) {
 		case <-ticker.C:
 		}
 	}
+}
+
+func (p *poller) handleEmptyRoutes() {
+	log.Info(LogRoutesEmpty)
+	p.metrics.IncCounter("routes.empty")
 }
 
 func (p *poller) process(routes []*eskip.Route) []*eskip.Route {
@@ -135,6 +156,27 @@ func (p *poller) process(routes []*eskip.Route) []*eskip.Route {
 
 func (p *poller) setGaugeToCurrentTime(name string) {
 	p.metrics.UpdateGauge(name, (float64(time.Now().UnixNano()) / 1e9))
+}
+
+func hasChanged(lastRoutes, newRoutes []*eskip.Route) bool {
+	if len(lastRoutes) != len(newRoutes) {
+		return true
+	}
+	sort.SliceStable(newRoutes, func(i, j int) bool {
+		comp := strings.Compare(newRoutes[i].Id, newRoutes[j].Id)
+		switch comp {
+		case 0:
+			return true
+		case 1:
+			return true
+		case -1:
+			return false
+		}
+		log.Fatalf("Failed to run strings.Compare(%q,%q)", newRoutes[i].Id, newRoutes[j].Id)
+		return true // never happens
+	})
+
+	return !eskip.EqLists(lastRoutes, newRoutes)
 }
 
 func mapRoutes(routes []*eskip.Route) map[string]string {


### PR DESCRIPTION
optimize: routesrv eskip route creation

We store lastRoutes to compare with new routes to reduce processing routes if there was no change detected. We do this because we observe a high memory objects creation and high cpu usage on the processing (Editor and formatAndSet)

## non-busy cluster

### current

memory profile
<img width="1920" height="691" alt="image" src="https://github.com/user-attachments/assets/887c52e5-5ea9-4d5c-84cc-1b2ad6f78a0f" />

### after change

memory profile
<img width="1920" height="755" alt="image" src="https://github.com/user-attachments/assets/2562ffc5-cdaf-4f48-90ea-864d3c3da2b2" />

## busy cluster

memory profile
<img width="1920" height="779" alt="image" src="https://github.com/user-attachments/assets/8ea1a727-6b3c-4d30-a012-d175b03a25f5" />

cpu profile
<img width="1919" height="816" alt="image" src="https://github.com/user-attachments/assets/41a62a59-9851-4564-a462-6ce9aee83470" />

## after change

memory profile
<img width="1920" height="701" alt="image" src="https://github.com/user-attachments/assets/0af6dfc3-ac41-412a-9744-da6b012e9acf" />

cpu profile
<img width="1920" height="671" alt="image" src="https://github.com/user-attachments/assets/f9074a37-0a32-47bf-8f8e-16f464933c34" />
