### PR TITLE
Make request header bucket sizes configurable

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -95,6 +95,7 @@ func defaultConfig(with func(*Config)) *Config {
 		RuntimeMetrics:                          true,
 		HistogramMetricBuckets:                  []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		ResponseSizeBuckets:                     metrics.DefaultResponseSizeBuckets,
+		RequestSizeBuckets:                      metrics.DefaultRequestSizeBuckets,
 		ApplicationLogLevel:                     log.InfoLevel,
 		ApplicationLogLevelString:               "INFO",
 		ApplicationLogPrefix:                    "[APP]",
@@ -278,6 +279,7 @@ func Test_Validate(t *testing.T) {
 			change: func(c *Config) {
 				c.HistogramMetricBucketsString = ""
 				c.ResponseSizeBucketsString = ""
+				c.RequestSizeBucketsString = ""
 				c.ApplicationLogLevel = log.InfoLevel
 				c.ApplicationLogLevelString = "INFO"
 			},

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -191,6 +191,10 @@ type Options struct {
 	// response in bytes metrics.
 	ResponseSizeBuckets []float64
 
+	// RequestSizeBuckets defines buckets into which the observations are counted for
+	// request header in bytes metrics.
+	RequestSizeBuckets []float64
+
 	// The following options, for backwards compatibility, are true
 	// by default: EnableAllFiltersMetrics, EnableRouteResponseMetrics,
 	// EnableRouteBackendErrorsCounters, EnableRouteStreamingErrorsCounters,

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -31,12 +31,12 @@ const (
 	GiB = 1024 * MiB
 )
 
-// headerSizeBuckets are chosen to cover typical max request header sizes:
+// DefaultRequestSizeBuckets are chosen to cover typical max request header sizes:
 //   - 64 KiB for [AWS ELB](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#http-header-limits)
 //   - 16 KiB for [NodeJS](https://nodejs.org/api/cli.html#cli_max_http_header_size_size)
 //   - 8 KiB for [Nginx](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)
 //   - 8 KiB for [Spring Boot](https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.server.server.max-http-request-header-size)
-var headerSizeBuckets = []float64{4 * KiB, 8 * KiB, 16 * KiB, 64 * KiB}
+var DefaultRequestSizeBuckets = []float64{4 * KiB, 8 * KiB, 16 * KiB, 64 * KiB}
 
 // DefaultResponseSizeBuckets are chosen to cover 2^(10*n) sizes up to 1 GiB and halves of those.
 var DefaultResponseSizeBuckets = []float64{1, 512, 1 * KiB, 512 * KiB, 1 * MiB, 512 * MiB, 1 * GiB}
@@ -94,6 +94,11 @@ func NewPrometheus(opts Options) *Prometheus {
 	responseSizeBuckets := DefaultResponseSizeBuckets
 	if len(opts.ResponseSizeBuckets) > 1 {
 		responseSizeBuckets = opts.ResponseSizeBuckets
+	}
+
+	requestSizeBuckets := DefaultRequestSizeBuckets
+	if len(opts.RequestSizeBuckets) > 1 {
+		requestSizeBuckets = opts.RequestSizeBuckets
 	}
 
 	namespace := promNamespace
@@ -169,7 +174,7 @@ func NewPrometheus(opts Options) *Prometheus {
 		Subsystem: promBackendSubsystem,
 		Name:      "request_header_bytes",
 		Help:      "Size of a backend request header.",
-		Buckets:   headerSizeBuckets,
+		Buckets:   requestSizeBuckets,
 	}, []string{"host"}))
 
 	p.backendM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/skipper.go
+++ b/skipper.go
@@ -597,6 +597,9 @@ type Options struct {
 	// Use custom buckets for prometheus response body size.
 	ResponseSizeBuckets []float64
 
+	// Use custom buckets for prometheus request header size.
+	RequestSizeBuckets []float64
+
 	// The following options, for backwards compatibility, are true
 	// by default: EnableAllFiltersMetrics, EnableRouteResponseMetrics,
 	// EnableRouteBackendErrorsCounters, EnableRouteStreamingErrorsCounters,
@@ -1637,6 +1640,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		UseExpDecaySample:                  o.MetricsUseExpDecaySample,
 		HistogramBuckets:                   o.HistogramMetricBuckets,
 		ResponseSizeBuckets:                o.ResponseSizeBuckets,
+		RequestSizeBuckets:                 o.RequestSizeBuckets,
 		DisableCompatibilityDefaults:       o.DisableMetricsCompatibilityDefaults,
 		PrometheusRegistry:                 o.PrometheusRegistry,
 		EnablePrometheusStartLabel:         o.EnablePrometheusStartLabel,


### PR DESCRIPTION
This PR makes the request header bucket sizes configurable. 

To test:
`echo 'hello: Path("/hello") -> "https://example.com";' > routes.eskip`

`./bin/skipper -routes-file routes.eskip -support-listener :9911 -metrics-flavour=prometheus  -request-size-buckets="1024,$((4 *1024)),$((8 *1024)),$((16 *1024)),$((1024 *1024))"`

Output:
```
# HELP skipper_backend_request_header_bytes Size of a backend request header.
# TYPE skipper_backend_request_header_bytes histogram
skipper_backend_request_header_bytes_bucket{host="_unknownhost_",le="1024"} 1
skipper_backend_request_header_bytes_bucket{host="_unknownhost_",le="4096"} 1
skipper_backend_request_header_bytes_bucket{host="_unknownhost_",le="8192"} 2
skipper_backend_request_header_bytes_bucket{host="_unknownhost_",le="16384"} 2
skipper_backend_request_header_bytes_bucket{host="_unknownhost_",le="1.048576e+06"} 3
skipper_backend_request_header_bytes_bucket{host="_unknownhost_",le="+Inf"} 3
skipper_backend_request_header_bytes_sum{host="_unknownhost_"} 70277
skipper_backend_request_header_bytes_count{host="_unknownhost_"} 3
```
