### PR TITLE
fix: implement ConfigDiscoveryHook for PrometheusOverride to enable OPA status metrics

### DIFF
--- a/filters/openpolicyagent/internal/confighook.go
+++ b/filters/openpolicyagent/internal/confighook.go
@@ -89,25 +89,30 @@ type PrometheusOverride struct {
 }
 
 func (p *PrometheusOverride) OnConfig(ctx context.Context, config *config.Config) (*config.Config, error) {
-	var (
-		statusConfig status.Config
-		message      []byte
-	)
+	return enablePrometheusForStatus(config)
+}
 
-	if config.Status != nil {
-		err := json.Unmarshal(config.Status, &statusConfig)
-		if err != nil {
-			return nil, err
-		}
+func (p *PrometheusOverride) OnConfigDiscovery(ctx context.Context, config *config.Config) (*config.Config, error) {
+	return enablePrometheusForStatus(config)
+}
 
-		statusConfig.Prometheus = true
-
-		message, err = json.Marshal(statusConfig)
-		if err != nil {
-			return nil, err
-		}
-		config.Status = message
+func enablePrometheusForStatus(config *config.Config) (*config.Config, error) {
+	if config.Status == nil {
+		return config, nil
 	}
+
+	var statusConfig status.Config
+	if err := json.Unmarshal(config.Status, &statusConfig); err != nil {
+		return nil, err
+	}
+
+	statusConfig.Prometheus = true
+
+	message, err := json.Marshal(statusConfig)
+	if err != nil {
+		return nil, err
+	}
+	config.Status = message
 
 	return config, nil
 }


### PR DESCRIPTION
## What & Why?

Implement ConfigDiscoveryHook.OnConfigDiscovery() for PrometheusOverride to enable Prometheus status metrics when using discovery bundles.

https://github.com/zalando/skipper/pull/3631 added support to also expose native OPA metrics via Skipper's metrics endpoint. This PR extends it by also ensuring that we also enable it when using discovery bundles

_TODO: Extract some reusable methods if this is the way we want to go_