### PR TITLE
feat: integrate preprocessors into validation mode

### DIFF
--- a/dataclients/kubernetes/definitions/ingressvalidator.go
+++ b/dataclients/kubernetes/definitions/ingressvalidator.go
@@ -5,15 +5,11 @@ import (
 	"fmt"
 
 	"github.com/zalando/skipper/eskip"
-	"github.com/zalando/skipper/filters"
-	"github.com/zalando/skipper/metrics"
 	"github.com/zalando/skipper/routing"
 )
 
 type IngressV1Validator struct {
-	FilterRegistry           filters.Registry
-	PredicateSpecs           []routing.PredicateSpec
-	Metrics                  metrics.Metrics
+	RoutingOptions           routing.Options
 	EnableAdvancedValidation bool
 }
 
@@ -41,7 +37,7 @@ func (igv *IngressV1Validator) validateFilterAnnotation(item *IngressV1Item) err
 				Namespace:    item.Metadata.Namespace,
 				Name:         item.Metadata.Name,
 				ResourceType: ResourceTypeIngress,
-			}, igv.FilterRegistry, igv.Metrics, parsedFilters); err != nil {
+			}, igv.RoutingOptions, parsedFilters); err != nil {
 				return fmt.Errorf("invalid %q annotation: %w", IngressFilterAnnotation, err)
 			}
 		}
@@ -62,7 +58,7 @@ func (igv *IngressV1Validator) validatePredicateAnnotation(item *IngressV1Item) 
 				Namespace:    item.Metadata.Namespace,
 				Name:         item.Metadata.Name,
 				ResourceType: ResourceTypeIngress,
-			}, igv.PredicateSpecs, igv.Metrics, parsedPredicates); err != nil {
+			}, igv.RoutingOptions, parsedPredicates); err != nil {
 				return fmt.Errorf("invalid %q annotation: %w", IngressPredicateAnnotation, err)
 			}
 		}
@@ -79,16 +75,12 @@ func (igv *IngressV1Validator) validateRoutesAnnotation(item *IngressV1Item) err
 			return fmt.Errorf("invalid %q annotation: %w", IngressRoutesAnnotation, err)
 		}
 		if igv.EnableAdvancedValidation {
-			opts := routing.Options{
-				FilterRegistry: igv.FilterRegistry,
-				Predicates:     igv.PredicateSpecs,
-			}
 			for _, r := range parsedRoutes {
 				if err := validateRoute(ResourceContext{
 					Namespace:    item.Metadata.Namespace,
 					Name:         item.Metadata.Name,
 					ResourceType: ResourceTypeIngress,
-				}, opts, igv.Metrics, r); err != nil {
+				}, igv.RoutingOptions, r); err != nil {
 					errs = append(errs, fmt.Errorf("invalid %q annotation: %w", IngressRoutesAnnotation, err))
 				}
 			}

--- a/dataclients/kubernetes/definitions/routegroupvalidator.go
+++ b/dataclients/kubernetes/definitions/routegroupvalidator.go
@@ -6,15 +6,11 @@ import (
 	"net/url"
 
 	"github.com/zalando/skipper/eskip"
-	"github.com/zalando/skipper/filters"
-	"github.com/zalando/skipper/metrics"
 	"github.com/zalando/skipper/routing"
 )
 
 type RouteGroupValidator struct {
-	FilterRegistry           filters.Registry
-	PredicateSpecs           []routing.PredicateSpec
-	Metrics                  metrics.Metrics
+	RoutingOptions           routing.Options
 	EnableAdvancedValidation bool
 }
 
@@ -92,7 +88,7 @@ func (rgv *RouteGroupValidator) validateFilters(item *RouteGroupItem) error {
 					Namespace:    item.Metadata.Namespace,
 					Name:         item.Metadata.Name,
 					ResourceType: ResourceTypeRouteGroup,
-				}, rgv.FilterRegistry, rgv.Metrics, parsedFilters); err != nil {
+				}, rgv.RoutingOptions, parsedFilters); err != nil {
 					errs = append(errs, fmt.Errorf("invalid filter %q: %w", f, err))
 				}
 			}
@@ -122,7 +118,7 @@ func (rgv *RouteGroupValidator) validatePredicates(item *RouteGroupItem) error {
 				Namespace:    item.Metadata.Namespace,
 				Name:         item.Metadata.Name,
 				ResourceType: ResourceTypeRouteGroup,
-			}, rgv.PredicateSpecs, rgv.Metrics, routePredicates); err != nil {
+			}, rgv.RoutingOptions, routePredicates); err != nil {
 				errs = append(errs, err)
 			}
 		}
@@ -150,7 +146,7 @@ func (rgv *RouteGroupValidator) validateBackends(item *RouteGroupItem) error {
 				Namespace:    item.Metadata.Namespace,
 				Name:         item.Metadata.Name,
 				ResourceType: ResourceTypeRouteGroup,
-			}, backend.Address, backend.Type, rgv.Metrics); err != nil {
+			}, backend.Address, backend.Type, rgv.RoutingOptions.Metrics); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -475,6 +475,15 @@ func processTreePredicates(r *Route, predicateList []*eskip.Predicate) error {
 // ValidateRoute processes a route definition for the routing table.
 // This function is exported to be used by validation webhooks.
 func ValidateRoute(o *Options, def *eskip.Route) (*Route, error) {
+
+	for _, preprocessor := range o.PreProcessors {
+		mdef := preprocessor.Do([]*eskip.Route{def})
+		if mdefLen := len(mdef); mdefLen != 1 {
+			return nil, fmt.Errorf("preprocessing route failed while validating")
+		}
+		def = mdef[0]
+	}
+
 	route, err := processRouteDef(o, mapPredicates(o.Predicates), def)
 	if err != nil {
 		return nil, err

--- a/skipper.go
+++ b/skipper.go
@@ -2321,7 +2321,13 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	// start validation webhook server if enabled
 	if o.ValidationWebhookEnabled {
-		if err = validation.StartValidation(o.ValidationWebhookAddress, o.ValidationWebhookCertFile, o.ValidationWebhookKeyFile, o.EnableAdvancedValidation, ro.FilterRegistry, ro.Predicates, mtr); err != nil {
+		validationOptions := validation.Options{
+			Address:                  o.ValidationWebhookAddress,
+			CertFile:                 o.ValidationWebhookCertFile,
+			KeyFile:                  o.ValidationWebhookKeyFile,
+			EnableAdvancedValidation: o.EnableAdvancedValidation,
+		}
+		if err = validation.StartValidation(validationOptions, ro); err != nil {
 			log.Fatalf("Failed to start validation webhook: %v", err)
 		}
 	}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/dataclients/kubernetes/definitions"
+	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/block"
 	"github.com/zalando/skipper/metrics/metricstest"
@@ -19,10 +21,21 @@ import (
 	"github.com/zalando/skipper/routing"
 )
 
+// admissionReview represents the Kubernetes admission webhook response structure
+// used in tests. This avoids importing admission controller types directly.
+type admissionReview struct {
+	Response struct {
+		Allowed bool `json:"allowed"`
+		Status  struct {
+			Message string `json:"message"`
+		} `json:"status"`
+	} `json:"response"`
+}
+
 func TestStartValidationRequiresTLS(t *testing.T) {
 	patchLogrusExit(t)
 
-	err := StartValidation(":0", "", "", false, nil, nil, nil)
+	err := StartValidation(Options{Address: ":0", CertFile: "", KeyFile: "", EnableAdvancedValidation: false}, routing.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires TLS")
 }
@@ -41,7 +54,7 @@ func TestValidationHandlers(t *testing.T) {
 			path: "/routegroups",
 			payload: newRouteGroupPayload(func(spec map[string]any) {
 				spec["routes"] = []map[string]any{
-					{"filters": []string{"blockContent(\"abc\")"}},
+					{"filters": []string{`blockContent("abc")`}},
 				}
 			}),
 			expectedAllowed: true,
@@ -67,7 +80,7 @@ func TestValidationHandlers(t *testing.T) {
 					{"filters": []string{"unknownFilter()"}},
 				}
 			}),
-			expectedMessage: "filter \"unknownFilter\" not found",
+			expectedMessage: `filter "unknownFilter" not found`,
 			expectedInvalidRouteKeys: []string{
 				invalidRouteGaugeKey(definitions.ResourceTypeRouteGroup, "ns-test", "rg-test", "filters", "unknownFilter", "unknown_filter"),
 			},
@@ -77,7 +90,7 @@ func TestValidationHandlers(t *testing.T) {
 			path: "/routegroups",
 			payload: newRouteGroupPayload(func(spec map[string]any) {
 				spec["routes"] = []map[string]any{
-					{"predicates": []string{"Methods(\"GET\")"}},
+					{"predicates": []string{`Methods("GET")`}},
 				}
 			}),
 			expectedAllowed: true,
@@ -103,7 +116,7 @@ func TestValidationHandlers(t *testing.T) {
 					{"predicates": []string{"UnknownPredicate()"}},
 				}
 			}),
-			expectedMessage: "predicate \"UnknownPredicate\" not found",
+			expectedMessage: `predicate "UnknownPredicate" not found`,
 			expectedInvalidRouteKeys: []string{
 				invalidRouteGaugeKey(definitions.ResourceTypeRouteGroup, "ns-test", "rg-test", "predicates", "UnknownPredicate", "unknown_predicate"),
 			},
@@ -123,7 +136,7 @@ func TestValidationHandlers(t *testing.T) {
 			path: "/ingresses",
 			payload: newIngressPayload(func(meta map[string]any) {
 				annotations := meta["annotations"].(map[string]any)
-				annotations[definitions.IngressPredicateAnnotation] = "Methods(\"GET\")"
+				annotations[definitions.IngressPredicateAnnotation] = `Methods("GET")`
 			}),
 			expectedAllowed: true,
 		},
@@ -146,7 +159,7 @@ func TestValidationHandlers(t *testing.T) {
 				annotations := meta["annotations"].(map[string]any)
 				annotations[definitions.IngressPredicateAnnotation] = "UnknownPredicate()"
 			}),
-			expectedMessage: "predicate \"UnknownPredicate\" not found",
+			expectedMessage: `predicate "UnknownPredicate" not found`,
 			expectedInvalidRouteKeys: []string{
 				invalidRouteGaugeKey(definitions.ResourceTypeIngress, "ns-test", "ing-test", "predicates", "UnknownPredicate", "unknown_predicate"),
 			},
@@ -156,7 +169,7 @@ func TestValidationHandlers(t *testing.T) {
 			path: "/ingresses",
 			payload: newIngressPayload(func(meta map[string]any) {
 				annotations := meta["annotations"].(map[string]any)
-				annotations[definitions.IngressFilterAnnotation] = "blockContent(\"abc\")"
+				annotations[definitions.IngressFilterAnnotation] = `blockContent("abc")`
 			}),
 			expectedAllowed: true,
 		},
@@ -179,7 +192,7 @@ func TestValidationHandlers(t *testing.T) {
 				annotations := meta["annotations"].(map[string]any)
 				annotations[definitions.IngressFilterAnnotation] = "unknownFilter()"
 			}),
-			expectedMessage: "filter \"unknownFilter\" not found",
+			expectedMessage: `filter "unknownFilter" not found`,
 			expectedInvalidRouteKeys: []string{
 				invalidRouteGaugeKey(definitions.ResourceTypeIngress, "ns-test", "ing-test", "filters", "unknownFilter", "unknown_filter"),
 			},
@@ -189,7 +202,7 @@ func TestValidationHandlers(t *testing.T) {
 			path: "/ingresses",
 			payload: newIngressPayload(func(meta map[string]any) {
 				annotations := meta["annotations"].(map[string]any)
-				annotations[definitions.IngressRoutesAnnotation] = "r1: * -> blockContent(\"abc\") -> \"https://example.org\""
+				annotations[definitions.IngressRoutesAnnotation] = `r1: * -> blockContent("abc") -> "https://example.org"`
 			}),
 			expectedAllowed: true,
 		},
@@ -198,7 +211,7 @@ func TestValidationHandlers(t *testing.T) {
 			path: "/ingresses",
 			payload: newIngressPayload(func(meta map[string]any) {
 				annotations := meta["annotations"].(map[string]any)
-				annotations[definitions.IngressRoutesAnnotation] = "r1: * -> blockContent() -> \"https://example.org\""
+				annotations[definitions.IngressRoutesAnnotation] = `r1: * -> blockContent() -> "https://example.org"`
 			}),
 			expectedMessage: "invalid filter parameters",
 			expectedInvalidRouteKeys: []string{
@@ -210,9 +223,9 @@ func TestValidationHandlers(t *testing.T) {
 			path: "/ingresses",
 			payload: newIngressPayload(func(meta map[string]any) {
 				annotations := meta["annotations"].(map[string]any)
-				annotations[definitions.IngressRoutesAnnotation] = "r1: * -> unknownFilter() -> \"https://example.org\""
+				annotations[definitions.IngressRoutesAnnotation] = `r1: * -> unknownFilter() -> "https://example.org"`
 			}),
-			expectedMessage: "filter \"unknownFilter\" not found",
+			expectedMessage: `filter "unknownFilter" not found`,
 			expectedInvalidRouteKeys: []string{
 				invalidRouteGaugeKey(definitions.ResourceTypeIngress, "ns-test", "ing-test", "route", "r1", "unknown_filter"),
 			},
@@ -230,7 +243,12 @@ func TestValidationHandlers(t *testing.T) {
 
 			metricsMock := &metricstest.MockMetrics{}
 
-			handler := newValidationHandler(true, filterRegistry, predicateSpecs, metricsMock)
+			routingOptions := routing.Options{
+				FilterRegistry: filterRegistry,
+				Predicates:     predicateSpecs,
+				Metrics:        metricsMock,
+			}
+			handler := newValidationHandler(true, routingOptions)
 
 			body, err := json.Marshal(tc.payload)
 			require.NoError(t, err)
@@ -244,21 +262,14 @@ func TestValidationHandlers(t *testing.T) {
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			var review struct {
-				Response struct {
-					Allowed bool `json:"allowed"`
-					Status  struct {
-						Message string `json:"message"`
-					} `json:"status"`
-				} `json:"response"`
-			}
+			var admissionResponse admissionReview
 
-			require.NoError(t, json.NewDecoder(resp.Body).Decode(&review))
-			assert.Equal(t, tc.expectedAllowed, review.Response.Allowed)
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&admissionResponse))
+			assert.Equal(t, tc.expectedAllowed, admissionResponse.Response.Allowed)
 			if tc.expectedMessage != "" {
-				assert.Contains(t, review.Response.Status.Message, tc.expectedMessage)
+				assert.Contains(t, admissionResponse.Response.Status.Message, tc.expectedMessage)
 			} else {
-				assert.Empty(t, review.Response.Status.Message)
+				assert.Empty(t, admissionResponse.Response.Status.Message)
 			}
 
 			actualInvalidRouteKeys := collectPositiveInvalidRouteKeys(metricsMock)
@@ -266,6 +277,135 @@ func TestValidationHandlers(t *testing.T) {
 				assert.Empty(t, actualInvalidRouteKeys)
 			} else {
 				assert.ElementsMatch(t, tc.expectedInvalidRouteKeys, actualInvalidRouteKeys)
+			}
+		})
+	}
+}
+
+func TestValidationWithPreProcessors(t *testing.T) {
+	testCases := []struct {
+		name              string
+		path              string
+		payload           map[string]any
+		withPreProcessors bool
+		expectedAllowed   bool
+		expectedMessage   string
+	}{
+		{
+			name: "routegroup with EditRoute preprocessor - should succeed after transformation",
+			path: "/routegroups",
+			payload: newRouteGroupPayload(func(spec map[string]any) {
+				spec["routes"] = []map[string]any{
+					{"filters": []string{`unknownFilter("test")`}}, // Will be transformed to blockContent("test")
+				}
+			}),
+			withPreProcessors: true,
+			expectedAllowed:   true,
+		},
+		{
+			name: "routegroup without preprocessor - should fail with unknown filter",
+			path: "/routegroups",
+			payload: newRouteGroupPayload(func(spec map[string]any) {
+				spec["routes"] = []map[string]any{
+					{"filters": []string{`unknownFilter("test")`}}, // Will fail without preprocessing
+				}
+			}),
+			withPreProcessors: false,
+			expectedAllowed:   false,
+			expectedMessage:   `filter "unknownFilter" not found`,
+		},
+		{
+			name: "ingress with EditRoute preprocessor - should succeed after transformation",
+			path: "/ingresses",
+			payload: newIngressPayload(func(meta map[string]any) {
+				annotations := meta["annotations"].(map[string]any)
+				annotations[definitions.IngressFilterAnnotation] = `unknownFilter("test")`
+			}),
+			withPreProcessors: true,
+			expectedAllowed:   true,
+		},
+		{
+			name: "ingress without preprocessor - should fail with unknown filter",
+			path: "/ingresses",
+			payload: newIngressPayload(func(meta map[string]any) {
+				annotations := meta["annotations"].(map[string]any)
+				annotations[definitions.IngressFilterAnnotation] = `unknownFilter("test")`
+			}),
+			withPreProcessors: false,
+			expectedAllowed:   false,
+			expectedMessage:   `filter "unknownFilter" not found`,
+		},
+		{
+			name: "ingress routes with EditRoute preprocessor - should succeed",
+			path: "/ingresses",
+			payload: newIngressPayload(func(meta map[string]any) {
+				annotations := meta["annotations"].(map[string]any)
+				annotations[definitions.IngressRoutesAnnotation] = `r1: * -> unknownFilter("test") -> "https://example.org"`
+			}),
+			withPreProcessors: true,
+			expectedAllowed:   true,
+		},
+		{
+			name: "ingress routes without preprocessor - should fail",
+			path: "/ingresses",
+			payload: newIngressPayload(func(meta map[string]any) {
+				annotations := meta["annotations"].(map[string]any)
+				annotations[definitions.IngressRoutesAnnotation] = `r1: * -> unknownFilter("test") -> "https://example.org"`
+			}),
+			withPreProcessors: false,
+			expectedAllowed:   false,
+			expectedMessage:   `filter "unknownFilter" not found`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filterRegistry := filters.Registry{}
+			filterRegistry.Register(block.NewBlock(1024))
+
+			predicateSpecs := []routing.PredicateSpec{
+				methods.New(),
+			}
+
+			metricsMock := &metricstest.MockMetrics{}
+
+			routingOptions := routing.Options{
+				FilterRegistry: filterRegistry,
+				Predicates:     predicateSpecs,
+				Metrics:        metricsMock,
+			}
+
+			if tc.withPreProcessors {
+				editRegex := regexp.MustCompile(`unknownFilter\(([^)]*)\)`)
+				editRoute := eskip.NewEditor(editRegex, `blockContent($1)`)
+
+				routingOptions.PreProcessors = []routing.PreProcessor{
+					editRoute,
+				}
+			}
+
+			handler := newValidationHandler(true, routingOptions)
+
+			body, err := json.Marshal(tc.payload)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, tc.path, bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			resp := recorder.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var admissionResponse admissionReview
+
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&admissionResponse))
+			assert.Equal(t, tc.expectedAllowed, admissionResponse.Response.Allowed)
+			if tc.expectedMessage != "" {
+				assert.Contains(t, admissionResponse.Response.Status.Message, tc.expectedMessage)
+			} else {
+				assert.Empty(t, admissionResponse.Response.Status.Message)
 			}
 		})
 	}


### PR DESCRIPTION
While skipper runs in validation mode, it doesn't apply prepocessors which can result in a valid route being blocked as it have invalid argument before applying preprocessor.

```
r1: SourceFromLast("application") -> <shunt>;
// After preprocessing
r1: * -> SourceFromLast("1.1.1.1") -> <shunt>;
```

This can be test locally via

```bash
~ ./bin/skipper -edit-route=@"application"@"1.1.1.1"@ -validation-webhook-enabled=true -validation-webhook-address=:9085 -validation-webhook-cert-file="validation.crt" -validation-webhook-key-file="validation.key" -enable-advanced-validation=true -application-log-level=debug -kubernetes

~ curl -i -k -X POST -H "Content-Type: application/json" -d @./dataclients/kubernetes/admission/testdata/rg/rg-with-valid-eskip-predicates.json https://127.0.0.1:9085/routegroups
```