### PR TITLE
bugfix: routesrv return full routingTable with zone

### DIFF
--- a/routesrv/eskipbytes.go
+++ b/routesrv/eskipbytes.go
@@ -52,16 +52,20 @@ var (
 // provides synchronized r/w access to them. Additionally it can
 // serve as an HTTP handler exposing its content.
 type eskipBytes struct {
-	mu           sync.RWMutex
-	data         []byte
-	zoneData     map[string][]byte
-	hash         string
-	lastModified time.Time
-	initialized  bool
-	count        int
+	mu               sync.RWMutex
+	data             []byte
+	zoneData         map[string][]byte
+	hash             string
+	zoneHash         map[string]string
+	lastModified     time.Time
+	zoneLastModified map[string]time.Time
+	initialized      bool
+	count            int
+	zoneCount        map[string]int
 
-	zw    *gzip.Writer
-	zdata []byte
+	zw                 *gzip.Writer
+	zdata              []byte
+	zoneDataCompressed map[string][]byte
 
 	tracer  ot.Tracer
 	metrics metrics.Metrics
@@ -82,15 +86,21 @@ func (e *eskipBytes) formatAndSet(routes []*eskip.Route, zoneAwareRoutes map[str
 
 	updated = !bytes.Equal(e.data, data)
 	if updated {
-		if len(zoneAwareRoutes) > 0 {
-			e.zoneData = make(map[string][]byte)
-			for zone, routes := range zoneAwareRoutes {
-				zoneBuf := &bytes.Buffer{}
-				eskip.Fprint(zoneBuf, eskip.PrettyPrintInfo{Pretty: false, IndentStr: ""}, routes...)
-				e.zoneData[zone] = zoneBuf.Bytes()
-			}
+		now := e.now()
+		e.zoneData, e.zoneDataCompressed, e.zoneCount = make(map[string][]byte), make(map[string][]byte), make(map[string]int)
+		e.zoneHash = make(map[string]string)
+		e.zoneLastModified = make(map[string]time.Time)
+		for zone, routes := range zoneAwareRoutes {
+			zoneBuf := &bytes.Buffer{}
+			eskip.Fprint(zoneBuf, eskip.PrettyPrintInfo{Pretty: false, IndentStr: ""}, routes...)
+			zoneData := zoneBuf.Bytes()
+			e.zoneLastModified[zone] = now
+			e.zoneData[zone] = zoneData
+			e.zoneDataCompressed[zone] = e.compressLocked(zoneData)
+			e.zoneHash[zone] = fmt.Sprintf("%x", sha256.Sum256(zoneData))
+			e.zoneCount[zone] = len(routes)
 		}
-		e.lastModified = e.now()
+		e.lastModified = now
 		e.data = data
 		e.zdata = e.compressLocked(data)
 		e.hash = fmt.Sprintf("%x", sha256.Sum256(e.data))
@@ -157,9 +167,12 @@ func (e *eskipBytes) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	// we check for three endpoints because three is good choice for availability; it guarantees that at least one endpoint will be healthy even if the others are on update or have some issues
 	zone := r.PathValue("zone")
 	if zone != "" {
-		zoneData, ok := e.zoneData[zone]
-		if ok {
-			data = zoneData
+		if zd, ok := e.zoneData[zone]; ok {
+			data = zd
+			zdata = e.zoneDataCompressed[zone]
+			count = e.zoneCount[zone]
+			hash = e.zoneHash[zone]
+			lastModified = e.zoneLastModified[zone]
 		}
 	}
 

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -70,10 +70,14 @@ func New(opts skipper.Options) (*RouteServer, error) {
 	rs.tracerShutdown = shutdown
 
 	b := &eskipBytes{
-		tracer:   tracer,
-		metrics:  m,
-		now:      time.Now,
-		zoneData: make(map[string][]byte),
+		tracer:             tracer,
+		metrics:            m,
+		now:                time.Now,
+		zoneData:           make(map[string][]byte),
+		zoneDataCompressed: make(map[string][]byte),
+		zoneCount:          make(map[string]int),
+		zoneLastModified:   make(map[string]time.Time),
+		zoneHash:           make(map[string]string),
 	}
 	bs := &eskipBytesStatus{
 		b: b,

--- a/routesrv/routesrv_test.go
+++ b/routesrv/routesrv_test.go
@@ -130,6 +130,26 @@ func getZoneAwareRoutesGzip(rs *routesrv.RouteServer, zone string) *httptest.Res
 	return w
 }
 
+func getZoneAwareRoutesWithHeaders(rs *routesrv.RouteServer, zone string, headers map[string]string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/routes/"+zone, nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	rs.ServeHTTP(w, r)
+	return w
+}
+
+func decompressGzip(t *testing.T, b *bytes.Buffer) []byte {
+	t.Helper()
+	zr, err := gzip.NewReader(b)
+	require.NoError(t, err)
+	defer zr.Close()
+	out, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	return out
+}
+
 func getHealth(rs *routesrv.RouteServer) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/health", nil)
@@ -1179,4 +1199,205 @@ func TestZoneAwareRoutesGzip(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, eskip.EqLists(gotGzip, want))
+}
+
+// TestZoneAwareXCount verifies that X-Count reflects the number of routes
+// in the zone-filtered response, not the full route set.
+func TestZoneAwareXCount(t *testing.T) {
+	defer tl.Reset()
+
+	// all-zones-3-addr has 3 zones × 3 endpoints each.
+	// Zone eu-central-1a produces 1 zone-filtered route (3 backends in that zone).
+	ks, _ := newKubeServer(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr.yaml"))
+	ks.Start()
+	defer ks.Close()
+	rs := newRouteServerWithOptions(t, skipper.Options{
+		SourcePollTimeout:              pollInterval,
+		Kubernetes:                     true,
+		KubernetesURL:                  ks.URL,
+		KubernetesEnableEndpointslices: true,
+	})
+	rs.StartUpdates()
+	defer rs.StopUpdates()
+	require.NoError(t, tl.WaitFor(routesrv.LogRoutesInitialized, waitTimeout))
+
+	zoneWant := parseEskipFixture(t, "testdata/zone-aware-traffic/all-zones-3-addr.eskip")
+	expectedCount := strconv.Itoa(len(zoneWant))
+
+	plainResp := getZoneAwareRoutes(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, plainResp.Code)
+	assert.Equal(t, expectedCount, plainResp.Header().Get(routing.RoutesCountName), "X-Count must equal the number of zone-filtered routes")
+
+	gzipResp := getZoneAwareRoutesGzip(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, gzipResp.Code)
+	assert.Equal(t, expectedCount, gzipResp.Header().Get(routing.RoutesCountName), "gzip X-Count must also reflect zone-filtered route count")
+
+	gotPlain, err := eskip.Parse(plainResp.Body.String())
+	require.NoError(t, err)
+	assert.Equal(t, expectedCount, strconv.Itoa(len(gotPlain)), "X-Count must match the actual number of routes in the response body")
+}
+
+func TestZoneAwareEtag(t *testing.T) {
+	defer tl.Reset()
+
+	ks, handler := newKubeServer(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr.yaml"))
+	ks.Start()
+	defer ks.Close()
+	rs := newRouteServerWithOptions(t, skipper.Options{
+		SourcePollTimeout:              pollInterval,
+		Kubernetes:                     true,
+		KubernetesURL:                  ks.URL,
+		KubernetesEnableEndpointslices: true,
+	})
+	rs.StartUpdates()
+	defer rs.StopUpdates()
+	require.NoError(t, tl.WaitFor(routesrv.LogRoutesInitialized, waitTimeout))
+
+	plainResp := getZoneAwareRoutes(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, plainResp.Code)
+	plainEtag := plainResp.Header().Get("Etag")
+	require.NotEmpty(t, plainEtag)
+
+	gzipResp := getZoneAwareRoutesGzip(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, gzipResp.Code)
+	gzipEtag := gzipResp.Header().Get("Etag")
+	require.NotEmpty(t, gzipEtag)
+
+	assert.NotEqual(t, plainEtag, gzipEtag, "plain and gzip ETags must differ")
+	assert.Contains(t, gzipEtag, "+gzip", "gzip ETag must contain +gzip suffix")
+
+	fullResp := getRoutes(rs)
+	require.Equal(t, http.StatusOK, fullResp.Code)
+	fullEtag := fullResp.Header().Get("Etag")
+	assert.NotEqual(t, plainEtag, fullEtag, "zone ETag must differ from full-routes ETag")
+
+	handler.set(newKubeAPI(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr-updated.yaml")))
+	require.NoError(t, tl.WaitForN(routesrv.LogRoutesUpdated, 2, waitTimeout))
+
+	updatedResp := getZoneAwareRoutes(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, updatedResp.Code)
+	updatedEtag := updatedResp.Header().Get("Etag")
+	assert.NotEqual(t, plainEtag, updatedEtag, "zone ETag must change after routes update")
+}
+
+func TestZoneAwareConditionalGetEtag(t *testing.T) {
+	defer tl.Reset()
+
+	ks, handler := newKubeServer(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr.yaml"))
+	ks.Start()
+	defer ks.Close()
+	rs := newRouteServerWithOptions(t, skipper.Options{
+		SourcePollTimeout:              pollInterval,
+		Kubernetes:                     true,
+		KubernetesURL:                  ks.URL,
+		KubernetesEnableEndpointslices: true,
+	})
+	rs.StartUpdates()
+	defer rs.StopUpdates()
+	require.NoError(t, tl.WaitFor(routesrv.LogRoutesInitialized, waitTimeout))
+
+	w1 := getZoneAwareRoutes(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, w1.Code)
+	etag := w1.Header().Get("Etag")
+	require.NotEmpty(t, etag)
+
+	// Should return 304 when it gets the right Etag
+	w2 := getZoneAwareRoutesWithHeaders(rs, "eu-central-1a", map[string]string{"If-None-Match": etag})
+	assert.Equal(t, http.StatusNotModified, w2.Code)
+	assert.Empty(t, w2.Body.String())
+
+	// same with gzip ETag
+	wg1 := getZoneAwareRoutesGzip(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, wg1.Code)
+	gzipEtag := wg1.Header().Get("Etag")
+
+	wg2 := getZoneAwareRoutesWithHeaders(rs, "eu-central-1a", map[string]string{
+		"If-None-Match":   gzipEtag,
+		"Accept-Encoding": "gzip",
+	})
+	assert.Equal(t, http.StatusNotModified, wg2.Code)
+	assert.Empty(t, wg2.Body.String())
+
+	// update routes -> new Etag
+	handler.set(newKubeAPI(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr-updated.yaml")))
+	require.NoError(t, tl.WaitForN(routesrv.LogRoutesUpdated, 2, waitTimeout))
+
+	w3 := getZoneAwareRoutesWithHeaders(rs, "eu-central-1a", map[string]string{"If-None-Match": etag})
+	assert.Equal(t, http.StatusOK, w3.Code)
+	assert.NotEmpty(t, w3.Body.String())
+}
+
+func TestZoneAwareConditionalGetLastModified(t *testing.T) {
+	defer tl.Reset()
+
+	ks, handler := newKubeServer(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr.yaml"))
+	ks.Start()
+	defer ks.Close()
+	rs := newRouteServerWithOptions(t, skipper.Options{
+		SourcePollTimeout:              pollInterval,
+		Kubernetes:                     true,
+		KubernetesURL:                  ks.URL,
+		KubernetesEnableEndpointslices: true,
+	})
+	rs.StartUpdates()
+	defer rs.StopUpdates()
+	require.NoError(t, tl.WaitFor(routesrv.LogRoutesInitialized, waitTimeout))
+
+	w1 := getZoneAwareRoutes(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, w1.Code)
+	lastModified := w1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	w2 := getZoneAwareRoutesWithHeaders(rs, "eu-central-1a", map[string]string{"If-Modified-Since": lastModified})
+	assert.Equal(t, http.StatusNotModified, w2.Code)
+	assert.Empty(t, w2.Body.String())
+
+	// change Last-Modified
+	routesrv.SetNow(rs, func() time.Time { return time.Now().Add(2 * time.Second) })
+	handler.set(newKubeAPI(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr-updated.yaml")))
+	require.NoError(t, tl.WaitForN(routesrv.LogRoutesUpdated, 2, waitTimeout))
+
+	// old Last-Modified is now stale → 200 with new content
+	w3 := getZoneAwareRoutesWithHeaders(rs, "eu-central-1a", map[string]string{"If-Modified-Since": lastModified})
+	assert.Equal(t, http.StatusOK, w3.Code)
+	assert.NotEmpty(t, w3.Body.String())
+}
+
+func TestZoneAwareFallbackToAllRoutesWhenBelowThreshold(t *testing.T) {
+	defer tl.Reset()
+
+	// Serve full routing table
+	ks, _ := newKubeServer(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-2-addr.yaml"))
+	ks.Start()
+	defer ks.Close()
+	rs := newRouteServerWithOptions(t, skipper.Options{
+		SourcePollTimeout:              pollInterval,
+		Kubernetes:                     true,
+		KubernetesURL:                  ks.URL,
+		KubernetesEnableEndpointslices: true,
+	})
+	rs.StartUpdates()
+	defer rs.StopUpdates()
+	require.NoError(t, tl.WaitFor(routesrv.LogRoutesInitialized, waitTimeout))
+
+	expectedRoutes := parseEskipFixture(t, "testdata/zone-aware-traffic/all-zones-2-addr.eskip")
+
+	plainResp := getZoneAwareRoutes(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, plainResp.Code)
+	gotPlain, err := eskip.Parse(plainResp.Body.String())
+	require.NoError(t, err)
+	assert.True(t, eskip.EqLists(gotPlain, expectedRoutes), "expected full routes (fallback) when zone has <3 endpoints")
+
+	// same for gzip
+	gzipResp := getZoneAwareRoutesGzip(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, gzipResp.Code)
+	require.Equal(t, "gzip", gzipResp.Header().Get("Content-Encoding"))
+	gotGzip, err := eskip.Parse(string(decompressGzip(t, gzipResp.Body)))
+	require.NoError(t, err)
+	assert.True(t, eskip.EqLists(gotGzip, expectedRoutes), "gzip fallback must also serve full routes when zone has <3 endpoints")
+
+	// X-Count for both must match the full route count
+	fullCount := strconv.Itoa(len(expectedRoutes))
+	assert.Equal(t, fullCount, plainResp.Header().Get(routing.RoutesCountName))
+	assert.Equal(t, fullCount, gzipResp.Header().Get(routing.RoutesCountName))
 }

--- a/routesrv/routesrv_test.go
+++ b/routesrv/routesrv_test.go
@@ -121,6 +121,15 @@ func getZoneAwareRoutes(rs *routesrv.RouteServer, zone string) *httptest.Respons
 	return w
 }
 
+func getZoneAwareRoutesGzip(rs *routesrv.RouteServer, zone string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/routes/"+zone, nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	rs.ServeHTTP(w, r)
+
+	return w
+}
+
 func getHealth(rs *routesrv.RouteServer) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/health", nil)
@@ -1124,4 +1133,50 @@ func TestEtagWithZoneAwareRoutingFallback(t *testing.T) {
 	etag2 := w2.Header().Get("Etag")
 
 	require.NotEqual(t, etag1, etag2, "Etag should change after routes update")
+}
+
+func TestZoneAwareRoutesGzip(t *testing.T) {
+	defer tl.Reset()
+
+	// 3 endpoints per zone — enough to populate zoneData
+	ks, _ := newKubeServer(t, loadKubeYAML(t, "testdata/zone-aware-traffic/all-zones-3-addr.yaml"))
+	ks.Start()
+	defer ks.Close()
+	rs := newRouteServerWithOptions(t, skipper.Options{
+		SourcePollTimeout:              pollInterval,
+		Kubernetes:                     true,
+		KubernetesURL:                  ks.URL,
+		KubernetesEnableEndpointslices: true,
+	})
+
+	rs.StartUpdates()
+	defer rs.StopUpdates()
+
+	require.NoError(t, tl.WaitFor(routesrv.LogRoutesInitialized, waitTimeout))
+
+	// plain request returns zone-filtered routes
+	want := parseEskipFixture(t, "testdata/zone-aware-traffic/all-zones-3-addr.eskip")
+
+	plainResponse := getZoneAwareRoutes(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, plainResponse.Code)
+	gotPlain, err := eskip.Parse(plainResponse.Body.String())
+	require.NoError(t, err)
+	require.True(t, eskip.EqLists(gotPlain, want))
+
+	// gzip request must also return zone-filtered routes, not the full set
+	gzipResponse := getZoneAwareRoutesGzip(rs, "eu-central-1a")
+	require.Equal(t, http.StatusOK, gzipResponse.Code)
+	require.Equal(t, "gzip", gzipResponse.Header().Get("Content-Encoding"))
+
+	zr, err := gzip.NewReader(gzipResponse.Body)
+	require.NoError(t, err)
+	defer zr.Close()
+
+	decompressed, err := io.ReadAll(zr)
+	require.NoError(t, err)
+
+	gotGzip, err := eskip.Parse(string(decompressed))
+	require.NoError(t, err)
+
+	require.True(t, eskip.EqLists(gotGzip, want))
 }


### PR DESCRIPTION
In routeSRV, when we serve zone aware routes after `zone: r.PathValue("zone")` we only update uncompressed data, while http.Client serves compressed data by default. Which made all requests land in `gzip` branch later.

And `gzip` branch is serving `zdata` which was never updated with the new routingTable.

This commit include a reproducer testcase and the fix is in the next commit.