### PR TITLE
fix: config and flag for kubernetes status from service

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -203,7 +203,7 @@ type Config struct {
 	KubernetesBackendTrafficAlgorithm                    kubernetes.BackendTrafficAlgorithm `yaml:"-"`
 	KubernetesDefaultLoadBalancerAlgorithm               string                             `yaml:"kubernetes-default-lb-algorithm"`
 	KubernetesForceService                               bool                               `yaml:"kubernetes-force-service"`
-	KubernetesStatusFromService                          string                             `yaml:"kubernetes-ingress-status-from-service"`
+	KubernetesStatusFromService                          string                             `yaml:"kubernetes-status-from-service"`
 
 	// Default filters
 	DefaultFiltersDir string `yaml:"default-filters-dir"`
@@ -549,7 +549,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.KubernetesBackendTrafficAlgorithmString, "kubernetes-backend-traffic-algorithm", kubernetes.TrafficPredicateAlgorithm.String(), "sets the algorithm to be used for traffic splitting between backends: traffic-predicate or traffic-segment-predicate")
 	flag.StringVar(&cfg.KubernetesDefaultLoadBalancerAlgorithm, "kubernetes-default-lb-algorithm", kubernetes.DefaultLoadBalancerAlgorithm, "sets the default algorithm to be used for load balancing between backend endpoints, available options: roundRobin, consistentHash, random, powerOfRandomNChoices")
 	flag.BoolVar(&cfg.KubernetesForceService, "kubernetes-force-service", false, "overrides default Skipper functionality and routes traffic using Kubernetes Services instead of Endpoints")
-	flag.StringVar(&cfg.KubernetesStatusFromService, "kubernetes-ingress-status-from-service", "", "when set to <namespace>/<name>, updates ingress status.loadBalancer.ingress from the referenced service")
+	flag.StringVar(&cfg.KubernetesStatusFromService, "kubernetes-status-from-service", "", "when set to <namespace>/<name>, updates Ingress status.loadBalancer.ingress from the referenced service")
 
 	// Auth:
 	flag.BoolVar(&cfg.EnableOAuth2GrantFlow, "enable-oauth2-grant-flow", false, "enables OAuth2 Grant Flow filter")

--- a/docs/kubernetes/ingress-controller.md
+++ b/docs/kubernetes/ingress-controller.md
@@ -493,12 +493,12 @@ instance to be cluster-wide, watching all `Ingress` objects across all namespace
 Skipper can update `Ingress.status.loadBalancer.ingress` from a configured
 Service by setting:
 
-`-kubernetes-ingress-status-from-service=<namespace>/<service-name>`
+`-kubernetes-status-from-service=<namespace>/<service-name>`
 
 Example:
 
 ```bash
-skipper -kubernetes-ingress-status-from-service=ingress-system/skipper
+skipper -kubernetes-status-from-service=ingress-system/skipper
 ```
 
 When enabled, Skipper reads the configured Service and patches the


### PR DESCRIPTION
fix: config and flag for kubernetes status from service

We (@MustafaSaber , @lambertpandian and me) agreed to drop `ingress` from the config and flag and skipper.Option. This fixes docs, config and flag according to our agreement

ref: https://github.com/zalando/skipper/releases/tag/v0.24.29
ref: https://github.com/zalando/skipper/pull/3877