### PR TITLE
tracing: to reduce costs on the next tracing provider, add a config option migrate span logs/events to span tags/attributes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,7 @@ type Config struct {
 	OpenTracingDisableFilterSpans       bool      `yaml:"opentracing-disable-filter-spans"`
 	OpentracingLogFilterLifecycleEvents bool      `yaml:"opentracing-log-filter-lifecycle-events"`
 	OpentracingLogStreamEvents          bool      `yaml:"opentracing-log-stream-events"`
+	OpenTracingClientTraceByTag         bool      `yaml:"opentracing-client-trace-by-tag"`
 	OpentracingBackendNameTag           bool      `yaml:"opentracing-backend-name-tag"`
 	MetricsListener                     string    `yaml:"metrics-listener"`
 	MetricsPrefix                       string    `yaml:"metrics-prefix"`
@@ -433,6 +434,7 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.OpenTracingDisableFilterSpans, "opentracing-disable-filter-spans", false, "disable creation of spans representing request and response filters")
 	flag.BoolVar(&cfg.OpentracingLogFilterLifecycleEvents, "opentracing-log-filter-lifecycle-events", true, "enables the logs for request & response filters' lifecycle events that are marking start & end times.")
 	flag.BoolVar(&cfg.OpentracingLogStreamEvents, "opentracing-log-stream-events", true, "enables the logs for events marking the times response headers & payload are streamed to the client")
+	flag.BoolVar(&cfg.OpenTracingClientTraceByTag, "opentracing-client-trace-by-tag", false, "enables the logs for events marking the times response headers & payload are streamed to the client")
 	flag.BoolVar(&cfg.OpentracingBackendNameTag, "opentracing-backend-name-tag", false, "enables an additional tracing tag that contains a backend name for a route when it's available  (e.g. for RouteGroups) (default false)")
 	flag.StringVar(&cfg.MetricsListener, "metrics-listener", ":9911", "network address used for exposing the /metrics endpoint. An empty value disables metrics iff support listener is also empty.")
 	flag.StringVar(&cfg.MetricsPrefix, "metrics-prefix", "skipper.", "allows setting a custom path prefix for metrics export")
@@ -891,6 +893,7 @@ func (c *Config) ToOptions() skipper.Options {
 		OpenTracingExcludedProxyTags:        strings.Split(c.OpenTracingExcludedProxyTags, ","),
 		OpenTracingDisableFilterSpans:       c.OpenTracingDisableFilterSpans,
 		OpenTracingLogStreamEvents:          c.OpentracingLogStreamEvents,
+		OpenTracingClientTraceByTag:         c.OpenTracingClientTraceByTag,
 		OpenTracingLogFilterLifecycleEvents: c.OpentracingLogFilterLifecycleEvents,
 		MetricsListener:                     c.MetricsListener,
 		MetricsPrefix:                       c.MetricsPrefix,

--- a/filters/auth/authclient.go
+++ b/filters/auth/authclient.go
@@ -37,7 +37,7 @@ type tokeninfoClient interface {
 
 var _ tokeninfoClient = &authClient{}
 
-func newAuthClient(baseURL, spanName string, timeout time.Duration, maxIdleConns int, tracer opentracing.Tracer) (*authClient, error) {
+func newAuthClient(baseURL, spanName string, timeout time.Duration, maxIdleConns int, tracer opentracing.Tracer, openTracingClientTraceByTag bool) (*authClient, error) {
 	if tracer == nil {
 		tracer = opentracing.NoopTracer{}
 	}
@@ -57,6 +57,7 @@ func newAuthClient(baseURL, spanName string, timeout time.Duration, maxIdleConns
 		Tracer:                  tracer,
 		OpentracingComponentTag: "skipper",
 		OpentracingSpanName:     spanName,
+		OpentracingEventsByTag:  openTracingClientTraceByTag,
 	})
 
 	return &authClient{url: u, cli: cli}, nil

--- a/filters/auth/grantconfig.go
+++ b/filters/auth/grantconfig.go
@@ -125,6 +125,10 @@ type OAuthConfig struct {
 
 	// Tracer used for tokeninfo, access-token and refresh-token endpoint.
 	Tracer opentracing.Tracer
+
+	// OpenTracingClientTraceByTag instead of events use span Tags
+	// to measure client connection pool actions
+	OpenTracingClientTraceByTag bool
 }
 
 var (
@@ -180,6 +184,7 @@ func (c *OAuthConfig) Init() error {
 			c.ConnectionTimeout,
 			c.MaxIdleConnectionsPerHost,
 			c.Tracer,
+			c.OpenTracingClientTraceByTag,
 		)
 		if err != nil {
 			return err
@@ -195,6 +200,7 @@ func (c *OAuthConfig) Init() error {
 			Tracer:                  c.Tracer,
 			OpentracingComponentTag: "skipper",
 			OpentracingSpanName:     "grantauth",
+			OpentracingEventsByTag:  c.OpenTracingClientTraceByTag,
 		})
 	}
 

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -96,6 +96,10 @@ type OidcOptions struct {
 	Tracer                 opentracing.Tracer
 	OidcClientId           string
 	OidcClientSecret       string
+
+	// OpenTracingClientTraceByTag instead of events use span Tags
+	// to measure client connection pool actions
+	OpenTracingClientTraceByTag bool
 }
 
 type (
@@ -1062,6 +1066,7 @@ func (f *tokenOidcFilter) initClient() *snet.Client {
 		Tracer:                  f.oidcOptions.Tracer,
 		OpentracingComponentTag: "skipper",
 		OpentracingSpanName:     "distributedClaims",
+		OpentracingEventsByTag:  f.oidcOptions.OpenTracingClientTraceByTag,
 	})
 	return newCli
 }

--- a/filters/auth/tokeninfo.go
+++ b/filters/auth/tokeninfo.go
@@ -35,6 +35,10 @@ type TokeninfoOptions struct {
 	Tracer       opentracing.Tracer
 	Metrics      metrics.Metrics
 
+	// OpenTracingClientTraceByTag instead of events use span Tags
+	// to measure client connection pool actions
+	OpenTracingClientTraceByTag bool
+
 	// CacheSize configures the maximum number of cached tokens.
 	// The cache periodically evicts random items when number of cached tokens exceeds CacheSize.
 	// Zero value disables tokeninfo cache.
@@ -96,7 +100,7 @@ func (o *TokeninfoOptions) getTokeninfoClient() (tokeninfoClient, error) {
 func (o *TokeninfoOptions) newTokeninfoClient() (tokeninfoClient, error) {
 	var c tokeninfoClient
 
-	c, err := newAuthClient(o.URL, tokenInfoSpanName, o.Timeout, o.MaxIdleConns, o.Tracer)
+	c, err := newAuthClient(o.URL, tokenInfoSpanName, o.Timeout, o.MaxIdleConns, o.Tracer, o.OpenTracingClientTraceByTag)
 	if err != nil {
 		return nil, err
 	}

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -39,6 +39,10 @@ type TokenintrospectionOptions struct {
 	Timeout      time.Duration
 	Tracer       opentracing.Tracer
 	MaxIdleConns int
+
+	// OpenTracingClientTraceByTag instead of events use span Tags
+	// to measure client connection pool actions
+	OpenTracingClientTraceByTag bool
 }
 
 type (
@@ -288,7 +292,7 @@ func (s *tokenIntrospectionSpec) CreateFilter(args []interface{}) (filters.Filte
 	var ac *authClient
 	var ok bool
 	if ac, ok = issuerAuthClient[issuerURL]; !ok {
-		ac, err = newAuthClient(cfg.IntrospectionEndpoint, tokenIntrospectionSpanName, s.options.Timeout, s.options.MaxIdleConns, s.options.Tracer)
+		ac, err = newAuthClient(cfg.IntrospectionEndpoint, tokenIntrospectionSpanName, s.options.Timeout, s.options.MaxIdleConns, s.options.Tracer, s.options.OpenTracingClientTraceByTag)
 		if err != nil {
 			return nil, filters.ErrInvalidFilterParameters
 		}

--- a/filters/auth/webhook.go
+++ b/filters/auth/webhook.go
@@ -21,6 +21,10 @@ type WebhookOptions struct {
 	Timeout      time.Duration
 	MaxIdleConns int
 	Tracer       opentracing.Tracer
+
+	// OpenTracingClientTraceByTag instead of events use span Tags
+	// to measure client connection pool actions
+	OpenTracingClientTraceByTag bool
 }
 
 type (
@@ -93,7 +97,7 @@ func (ws *webhookSpec) CreateFilter(args []interface{}) (filters.Filter, error) 
 	var ac *authClient
 	var err error
 	if ac, ok = webhookAuthClient[s]; !ok {
-		ac, err = newAuthClient(s, webhookSpanName, ws.options.Timeout, ws.options.MaxIdleConns, ws.options.Tracer)
+		ac, err = newAuthClient(s, webhookSpanName, ws.options.Timeout, ws.options.MaxIdleConns, ws.options.Tracer, ws.options.OpenTracingClientTraceByTag)
 		if err != nil {
 			return nil, filters.ErrInvalidFilterParameters
 		}

--- a/filters/shedder/admission.go
+++ b/filters/shedder/admission.go
@@ -96,6 +96,10 @@ const (
 type Options struct {
 	Tracer   opentracing.Tracer
 	testRand bool
+
+	// OpenTracingClientTraceByTag instead of events use span Tags
+	// to measure client connection pool actions
+	OpenTracingClientTraceByTag bool
 }
 
 type admissionControlPre struct{}

--- a/filters/tee/tee.go
+++ b/filters/tee/tee.go
@@ -54,6 +54,9 @@ type Options struct {
 	// Tracer is the opentracing tracer to use in the client
 	Tracer opentracing.Tracer
 
+	// OpenTracingClientTraceByTag instead of events use span Tags/Attributes
+	OpenTracingClientTraceByTag bool
+
 	// MaxIdleConns defaults to 100
 	MaxIdleConns int
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -266,13 +267,7 @@ func (tp *testProxy) close() {
 }
 
 func hasArg(arg string) bool {
-	for _, a := range os.Args {
-		if a == arg {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(os.Args, arg)
 }
 
 func voidCheck(*http.Request) {}
@@ -508,7 +503,7 @@ func TestSetRequestUrlFromRequest(t *testing.T) {
 func TestSetRequestUrlForDynamicBackend(t *testing.T) {
 	for _, ti := range []struct {
 		msg         string
-		expectedUrl *url.URL
+		expectedURL *url.URL
 		stateBag    map[string]interface{}
 	}{{
 		"DynamicBackendURLKey is set",
@@ -537,9 +532,9 @@ func TestSetRequestUrlForDynamicBackend(t *testing.T) {
 		u := &url.URL{}
 		setRequestURLForDynamicBackend(u, ti.stateBag)
 
-		beq := reflect.DeepEqual(ti.expectedUrl, u)
+		beq := reflect.DeepEqual(ti.expectedURL, u)
 		if !beq {
-			t.Error(ti.msg, "<urls don't match>", ti.expectedUrl, u)
+			t.Error(ti.msg, "<urls don't match>", ti.expectedURL, u)
 		}
 	}
 }

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	ot "github.com/opentracing/opentracing-go"
 
+	"github.com/zalando/skipper/net"
 	"github.com/zalando/skipper/tracing"
 )
 
@@ -24,19 +25,30 @@ const (
 	SpanKindTag           = "span.kind"
 
 	ClientRequestCanceled = "canceled"
-	SpanKindClient        = "client"
+	SpanKindClient        = net.SpanKindClient
 	SpanKindServer        = "server"
 
-	EndEvent           = "end"
-	StartEvent         = "start"
+	EndEvent           = net.EndEvent
+	StartEvent         = net.StartEvent
 	StreamHeadersEvent = "stream_Headers"
 	StreamBodyEvent    = "streamBody.byte"
 	StreamBodyError    = "streamBody error"
+
+	ClientTraceDNS            = net.ClientTraceDNS
+	ClientTraceConnect        = net.ClientTraceConnect
+	ClientTraceTLS            = net.ClientTraceTLS
+	ClientTraceGetConn        = net.ClientTraceGetConn
+	ClientTraceGot100Continue = net.ClientTraceGot100Continue
+	ClientTraceWroteHeaders   = net.ClientTraceWroteHeaders
+	ClientTraceWroteRequest   = net.ClientTraceWroteRequest
+	ClientTraceGotFirstByte   = net.ClientTraceGotFirstByte
+	ClientTraceHTTPRoundTrip  = "http_roundtrip"
 )
 
 type proxyTracing struct {
 	tracer                   ot.Tracer
 	initialOperationName     string
+	clientTraceByTag         bool
 	disableFilterSpans       bool
 	logFilterLifecycleEvents bool
 	logStreamEvents          bool
@@ -70,6 +82,7 @@ func newProxyTracing(p *OpenTracingParams) *proxyTracing {
 	return &proxyTracing{
 		tracer:                   p.Tracer,
 		initialOperationName:     p.InitialSpan,
+		clientTraceByTag:         p.ClientTraceByTag,
 		disableFilterSpans:       p.DisableFilterSpans,
 		logFilterLifecycleEvents: p.LogFilterEvents,
 		logStreamEvents:          p.LogStreamEvents,


### PR DESCRIPTION
tracing: to reduce costs on the next tracing provider, add a config option migrate span logs/events to span tags/attributes

In some tracing providers this has the advantage that you can create timeseries of the instrumented http clients: example connect() times, ..