### PR TITLE
bump go version to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,4 +206,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-go 1.25.6
+go 1.25.7


### PR DESCRIPTION
https://osv.dev/GO-2026-4337