### PR TITLE
fix: implement ConfigDiscoveryHook for PrometheusOverride to enable OPA status metrics

### DIFF
--- a/filters/openpolicyagent/internal/confighook.go
+++ b/filters/openpolicyagent/internal/confighook.go
@@ -89,6 +89,15 @@ type PrometheusOverride struct {
 }
 
 func (p *PrometheusOverride) OnConfig(ctx context.Context, config *config.Config) (*config.Config, error) {
+	return enablePrometheusMetrics(config)
+}
+
+// TODO: Commented out to showcase failing test
+//func (p *PrometheusOverride) OnConfigDiscovery(ctx context.Context, config *config.Config) (*config.Config, error) {
+//	return enablePrometheusMetrics(config)
+//}
+
+func enablePrometheusMetrics(config *config.Config) (*config.Config, error) {
 	var (
 		statusConfig status.Config
 		message      []byte


### PR DESCRIPTION
What & Why?

Implement ConfigDiscoveryHook.OnConfigDiscovery() for PrometheusOverride to enable Prometheus status metrics when using discovery bundles.

https://github.com/zalando/skipper/pull/3631 added support to also expose native OPA metrics via Skipper's metrics endpoint. This PR extends it by also ensuring that we also enable it when using discovery bundles