### PR TITLE
feat: add a flag to require dataclients to exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -129,24 +129,25 @@ type Config struct {
 	OpenTelemetry *otel.Options `yaml:"open-telemetry"`
 
 	// route sources:
-	EtcdUrls           string               `yaml:"etcd-urls"`
-	EtcdPrefix         string               `yaml:"etcd-prefix"`
-	EtcdTimeout        time.Duration        `yaml:"etcd-timeout"`
-	EtcdInsecure       bool                 `yaml:"etcd-insecure"`
-	EtcdOAuthToken     string               `yaml:"etcd-oauth-token"`
-	EtcdUsername       string               `yaml:"etcd-username"`
-	EtcdPassword       string               `yaml:"etcd-password"`
-	RoutesFile         string               `yaml:"routes-file"`
-	RoutesURLs         *listFlag            `yaml:"routes-urls"`
-	InlineRoutes       string               `yaml:"inline-routes"`
-	ForwardBackendURL  string               `yaml:"forward-backend-url"`
-	AppendFilters      *defaultFiltersFlags `yaml:"default-filters-append"`
-	PrependFilters     *defaultFiltersFlags `yaml:"default-filters-prepend"`
-	DisabledFilters    *listFlag            `yaml:"disabled-filters"`
-	EditRoute          routeChangerConfig   `yaml:"edit-route"`
-	CloneRoute         routeChangerConfig   `yaml:"clone-route"`
-	SourcePollTimeout  int64                `yaml:"source-poll-timeout"`
-	WaitFirstRouteLoad bool                 `yaml:"wait-first-route-load"`
+	EtcdUrls            string               `yaml:"etcd-urls"`
+	EtcdPrefix          string               `yaml:"etcd-prefix"`
+	EtcdTimeout         time.Duration        `yaml:"etcd-timeout"`
+	EtcdInsecure        bool                 `yaml:"etcd-insecure"`
+	EtcdOAuthToken      string               `yaml:"etcd-oauth-token"`
+	EtcdUsername        string               `yaml:"etcd-username"`
+	EtcdPassword        string               `yaml:"etcd-password"`
+	RoutesFile          string               `yaml:"routes-file"`
+	RoutesURLs          *listFlag            `yaml:"routes-urls"`
+	InlineRoutes        string               `yaml:"inline-routes"`
+	RequiredDataClients *listFlag            `yaml:"required-dataclients"`
+	ForwardBackendURL   string               `yaml:"forward-backend-url"`
+	AppendFilters       *defaultFiltersFlags `yaml:"default-filters-append"`
+	PrependFilters      *defaultFiltersFlags `yaml:"default-filters-prepend"`
+	DisabledFilters     *listFlag            `yaml:"disabled-filters"`
+	EditRoute           routeChangerConfig   `yaml:"edit-route"`
+	CloneRoute          routeChangerConfig   `yaml:"clone-route"`
+	SourcePollTimeout   int64                `yaml:"source-poll-timeout"`
+	WaitFirstRouteLoad  bool                 `yaml:"wait-first-route-load"`
 
 	// Forwarded headers
 	ForwardedHeadersList            *listFlag            `yaml:"forwarded-headers"`
@@ -385,6 +386,7 @@ func NewConfig() *Config {
 	cfg.EditRoute = routeChangerConfig{}
 	cfg.KubernetesEastWestRangeDomains = commaListFlag()
 	cfg.RoutesURLs = commaListFlag()
+	cfg.RequiredDataClients = commaListFlag("kubernetes", "etcd", "routesfile", "routesurls", "inlineroutes", "plugins")
 	cfg.ForwardedHeadersList = commaListFlag()
 	cfg.ForwardedHeadersExcludeCIDRList = commaListFlag()
 	cfg.CompressEncodings = commaListFlag("gzip", "deflate", "br", "zstd")
@@ -502,6 +504,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.RoutesFile, "routes-file", "", "file containing route definitions")
 	flag.Var(cfg.RoutesURLs, "routes-urls", "comma separated URLs to route definitions in eskip format")
 	flag.StringVar(&cfg.InlineRoutes, "inline-routes", "", "inline routes in eskip format")
+	flag.Var(cfg.RequiredDataClients, "required-dataclients", "comma-separated list of dataclients that must be configured at startup; valid values: kubernetes, etcd, routesfile, routesurls, inlineroutes, plugins")
 	flag.StringVar(&cfg.ForwardBackendURL, "forward-backend-url", "", "target url of the <forward> backend")
 	flag.Int64Var(&cfg.SourcePollTimeout, "source-poll-timeout", int64(3000), "polling timeout of the routing data sources, in milliseconds")
 	flag.Var(cfg.AppendFilters, "default-filters-append", "set of default filters to apply to append to all filters of all routes")
@@ -958,17 +961,18 @@ func (c *Config) ToOptions() skipper.Options {
 		OpenTelemetry: c.OpenTelemetry,
 
 		// route sources:
-		EtcdUrls:          eus,
-		EtcdPrefix:        c.EtcdPrefix,
-		EtcdWaitTimeout:   c.EtcdTimeout,
-		EtcdInsecure:      c.EtcdInsecure,
-		EtcdOAuthToken:    c.EtcdOAuthToken,
-		EtcdUsername:      c.EtcdUsername,
-		EtcdPassword:      c.EtcdPassword,
-		WatchRoutesFile:   c.RoutesFile,
-		RoutesURLs:        c.RoutesURLs.values,
-		InlineRoutes:      c.InlineRoutes,
-		ForwardBackendURL: c.ForwardBackendURL,
+		EtcdUrls:            eus,
+		EtcdPrefix:          c.EtcdPrefix,
+		EtcdWaitTimeout:     c.EtcdTimeout,
+		EtcdInsecure:        c.EtcdInsecure,
+		EtcdOAuthToken:      c.EtcdOAuthToken,
+		EtcdUsername:        c.EtcdUsername,
+		EtcdPassword:        c.EtcdPassword,
+		WatchRoutesFile:     c.RoutesFile,
+		RoutesURLs:          c.RoutesURLs.values,
+		InlineRoutes:        c.InlineRoutes,
+		RequiredDataClients: c.RequiredDataClients.values,
+		ForwardBackendURL:   c.ForwardBackendURL,
 		DefaultFilters: &eskip.DefaultFilters{
 			Prepend: c.PrependFilters.filters,
 			Append:  c.AppendFilters.filters,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -187,6 +187,7 @@ func defaultConfig(with func(*Config)) *Config {
 		ProxyAllowListCIDRs:                     commaListFlag(),
 		ProxyDenyListCIDRs:                      commaListFlag(),
 		ProxySkipListCIDRs:                      commaListFlag(),
+		RequiredDataClients:                     commaListFlag("kubernetes", "etcd", "routesfile", "routesurls", "inlineroutes", "plugins"),
 	}
 	with(cfg)
 	return cfg
@@ -642,6 +643,58 @@ func TestParseAnnotationConfigInvalid(t *testing.T) {
 				assert.Error(t, err)
 			})
 		}
+	})
+}
+
+func TestRequiredDataClientsFlag(t *testing.T) {
+	t.Run("valid single value parses correctly", func(t *testing.T) {
+		cfg := NewConfig()
+		err := cfg.ParseArgs("skipper", []string{"-required-dataclients=kubernetes"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"kubernetes"}, cfg.RequiredDataClients.values)
+	})
+
+	t.Run("valid comma-separated values parse correctly", func(t *testing.T) {
+		cfg := NewConfig()
+		err := cfg.ParseArgs("skipper", []string{"-required-dataclients=kubernetes,etcd"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"kubernetes", "etcd"}, cfg.RequiredDataClients.values)
+	})
+
+	t.Run("unknown value returns error when set directly", func(t *testing.T) {
+		lf := commaListFlag("kubernetes", "etcd", "routesfile", "routesurls", "inlineroutes", "plugins")
+		err := lf.Set("unknown")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value not allowed: unknown")
+	})
+
+	t.Run("ToOptions propagates values", func(t *testing.T) {
+		cfg := NewConfig()
+		err := cfg.ParseArgs("skipper", []string{"-required-dataclients=kubernetes,routesfile"})
+		require.NoError(t, err)
+		opts := cfg.ToOptions()
+		assert.Equal(t, []string{"kubernetes", "routesfile"}, opts.RequiredDataClients)
+	})
+
+	t.Run("YAML parses correctly", func(t *testing.T) {
+		var lf listFlag
+		lf.allowed = map[string]bool{
+			"kubernetes": true, "etcd": true, "routesfile": true,
+			"routesurls": true, "inlineroutes": true, "plugins": true,
+		}
+		err := yaml.Unmarshal([]byte("- kubernetes\n- etcd\n"), &lf)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"kubernetes", "etcd"}, lf.values)
+	})
+
+	t.Run("YAML with unknown value returns error", func(t *testing.T) {
+		var lf listFlag
+		lf.allowed = map[string]bool{
+			"kubernetes": true, "etcd": true,
+		}
+		err := yaml.Unmarshal([]byte("- unknown\n"), &lf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value not allowed: unknown")
 	})
 }
 

--- a/skipper.go
+++ b/skipper.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -471,6 +473,11 @@ type Options struct {
 
 	// Custom data clients to be used together with the default etcd and Innkeeper.
 	CustomDataClients []routing.DataClient
+
+	// RequiredDataClients lists dataclient names that must be configured at startup.
+	// Valid names: kubernetes, etcd, routesfile, routesurls, inlineroutes, plugins.
+	// If any listed dataclient is not active, skipper will refuse to start.
+	RequiredDataClients []string
 
 	// CustomHttpHandlerWrap provides ability to wrap http.Handler created by skipper.
 	// http.Handler is used for accepting incoming http requests.
@@ -1245,6 +1252,42 @@ func createDataClients(o Options, cr *certregistry.CertRegistry) ([]routing.Data
 	return clients, nil
 }
 
+func checkRequiredDataClients(o Options) error {
+	validDataClients := map[string]struct{}{
+		"kubernetes":   {},
+		"etcd":         {},
+		"routesfile":   {},
+		"routesurls":   {},
+		"inlineroutes": {},
+		"plugins":      {},
+	}
+
+	for _, name := range o.RequiredDataClients {
+		if _, ok := validDataClients[name]; !ok {
+			return fmt.Errorf("invalid dataclient name %q; accepted names: %s", name, strings.Join(slices.Sorted(maps.Keys(validDataClients)), ", "))
+		}
+		var active bool
+		switch name {
+		case "kubernetes":
+			active = o.Kubernetes
+		case "etcd":
+			active = len(o.EtcdUrls) > 0
+		case "routesfile":
+			active = o.WatchRoutesFile != ""
+		case "routesurls":
+			active = len(o.RoutesURLs) > 0
+		case "inlineroutes":
+			active = o.InlineRoutes != ""
+		case "plugins":
+			active = len(o.DataClientPlugins) > 0 || len(o.Plugins) > 0
+		}
+		if !active {
+			return fmt.Errorf("required dataclient %q is not configured", name)
+		}
+	}
+	return nil
+}
+
 func getLogOutput(name string) (io.Writer, error) {
 	name = path.Clean(name)
 
@@ -1750,6 +1793,10 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	// append custom data clients
 	dataClients = append(dataClients, o.CustomDataClients...)
+
+	if err := checkRequiredDataClients(o); err != nil {
+		return err
+	}
 
 	if len(dataClients) == 0 {
 		log.Warning("no route source specified")

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -630,3 +630,112 @@ func TestDataClients(t *testing.T) {
 
 	sigs <- syscall.SIGTERM
 }
+
+func TestCheckRequiredDataClients(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		opts    Options
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "empty required list",
+			opts:    Options{},
+			wantErr: false,
+		},
+		{
+			name:    "kubernetes required and configured",
+			opts:    Options{RequiredDataClients: []string{"kubernetes"}, Kubernetes: true},
+			wantErr: false,
+		},
+		{
+			name:    "kubernetes required but not configured",
+			opts:    Options{RequiredDataClients: []string{"kubernetes"}},
+			wantErr: true,
+			errMsg:  `required dataclient "kubernetes" is not configured`,
+		},
+		{
+			name:    "etcd required and configured",
+			opts:    Options{RequiredDataClients: []string{"etcd"}, EtcdUrls: []string{"http://127.0.0.1:2379"}},
+			wantErr: false,
+		},
+		{
+			name:    "etcd required but not configured",
+			opts:    Options{RequiredDataClients: []string{"etcd"}},
+			wantErr: true,
+			errMsg:  `required dataclient "etcd" is not configured`,
+		},
+		{
+			name:    "routesfile required and configured",
+			opts:    Options{RequiredDataClients: []string{"routesfile"}, WatchRoutesFile: "routes.eskip"},
+			wantErr: false,
+		},
+		{
+			name:    "routesfile required but not configured",
+			opts:    Options{RequiredDataClients: []string{"routesfile"}},
+			wantErr: true,
+			errMsg:  `required dataclient "routesfile" is not configured`,
+		},
+		{
+			name:    "routesurls required and configured",
+			opts:    Options{RequiredDataClients: []string{"routesurls"}, RoutesURLs: []string{"http://example.com/routes"}},
+			wantErr: false,
+		},
+		{
+			name:    "routesurls required but not configured",
+			opts:    Options{RequiredDataClients: []string{"routesurls"}},
+			wantErr: true,
+			errMsg:  `required dataclient "routesurls" is not configured`,
+		},
+		{
+			name:    "inlineroutes required and configured",
+			opts:    Options{RequiredDataClients: []string{"inlineroutes"}, InlineRoutes: `r: * -> <shunt>;`},
+			wantErr: false,
+		},
+		{
+			name:    "inlineroutes required but not configured",
+			opts:    Options{RequiredDataClients: []string{"inlineroutes"}},
+			wantErr: true,
+			errMsg:  `required dataclient "inlineroutes" is not configured`,
+		},
+		{
+			name:    "plugins required with dataclient plugins",
+			opts:    Options{RequiredDataClients: []string{"plugins"}, DataClientPlugins: [][]string{{"myplugin"}}},
+			wantErr: false,
+		},
+		{
+			name:    "plugins required but not configured",
+			opts:    Options{RequiredDataClients: []string{"plugins"}},
+			wantErr: true,
+			errMsg:  `required dataclient "plugins" is not configured`,
+		},
+		{
+			name:    "unknown dataclient name",
+			opts:    Options{RequiredDataClients: []string{"unknown"}},
+			wantErr: true,
+			errMsg:  `invalid dataclient name "unknown"`,
+		},
+		{
+			name:    "multiple required, all configured",
+			opts:    Options{RequiredDataClients: []string{"kubernetes", "etcd"}, Kubernetes: true, EtcdUrls: []string{"http://127.0.0.1:2379"}},
+			wantErr: false,
+		},
+		{
+			name:    "multiple required, one missing",
+			opts:    Options{RequiredDataClients: []string{"kubernetes", "etcd"}, Kubernetes: true},
+			wantErr: true,
+			errMsg:  `required dataclient "etcd" is not configured`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkRequiredDataClients(tt.opts)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}


### PR DESCRIPTION
Add an opt in flag to fatal if some dataclients are not configured. If the flag is set it will ensure that skipper doesn't start without this set of dataclients