### PR TITLE
fix: fatal at startup, if we can not create a valkey connection

### DIFF
--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -40,7 +40,7 @@ func NewSwarmRegistry(swarm Swarmer, ro *net.RedisOptions, vo *net.ValkeyOptions
 	if vo != nil {
 		reg, err := NewValkeySwarmRegistry(vo, settings...)
 		if err != nil {
-			log.Errorf("Failed to create valkey swarm registry: %v", err)
+			log.Fatalf("Failed to create valkey swarm registry: %v", err)
 		} else {
 			return reg
 		}


### PR DESCRIPTION
fix: fatal at startup, if we can not create a valkey connection, we should assume something is wrong, because we have this dependency