### PR TITLE
feat: Add print statements from Open Policy Agent to spans

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -340,6 +340,7 @@ type Config struct {
 	OpenPolicyAgentControlLoopMaxJitter                time.Duration `yaml:"open-policy-agent-control-loop-max-jitter"`
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool          `yaml:"enable-open-policy-agent-data-preprocessing-optimization"`
 	EnableOpenPolicyAgentPreloading                    bool          `yaml:"enable-open-policy-agent-preloading"`
+	EnableOpenPolicyAgentPrintTracing                  bool          `yaml:"enable-open-policy-agent-print-tracing"`
 	OpenPolicyAgentConfigTemplate                      string        `yaml:"open-policy-agent-config-template"`
 	OpenPolicyAgentEnvoyMetadata                       string        `yaml:"open-policy-agent-envoy-metadata"`
 	OpenPolicyAgentCleanerInterval                     time.Duration `yaml:"open-policy-agent-cleaner-interval"`
@@ -607,6 +608,7 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopInterval, "open-policy-agent-control-loop-interval", openpolicyagent.DefaultControlLoopInterval, "Interval between the execution of the control loop. Only applies if the custom control loop is enabled")
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopMaxJitter, "open-policy-agent-control-loop-max-jitter", openpolicyagent.DefaultControlLoopMaxJitter, "Maximum jitter to add to the control loop interval. Only applies if the custom control loop is enabled")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentDataPreProcessingOptimization, "enable-open-policy-agent-data-preprocessing-optimization", false, "As a latency optimization, open policy agent will read values from in-memory storage as pre converted ASTs, removing conversion overhead at evaluation time. Currently experimental and if successful will be enabled by default")
+	flag.BoolVar(&cfg.EnableOpenPolicyAgentPrintTracing, "enable-open-policy-agent-print-tracing", false, "when enabled, OPA print() statements in policies are emitted as events on the OpenTracing span")
 	flag.StringVar(&cfg.OpenPolicyAgentConfigTemplate, "open-policy-agent-config-template", "", "file containing a template for an Open Policy Agent configuration file that is interpolated for each OPA filter instance")
 	flag.StringVar(&cfg.OpenPolicyAgentEnvoyMetadata, "open-policy-agent-envoy-metadata", "", "JSON file containing meta-data passed as input for compatibility with Envoy policies in the format")
 	flag.DurationVar(&cfg.OpenPolicyAgentCleanerInterval, "open-policy-agent-cleaner-interval", openpolicyagent.DefaultCleanIdlePeriod, "Duration in seconds to wait before cleaning up unused opa instances")
@@ -1127,6 +1129,7 @@ func (c *Config) ToOptions() skipper.Options {
 		OpenPolicyAgentControlLoopMaxJitter:                c.OpenPolicyAgentControlLoopMaxJitter,
 		EnableOpenPolicyAgentDataPreProcessingOptimization: c.EnableOpenPolicyAgentDataPreProcessingOptimization,
 		EnableOpenPolicyAgentPreloading:                    c.EnableOpenPolicyAgentPreloading,
+		EnableOpenPolicyAgentPrintTracing:                  c.EnableOpenPolicyAgentPrintTracing,
 		OpenPolicyAgentConfigTemplate:                      c.OpenPolicyAgentConfigTemplate,
 		OpenPolicyAgentEnvoyMetadata:                       c.OpenPolicyAgentEnvoyMetadata,
 		OpenPolicyAgentCleanerInterval:                     c.OpenPolicyAgentCleanerInterval,

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -12,8 +12,10 @@ import (
 	"github.com/open-policy-agent/opa-envoy-plugin/opa/decisionlog"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/plugins/logs"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/server"
 	"github.com/open-policy-agent/opa/v1/topdown"
+	"github.com/open-policy-agent/opa/v1/topdown/print"
 	"github.com/opentracing/opentracing-go"
 	pbstruct "google.golang.org/protobuf/types/known/structpb"
 )
@@ -76,7 +78,11 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 			return
 		}
 
-		err = envoyauth.Eval(ctx, &evalContext{opa}, inputValue, result)
+		evalOpts := []rego.EvalOption{}
+		if span != nil && opa.registry.enablePrintTracing {
+			evalOpts = append(evalOpts, rego.EvalPrintHook(&spanPrintHook{span: span}))
+		}
+		err = envoyauth.Eval(ctx, &evalContext{opa}, inputValue, result, evalOpts...)
 	})
 
 	if err != nil {
@@ -131,4 +137,13 @@ func withDecisionID(decisionID string) func(*envoyauth.EvalResult) {
 	return func(result *envoyauth.EvalResult) {
 		result.DecisionID = decisionID
 	}
+}
+
+type spanPrintHook struct {
+	span opentracing.Span
+}
+
+func (h *spanPrintHook) Print(pctx print.Context, msg string) error {
+	h.span.LogKV("event", "print", "opa.print.location", pctx.Location.String(), "message", msg)
+	return nil
 }

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -122,6 +122,7 @@ type OpenPolicyAgentRegistry struct {
 	controlLoopMaxJitter    time.Duration
 
 	enableDataPreProcessingOptimization bool
+	enablePrintTracing                  bool
 
 	valueCache iCache.InterQueryValueCache
 
@@ -202,6 +203,13 @@ func WithTracer(tracer opentracing.Tracer) func(*OpenPolicyAgentRegistry) error 
 func WithEnableCustomControlLoop(enabled bool) func(*OpenPolicyAgentRegistry) error {
 	return func(cfg *OpenPolicyAgentRegistry) error {
 		cfg.enableCustomControlLoop = enabled
+		return nil
+	}
+}
+
+func WithEnablePrintTracing(enabled bool) func(*OpenPolicyAgentRegistry) error {
+	return func(cfg *OpenPolicyAgentRegistry) error {
+		cfg.enablePrintTracing = enabled
 		return nil
 	}
 }
@@ -717,6 +725,7 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 		store,
 		configLabelsInfo(*opaConfig),
 		plugins.Logger(logger),
+		plugins.EnablePrintStatements(registry.enablePrintTracing),
 		registry.withTracingOptions(bundleName),
 		plugins.WithHooks(hooks.New(configHooks...)),
 		plugins.WithPrometheusRegister(registerer))

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -1370,3 +1370,102 @@ func runWithTestCases(t *testing.T, cases []opaInstanceStartupTestCase, test fun
 		})
 	}
 }
+
+func TestPrintTracing(t *testing.T) {
+	for _, ti := range []struct {
+		msg                string
+		enablePrintTracing bool
+		expectPrintInSpan  bool
+	}{
+		{
+			msg:                "print output appears in span when print tracing is enabled",
+			enablePrintTracing: true,
+			expectPrintInSpan:  true,
+		},
+		{
+			msg:                "print output does not appear in span when print tracing is disabled",
+			enablePrintTracing: false,
+			expectPrintInSpan:  false,
+		},
+	} {
+		t.Run(ti.msg, func(t *testing.T) {
+			opaControlPlane := opasdktest.MustNewServer(
+				opasdktest.MockBundle("/bundles/test", map[string]string{
+					"main.rego": `
+						package envoy.authz
+						import rego.v1
+
+						default allow := false
+
+						allow if {
+							print("hello from policy")
+							true
+						}
+					`,
+				}),
+			)
+			defer opaControlPlane.Stop()
+
+			config := fmt.Appendf(nil, `{
+				"services": {
+					"test": {
+						"url": %q
+					}
+				},
+				"bundles": {
+					"test": {
+						"resource": "/bundles/test"
+					}
+				},
+				"plugins": {
+					"envoy_ext_authz_grpc": {
+						"path": "envoy/authz/allow",
+						"dry-run": false
+					}
+				}
+			}`, opaControlPlane.URL())
+
+			registry, err := NewOpenPolicyAgentRegistry(
+				WithReuseDuration(1*time.Second),
+				WithCleanInterval(1*time.Second),
+				WithEnablePrintTracing(ti.enablePrintTracing),
+				WithOpenPolicyAgentInstanceConfig(WithConfigTemplate(config)),
+			)
+			require.NoError(t, err)
+
+			inst, err := registry.GetOrStartInstance("test")
+			require.NoError(t, err)
+
+			tracer := tracingtest.NewTracer()
+			parentSpan := tracer.StartSpan("parent")
+			ctx := opentracing.ContextWithSpan(context.Background(), parentSpan)
+
+			_, err = inst.Eval(ctx, &authv3.CheckRequest{
+				Attributes: &authv3.AttributeContext{},
+			})
+			require.NoError(t, err)
+
+			parentSpan.Finish()
+
+			recspan := tracer.FindSpan("parent")
+			require.NotNil(t, recspan, "expected parent span")
+
+			var printLogs []string
+			for _, lr := range recspan.Logs() {
+				fields := make(map[string]string)
+				for _, f := range lr.Fields {
+					fields[f.Key] = f.ValueString
+				}
+				if fields["event"] == "print" {
+					printLogs = append(printLogs, fields["message"])
+				}
+			}
+
+			if ti.expectPrintInSpan {
+				assert.Contains(t, printLogs, "hello from policy", "expected print output in span logs")
+			} else {
+				assert.Empty(t, printLogs, "expected no print output in span logs")
+			}
+		})
+	}
+}

--- a/skipper.go
+++ b/skipper.go
@@ -1050,6 +1050,7 @@ type Options struct {
 	OpenPolicyAgentControlLoopMaxJitter                time.Duration
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool
 	EnableOpenPolicyAgentPreloading                    bool
+	EnableOpenPolicyAgentPrintTracing                  bool
 	OpenPolicyAgentConfigTemplate                      string
 	OpenPolicyAgentEnvoyMetadata                       string
 	OpenPolicyAgentCleanerInterval                     time.Duration
@@ -2158,6 +2159,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			openpolicyagent.WithInstanceStartupTimeout(o.OpenPolicyAgentStartupTimeout),
 			openpolicyagent.WithTracer(tracer),
 			openpolicyagent.WithEnableCustomControlLoop(o.EnableOpenPolicyAgentCustomControlLoop),
+			openpolicyagent.WithEnablePrintTracing(o.EnableOpenPolicyAgentPrintTracing),
 			openpolicyagent.WithControlLoopInterval(o.OpenPolicyAgentControlLoopInterval),
 			openpolicyagent.WithControlLoopMaxJitter(o.OpenPolicyAgentControlLoopMaxJitter),
 			openpolicyagent.WithEnableDataPreProcessingOptimization(o.EnableOpenPolicyAgentDataPreProcessingOptimization),


### PR DESCRIPTION
## Summary

Closes #3304

OPA policies can use `print()` for diagnostic output, but until now this output was only logged to OPA's internal logger — completely disconnected from request tracing. This PR captures `print()` output during policy evaluation and emits it as events on the active OpenTracing span, enabling contextual, per-request debugging of policy logic.

The feature is opt-in via a new flag:

```
--enable-open-policy-agent-print-tracing
```

When enabled, each `print()` call in a Rego policy produces a span log event with the following fields:
- `event`: `"print"`
- `opa.print.location`: source location of the `print()` call (e.g. `main.rego:10`)
- `message`: the printed string

## Implementation notes

Two changes are required to make this work end-to-end:

1. **Manager level** (`plugins.EnablePrintStatements`): the OPA compiler silently drops `print()` calls unless explicitly enabled at manager creation time. This flag is now passed conditionally based on `--enable-open-policy-agent-print-tracing`.

2. **Eval level** (`rego.EvalPrintHook`): a custom `spanPrintHook` is registered per evaluation that routes `print()` output to the active OpenTracing span via `LogKV`. It overrides the default opa-envoy-plugin hook (which logs to OPA's internal logger) since `envoyauth.Eval` appends caller-supplied options after its defaults, and the last `EvalPrintHook` wins.

Both changes are no-ops when the flag is disabled, so there is no overhead on existing deployments.

## Test plan

- [x] New test `TestPrintTracing` in `filters/openpolicyagent/openpolicyagent_test.go` verifies:
  - With `--enable-open-policy-agent-print-tracing`: `print()` output appears as span log events with the correct fields
  - Without the flag (default): span logs are empty — no overhead, no leakage
