### PR TITLE
feat: add configurable Redis heartbeat frequency for swarm

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -298,6 +298,8 @@ type Config struct {
 	SwarmRedisMinConns           int           `yaml:"swarm-redis-min-conns"`
 	SwarmRedisMaxConns           int           `yaml:"swarm-redis-max-conns"`
 	SwarmRedisEndpointsRemoteURL string        `yaml:"swarm-redis-remote"`
+	SwarmRedisUpdateInterval     time.Duration `yaml:"swarm-redis-update-interval"`
+	SwarmRedisHeartbeatFrequency time.Duration `yaml:"swarm-redis-heartbeat-frequency"`
 	// swim based
 	SwarmKubernetesNamespace          string        `yaml:"swarm-namespace"`
 	SwarmKubernetesLabelSelectorKey   string        `yaml:"swarm-label-selector-key"`
@@ -634,6 +636,8 @@ func NewConfig() *Config {
 	flag.IntVar(&cfg.SwarmRedisMinConns, "swarm-redis-min-conns", net.DefaultMinConns, "set min number of connections to redis")
 	flag.IntVar(&cfg.SwarmRedisMaxConns, "swarm-redis-max-conns", net.DefaultMaxConns, "set max number of connections to redis")
 	flag.StringVar(&cfg.SwarmRedisEndpointsRemoteURL, "swarm-redis-remote", "", "Remote URL to pull redis endpoints from.")
+	flag.DurationVar(&cfg.SwarmRedisUpdateInterval, "swarm-redis-update-interval", net.DefaultUpdateInterval, "set update interval to update redis addresses")
+	flag.DurationVar(&cfg.SwarmRedisHeartbeatFrequency, "swarm-redis-heartbeat-frequency", net.DefaultHeartbeatFrequency, "set redis heartbeat frequency")
 	flag.StringVar(&cfg.SwarmKubernetesNamespace, "swarm-namespace", swarm.DefaultNamespace, "Kubernetes namespace to find swarm peer instances")
 	flag.StringVar(&cfg.SwarmKubernetesLabelSelectorKey, "swarm-label-selector-key", swarm.DefaultLabelSelectorKey, "Kubernetes labelselector key to find swarm peer instances")
 	flag.StringVar(&cfg.SwarmKubernetesLabelSelectorValue, "swarm-label-selector-value", swarm.DefaultLabelSelectorValue, "Kubernetes labelselector value to find swarm peer instances")
@@ -1024,6 +1028,8 @@ func (c *Config) ToOptions() skipper.Options {
 		SwarmRedisMinIdleConns:       c.SwarmRedisMinConns,
 		SwarmRedisMaxIdleConns:       c.SwarmRedisMaxConns,
 		SwarmRedisEndpointsRemoteURL: c.SwarmRedisEndpointsRemoteURL,
+		SwarmRedisUpdateInterval:     c.SwarmRedisUpdateInterval,
+		SwarmRedisHeartbeatFrequency: c.SwarmRedisHeartbeatFrequency,
 		// swim based
 		SwarmKubernetesNamespace:          c.SwarmKubernetesNamespace,
 		SwarmKubernetesLabelSelectorKey:   c.SwarmKubernetesLabelSelectorKey,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -151,6 +151,8 @@ func defaultConfig(with func(*Config)) *Config {
 		SwarmRedisReadTimeout:                   25 * time.Millisecond,
 		SwarmRedisWriteTimeout:                  25 * time.Millisecond,
 		SwarmRedisPoolTimeout:                   25 * time.Millisecond,
+		SwarmRedisUpdateInterval:                10 * time.Second,
+		SwarmRedisHeartbeatFrequency:            500 * time.Millisecond,
 		SwarmRedisMinConns:                      100,
 		SwarmRedisMaxConns:                      100,
 		SwarmKubernetesNamespace:                "kube-system",

--- a/redis_test.go
+++ b/redis_test.go
@@ -165,6 +165,7 @@ spec:
 		SuppressRouteUpdateLogs:        false,
 		SupportListener:                skipper.FindAddress(t),
 		SwarmRedisUpdateInterval:       time.Second,
+		SwarmRedisHeartbeatFrequency:   time.Second,
 	}
 
 	runResult := make(chan error)
@@ -329,6 +330,7 @@ spec:
 		SuppressRouteUpdateLogs:         false,
 		SupportListener:                 skipper.FindAddress(t),
 		SwarmRedisUpdateInterval:        time.Second,
+		SwarmRedisHeartbeatFrequency:    time.Second,
 	}
 
 	runResult := make(chan error)

--- a/skipper.go
+++ b/skipper.go
@@ -964,6 +964,7 @@ type Options struct {
 	SwarmRedisEndpointsRemoteURL  string
 	SwarmRedisConnMetricsInterval time.Duration
 	SwarmRedisUpdateInterval      time.Duration
+	SwarmRedisHeartbeatFrequency  time.Duration
 	// swim based swarm
 	SwarmKubernetesNamespace          string
 	SwarmKubernetesLabelSelectorKey   string
@@ -1844,6 +1845,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 				MaxIdleConns:        o.SwarmRedisMaxIdleConns,
 				ConnMetricsInterval: o.SwarmRedisConnMetricsInterval,
 				UpdateInterval:      o.SwarmRedisUpdateInterval,
+				HeartbeatFrequency:  o.SwarmRedisHeartbeatFrequency,
 				Tracer:              tracer,
 				Log:                 log.New(),
 			}


### PR DESCRIPTION
- Minor cleanup: improve error handling in validation and modernize loop syntax

This allows fine-tuning of Redis cluster health check intervals for better performance optimization in different deployment scenarios.

Maybe needed to reduce beats from validation webhook to fix memory leak