### PR TITLE
Replace stdlib gzip/flate with klauspost/compress in compress filter

### DIFF
--- a/filters/builtin/compress.go
+++ b/filters/builtin/compress.go
@@ -1,8 +1,8 @@
 package builtin
 
 import (
-	"compress/flate"
-	"compress/gzip"
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/gzip"
 	"errors"
 	"io"
 	"math"

--- a/filters/builtin/compress_test.go
+++ b/filters/builtin/compress_test.go
@@ -2,8 +2,8 @@ package builtin
 
 import (
 	"bytes"
-	"compress/flate"
-	"compress/gzip"
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/gzip"
 	"errors"
 	"io"
 	"math/rand"
@@ -785,6 +785,70 @@ func BenchmarkCompressBrotli2(b *testing.B) { benchmarkCompress(b, 100, []string
 func BenchmarkCompressBrotli4(b *testing.B) { benchmarkCompress(b, 10000, []string{"br"}) }
 func BenchmarkCompressBrotli6(b *testing.B) { benchmarkCompress(b, 1000000, []string{"br"}) }
 func BenchmarkCompressBrotli8(b *testing.B) { benchmarkCompress(b, 100000000, []string{"br"}) }
+
+func benchmarkCompressJSON(b *testing.B, n int64, encoding []string) {
+	// Repeating JSON pattern — highly compressible, realistic payload
+	pattern := []byte(`{"id":12345,"name":"test-user","email":"user@example.com","active":true,"tags":["a","b"]},`)
+	buf := make([]byte, n)
+	for i := 0; i < len(buf); i += len(pattern) {
+		copy(buf[i:], pattern)
+	}
+
+	s := NewCompress()
+	f, _ := s.CreateFilter(nil)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			body := io.NopCloser(bytes.NewReader(buf))
+			req := &http.Request{Header: http.Header{"Accept-Encoding": encoding}}
+			rsp := &http.Response{
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Body:   body}
+			ctx := &filtertest.Context{
+				FRequest:  req,
+				FResponse: rsp}
+			f.Response(ctx)
+			_, err := io.ReadAll(rsp.Body)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func benchmarkCompressLevel(b *testing.B, n int64, level int, encoding []string) {
+	s := NewCompress()
+	f, _ := s.CreateFilter([]interface{}{float64(level)})
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			body := io.NopCloser(&io.LimitedReader{R: rand.New(rand.NewSource(0)), N: n})
+			req := &http.Request{Header: http.Header{"Accept-Encoding": encoding}}
+			rsp := &http.Response{
+				Header: http.Header{"Content-Type": []string{"application/octet-stream"}},
+				Body:   body}
+			ctx := &filtertest.Context{
+				FRequest:  req,
+				FResponse: rsp}
+			f.Response(ctx)
+			_, err := io.ReadAll(rsp.Body)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// JSON payload benchmarks (compressible data)
+func BenchmarkCompressGzipJSON4(b *testing.B)  { benchmarkCompressJSON(b, 10000, []string{"gzip"}) }
+func BenchmarkCompressGzipJSON6(b *testing.B)  { benchmarkCompressJSON(b, 1000000, []string{"gzip"}) }
+func BenchmarkCompressGzipJSON8(b *testing.B)  { benchmarkCompressJSON(b, 100000000, []string{"gzip"}) }
+
+// Deflate-only benchmarks
+func BenchmarkCompressDeflate4(b *testing.B) { benchmarkCompress(b, 10000, []string{"deflate"}) }
+func BenchmarkCompressDeflate6(b *testing.B) { benchmarkCompress(b, 1000000, []string{"deflate"}) }
+
+// Higher compression level (level 6 = DefaultCompression)
+func BenchmarkCompressGzipLevel6_4(b *testing.B) { benchmarkCompressLevel(b, 10000, 6, []string{"gzip"}) }
+func BenchmarkCompressGzipLevel6_6(b *testing.B) { benchmarkCompressLevel(b, 1000000, 6, []string{"gzip"}) }
 
 func BenchmarkCanEncodeEntity(b *testing.B) {
 	testCases := []struct {

--- a/go.mod
+++ b/go.mod
@@ -195,7 +195,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.7 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/klauspost/compress v1.18.2 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=


### PR DESCRIPTION
## Summary

Replace `compress/gzip` and `compress/flate` with `github.com/klauspost/compress` in the compress filter. Drop-in API-compatible replacement with significantly better CPU performance.

Scoped to the compress filter only — decompress, routesrv, and OIDC cookie compression can follow up separately.

## Motivation

Profiling shows 30% CPU spent in `compress/flate` on high-traffic clusters (#3932).

## Benchmark results (Apple M2 Max, 6 samples)

### Default level (BestSpeed — production path)

```
                     │  stdlib   │ klauspost │  change  │
CompressGzip4  10KB    16.12µs    9.38µs      -42%
CompressGzip6  1MB     985.9µs   401.1µs      -59%
CompressGzip8  100MB   88.76ms   24.56ms      -72%
```

### JSON payload (compressible, realistic)

```
                     │  stdlib   │ klauspost │  change  │
GzipJSON6      1MB    113.9µs    72.4µs      -36%
GzipJSON8      100MB  10.68ms    6.77ms      -37%
```

### Deflate-only

```
                     │  stdlib   │ klauspost │  change  │
Deflate4       10KB   16.50µs    9.06µs      -45%
Deflate6       1MB    1041.2µs   366.0µs     -65%
```

### Higher compression level (level 6)

```
                     │  stdlib   │ klauspost │  change  │
GzipLevel6_6   1MB   2293.3µs   464.0µs     -80%
```

Memory allocation nearly identical. Brotli unchanged (separate library).

Closes #3932

## Test plan

- [x] All existing compress filter tests pass
- [x] Benchmarks across random data, JSON, deflate, and compression levels