### PR TITLE
feature: disable metrics compression

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	EnableRouteFIFOMetrics           bool           `yaml:"enable-route-fifo-metrics"`
 	EnableRouteLIFOMetrics           bool           `yaml:"enable-route-lifo-metrics"`
 	MetricsFlavour                   *listFlag      `yaml:"metrics-flavour"`
+	DisableMetricsCompression        bool           `yaml:"disable-metrics-compression"`
 	FilterPlugins                    *pluginFlag    `yaml:"filter-plugin"`
 	PredicatePlugins                 *pluginFlag    `yaml:"predicate-plugin"`
 	DataclientPlugins                *pluginFlag    `yaml:"dataclient-plugin"`
@@ -429,6 +430,7 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableRouteFIFOMetrics, "enable-route-fifo-metrics", false, "enable metrics for the individual route FIFO queues")
 	flag.BoolVar(&cfg.EnableRouteLIFOMetrics, "enable-route-lifo-metrics", false, "enable metrics for the individual route LIFO queues")
 	flag.Var(cfg.MetricsFlavour, "metrics-flavour", "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale' and 'prometheus', you can select both of them by using one option with ',' separated values")
+	flag.BoolVar(&cfg.DisableMetricsCompression, "disable-metrics-compression", false, "disable metrics compression on /metrics handler endpoint.")
 	flag.Var(cfg.FilterPlugins, "filter-plugin", "set a custom filter plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.PredicatePlugins, "predicate-plugin", "set a custom predicate plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.DataclientPlugins, "dataclient-plugin", "set a custom dataclient plugins to load, a comma separated list of name and arguments")
@@ -894,6 +896,7 @@ func (c *Config) ToOptions() skipper.Options {
 		EnableRouteFIFOMetrics:           c.EnableRouteFIFOMetrics,
 		EnableRouteLIFOMetrics:           c.EnableRouteLIFOMetrics,
 		MetricsFlavours:                  c.MetricsFlavour.values,
+		DisableMetricsCompression:        c.DisableMetricsCompression,
 		FilterPlugins:                    c.FilterPlugins.values,
 		PredicatePlugins:                 c.PredicatePlugins.values,
 		DataClientPlugins:                c.DataclientPlugins.values,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -231,6 +231,9 @@ type Options struct {
 	// EnablePrometheusStartLabel adds start label to each prometheus counter with the value of counter creation
 	// timestamp as unix nanoseconds.
 	EnablePrometheusStartLabel bool
+
+	// DisableCompression defaults to enable compression on the metrics endpoint, can be disabled if set to true
+	DisableCompression bool
 }
 
 var (

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -350,7 +350,9 @@ func (p *Prometheus) CreateHandler() http.Handler {
 	if p.opts.EnablePrometheusStartLabel {
 		gatherer = withStartLabelGatherer{p.registry}
 	}
-	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
+		DisableCompression: p.opts.DisableCompression,
+	})
 }
 
 func (p *Prometheus) getHandler() http.Handler {

--- a/skipper.go
+++ b/skipper.go
@@ -833,6 +833,9 @@ type Options struct {
 	// of metrics endpoints.
 	MetricsFlavours []string
 
+	// DisableMetricsCompression if enabled it will disable compression on the metrics handler, defaults to false
+	DisableMetricsCompression bool
+
 	// LoadBalancerHealthCheckInterval is *deprecated* and not in use anymore
 	LoadBalancerHealthCheckInterval time.Duration
 
@@ -1714,6 +1717,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		DisableCompatibilityDefaults:       o.DisableMetricsCompatibilityDefaults,
 		PrometheusRegistry:                 o.PrometheusRegistry,
 		EnablePrometheusStartLabel:         o.EnablePrometheusStartLabel,
+		DisableCompression:                 o.DisableMetricsCompression,
 	}
 
 	mtr := o.MetricsBackend


### PR DESCRIPTION
feature: disable metrics compression

new config flag: `-disable-metrics-compression=true`

polarsignals profiling finding