### PR TITLE
Remove link to helm repo

### DIFF
--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -490,48 +490,8 @@ instance to be cluster-wide, watching all `Ingress` objects across all namespace
 
 ## Helm-based deployment
 
-[Helm](https://helm.sh/) calls itself the package manager for Kubernetes and therefore take cares of the deployment of whole applications including resources like services, configurations and so on.
-
-Skipper is also available as community contributed Helm chart in the public [quay.io](https://quay.io/repository/) registry.
-The latest packaged release can be found [here](https://quay.io/application/baez/skipper).
-The source code is available at [GitHub](https://github.com/baez90/skipper-helm).
-
-The chart includes resource definitions for the following use cases:
-
-- RBAC
-- [Prometheus-Operator](https://github.com/prometheus-operator/prometheus-operator)
-
-As this chart is not maintained by the Skipper developers and is still under development only the basic deployment workflow is covered here.
-Check the GitHub repository for all details.
-
-To be able to deploy the chart you will need the following components:
-
-- `helm` CLI (Install guide [here](https://github.com/kubernetes/helm))
-- Helm registry plugin (available [here](https://github.com/app-registry/appr-helm-plugin))
-
-If your environment is setup correctly you should be able to run `helm version --client` and `helm registry version quay.io` and get some information about your tooling without any error.
-
-It is possible to deploy the chart without any further configuration like this:
-
-    helm registry upgrade quay.io/baez/skipper -- \
-        --install \
-        --wait \
-        "your release name e.g. skipper"
-
-The `--wait` switch can be omitted as it only takes care that Helm is waiting until the chart is completely deployed (meaning all resources are created).
-
-To update the deployment to a newer version the same command can be used.
-
-If you have RBAC enabled in your Kubernetes instance you don't have to create all the previously described resources on your own but you can let Helm create them by simply adding one more switch:
-
-    helm registry upgrade quay.io/baez/skipper -- \
-        --install \
-        --wait \
-        --set rbac.create=true \
-        "your release name e.g. skipper"
-
-There are some more options available for customization of the chart.
-Check the repository if you need more configuration possibilities.
+Skipper is not available as a Helm chart.
+There is a [ticket asking for a helm chart](https://github.com/zalando/skipper/issues/3355).
 
 ## Run as API Gateway with East-West setup
 


### PR DESCRIPTION
- Point to #3355

The current content https://quay.io/application/baez/skipper:
> Helm chart for [Skipper](https://github.com/zalando/skipper)
> #### Build Status
> [![Build Status](https://travis-ci.org/baez90/skipper-helm.svg?branch=master)](https://travis-ci.org/baez90/skipper-helm)
> #### Documentation
> The documentation for this package is available on [GitHub](https://github.com/baez90/skipper-helm)

The linked repository https://github.com/baez90/skipper-helm:
<img width="740" height="603" alt="404: GitHub: baez90/skipper-helm" src="https://github.com/user-attachments/assets/f06c3222-9e0f-4027-83e1-7218094bcb52" />

The relevant user doesn't exist https://github.com/baez90/:
<img width="765" height="632" alt="404: GitHub: baez90" src="https://github.com/user-attachments/assets/415ea762-cf6c-4b7f-9ecc-7fd15a6ff66f" />

It's likely that someone could create this account and then populate it with evil content. I'm not absolutely certain whether Quay would automatically populate based on the content, but at the very least, links from Quay would be to the evil content.