### PR TITLE
feature: ensure-dataclient

### DIFF
--- a/cmd/skipper/main.go
+++ b/cmd/skipper/main.go
@@ -62,6 +62,6 @@ func main() {
 
 	log.SetLevel(cfg.ApplicationLogLevel)
 	if err := skipper.Run(cfg.ToOptions()); err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to start skipper: %v", err)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -147,6 +147,7 @@ type Config struct {
 	CloneRoute         routeChangerConfig   `yaml:"clone-route"`
 	SourcePollTimeout  int64                `yaml:"source-poll-timeout"`
 	WaitFirstRouteLoad bool                 `yaml:"wait-first-route-load"`
+	EnsureDataClients  *listFlag            `yaml:"ensure-dataclients"`
 
 	// Forwarded headers
 	ForwardedHeadersList            *listFlag            `yaml:"forwarded-headers"`
@@ -394,6 +395,7 @@ func NewConfig() *Config {
 	cfg.ProxyAllowListCIDRs = commaListFlag()
 	cfg.ProxyDenyListCIDRs = commaListFlag()
 	cfg.ProxySkipListCIDRs = commaListFlag()
+	cfg.EnsureDataClients = commaListFlag()
 
 	flag := flag.NewFlagSet("", flag.ExitOnError)
 	flag.StringVar(&cfg.ConfigFile, "config-file", "", "if provided the flags will be loaded/overwritten by the values on the file (yaml)")
@@ -510,6 +512,7 @@ func NewConfig() *Config {
 	flag.Var(&cfg.EditRoute, "edit-route", "match and edit filters and predicates of all routes")
 	flag.Var(&cfg.CloneRoute, "clone-route", "clone all matching routes and replace filters and predicates of all matched routes")
 	flag.BoolVar(&cfg.WaitFirstRouteLoad, "wait-first-route-load", false, "prevent starting the listener before the first batch of routes were loaded")
+	flag.Var(cfg.EnsureDataClients, "ensure-dataclients", `comma separated list of routing.NamedDataClient names: "etcd", "eskipfile-watch", "eskipfile-remote", "eskipfile", "inline", "kubernetes"`)
 
 	// Forwarded headers
 	flag.Var(cfg.ForwardedHeadersList, "forwarded-headers", "comma separated list of headers to add to the incoming request before routing\n"+
@@ -976,6 +979,7 @@ func (c *Config) ToOptions() skipper.Options {
 		DisabledFilters:    c.DisabledFilters.values,
 		SourcePollTimeout:  time.Duration(c.SourcePollTimeout) * time.Millisecond,
 		WaitFirstRouteLoad: c.WaitFirstRouteLoad,
+		EnsureDataClient:   c.EnsureDataClients.values,
 
 		// Kubernetes:
 		Kubernetes:                                     c.KubernetesIngress,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -132,6 +132,7 @@ func defaultConfig(with func(*Config)) *Config {
 		ApiUsageMonitoringClientKeys:            "sub",
 		ApiUsageMonitoringRealmsTrackingPattern: "services",
 		WaitForHealthcheckInterval:              45 * time.Second,
+		EnsureDataClients:                       commaListFlag(),
 		IdleConnsPerHost:                        64,
 		CloseIdleConnsPeriod:                    20 * time.Second,
 		BackendFlushInterval:                    20 * time.Millisecond,

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -372,6 +372,10 @@ func New(o Options) (*Client, error) {
 	}, nil
 }
 
+func (*Client) Name() string {
+	return "kubernetes"
+}
+
 func buildAPIURL(o Options) (string, error) {
 	if !o.KubernetesInCluster {
 		if o.KubernetesURL == "" {

--- a/dataclients/routestring/string.go
+++ b/dataclients/routestring/string.go
@@ -26,6 +26,10 @@ func New(r string) (routing.DataClient, error) {
 	return &routes{parsed: parsed}, nil
 }
 
+func (*routes) Name() string {
+	return "inline"
+}
+
 func (r *routes) LoadAll() ([]*eskip.Route, error) {
 	return r.parsed, nil
 }

--- a/eskipfile/file.go
+++ b/eskipfile/file.go
@@ -6,11 +6,13 @@ import (
 	"github.com/zalando/skipper/eskip"
 )
 
-// Client contains the route definitions from an eskip file, not implementing file watch. Use the Open function
-// to create instances of it.
+// Client contains the route definitions from an eskip file, if you
+// need file watch use WatchClient instead.
+//
+// Use the Open function to create instances of Client.
 type Client struct{ routes []*eskip.Route }
 
-// Opens an eskip file and parses it, returning a DataClient implementation. If reading or parsing the file
+// Open opens an eskip file and parses it, returning a DataClient implementation. If reading or parsing the file
 // fails, returns an error. This implementation doesn't provide file watch.
 func Open(path string) (*Client, error) {
 	content, err := os.ReadFile(path)
@@ -26,6 +28,10 @@ func Open(path string) (*Client, error) {
 	return &Client{routes}, nil
 }
 
+func (Client) Name() string {
+	return "eskipfile"
+}
+
 func (c Client) LoadAndParseAll() (routeInfos []*eskip.RouteInfo, err error) {
 	for _, route := range c.routes {
 		routeInfos = append(routeInfos, &eskip.RouteInfo{Route: *route})
@@ -36,5 +42,5 @@ func (c Client) LoadAndParseAll() (routeInfos []*eskip.RouteInfo, err error) {
 // LoadAll returns the parsed route definitions found in the file.
 func (c Client) LoadAll() ([]*eskip.Route, error) { return c.routes, nil }
 
-// LoadUpdate: noop. The current implementation doesn't support watching the eskip file for changes.
+// LoadUpdate is a noop.
 func (c Client) LoadUpdate() ([]*eskip.Route, []string, error) { return nil, nil, nil }

--- a/eskipfile/remote.go
+++ b/eskipfile/remote.go
@@ -96,6 +96,10 @@ func RemoteWatch(o *RemoteWatchOptions) (routing.DataClient, error) {
 	return dataClient, nil
 }
 
+func (*remoteEskipFile) Name() string {
+	return "eskipfile-remote"
+}
+
 // LoadAll returns the parsed route definitions found in the file.
 func (client *remoteEskipFile) LoadAll() ([]*eskip.Route, error) {
 	var err error = nil

--- a/eskipfile/watch.go
+++ b/eskipfile/watch.go
@@ -42,6 +42,10 @@ func Watch(name string) *WatchClient {
 	return c
 }
 
+func (*WatchClient) Name() string {
+	return "eskipfile-watch"
+}
+
 func mapRoutes(r []*eskip.Route) map[string]*eskip.Route {
 	m := make(map[string]*eskip.Route)
 	for i := range r {

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -161,6 +161,10 @@ func New(o Options) (*Client, error) {
 		password:   o.Password}, nil
 }
 
+func (*Client) Name() string {
+	return "etcd"
+}
+
 func isTimeout(err error) bool {
 	nerr, ok := err.(net.Error)
 	return ok && nerr.Timeout()

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -55,6 +55,14 @@ type DataClient interface {
 	LoadUpdate() ([]*eskip.Route, []string, error)
 }
 
+// NamedDataClient is like DataClient but has a name, which can be
+// used to EnsureDataClient or -ensure-dataclients.
+type NamedDataClient interface {
+	LoadAll() ([]*eskip.Route, error)
+	LoadUpdate() ([]*eskip.Route, []string, error)
+	Name() string
+}
+
 // Predicate instances are used as custom user defined route
 // matching predicates.
 type Predicate interface {

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -58,8 +58,7 @@ type DataClient interface {
 // NamedDataClient is like DataClient but has a name, which can be
 // used to EnsureDataClient or -ensure-dataclients.
 type NamedDataClient interface {
-	LoadAll() ([]*eskip.Route, error)
-	LoadUpdate() ([]*eskip.Route, []string, error)
+	DataClient
 	Name() string
 }
 

--- a/skipper.go
+++ b/skipper.go
@@ -1753,18 +1753,8 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	// append custom data clients
 	dataClients = append(dataClients, o.CustomDataClients...)
 
-	for _, s := range o.EnsureDataClient {
-		found := false
-		for _, client := range dataClients {
-			if ndc, ok := client.(routing.NamedDataClient); ok {
-				if ndc.Name() == s {
-					found = true
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("failed to find dataclient that was ensured: %q", s)
-		}
+	if err = ensureExpectedDataclients(o, dataClients); err != nil {
+		return err
 	}
 
 	if len(dataClients) == 0 {
@@ -2490,6 +2480,23 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	}
 
 	return listenAndServeQuit(o.CustomHttpHandlerWrap(proxy), &o, sig, idleConnsCH, mtr, cr)
+}
+
+func ensureExpectedDataclients(o Options, dataClients []routing.DataClient) error {
+	for _, s := range o.EnsureDataClient {
+		found := false
+		for _, client := range dataClients {
+			if ndc, ok := client.(routing.NamedDataClient); ok {
+				if ndc.Name() == s {
+					found = true
+				}
+			}
+		}
+		if !found {
+			return fmt.Errorf("failed to find dataclient that was ensured: %q", s)
+		}
+	}
+	return nil
 }
 
 // Run skipper.

--- a/skipper.go
+++ b/skipper.go
@@ -488,6 +488,8 @@ type Options struct {
 	// of routes were applied.
 	WaitFirstRouteLoad bool
 
+	EnsureDataClient []string
+
 	// SuppressRouteUpdateLogs indicates to log only summaries of the routing updates
 	// instead of full details of the updated/deleted routes.
 	SuppressRouteUpdateLogs bool
@@ -1240,6 +1242,20 @@ func createDataClients(o Options, cr *certregistry.CertRegistry) ([]routing.Data
 			return nil, fmt.Errorf("error while creating kubernetes data client: %w", err)
 		}
 		clients = append(clients, kubernetesClient)
+	}
+
+	for _, s := range o.EnsureDataClient {
+		found := false
+		for _, client := range clients {
+			if ndc, ok := client.(routing.NamedDataClient); ok {
+				if ndc.Name() == s {
+					found = true
+				}
+			}
+		}
+		if !found {
+			log.Fatalf("Failed to find dataclient that was ensured: %q", s)
+		}
 	}
 
 	return clients, nil

--- a/skipper.go
+++ b/skipper.go
@@ -1244,20 +1244,6 @@ func createDataClients(o Options, cr *certregistry.CertRegistry) ([]routing.Data
 		clients = append(clients, kubernetesClient)
 	}
 
-	for _, s := range o.EnsureDataClient {
-		found := false
-		for _, client := range clients {
-			if ndc, ok := client.(routing.NamedDataClient); ok {
-				if ndc.Name() == s {
-					found = true
-				}
-			}
-		}
-		if !found {
-			return nil, fmt.Errorf("failed to find dataclient that was ensured: %q", s)
-		}
-	}
-
 	return clients, nil
 }
 
@@ -1766,6 +1752,20 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	// append custom data clients
 	dataClients = append(dataClients, o.CustomDataClients...)
+
+	for _, s := range o.EnsureDataClient {
+		found := false
+		for _, client := range dataClients {
+			if ndc, ok := client.(routing.NamedDataClient); ok {
+				if ndc.Name() == s {
+					found = true
+				}
+			}
+		}
+		if !found {
+			return fmt.Errorf("failed to find dataclient that was ensured: %q", s)
+		}
+	}
 
 	if len(dataClients) == 0 {
 		log.Warning("no route source specified")

--- a/skipper.go
+++ b/skipper.go
@@ -1254,7 +1254,7 @@ func createDataClients(o Options, cr *certregistry.CertRegistry) ([]routing.Data
 			}
 		}
 		if !found {
-			log.Fatalf("Failed to find dataclient that was ensured: %q", s)
+			return nil, fmt.Errorf("failed to find dataclient that was ensured: %q", s)
 		}
 	}
 

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -811,11 +811,59 @@ func TestDataClients(t *testing.T) {
 			StatusChecks:                    []string{"http://127.0.0.1:8091/metrics", "http://127.0.0.1:8092"},
 		}
 
-		if _, err := createDataClients(o, nil); err != nil {
+		dcs, err := createDataClients(o, nil)
+		if err != nil {
+			t.Fatalf("Failed to createDataclients: %v", err)
+		}
+
+		fr := createFilterRegistry(
+			fscheduler.NewFifo(),
+			flog.NewDisableAccessLog(),
+			builtin.NewStatus(),
+			builtin.NewInlineContent(),
+		)
+		metrics := &metricstest.MockMetrics{}
+		reg := scheduler.RegistryWith(scheduler.Options{
+			Metrics:                metrics,
+			EnableRouteFIFOMetrics: true,
+		})
+		defer reg.Close()
+
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
+
+		// create LB in front of apiservers to be able to switch the data served by apiserver
+		ro := routing.Options{
+			SignalFirstLoad: true,
+			FilterRegistry:  fr,
+			DataClients:     dcs, //[]routing.DataClient{dc},
+			PostProcessors: []routing.PostProcessor{
+				loadbalancer.NewAlgorithmProvider(),
+				endpointRegistry,
+				reg,
+			},
+			SuppressLogs: true,
+		}
+		rt := routing.New(ro)
+		defer rt.Close()
+		<-rt.FirstLoad()
+		tracer := tracingtest.NewTracer()
+		pr := proxy.WithParams(proxy.Params{
+			Routing:     rt,
+			OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
+		})
+		defer pr.Close()
+		lb := stdlibhttptest.NewServer(pr)
+		defer lb.Close()
+
+		sigs := make(chan os.Signal, 1)
+		err = run(o, sigs, nil)
+		if err != nil {
 			t.Logf("Detected broken dataclient routes: %v", err)
 		} else {
 			t.Fatal(`Failed to detect broken dataclient routes "eskipfile"`)
 		}
+
 	})
 
 }

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -509,124 +509,313 @@ func createRoutesFile(route string) (string, error) {
 }
 
 func TestDataClients(t *testing.T) {
-	// routesfile
-	routesFileStatus := 201
-	routeStringFmt := `r%d: Path("/routes-file") -> disableAccessLog() -> status(%d) -> inlineContent("Got it") -> <shunt>;`
-	filePath, err := createRoutesFile(fmt.Sprintf(routeStringFmt, routesFileStatus, routesFileStatus))
-	if err != nil {
-		t.Fatalf("Failed to create routes file: %v", err)
-	}
-	defer os.Remove(filePath)
-
-	// application log
-	fdApp, err := os.CreateTemp("/tmp", "app_log_")
-	if err != nil {
-		t.Fatalf("Failed to create tempfile: %v", err)
-	}
-	defer fdApp.Close()
-
-	// access log
-	fdAccess, err := os.CreateTemp("/tmp", "access_log_")
-	if err != nil {
-		t.Fatalf("Failed to create tempfile: %v", err)
-	}
-	defer fdAccess.Close()
-
-	// run skipper proxy that we want to test
-	o := Options{
-		Address:                         ":8090",
-		EnableRatelimiters:              true,
-		SourcePollTimeout:               1500 * time.Millisecond,
-		WaitFirstRouteLoad:              true,
-		SuppressRouteUpdateLogs:         false,
-		MetricsListener:                 ":8091",
-		RoutesFile:                      filePath,
-		InlineRoutes:                    `healthz: Path("/healthz") -> status(200) -> inlineContent("OK") -> <shunt>;`,
-		ApplicationLogOutput:            fdApp.Name(),
-		AccessLogOutput:                 fdAccess.Name(),
-		AccessLogDisabled:               false,
-		MaxTCPListenerConcurrency:       0,
-		ExpectedBytesPerRequest:         1024,
-		ReadHeaderTimeoutServer:         0,
-		ReadTimeoutServer:               1 * time.Second,
-		MetricsFlavours:                 []string{"codahale"},
-		EnablePrometheusMetrics:         true,
-		LoadBalancerHealthCheckInterval: 3 * time.Second,
-		OAuthTokeninfoURL:               "http://127.0.0.1:12345",
-		CredentialsPaths:                []string{"/does-not-exist"},
-		CompressEncodings:               []string{"gzip"},
-		IgnoreTrailingSlash:             true,
-		EnableBreakers:                  true,
-		DebugListener:                   ":8092",
-		StatusChecks:                    []string{"http://127.0.0.1:8091/metrics", "http://127.0.0.1:8092"},
-	}
-
-	dcs, err := createDataClients(o, nil)
-	if err != nil {
-		t.Fatalf("Failed to createDataclients: %v", err)
-	}
-
-	fr := createFilterRegistry(
-		fscheduler.NewFifo(),
-		flog.NewDisableAccessLog(),
-		builtin.NewStatus(),
-		builtin.NewInlineContent(),
-	)
-	metrics := &metricstest.MockMetrics{}
-	reg := scheduler.RegistryWith(scheduler.Options{
-		Metrics:                metrics,
-		EnableRouteFIFOMetrics: true,
-	})
-	defer reg.Close()
-
-	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
-	defer endpointRegistry.Close()
-
-	// create LB in front of apiservers to be able to switch the data served by apiserver
-	ro := routing.Options{
-		SignalFirstLoad: true,
-		FilterRegistry:  fr,
-		DataClients:     dcs, //[]routing.DataClient{dc},
-		PostProcessors: []routing.PostProcessor{
-			loadbalancer.NewAlgorithmProvider(),
-			endpointRegistry,
-			reg,
-		},
-		SuppressLogs: true,
-	}
-	rt := routing.New(ro)
-	defer rt.Close()
-	<-rt.FirstLoad()
-	tracer := tracingtest.NewTracer()
-	pr := proxy.WithParams(proxy.Params{
-		Routing:     rt,
-		OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
-	})
-	defer pr.Close()
-	lb := stdlibhttptest.NewServer(pr)
-	defer lb.Close()
-
-	sigs := make(chan os.Signal, 1)
-	go run(o, sigs, nil)
-
-	for range 30 {
-		t.Logf("Waiting for proxy being ready")
-
-		rsp, _ := http.DefaultClient.Get("http://localhost:8090/healthz")
-		if rsp != nil && rsp.StatusCode == 200 {
-			break
+	t.Run("all dataclients work as expected", func(t *testing.T) {
+		// routesfile
+		routesFileStatus := 201
+		routeStringFmt := `r%d: Path("/routes-file") -> disableAccessLog() -> status(%d) -> inlineContent("Got it") -> <shunt>;`
+		filePath, err := createRoutesFile(fmt.Sprintf(routeStringFmt, routesFileStatus, routesFileStatus))
+		if err != nil {
+			t.Fatalf("Failed to create routes file: %v", err)
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
+		defer os.Remove(filePath)
 
-	rsp, err := http.DefaultClient.Get("http://localhost:8090/routes-file")
-	if err != nil {
-		t.Fatalf("Failed to GET routes file route: %v", err)
-	}
+		// application log
+		fdApp, err := os.CreateTemp("/tmp", "app_log_")
+		if err != nil {
+			t.Fatalf("Failed to create tempfile: %v", err)
+		}
+		defer fdApp.Close()
 
-	if rsp.StatusCode != routesFileStatus {
-		t.Fatalf("Failed to GET the status of routes file route: %d", rsp.StatusCode)
-	}
+		// access log
+		fdAccess, err := os.CreateTemp("/tmp", "access_log_")
+		if err != nil {
+			t.Fatalf("Failed to create tempfile: %v", err)
+		}
+		defer fdAccess.Close()
 
-	sigs <- syscall.SIGTERM
+		// run skipper proxy that we want to test
+		o := Options{
+			Address:                         ":8090",
+			EnableRatelimiters:              true,
+			SourcePollTimeout:               1500 * time.Millisecond,
+			WaitFirstRouteLoad:              true,
+			SuppressRouteUpdateLogs:         false,
+			MetricsListener:                 ":8091",
+			RoutesFile:                      filePath,
+			InlineRoutes:                    `healthz: Path("/healthz") -> status(200) -> inlineContent("OK") -> <shunt>;`,
+			ApplicationLogOutput:            fdApp.Name(),
+			AccessLogOutput:                 fdAccess.Name(),
+			AccessLogDisabled:               false,
+			MaxTCPListenerConcurrency:       0,
+			ExpectedBytesPerRequest:         1024,
+			ReadHeaderTimeoutServer:         0,
+			ReadTimeoutServer:               1 * time.Second,
+			MetricsFlavours:                 []string{"codahale"},
+			EnablePrometheusMetrics:         true,
+			LoadBalancerHealthCheckInterval: 3 * time.Second,
+			OAuthTokeninfoURL:               "http://127.0.0.1:12345",
+			CredentialsPaths:                []string{"/does-not-exist"},
+			CompressEncodings:               []string{"gzip"},
+			IgnoreTrailingSlash:             true,
+			EnableBreakers:                  true,
+			DebugListener:                   ":8092",
+			StatusChecks:                    []string{"http://127.0.0.1:8091/metrics", "http://127.0.0.1:8092"},
+		}
+
+		dcs, err := createDataClients(o, nil)
+		if err != nil {
+			t.Fatalf("Failed to createDataclients: %v", err)
+		}
+
+		fr := createFilterRegistry(
+			fscheduler.NewFifo(),
+			flog.NewDisableAccessLog(),
+			builtin.NewStatus(),
+			builtin.NewInlineContent(),
+		)
+		metrics := &metricstest.MockMetrics{}
+		reg := scheduler.RegistryWith(scheduler.Options{
+			Metrics:                metrics,
+			EnableRouteFIFOMetrics: true,
+		})
+		defer reg.Close()
+
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
+
+		// create LB in front of apiservers to be able to switch the data served by apiserver
+		ro := routing.Options{
+			SignalFirstLoad: true,
+			FilterRegistry:  fr,
+			DataClients:     dcs,
+			PostProcessors: []routing.PostProcessor{
+				loadbalancer.NewAlgorithmProvider(),
+				endpointRegistry,
+				reg,
+			},
+			SuppressLogs: true,
+		}
+		rt := routing.New(ro)
+		defer rt.Close()
+		<-rt.FirstLoad()
+		tracer := tracingtest.NewTracer()
+		pr := proxy.WithParams(proxy.Params{
+			Routing:     rt,
+			OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
+		})
+		defer pr.Close()
+		lb := stdlibhttptest.NewServer(pr)
+		defer lb.Close()
+
+		sigs := make(chan os.Signal, 1)
+		go run(o, sigs, nil)
+
+		for range 30 {
+			t.Logf("Waiting for proxy being ready")
+
+			rsp, _ := http.DefaultClient.Get("http://localhost:8090/healthz")
+			if rsp != nil && rsp.StatusCode == 200 {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		rsp, err := http.DefaultClient.Get("http://localhost:8090/routes-file")
+		if err != nil {
+			t.Fatalf("Failed to GET routes file route: %v", err)
+		}
+
+		if rsp.StatusCode != routesFileStatus {
+			t.Fatalf("Failed to GET the status of routes file route: %d", rsp.StatusCode)
+		}
+
+		sigs <- syscall.SIGTERM
+	})
+
+	t.Run("ensure all dataclients work as expected", func(t *testing.T) {
+		// routesfile
+		routesFileStatus := 201
+		routeStringFmt := `r%d: Path("/routes-file") -> disableAccessLog() -> status(%d) -> inlineContent("Got it") -> <shunt>;`
+		filePath, err := createRoutesFile(fmt.Sprintf(routeStringFmt, routesFileStatus, routesFileStatus))
+		if err != nil {
+			t.Fatalf("Failed to create routes file: %v", err)
+		}
+		defer os.Remove(filePath)
+
+		// application log
+		fdApp, err := os.CreateTemp("/tmp", "app_log_")
+		if err != nil {
+			t.Fatalf("Failed to create tempfile: %v", err)
+		}
+		defer fdApp.Close()
+
+		// access log
+		fdAccess, err := os.CreateTemp("/tmp", "access_log_")
+		if err != nil {
+			t.Fatalf("Failed to create tempfile: %v", err)
+		}
+		defer fdAccess.Close()
+
+		// run skipper proxy that we want to test
+		o := Options{
+			EnsureDataClient:                []string{"inline", "eskipfile"},
+			Address:                         ":8090",
+			EnableRatelimiters:              true,
+			SourcePollTimeout:               1500 * time.Millisecond,
+			WaitFirstRouteLoad:              true,
+			SuppressRouteUpdateLogs:         false,
+			MetricsListener:                 ":8091",
+			RoutesFile:                      filePath,
+			InlineRoutes:                    `healthz: Path("/healthz") -> status(200) -> inlineContent("OK") -> <shunt>;`,
+			ApplicationLogOutput:            fdApp.Name(),
+			AccessLogOutput:                 fdAccess.Name(),
+			AccessLogDisabled:               false,
+			MaxTCPListenerConcurrency:       0,
+			ExpectedBytesPerRequest:         1024,
+			ReadHeaderTimeoutServer:         0,
+			ReadTimeoutServer:               1 * time.Second,
+			MetricsFlavours:                 []string{"prometheus"},
+			EnablePrometheusMetrics:         true,
+			LoadBalancerHealthCheckInterval: 3 * time.Second,
+			OAuthTokeninfoURL:               "http://127.0.0.1:12345",
+			CredentialsPaths:                []string{"/does-not-exist"},
+			CompressEncodings:               []string{"gzip"},
+			IgnoreTrailingSlash:             true,
+			EnableBreakers:                  true,
+			DebugListener:                   ":8092",
+			StatusChecks:                    []string{"http://127.0.0.1:8091/metrics", "http://127.0.0.1:8092"},
+		}
+
+		dcs, err := createDataClients(o, nil)
+		if err != nil {
+			t.Fatalf("Failed to createDataclients: %v", err)
+		}
+
+		fr := createFilterRegistry(
+			fscheduler.NewFifo(),
+			flog.NewDisableAccessLog(),
+			builtin.NewStatus(),
+			builtin.NewInlineContent(),
+		)
+		metrics := &metricstest.MockMetrics{}
+		reg := scheduler.RegistryWith(scheduler.Options{
+			Metrics:                metrics,
+			EnableRouteFIFOMetrics: true,
+		})
+		defer reg.Close()
+
+		endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+		defer endpointRegistry.Close()
+
+		// create LB in front of apiservers to be able to switch the data served by apiserver
+		ro := routing.Options{
+			SignalFirstLoad: true,
+			FilterRegistry:  fr,
+			DataClients:     dcs, //[]routing.DataClient{dc},
+			PostProcessors: []routing.PostProcessor{
+				loadbalancer.NewAlgorithmProvider(),
+				endpointRegistry,
+				reg,
+			},
+			SuppressLogs: true,
+		}
+		rt := routing.New(ro)
+		defer rt.Close()
+		<-rt.FirstLoad()
+		tracer := tracingtest.NewTracer()
+		pr := proxy.WithParams(proxy.Params{
+			Routing:     rt,
+			OpenTracing: &proxy.OpenTracingParams{Tracer: tracer},
+		})
+		defer pr.Close()
+		lb := stdlibhttptest.NewServer(pr)
+		defer lb.Close()
+
+		sigs := make(chan os.Signal, 1)
+		go run(o, sigs, nil)
+
+		for range 30 {
+			t.Logf("Waiting for proxy being ready")
+
+			rsp, _ := http.DefaultClient.Get("http://localhost:8090/healthz")
+			if rsp != nil && rsp.StatusCode == 200 {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		rsp, err := http.DefaultClient.Get("http://localhost:8090/routes-file")
+		if err != nil {
+			t.Fatalf("Failed to GET routes file route: %v", err)
+		}
+
+		if rsp.StatusCode != routesFileStatus {
+			t.Fatalf("Failed to GET the status of routes file route: %d", rsp.StatusCode)
+		}
+
+		sigs <- syscall.SIGTERM
+	})
+
+	t.Run("ensure fail if dataclients do not work as expected", func(t *testing.T) {
+		// routesfile
+		routesFileStatus := 201
+		routeStringFmt := `r%d: Path("/routes-file") -> disableAccessLog() -> status(%d) -> inlineContent("Got it") -> <shunt>;`
+		filePath, err := createRoutesFile(fmt.Sprintf(routeStringFmt, routesFileStatus, routesFileStatus))
+		if err != nil {
+			t.Fatalf("Failed to create routes file: %v", err)
+		}
+		defer os.Remove(filePath)
+
+		// application log
+		fdApp, err := os.CreateTemp("/tmp", "app_log_")
+		if err != nil {
+			t.Fatalf("Failed to create tempfile: %v", err)
+		}
+		defer fdApp.Close()
+
+		// access log
+		fdAccess, err := os.CreateTemp("/tmp", "access_log_")
+		if err != nil {
+			t.Fatalf("Failed to create tempfile: %v", err)
+		}
+		defer fdAccess.Close()
+
+		// run skipper proxy that we want to test
+		o := Options{
+			EnsureDataClient:        []string{"inline", "eskipfile"},
+			Address:                 ":8090",
+			EnableRatelimiters:      true,
+			SourcePollTimeout:       1500 * time.Millisecond,
+			WaitFirstRouteLoad:      true,
+			SuppressRouteUpdateLogs: false,
+			MetricsListener:         ":8091",
+			// broken route-file
+			// RoutesFile:                      filePath,
+			InlineRoutes:                    `healthz: Path("/healthz") -> status(200) -> inlineContent("OK") -> <shunt>;`,
+			ApplicationLogOutput:            fdApp.Name(),
+			AccessLogOutput:                 fdAccess.Name(),
+			AccessLogDisabled:               false,
+			MaxTCPListenerConcurrency:       0,
+			ExpectedBytesPerRequest:         1024,
+			ReadHeaderTimeoutServer:         0,
+			ReadTimeoutServer:               1 * time.Second,
+			MetricsFlavours:                 []string{"prometheus"},
+			EnablePrometheusMetrics:         true,
+			LoadBalancerHealthCheckInterval: 3 * time.Second,
+			OAuthTokeninfoURL:               "http://127.0.0.1:12345",
+			CredentialsPaths:                []string{"/does-not-exist"},
+			CompressEncodings:               []string{"gzip"},
+			IgnoreTrailingSlash:             true,
+			EnableBreakers:                  true,
+			DebugListener:                   ":8092",
+			StatusChecks:                    []string{"http://127.0.0.1:8091/metrics", "http://127.0.0.1:8092"},
+		}
+
+		if _, err := createDataClients(o, nil); err != nil {
+			t.Logf("Detected broken dataclient routes: %v", err)
+		} else {
+			t.Fatal(`Failed to detect broken dataclient routes "eskipfile"`)
+		}
+	})
+
 }


### PR DESCRIPTION
The new flag -ensure-dataclient="inline,kubernetes,.." can be used to ensure that specific dataclients were created. This makes sense to use if you have templated configuration files and you want to make sure a given dataclient will be started.

Good:
```
% ./bin/skipper -inline-routes='r: * -> status(201) -> <shunt>' -address :9002 -ensure-dataclients "inline"
[APP]INFO[0000] Expose metrics in codahale format
[APP]INFO[0000] enable swarm: false
[APP]INFO[0000] Replacing tee filter specification
[APP]INFO[0000] Replacing teenf filter specification
[APP]INFO[0000] Replacing teeResponse filter specification
[APP]INFO[0000] route settings, reset, route: r: * -> status(201) -> <shunt>
[APP]INFO[0000] route settings received, id: 1
[APP]INFO[0000] route settings applied, id: 1
[APP]INFO[0000] support listener on :9911
[APP]INFO[0000] Dataclients are updated once, first load complete
[APP]INFO[0000] Listen on :9002
[APP]INFO[0000] TLS settings not found, defaulting to HTTP
```

Bad:
```
% ./bin/skipper -inline-routes='r: * -> status(201) -> <shunt>' -address :9002 -ensure-dataclients "kubernetes"
[APP]INFO[0000] Expose metrics in codahale format
[APP]FATA[0000] Failed to start skipper: failed to find dataclient that was ensured: "kubernetes"
zsh: exit 1
```