### PR TITLE
docs(filters): note static() second-parameter file vs. directory pitfall

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1127,6 +1127,7 @@ Notes:
 * redirects to the directory when a file `index.html` exists and it is requested, i.e. `GET /foo/index.html` redirects to `/foo/` which serves then the `/foo/index.html`
 * serves the content of the `index.html` when a directory is requested
 * does a simple directory listing of files / directories when no `index.html` is present
+* the second parameter must be a directory; pointing it at a single file path that ends in `/index.html` (e.g. `static("/foo", "/tmp/foo/index.html")`) inherits Go's [`http.FileServer`](https://pkg.go.dev/net/http#FileServer) behavior of redirecting any request ending in `/index.html` to the same path without the final `index.html`, which can produce surprising `301 Moved Permanently` responses with a `Location: ..//` header. Pass the parent directory instead (e.g. `static("/foo", "/tmp/foo")`).
 
 ### inlineContent
 


### PR DESCRIPTION
Issue #2233 documented a confusing redirect: setting `static("/foo", "/tmp/foo/index.html")` (with the second parameter pointing directly at a file named `index.html`) returns `301 Moved Permanently` with `Location: ..//`. The cause is Go's `http.FileServer` "redirect any request ending in /index.html to the same path without the final index.html" behavior, inherited transitively by `static()`.

The reporter asked to document this as an edge case in the filter docs. The existing `Notes` list near the `static` filter does mention the symmetric case (`GET /foo/index.html` redirects to `/foo/`) but doesn't call out that pointing the second parameter at a file - rather than its parent directory - hits the same redirect. This PR adds one bullet covering that case, with the fix (use the parent directory) inline.

No code changes; doc-only.

Closes #2233.

This contribution was developed with AI assistance (Claude Code).