### PR TITLE
Extend predicate OTelBaggage to match with value

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -776,10 +776,16 @@ predicates are able to match based on OTel data.
 ### OTelBaggage
 
 OpenTelemetry defined Baggage as [W3C spec](https://www.w3.org/TR/baggage/).
-OTelBaggage predicate is able to match the Baggage item by key.
+OTelBaggage predicate is able to match the Baggage item by key or by key and value.
 
-The example matches the key of a baggage item key `foo` whatever the baggage item value or property is:
+The example matches the key of a baggage item key `foo` regardless of value or properties:
 
 ```
 OTelBaggage("foo")
+```
+
+The example matches the key of baggage item key `foo` with its corresponding value `bar`:
+
+```
+OTelBaggage("foo", "bar")
 ```

--- a/predicates/otel/otel.go
+++ b/predicates/otel/otel.go
@@ -11,7 +11,8 @@ import (
 type baggageSpec struct{}
 
 type baggagePredicate struct {
-	key string
+	key   string
+	value string
 }
 
 // NewBaggage provides a predicate spec to create a Predicate instance that matches a baggage by key.
@@ -23,22 +24,38 @@ func (*baggageSpec) Name() string {
 
 // Create a predicate instance that always evaluates to baggage
 func (*baggageSpec) Create(args []interface{}) (routing.Predicate, error) {
-	if len(args) != 1 {
+	if len(args) == 0 || len(args) > 2 {
 		return nil, predicates.ErrInvalidPredicateParameters
 	}
 
 	var key string
+	var value string
+
 	if sarg, ok := args[0].(string); ok {
 		key = sarg
 	} else {
 		return nil, predicates.ErrInvalidPredicateParameters
 	}
+
+	if len(args) == 2 {
+		if sarg, ok := args[1].(string); ok {
+			value = sarg
+		} else {
+			return nil, predicates.ErrInvalidPredicateParameters
+		}
+	}
+
 	return &baggagePredicate{
-		key: key,
+		key:   key,
+		value: value,
 	}, nil
 }
 
 func (p *baggagePredicate) Match(r *http.Request) bool {
 	bp := baggage.FromContext(r.Context())
-	return bp.Member(p.key).Key() == p.key
+	member := bp.Member(p.key)
+	if p.value != "" {
+		return member.Key() == p.key && member.Value() == p.value
+	}
+	return member.Key() == p.key
 }

--- a/predicates/otel/otel_test.go
+++ b/predicates/otel/otel_test.go
@@ -26,6 +26,10 @@ func TestOTelBaggage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create property: %v", err)
 	}
+	keyValPropertyExistsEmptyVal, err := baggage.NewKeyValueProperty("exists", "")
+	if err != nil {
+		t.Fatalf("Failed to create property: %v", err)
+	}
 
 	member, err := baggage.NewMember("exists", "val")
 	if err != nil {
@@ -44,6 +48,10 @@ func TestOTelBaggage(t *testing.T) {
 		t.Fatalf("Failed to create member: %v", err)
 	}
 	noMatchMemberWithMatchingProperties, err := baggage.NewMember("kproperty", "val", keyPropertyExists, keyValPropertyExists)
+	if err != nil {
+		t.Fatalf("Failed to create member: %v", err)
+	}
+	memberWithMatchingKeyEmptyVal, err := baggage.NewMember("exists", "", keyPropertyExists, keyValPropertyExistsEmptyVal)
 	if err != nil {
 		t.Fatalf("Failed to create member: %v", err)
 	}
@@ -82,7 +90,7 @@ func TestOTelBaggage(t *testing.T) {
 		},
 		{
 			name: "test no match member with key-val property",
-			args: []interface{}{"no-match"},
+			args: []interface{}{"no-match", "no-val"},
 			member: []baggage.Member{
 				memberWithKeyValProperty,
 			},
@@ -122,12 +130,21 @@ func TestOTelBaggage(t *testing.T) {
 		},
 		{
 			name: "test match member with key-val property",
-			args: []interface{}{"exists"},
+			args: []interface{}{"exists", "val"},
 			member: []baggage.Member{
 				memberWithKeyValProperty,
 			},
 			want: true,
-		}} {
+		},
+		{
+			name: "test match member with matching key and no val",
+			args: []interface{}{"exists"},
+			member: []baggage.Member{
+				memberWithMatchingKeyEmptyVal,
+			},
+			want: true,
+		},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := NewBaggage()
 			pred, err := spec.Create(tt.args)


### PR DESCRIPTION
## Context

Currently the predicate OTelBaggage only matches based on key. 

This needs to be extended to match based on value if the value is not empty.

## Tasks

- [x] Update `baggagePredicate` struct to include optional value field
- [x] Modify `Create()` to accept 1 or 2 arguments (key only or key+value)
- [x] Update `Match()` to check value when provided, key-only when not
- [x] Add test cases for value matching scenarios
- [x] Run tests to verify working implementation