### PR TITLE
fix: improve bearerinjector logging for missing credentials

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -3464,7 +3464,7 @@ It is a special form of `setRequestHeaderFromSecret` with `"Authorization"` head
 `"Bearer "` prefix and empty suffix.
 
 The token file must be located in a directory passed via the `-credentials-paths` flag.
-See the [egress reference](https://opensource.zalando.com/skipper/reference/egress/#example-bearer-injection)
+See the [egress reference](egress.md#example-bearer-injection)
 for a complete configuration example.
 
 Example:

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -3463,6 +3463,10 @@ from file providing the token as content.
 It is a special form of `setRequestHeaderFromSecret` with `"Authorization"` header name,
 `"Bearer "` prefix and empty suffix.
 
+The token file must be located in a directory passed via the `-credentials-paths` flag.
+See the [egress reference](https://opensource.zalando.com/skipper/reference/egress/#example-bearer-injection)
+for a complete configuration example.
+
 Example:
 
 ```
@@ -3470,6 +3474,9 @@ egress: * -> bearerinjector("/tmp/secrets/my-token") -> "https://api.example.com
 
 // equivalent to setRequestHeaderFromSecret("Authorization", "/tmp/secrets/my-token", "Bearer ")
 ```
+
+Note: You must start skipper with `-credentials-paths=/tmp/secrets` for the
+filter to find the token file.
 
 ## Open Tracing
 ### tracingBaggageToTag

--- a/filters/auth/bearer.go
+++ b/filters/auth/bearer.go
@@ -53,7 +53,7 @@ func newBearerInjectorFilter(s string, sr secrets.SecretsReader) *bearerInjector
 func (f *bearerInjectorFilter) Request(ctx filters.FilterContext) {
 	b, ok := f.secretsReader.GetSecret(f.secretName)
 	if !ok {
-		log.Errorf("Secret %q not found for bearerinjector filter", f.secretName)
+		log.Errorf("Secret %q not found for bearerinjector filter. Make sure the file exists in a directory passed via -credentials-paths flag.", f.secretName)
 		return
 	}
 	ctx.Request().Header.Set(authHeaderName, authHeaderPrefix+string(b))

--- a/filters/auth/bearer.go
+++ b/filters/auth/bearer.go
@@ -53,7 +53,7 @@ func newBearerInjectorFilter(s string, sr secrets.SecretsReader) *bearerInjector
 func (f *bearerInjectorFilter) Request(ctx filters.FilterContext) {
 	b, ok := f.secretsReader.GetSecret(f.secretName)
 	if !ok {
-		log.Errorf("Secret %q not found for bearerinjector filter. Make sure the file exists in a directory passed via -credentials-paths flag.", f.secretName)
+		log.Errorf("Secret %q not found for bearerinjector filter. Make sure the file exists in a directory passed via -credentials-paths flag. See https://opensource.zalando.com/skipper/reference/egress/#example-bearer-injection", f.secretName)
 		return
 	}
 	ctx.Request().Header.Set(authHeaderName, authHeaderPrefix+string(b))


### PR DESCRIPTION
## Summary

When the bearerinjector filter can't find a secret, the error message now mentions the `-credentials-paths` flag. Previously it just said "Secret not found" with no hint about what to configure.

Also updates the bearerinjector docs to link to the egress reference and note the `-credentials-paths` requirement.

## Changes

- `filters/auth/bearer.go`: Improved error message at line 56 to mention `-credentials-paths`.
- `docs/reference/filters.md`: Added note about `-credentials-paths` and link to the egress reference with a complete configuration example.

## Testing

- `go build ./filters/auth/...` passes

Fixes #3507

This contribution was developed with AI assistance (Claude Code).