### PR TITLE
refactor: remove leftover splitseq

### DIFF
--- a/filters/builtin/compress.go
+++ b/filters/builtin/compress.go
@@ -263,7 +263,7 @@ func canEncodeEntity(r *http.Response, mime []string) bool {
 func (c *compress) acceptedEncoding(r *http.Request) string {
 	var encs encodings
 
-	for s := range splitSeq(r.Header.Get("Accept-Encoding"), ",") {
+	for s := range strings.SplitSeq(r.Header.Get("Accept-Encoding"), ",") {
 
 		name, weight, hasWeight := strings.Cut(s, ";")
 
@@ -308,24 +308,6 @@ func (c *compress) acceptedEncoding(r *http.Request) string {
 
 	sort.Sort(encs)
 	return encs[0].name
-}
-
-// TODO: use [strings.SplitSeq] added in go1.24 once go1.25 is released.
-func splitSeq(s string, sep string) func(yield func(string) bool) {
-	return func(yield func(string) bool) {
-		for {
-			i := strings.Index(s, sep)
-			if i < 0 {
-				break
-			}
-			frag := s[:i]
-			if !yield(frag) {
-				return
-			}
-			s = s[i+len(sep):]
-		}
-		yield(s)
-	}
 }
 
 func responseHeader(r *http.Response, enc string) {

--- a/filters/builtin/decompress.go
+++ b/filters/builtin/decompress.go
@@ -200,7 +200,7 @@ func (d decompress) Request(filters.FilterContext) {}
 
 func getEncodings(header string) []string {
 	var encs []string
-	for r := range splitSeq(header, ",") {
+	for r := range strings.SplitSeq(header, ",") {
 		r = strings.TrimSpace(r)
 		if r != "" {
 			encs = append(encs, r)

--- a/predicates/forwarded/forwarded.go
+++ b/predicates/forwarded/forwarded.go
@@ -132,8 +132,8 @@ type forwarded struct {
 func parseForwarded(fh string) *forwarded {
 	f := &forwarded{}
 
-	for forwardedFull := range splitSeq(fh, ",") {
-		for forwardedPair := range splitSeq(strings.TrimSpace(forwardedFull), ";") {
+	for forwardedFull := range strings.SplitSeq(fh, ",") {
+		for forwardedPair := range strings.SplitSeq(strings.TrimSpace(forwardedFull), ";") {
 			token, value, found := strings.Cut(forwardedPair, "=")
 			value = strings.Trim(value, `"`)
 			if found && value != "" {
@@ -147,22 +147,4 @@ func parseForwarded(fh string) *forwarded {
 		}
 	}
 	return f
-}
-
-// TODO: use [strings.SplitSeq] added in go1.24 once go1.25 is released.
-func splitSeq(s string, sep string) func(yield func(string) bool) {
-	return func(yield func(string) bool) {
-		for {
-			i := strings.Index(s, sep)
-			if i < 0 {
-				break
-			}
-			frag := s[:i]
-			if !yield(frag) {
-				return
-			}
-			s = s[i+len(sep):]
-		}
-		yield(s)
-	}
 }


### PR DESCRIPTION
Use standard `strings.SplitSeq`