### PR TITLE
Update .zappr.yaml team to gwproxy

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -17,5 +17,5 @@ pull-request:
       - bugfix
       - documentation
       - dependencies
-X-Zalando-Team: "teapot"
+X-Zalando-Team: "gwproxy"
 X-Zalando-Type: code


### PR DESCRIPTION
Change owning team since the project is maintained by gwproxy