### PR TITLE
update: Go to 1.26.2 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -326,4 +326,4 @@ require (
 	oras.land/oras-go/v2 v2.6.0 // indirect
 )
 
-go 1.26.1
+go 1.26.2


### PR DESCRIPTION
update: Go to 1.26.2 in go.mod

```
make osv-scanner
osv-scanner -r ./
Scanning dir ./
Scanning /home/runner/work/skipper/skipper/ at commit dd457320b4be15d29641eb4d0daed2d188653e80
Scanned /home/runner/work/skipper/skipper/go.mod file and found 321 packages
+------------------------------+------+-----------+---------+---------+--------+
| OSV URL                      | CVSS | ECOSYSTEM | PACKAGE | VERSION | SOURCE |
+------------------------------+------+-----------+---------+---------+--------+
| https://osv.dev/GO-2026-4865 |      | Go        | stdlib  | 1.26.1  | go.mod |
| https://osv.dev/GO-2026-4866 |      | Go        | stdlib  | 1.26.1  | go.mod |
| https://osv.dev/GO-2026-4869 |      | Go        | stdlib  | 1.26.1  | go.mod |
| https://osv.dev/GO-2026-4870 |      | Go        | stdlib  | 1.26.1  | go.mod |
| https://osv.dev/GO-2026-4946 |      | Go        | stdlib  | 1.26.1  | go.mod |
| https://osv.dev/GO-2026-4947 |      | Go        | stdlib  | 1.26.1  | go.mod |
+------------------------------+------+-----------+---------+---------+--------+
| Uncalled vulnerabilities     |      |           |         |         |        |
+------------------------------+------+-----------+---------+---------+--------+
| https://osv.dev/GO-2026-4864 |      | Go        | stdlib  | 1.26.1  | go.mod |
+------------------------------+------+-----------+---------+---------+--------+
```