### PR TITLE
[filter/inlineContentIfStatus] Clear content headers

### DIFF
--- a/filters/builtin/inlinecontentifstatus.go
+++ b/filters/builtin/inlinecontentifstatus.go
@@ -84,6 +84,10 @@ func (c *inlineContentIfStatus) Response(ctx filters.FilterContext) {
 
 	contentLength := len(c.text)
 	rsp.ContentLength = int64(contentLength)
+
+	rsp.Header.Del("Content-Length")
+	rsp.Header.Del("Content-Encoding")
+
 	rsp.Header.Set("Content-Type", c.mime)
 	rsp.Header.Set("Content-Length", strconv.Itoa(contentLength))
 	rsp.Body = io.NopCloser(bytes.NewBufferString(c.text))


### PR DESCRIPTION
We should remove Content-Length and Content-Encoding headers  to prevent mismatches between the original backend response and the inline content.
