### PR TITLE
skipper/routing: improve error message

### DIFF
--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -241,7 +241,7 @@ func createFilter(o *Options, def *eskip.Filter, cpm map[string]PredicateSpec) (
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to create filter %q: %w", errInvalidFilterParams, spec.Name(), err)
+		return nil, fmt.Errorf("%w: failed to create filter %v: %w", errInvalidFilterParams, def, err)
 	}
 	return f, nil
 }
@@ -401,7 +401,7 @@ func processPredicates(o *Options, cpm map[string]PredicateSpec, defs []*eskip.P
 
 		cp, err := spec.Create(def.Args)
 		if err != nil {
-			return nil, 0, fmt.Errorf("%w: failed to create predicate %q: %w", errInvalidPredicateParams, spec.Name(), err)
+			return nil, 0, fmt.Errorf("%w: failed to create predicate %v: %w", errInvalidPredicateParams, def, err)
 		}
 
 		if ws, ok := spec.(WeightedPredicateSpec); ok {
@@ -515,7 +515,7 @@ func ValidateRoute(o *Options, def *eskip.Route) error {
 func processRouteDef(o *Options, cpm map[string]PredicateSpec, def *eskip.Route) (*Route, error) {
 	scheme, host, err := SplitBackend(def.Backend, def.BackendType, def.Shunt)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errFailedBackendSplit, err)
+		return nil, fmt.Errorf("%w: failed to parse backend address %q: %w", errFailedBackendSplit, def.Backend, err)
 	}
 
 	fs, err := createFilters(o, def.Filters, cpm)

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zalando/skipper/metrics/metricstest"
 	"github.com/zalando/skipper/predicates/primitive"
 	"github.com/zalando/skipper/predicates/query"
+	"github.com/zalando/skipper/predicates/traffic"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/routing/testdataclient"
 )
@@ -101,10 +102,22 @@ func TestProcessRouteDefErrors(t *testing.T) {
 			`unknown_predicate: predicate "Unknown" not found`,
 		}, {
 			`QueryParam() -> <shunt>`,
-			`invalid_predicate_params: failed to create predicate "QueryParam": invalid predicate parameters`,
+			`invalid_predicate_params: failed to create predicate QueryParam(): invalid predicate parameters`,
+		}, {
+			`QueryParam("a", "b", "c") -> <shunt>`,
+			`invalid_predicate_params: failed to create predicate QueryParam("a", "b", "c"): invalid predicate parameters`,
 		}, {
 			`* -> setPath() -> <shunt>`,
-			`invalid_filter_params: failed to create filter "setPath": invalid filter parameters`,
+			`invalid_filter_params: failed to create filter setPath(): invalid filter parameters`,
+		}, {
+			`TrafficSegment(0.5, 1.5) -> <shunt>`,
+			`invalid_predicate_params: failed to create predicate TrafficSegment(0.5, 1.5): invalid predicate parameters: max is out of range`,
+		}, {
+			`TrafficSegment(1, 0) -> <shunt>`,
+			`invalid_predicate_params: failed to create predicate TrafficSegment(1, 0): invalid predicate parameters: invalid range`,
+		}, {
+			`* -> "invalid-url"`,
+			`failed_backend_split: failed to parse backend address "invalid-url": parse "invalid-url": invalid URI for request`,
 		},
 	} {
 		func() {
@@ -124,7 +137,7 @@ func TestProcessRouteDefErrors(t *testing.T) {
 			}
 
 			pr := map[string]routing.PredicateSpec{}
-			for _, s := range []routing.PredicateSpec{primitive.NewTrue(), query.New()} {
+			for _, s := range []routing.PredicateSpec{primitive.NewTrue(), query.New(), traffic.NewSegment()} {
 				pr[s.Name()] = s
 			}
 			fr := make(filters.Registry)


### PR DESCRIPTION
- added failed parameter definitions to the invalid filters and predicates error
- added the failed backend address to the split backend error