### PR TITLE
Optimize: consistent hash algorithm

### DIFF
--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"net/netip"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -118,7 +119,7 @@ func newConsistentHashInternal(endpoints []string, hashesPerEndpoint int) routin
 	}
 	for i, ep := range endpoints {
 		endpointStartIndex := hashesPerEndpoint * i
-		for j := 0; j < hashesPerEndpoint; j++ {
+		for j := range hashesPerEndpoint {
 			ch.hashRing[endpointStartIndex+j] = endpointHash{i, hash(fmt.Sprintf("%s-%d", ep, j))}
 		}
 	}
@@ -127,7 +128,8 @@ func newConsistentHashInternal(endpoints []string, hashesPerEndpoint int) routin
 }
 
 func newConsistentHash(endpoints []string) routing.LBAlgorithm {
-	return newConsistentHashInternal(endpoints, 100)
+	n := 10000 / len(endpoints)
+	return newConsistentHashInternal(endpoints, n)
 }
 
 func hash(s string) uint64 {
@@ -136,12 +138,40 @@ func hash(s string) uint64 {
 
 func skipEndpoint(c *routing.LBContext, index int) bool {
 	host := c.Route.LBEndpoints[index].Host
+	if len(c.LBEndpoints) > 300 { // 300 see https://github.com/zalando/skipper/pull/3918/
+		return !existsBinarySearch(host, c.LBEndpoints)
+	}
+	// linear scan for low numbers
 	for i := range c.LBEndpoints {
 		if c.LBEndpoints[i].Host == host {
 			return false
 		}
 	}
 	return true
+}
+
+func existsBinarySearch(target string, list []routing.LBEndpoint) bool {
+	targetAP, err := netip.ParseAddrPort(target)
+	if err != nil {
+		return false
+	}
+
+	idx := sort.Search(len(list), func(i int) bool {
+		itemAP, err := netip.ParseAddrPort(list[i].Host)
+		if err != nil {
+			return false
+		}
+
+		if itemAP.Addr() != targetAP.Addr() {
+			return !itemAP.Addr().Less(targetAP.Addr())
+		}
+		return itemAP.Port() >= targetAP.Port()
+	})
+
+	if idx < len(list) && list[idx].Host == target {
+		return true
+	}
+	return false
 }
 
 // Returns index in hash ring with the closest hash to key's hash

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/netip"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -229,10 +231,11 @@ func TestApply(t *testing.T) {
 	const R = 1000
 	const N = 10
 	eps := make([]string, 0, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		ep := fmt.Sprintf("http://127.0.0.1:123%d/foo", i)
 		eps = append(eps, ep)
 	}
+	sortLBEndpoints(eps)
 
 	for _, tt := range []struct {
 		name          string
@@ -283,7 +286,7 @@ func TestApply(t *testing.T) {
 			}
 
 			h := make(map[string]int)
-			for i := 0; i < R; i++ {
+			for range R {
 				lbe := tt.algorithm.Apply(lbctx)
 				h[lbe.Host] += 1
 			}
@@ -316,6 +319,7 @@ func TestConsistentHashSearch(t *testing.T) {
 	}
 
 	endpoints := []string{"http://127.0.0.1:8080", "http://127.0.0.2:8080", "http://127.0.0.3:8080"}
+	sortLBEndpoints(endpoints)
 	const key = "192.168.0.1"
 
 	ep := apply(key, endpoints)
@@ -339,6 +343,7 @@ func TestConsistentHashSearch(t *testing.T) {
 
 func TestConsistentHashBoundedLoadSearch(t *testing.T) {
 	endpoints := []string{"http://127.0.0.1:8080", "http://127.0.0.2:8080", "http://127.0.0.3:8080"}
+	sortLBEndpoints(endpoints)
 	r, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
 	route := NewAlgorithmProvider().Do([]*routing.Route{{
 		Route: eskip.Route{
@@ -359,7 +364,7 @@ func TestConsistentHashBoundedLoadSearch(t *testing.T) {
 	defer endpointRegistry.Close()
 	endpointRegistry.Do([]*routing.Route{route})
 	noLoad := ch.Apply(ctx)
-	nonBounded := ch.Apply(&routing.LBContext{Request: r, Route: route, LBEndpoints: route.LBEndpoints, Params: map[string]interface{}{}})
+	nonBounded := ch.Apply(&routing.LBContext{Request: r, Route: route, LBEndpoints: route.LBEndpoints, Params: map[string]any{}})
 
 	if noLoad != nonBounded {
 		t.Error("When no endpoints are overloaded, the chosen endpoint should be the same as standard consistentHash")
@@ -388,6 +393,7 @@ func TestConsistentHashBoundedLoadSearch(t *testing.T) {
 
 func TestConsistentHashKey(t *testing.T) {
 	endpoints := []string{"http://127.0.0.1:8080", "http://127.0.0.2:8080", "http://127.0.0.3:8080"}
+	sortLBEndpoints(endpoints)
 	ch := newConsistentHash(endpoints)
 
 	r, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
@@ -401,8 +407,8 @@ func TestConsistentHashKey(t *testing.T) {
 		},
 	}})[0]
 
-	defaultEndpoint := ch.Apply(&routing.LBContext{Request: r, Route: rt, LBEndpoints: rt.LBEndpoints, Params: make(map[string]interface{})})
-	remoteHostEndpoint := ch.Apply(&routing.LBContext{Request: r, Route: rt, LBEndpoints: rt.LBEndpoints, Params: map[string]interface{}{ConsistentHashKey: net.RemoteHost(r).String()}})
+	defaultEndpoint := ch.Apply(&routing.LBContext{Request: r, Route: rt, LBEndpoints: rt.LBEndpoints, Params: make(map[string]any)})
+	remoteHostEndpoint := ch.Apply(&routing.LBContext{Request: r, Route: rt, LBEndpoints: rt.LBEndpoints, Params: map[string]any{ConsistentHashKey: net.RemoteHost(r).String()}})
 
 	if defaultEndpoint != remoteHostEndpoint {
 		t.Error("remote host should be used as a default key")
@@ -410,7 +416,7 @@ func TestConsistentHashKey(t *testing.T) {
 
 	for i, ep := range endpoints {
 		key := fmt.Sprintf("%s-%d", ep, 1) // "ep-0" to "ep-99" is the range of keys for this endpoint. If we use this as the hash key it should select endpoint ep.
-		selected := ch.Apply(&routing.LBContext{Request: r, Route: rt, LBEndpoints: rt.LBEndpoints, Params: map[string]interface{}{ConsistentHashKey: key}})
+		selected := ch.Apply(&routing.LBContext{Request: r, Route: rt, LBEndpoints: rt.LBEndpoints, Params: map[string]any{ConsistentHashKey: key}})
 		if selected != rt.LBEndpoints[i] {
 			t.Errorf("expected: %v, got %v", rt.LBEndpoints[i], selected)
 		}
@@ -419,6 +425,7 @@ func TestConsistentHashKey(t *testing.T) {
 
 func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 	endpoints := []string{"http://127.0.0.1:8080", "http://127.0.0.2:8080", "http://127.0.0.3:8080"}
+	sortLBEndpoints(endpoints)
 	r, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
 	route := NewAlgorithmProvider().Do([]*routing.Route{{
 		Route: eskip.Route{
@@ -434,13 +441,13 @@ func TestConsistentHashBoundedLoadDistribution(t *testing.T) {
 		Request:     r,
 		Route:       route,
 		LBEndpoints: route.LBEndpoints,
-		Params:      map[string]interface{}{ConsistentHashBalanceFactor: balanceFactor},
+		Params:      map[string]any{ConsistentHashBalanceFactor: balanceFactor},
 	}
 	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
 	defer endpointRegistry.Close()
 	endpointRegistry.Do([]*routing.Route{route})
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ep := ch.Apply(ctx)
 		ifr0 := route.LBEndpoints[0].Metrics.InflightRequests()
 		ifr1 := route.LBEndpoints[1].Metrics.InflightRequests()
@@ -475,7 +482,7 @@ func TestConsistentHashKeyDistribution(t *testing.T) {
 }
 
 func addInflightRequests(registry *routing.EndpointRegistry, endpoint routing.LBEndpoint, count int) {
-	for i := 0; i < count; i++ {
+	for range count {
 		endpoint.Metrics.IncInflightRequest()
 		registry.GetMetrics(endpoint.Host).IncInflightRequest()
 	}
@@ -545,9 +552,88 @@ func BenchmarkRandomAlgorithm(b *testing.B) {
 		LBEndpoints: lbeps,
 	}
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		alg.Apply(lbc)
+	}
+}
+
+// similar to datasource processRouteDef() use of sort.SliceStable
+func sortLBEndpoints(lbEndpoints []string) {
+	sort.SliceStable(lbEndpoints, func(i, j int) bool {
+		apI, errI := netip.ParseAddrPort(lbEndpoints[i])
+		apJ, errJ := netip.ParseAddrPort(lbEndpoints[j])
+
+		if errI != nil || errJ != nil {
+			return errI == nil
+		}
+
+		ipI := apI.Addr()
+		ipJ := apJ.Addr()
+
+		if ipI != ipJ {
+			return ipI.Less(ipJ)
+		}
+
+		return apI.Port() < apJ.Port()
+	})
+
+}
+
+func BenchmarkConsistentHash(b *testing.B) {
+	for _, N := range []int{10, 100, 1000} {
+		eps := make([]string, 0, N)
+		var j int
+		for i := range N {
+			j = i / 255
+			ep := fmt.Sprintf("http://10.0.%d.%d:8080/", j, i%255)
+			eps = append(eps, ep)
+		}
+		sortLBEndpoints(eps)
+
+		req, err := http.NewRequest("GET", "http://consistent.bench.test", nil)
+		if err != nil {
+			b.Fatalf("Failed to create request: %v", err)
+		}
+
+		route := NewAlgorithmProvider().Do([]*routing.Route{{
+			Route: eskip.Route{
+				BackendType: eskip.LBBackend,
+				LBAlgorithm: ConsistentHash.String(),
+				LBEndpoints: eps,
+			},
+		}})[0]
+
+		alg := newConsistentHash(eps)
+		lbCtx := &routing.LBContext{
+			Request:     req,
+			Route:       route,
+			LBEndpoints: route.LBEndpoints,
+			Params: map[string]any{
+				ConsistentHashKey:           "Foo",
+				ConsistentHashBalanceFactor: 0.2,
+			},
+		}
+
+		// populate metrics
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
+		endpointRegistry.Do([]*routing.Route{route})
+
+		// set Foo header value
+		headerValues := [10000]string{}
+		for i := range len(headerValues) {
+			headerValues[i] = fmt.Sprintf("foo-%d", i)
+		}
+
+		b.Run(fmt.Sprintf("%d endpoints", N), func(b *testing.B) {
+			var iter int64
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				iter++
+				req.Header.Set("Foo", headerValues[iter%10000])
+				alg.Apply(lbCtx)
+			}
+		})
 	}
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2607,3 +2607,38 @@ func benchmarkCopyStream(b *testing.B, size int64, cpStream func(to flushWriter,
 		}
 	}
 }
+
+func BenchmarkConsistentHashSelectEndpoint(b *testing.B) {
+	for _, N := range []int{10, 100, 250, 300, 400, 500, 1000, 5000} {
+		eps := make([]string, 0, N)
+		var j int
+		for i := range N {
+			j = i / 255
+			ep := fmt.Sprintf("http://10.0.%d.%d:8080", j, i%255)
+			eps = append(eps, ep)
+		}
+		req, err := http.NewRequest("GET", "http://consistent.bench.test", nil)
+		if err != nil {
+			b.Fatalf("Failed to create request: %v", err)
+		}
+		doc := fmt.Sprintf(`r: * -> <consistentHash, "%s">`, strings.Join(eps, `", "`))
+		tp, err := newTestProxyWithParams(doc, Params{
+			AccessLogDisabled: false,
+		})
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		defer tp.close()
+		route, _ := tp.routing.Get().Do(req)
+		ctx := newContext(nil, req, tp.proxy)
+		ctx.route = route
+		b.Run(fmt.Sprintf("%d endpoints", N), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				tp.proxy.selectEndpoint(ctx)
+			}
+		})
+	}
+}

--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"sort"
 	"sync"
 	"time"
@@ -534,6 +535,26 @@ func processRouteDef(o *Options, cpm map[string]PredicateSpec, def *eskip.Route)
 	}
 
 	r := &Route{Route: *def, Scheme: scheme, Host: host, Predicates: cps, Filters: fs, weight: weight}
+	if def.LBAlgorithm == "consistentHash" {
+		sort.SliceStable(def.LBEndpoints, func(i, j int) bool {
+			apI, errI := netip.ParseAddrPort(def.LBEndpoints[i])
+			apJ, errJ := netip.ParseAddrPort(def.LBEndpoints[j])
+
+			if errI != nil || errJ != nil {
+				return errI == nil
+			}
+
+			ipI := apI.Addr()
+			ipJ := apJ.Addr()
+
+			if ipI != ipJ {
+				return ipI.Less(ipJ)
+			}
+
+			return apI.Port() < apJ.Port()
+		})
+	}
+
 	if err := processTreePredicates(r, def.Predicates); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
optimize: limit hash ring bucket size to max 10k
optimize: consistentHash linear scan by using binary search in case it is actually faster than linear scan

In practice we will see better results as the worst case will be in favor of the new code, because the linear scan had only to walk to index 332 instead of 5000 for example. I added some log during test to check it.

```
% benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/zalando/skipper/proxy
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
                                               │   old.txt    │               new.txt               │
                                               │    sec/op    │   sec/op     vs base                │
ConsistentHashSelectEndpoint/10_endpoints        195.8n ±  3%   182.7n ± 2%   -6.72% (p=0.001 n=10)
ConsistentHashSelectEndpoint/10_endpoints-2      243.4n ±  2%   231.6n ± 3%   -4.87% (p=0.001 n=10)
ConsistentHashSelectEndpoint/10_endpoints-4      235.2n ±  2%   218.1n ± 3%   -7.27% (p=0.000 n=10)
ConsistentHashSelectEndpoint/10_endpoints-8      240.6n ±  3%   232.3n ± 2%   -3.41% (p=0.000 n=10)
ConsistentHashSelectEndpoint/10_endpoints-16     239.9n ±  3%   231.1n ± 1%   -3.65% (p=0.000 n=10)
ConsistentHashSelectEndpoint/100_endpoints       339.0n ±  5%   334.4n ± 1%   -1.36% (p=0.011 n=10)
ConsistentHashSelectEndpoint/100_endpoints-2     376.8n ±  2%   360.0n ± 3%   -4.45% (p=0.000 n=10)
ConsistentHashSelectEndpoint/100_endpoints-4     390.5n ±  4%   356.1n ± 3%   -8.80% (p=0.000 n=10)
ConsistentHashSelectEndpoint/100_endpoints-8     394.8n ±  4%   370.8n ± 1%   -6.07% (p=0.000 n=10)
ConsistentHashSelectEndpoint/100_endpoints-16    391.8n ±  3%   368.4n ± 1%   -5.97% (p=0.000 n=10)
ConsistentHashSelectEndpoint/250_endpoints       276.8n ±  3%   286.2n ± 1%   +3.41% (p=0.003 n=10)
ConsistentHashSelectEndpoint/250_endpoints-2     296.0n ±  4%   303.2n ± 4%   +2.45% (p=0.043 n=10)
ConsistentHashSelectEndpoint/250_endpoints-4     283.3n ±  3%   303.1n ± 1%   +6.99% (p=0.000 n=10)
ConsistentHashSelectEndpoint/250_endpoints-8     303.9n ±  2%   318.3n ± 1%   +4.77% (p=0.000 n=10)
ConsistentHashSelectEndpoint/250_endpoints-16    302.1n ±  1%   314.4n ± 1%   +4.09% (p=0.000 n=10)
ConsistentHashSelectEndpoint/300_endpoints       272.9n ±  1%   288.4n ± 1%   +5.68% (p=0.000 n=10)
ConsistentHashSelectEndpoint/300_endpoints-2     277.3n ±  2%   304.7n ± 2%   +9.86% (p=0.000 n=10)
ConsistentHashSelectEndpoint/300_endpoints-4     271.9n ±  3%   296.1n ± 1%   +8.88% (p=0.000 n=10)
ConsistentHashSelectEndpoint/300_endpoints-8     276.0n ±  1%   307.1n ± 2%  +11.27% (p=0.000 n=10)
ConsistentHashSelectEndpoint/300_endpoints-16    284.3n ±  3%   304.2n ± 1%   +6.98% (p=0.000 n=10)
ConsistentHashSelectEndpoint/400_endpoints       968.4n ±  2%   710.4n ± 1%  -26.64% (p=0.000 n=10)
ConsistentHashSelectEndpoint/400_endpoints-2     976.3n ±  2%   698.5n ± 4%  -28.45% (p=0.000 n=10)
ConsistentHashSelectEndpoint/400_endpoints-4     975.3n ±  1%   690.0n ± 1%  -29.26% (p=0.000 n=10)
ConsistentHashSelectEndpoint/400_endpoints-8     981.5n ±  1%   701.9n ± 1%  -28.49% (p=0.000 n=10)
ConsistentHashSelectEndpoint/400_endpoints-16    985.3n ±  1%   700.5n ± 2%  -28.90% (p=0.000 n=10)
ConsistentHashSelectEndpoint/500_endpoints       987.3n ±  0%   725.2n ± 0%  -26.55% (p=0.000 n=10)
ConsistentHashSelectEndpoint/500_endpoints-2     960.5n ±  0%   702.5n ± 3%  -26.85% (p=0.000 n=10)
ConsistentHashSelectEndpoint/500_endpoints-4     968.0n ±  1%   698.5n ± 1%  -27.85% (p=0.000 n=10)
ConsistentHashSelectEndpoint/500_endpoints-8     975.9n ±  1%   715.6n ± 1%  -26.67% (p=0.000 n=10)
ConsistentHashSelectEndpoint/500_endpoints-16    977.6n ±  1%   711.1n ± 1%  -27.26% (p=0.000 n=10)
ConsistentHashSelectEndpoint/1000_endpoints      971.0n ±  0%   794.8n ± 2%  -18.15% (p=0.000 n=10)
ConsistentHashSelectEndpoint/1000_endpoints-2    955.0n ±  1%   748.6n ± 1%  -21.61% (p=0.000 n=10)
ConsistentHashSelectEndpoint/1000_endpoints-4    959.7n ±  1%   751.6n ± 1%  -21.68% (p=0.000 n=10)
ConsistentHashSelectEndpoint/1000_endpoints-8    968.8n ±  0%   755.1n ± 1%  -22.06% (p=0.000 n=10)
ConsistentHashSelectEndpoint/1000_endpoints-16   976.9n ± 11%   762.0n ± 1%  -22.00% (p=0.000 n=10)
ConsistentHashSelectEndpoint/5000_endpoints      957.2n ±  0%   879.9n ± 0%   -8.08% (p=0.000 n=10)
ConsistentHashSelectEndpoint/5000_endpoints-2    950.8n ±  6%   828.0n ± 0%  -12.92% (p=0.000 n=10)
ConsistentHashSelectEndpoint/5000_endpoints-4    951.0n ±  7%   834.9n ± 1%  -12.21% (p=0.000 n=10)
ConsistentHashSelectEndpoint/5000_endpoints-8    963.7n ±  9%   847.7n ± 1%  -12.04% (p=0.000 n=10)
ConsistentHashSelectEndpoint/5000_endpoints-16   962.4n ±  3%   852.9n ± 1%  -11.37% (p=0.000 n=10)
geomean                                          529.6n         467.9n       -11.65%
```