### PR TITLE
docs: update fadeIn documentation to reflect proxy-layer implementation

### DIFF
--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -299,8 +299,6 @@ Current implemented algorithms:
 - `powerOfRandomNChoices`: backend is chosen by powerOfRandomNChoices algorithm with selecting N random endpoints and picking the one with least outstanding requests from them. (http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf)
 - __TODO__: https://github.com/zalando/skipper/issues/557
 
-All algorithms except `powerOfRandomNChoices` support [fadeIn](filters.md#fadein) filter.
-
 Route example with 2 backends and the `roundRobin` algorithm:
 ```
 r0: * -> <roundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -3529,13 +3529,12 @@ Some filters influence how load balancing will be done
 
 ### fadeIn
 
-When this filter is set, and the route has a load balanced backend using [supported algorithm](backends.md#load-balancer-backend),
-then the newly added endpoints will receive
+When this filter is set, then the newly added endpoints will receive
 the traffic in a gradually increasing way, starting from their detection for the specified duration, after which
 they receive equal amount traffic as the previously existing routes. The detection time of a load balanced
 backend endpoint is preserved over multiple generations of the route configuration (over route changes). This
 filter can be used to saturate the load of autoscaling applications that require a warm-up time and therefore a
-smooth ramp-up. The fade-in feature can be used together with the roundRobin, random  or consistentHash LB algorithms.
+smooth ramp-up. The fade-in feature can be used together with all the available LB algorithms.
 
 While the default fade-in curve is linear, the optional exponent parameter can be used to adjust the shape of
 the fade-in curve, based on the following equation:

--- a/loadbalancer/doc.go
+++ b/loadbalancer/doc.go
@@ -25,7 +25,7 @@ powerOfRandomNChoices Algorithm
 	and picks the one with least outstanding requests from them.
 	Currently, N is 2.
 
-The roundRobin and the random algorithms also provide fade-in behavior for LB endpoints of routes where the
+The load balancing algorithms also provide fade-in behavior for LB endpoints of routes where the
 fade-in duration was configured. This feature can be used to gradually add traffic to new instances of
 applications that require a certain amount of warm-up time.
 


### PR DESCRIPTION
Since PR #2634 (Decouple fadeIn from loadbalancer), fadeIn filtering is now applied uniformly at the proxy layer for all load balancing algorithms.

This means all algorithms including powerOfRandomNChoices can now benefit from fadeIn behavior. The previous limitation where powerOfRandomNChoices did not support fadeIn was specific to the old loadbalancer-level implementation.

## Changes
- Remove outdated note that excluded powerOfRandomNChoices from fadeIn support
- Update loadbalancer/doc.go to clarify that all algorithms support fadeIn

## Related Issues
- PR #2634: Decouple fadeIn from loadbalancer