### PR TITLE
feat(routing): add Print method to RouteLookup for route inspection

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -414,6 +414,11 @@ type RouteLookup struct {
 	rt *routeTable
 }
 
+// Print returns valid routes from the captured routing Table.
+func (rl *RouteLookup) Print(pretty eskip.PrettyPrintInfo) string {
+	return eskip.Print(pretty, rl.rt.validRoutes...)
+}
+
 // Do executes the lookup against the captured routing table. Equivalent to
 // Routing.Route().
 func (rl *RouteLookup) Do(req *http.Request) (*Route, map[string]string) {


### PR DESCRIPTION
Add Print method to RouteLookup struct that returns a formatted string representation of valid routes from the captured routing table. This enables debugging and inspection of the current routing state. Since library users can't access routing table info, this can give nive view only access and to compare against ekip to validate routes.