### PR TITLE
feature: add cache() HTTP response caching filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -3681,3 +3681,96 @@ pr: Path("/products/:productId")
 ```
 consistentHashBalanceFactor(3)
 ```
+
+## Caching
+
+### cache
+
+Caches HTTP responses in a shared in-memory LRU store. Operates in two modes
+selected by the number of arguments.
+
+**RFC mode** (zero arguments): upstream `Cache-Control` is fully authoritative.
+Freshness, `no-store`, `private`, `Vary`, `s-maxage`, heuristic TTL
+(RFC 9111 §4.2.2), and conditional revalidation (`ETag`/`Last-Modified`) are
+all honoured.
+
+**Force mode** (3–5 arguments): operator TTL is authoritative; upstream
+`Cache-Control` freshness directives are ignored. Semantic blockers (`no-store`,
+`private`) are respected in RFC mode but ignored in force mode.
+
+Stale-while-revalidate (SWR): a stale entry within the SWR window is served
+immediately while a background fetch refreshes the entry. Concurrent cold-miss
+requests for the same key are coalesced into a single upstream fetch.
+
+Unsafe methods (`POST`, `PUT`, `DELETE`, `PATCH`) invalidate the cached entry on
+success. `HEAD 200` freshens stored headers without replacing the body.
+
+Parameters (force mode):
+
+* `ttl` – freshness duration for 200 responses (string, e.g. `"5m"`)
+* `errorTTL` – freshness duration for 404/5xx responses (string)
+* `swrWindow` – stale-while-revalidate window after TTL expires (string)
+* `staleIfError` – optional; how long a stale entry may be served on upstream
+  5xx (string, RFC 5861)
+* `keyHeaders` – optional; comma-separated request header names folded into the
+  cache key for per-header isolation (string, e.g. `"Authorization,X-Tenant-ID"`)
+
+Examples:
+
+RFC mode — upstream `Cache-Control` is authoritative:
+
+```
+-> cache() -> "https://cdn.example.org"
+```
+
+Force mode — 5 minute TTL, 15 second error TTL, 30 second SWR window:
+
+```
+-> cache("5m", "15s", "30s") -> "https://cdn.example.org"
+```
+
+Force mode with stale-if-error fallback:
+
+```
+-> cache("5m", "15s", "30s", "60s") -> "https://cdn.example.org"
+```
+
+Force mode with per-tenant cache key isolation:
+
+```
+-> cache("5m", "15s", "30s", "0s", "X-Tenant-ID") -> "https://cdn.example.org"
+```
+
+**Cache key**
+
+The key is derived from route ID + HTTP method + host + path + query string.
+Route ID is included so entries from different routes never collide when sharing
+the same storage instance. Additional request headers can be folded in via
+`keyHeaders`. Without `keyHeaders`, all requests to the same path share one
+cache entry regardless of caller identity.
+
+**Safety**
+
+The filter stores whatever the upstream returns and serves it to any request
+matching the same key. It has no awareness of other filters in the chain.
+
+* **Only use on routes where the response is identical for all callers** —
+  public CMS content, unauthenticated APIs, static assets.
+* **Do not use on routes that return user-specific data or set user-scoped
+  cookies** — those responses will be served to other users.
+* **`Authorization` is not in the key by default.** Requests from different
+  users hitting the same path share a cache entry unless `Authorization` is
+  added to `keyHeaders` or stripped before the filter.
+* **`Cache-Control: private` is ignored in force mode.** Audit the upstream
+  response before enabling force mode on any authenticated route.
+
+!!! note
+    The LRU store is shared across all `cache()` filter instances created from
+    the same spec. The storage budget is divided evenly across 256 internal
+    shards; a single entry larger than one shard's budget is dropped with a
+    warning log.
+
+!!! note
+    `s-maxage` implies `proxy-revalidate` per RFC 9111 §5.2.2.10: stale entries
+    stored under `s-maxage` are never served without revalidation, regardless of
+    the SWR window.

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -3743,7 +3743,8 @@ Force mode with per-tenant cache key isolation:
 
 **Cache key**
 
-The key is derived from route ID + HTTP method + host + path + query string.
+The key is derived from route ID + HTTP method + host + path + query string,
+hashed with SHA-256 for uniform shard distribution.
 Route ID is included so entries from different routes never collide when sharing
 the same storage instance. Additional request headers can be folded in via
 `keyHeaders`. Without `keyHeaders`, all requests to the same path share one
@@ -3758,17 +3759,24 @@ matching the same key. It has no awareness of other filters in the chain.
   public CMS content, unauthenticated APIs, static assets.
 * **Do not use on routes that return user-specific data or set user-scoped
   cookies** — those responses will be served to other users.
-* **`Authorization` is not in the key by default.** Requests from different
-  users hitting the same path share a cache entry unless `Authorization` is
-  added to `keyHeaders` or stripped before the filter.
+* **`Authorization` is not in the key by default.** Responses are stored and
+  served without regard to caller identity. To isolate per-user responses, add
+  `Authorization` to `keyHeaders`; without it, a response stored for one user
+  will be served to all others on the same path.
 * **`Cache-Control: private` is ignored in force mode.** Audit the upstream
   response before enabling force mode on any authenticated route.
 
 !!! note
-    The LRU store is shared across all `cache()` filter instances created from
-    the same spec. The storage budget is divided evenly across 256 internal
-    shards; a single entry larger than one shard's budget is dropped with a
-    warning log.
+    The LRU store is shared across all `cache()` filter instances. The storage
+    budget is divided evenly across 256 internal shards; a single entry larger
+    than one shard's budget is dropped with a warning log.
+
+!!! note
+    Three metrics track LRU behaviour: `lru_eviction` (counter, incremented each
+    time an entry is evicted due to memory pressure), `lru_bytes` (gauge,
+    updated on every eviction to reflect current storage usage in bytes), and
+    `lru_oversized` (counter, incremented when an entry is too large to fit in
+    any shard and is silently dropped).
 
 !!! note
     `s-maxage` implies `proxy-revalidate` per RFC 9111 §5.2.2.10: stale entries

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -3694,6 +3694,13 @@ Freshness, `no-store`, `private`, `Vary`, `s-maxage`, heuristic TTL
 (RFC 9111 §4.2.2), and conditional revalidation (`ETag`/`Last-Modified`) are
 all honoured.
 
+Request `Cache-Control` directives partially honoured: `no-store`, `no-cache`
+(including `max-age=0`), `only-if-cached`, `max-stale`, and `min-fresh`.
+Client `max-age` with non-zero values is not enforced — use `no-cache` to force
+revalidation. Per RFC 9111 §5.2.1, request directives are advisory (`MAY`) for
+shared caches; ignoring client `max-age` prevents cache-bypass abuse on shared
+routes.
+
 **Force mode** (3–5 arguments): operator TTL is authoritative; upstream
 `Cache-Control` freshness directives are ignored. Semantic blockers (`no-store`,
 `private`) are respected in RFC mode but ignored in force mode.

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -3691,13 +3691,13 @@ selected by the number of arguments.
 
 **RFC mode** (zero arguments): upstream `Cache-Control` is fully authoritative.
 Freshness, `no-store`, `private`, `Vary`, `s-maxage`, heuristic TTL
-(RFC 9111 §4.2.2), and conditional revalidation (`ETag`/`Last-Modified`) are
+([RFC 9111 §4.2.2](https://www.rfc-editor.org/rfc/rfc9111#section-4.2.2)), and conditional revalidation (`ETag`/`Last-Modified`) are
 all honoured.
 
 Request `Cache-Control` directives partially honoured: `no-store`, `no-cache`
 (including `max-age=0`), `only-if-cached`, `max-stale`, and `min-fresh`.
 Client `max-age` with non-zero values is not enforced — use `no-cache` to force
-revalidation. Per RFC 9111 §5.2.1, request directives are advisory (`MAY`) for
+revalidation. Per [RFC 9111 §5.2.1](https://www.rfc-editor.org/rfc/rfc9111#section-5.2.1), request directives are advisory (`MAY`) for
 shared caches; ignoring client `max-age` prevents cache-bypass abuse on shared
 routes.
 
@@ -3718,7 +3718,7 @@ Parameters (force mode):
 * `errorTTL` – freshness duration for 404/5xx responses (string)
 * `swrWindow` – stale-while-revalidate window after TTL expires (string)
 * `staleIfError` – optional; how long a stale entry may be served on upstream
-  5xx (string, RFC 5861)
+  5xx (string, [RFC 5861](https://www.rfc-editor.org/rfc/rfc5861))
 * `keyHeaders` – optional; comma-separated request header names folded into the
   cache key for per-header isolation (string, e.g. `"Authorization,X-Tenant-ID"`)
 
@@ -3786,6 +3786,6 @@ matching the same key. It has no awareness of other filters in the chain.
     any shard and is silently dropped).
 
 !!! note
-    `s-maxage` implies `proxy-revalidate` per RFC 9111 §5.2.2.10: stale entries
+    `s-maxage` implies `proxy-revalidate` per [RFC 9111 §5.2.2.10](https://www.rfc-editor.org/rfc/rfc9111#section-5.2.2.10): stale entries
     stored under `s-maxage` are never served without revalidation, regardless of
     the SWR window.

--- a/filters/cache/cache_control.go
+++ b/filters/cache/cache_control.go
@@ -1,29 +1,34 @@
 package cache
 
 import (
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 )
 
 type cacheDirectives struct {
-	NoStore        bool
-	NoCache        bool
-	Private        bool
-	MustRevalidate bool
-	Public         bool
-	SMaxAge        *time.Duration // RFC 9111 §5.2.2.10; nil means not present
+	NoStore         bool
+	NoCache         bool
+	Private         bool
+	MustRevalidate  bool
+	ProxyRevalidate bool
+	Public          bool
+	MaxAge          int64 // -1 = not present; 0 means max-age=0
+	SMaxAge         int64 // -1 = not present
 }
 
 type requestCacheDirectives struct {
 	NoStore      bool
-	NoCache      bool // includes max-age=0
+	NoCache      bool  // includes max-age=0
 	OnlyIfCached bool
+	MaxStale     int64 // -1 = not present; >= 0 = max staleness seconds client accepts
+	MinFresh     int64 // -1 = not present; >= 0 = min remaining freshness seconds required
 }
 
+// parseRequestCacheControl parses Cache-Control request directives from h.
 func parseRequestCacheControl(h http.Header) requestCacheDirectives {
-	var d requestCacheDirectives
+	d := requestCacheDirectives{MaxStale: -1, MinFresh: -1}
 	for _, line := range h.Values("Cache-Control") {
 		for token := range strings.SplitSeq(line, ",") {
 			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
@@ -39,6 +44,20 @@ func parseRequestCacheControl(h http.Header) requestCacheDirectives {
 				}
 			case "only-if-cached":
 				d.OnlyIfCached = true
+			case "max-stale":
+				if len(parts) == 2 {
+					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil && v >= 0 {
+						d.MaxStale = v
+					}
+				} else {
+					d.MaxStale = math.MaxInt32 // ~68 years; safe upper bound for *time.Second conversion
+				}
+			case "min-fresh":
+				if len(parts) == 2 {
+					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil && v >= 0 {
+						d.MinFresh = v
+					}
+				}
 			}
 		}
 	}
@@ -47,9 +66,9 @@ func parseRequestCacheControl(h http.Header) requestCacheDirectives {
 
 // parseCacheControl parses Cache-Control response directives from h.
 // Uses Header.Values to handle multiple header lines; matches names
-// case-insensitively per RFC 7234 §5.2.
+// case-insensitively per RFC 9111 §5.2.
 func parseCacheControl(h http.Header) cacheDirectives {
-	var d cacheDirectives
+	d := cacheDirectives{MaxAge: -1, SMaxAge: -1}
 	for _, line := range h.Values("Cache-Control") {
 		for token := range strings.SplitSeq(line, ",") {
 			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
@@ -63,13 +82,20 @@ func parseCacheControl(h http.Header) cacheDirectives {
 				d.Private = true
 			case "must-revalidate":
 				d.MustRevalidate = true
+			case "proxy-revalidate":
+				d.ProxyRevalidate = true
 			case "public":
 				d.Public = true
+			case "max-age":
+				if len(parts) == 2 {
+					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil {
+						d.MaxAge = v
+					}
+				}
 			case "s-maxage":
 				if len(parts) == 2 {
-					if secs, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil && secs >= 0 {
-						v := time.Duration(secs) * time.Second
-						d.SMaxAge = &v
+					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil {
+						d.SMaxAge = v
 					}
 				}
 			}

--- a/filters/cache/cache_control.go
+++ b/filters/cache/cache_control.go
@@ -1,0 +1,79 @@
+package cache
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type cacheDirectives struct {
+	NoStore        bool
+	NoCache        bool
+	Private        bool
+	MustRevalidate bool
+	Public         bool
+	SMaxAge        *time.Duration // RFC 9111 §5.2.2.10; nil means not present
+}
+
+type requestCacheDirectives struct {
+	NoStore      bool
+	NoCache      bool // includes max-age=0
+	OnlyIfCached bool
+}
+
+func parseRequestCacheControl(h http.Header) requestCacheDirectives {
+	var d requestCacheDirectives
+	for _, line := range h.Values("Cache-Control") {
+		for token := range strings.SplitSeq(line, ",") {
+			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
+			directive := strings.ToLower(strings.TrimSpace(parts[0]))
+			switch directive {
+			case "no-store":
+				d.NoStore = true
+			case "no-cache":
+				d.NoCache = true
+			case "max-age":
+				if len(parts) == 2 && strings.TrimSpace(parts[1]) == "0" {
+					d.NoCache = true
+				}
+			case "only-if-cached":
+				d.OnlyIfCached = true
+			}
+		}
+	}
+	return d
+}
+
+// parseCacheControl parses Cache-Control response directives from h.
+// Uses Header.Values to handle multiple header lines; matches names
+// case-insensitively per RFC 7234 §5.2.
+func parseCacheControl(h http.Header) cacheDirectives {
+	var d cacheDirectives
+	for _, line := range h.Values("Cache-Control") {
+		for token := range strings.SplitSeq(line, ",") {
+			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
+			directive := strings.ToLower(strings.TrimSpace(parts[0]))
+			switch directive {
+			case "no-store":
+				d.NoStore = true
+			case "no-cache":
+				d.NoCache = true
+			case "private":
+				d.Private = true
+			case "must-revalidate":
+				d.MustRevalidate = true
+			case "public":
+				d.Public = true
+			case "s-maxage":
+				if len(parts) == 2 {
+					if secs, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil && secs >= 0 {
+						v := time.Duration(secs) * time.Second
+						d.SMaxAge = &v
+					}
+				}
+			}
+		}
+	}
+	return d
+}

--- a/filters/cache/cache_control.go
+++ b/filters/cache/cache_control.go
@@ -20,7 +20,7 @@ type cacheDirectives struct {
 
 type requestCacheDirectives struct {
 	NoStore      bool
-	NoCache      bool  // includes max-age=0
+	NoCache      bool // includes max-age=0
 	OnlyIfCached bool
 	MaxStale     int64 // -1 = not present; >= 0 = max staleness seconds client accepts
 	MinFresh     int64 // -1 = not present; >= 0 = min remaining freshness seconds required

--- a/filters/cache/cache_control.go
+++ b/filters/cache/cache_control.go
@@ -8,54 +8,54 @@ import (
 )
 
 type cacheDirectives struct {
-	NoStore         bool
-	NoCache         bool
-	Private         bool
-	MustRevalidate  bool
-	ProxyRevalidate bool
-	Public          bool
-	MaxAge          int64 // -1 = not present; 0 means max-age=0
-	SMaxAge         int64 // -1 = not present
+	noStore         bool
+	noCache         bool
+	private         bool
+	mustRevalidate  bool
+	proxyRevalidate bool
+	public          bool
+	maxAge          int64 // -1 = not present; 0 means max-age=0
+	sMaxAge         int64 // -1 = not present
 }
 
 type requestCacheDirectives struct {
-	NoStore      bool
-	NoCache      bool // includes max-age=0
-	OnlyIfCached bool
-	MaxStale     int64 // -1 = not present; >= 0 = max staleness seconds client accepts
-	MinFresh     int64 // -1 = not present; >= 0 = min remaining freshness seconds required
+	noStore      bool
+	noCache      bool // includes max-age=0
+	onlyIfCached bool
+	maxStale     int64 // -1 = not present; >= 0 = max staleness seconds client accepts
+	minFresh     int64 // -1 = not present; >= 0 = min remaining freshness seconds required
 }
 
 // parseRequestCacheControl parses Cache-Control request directives from h.
 func parseRequestCacheControl(h http.Header) requestCacheDirectives {
-	d := requestCacheDirectives{MaxStale: -1, MinFresh: -1}
+	d := requestCacheDirectives{maxStale: -1, minFresh: -1}
 	for _, line := range h.Values("Cache-Control") {
 		for token := range strings.SplitSeq(line, ",") {
 			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
 			directive := strings.ToLower(strings.TrimSpace(parts[0]))
 			switch directive {
 			case "no-store":
-				d.NoStore = true
+				d.noStore = true
 			case "no-cache":
-				d.NoCache = true
+				d.noCache = true
 			case "max-age":
 				if len(parts) == 2 && strings.TrimSpace(parts[1]) == "0" {
-					d.NoCache = true
+					d.noCache = true
 				}
 			case "only-if-cached":
-				d.OnlyIfCached = true
+				d.onlyIfCached = true
 			case "max-stale":
 				if len(parts) == 2 {
 					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil && v >= 0 {
-						d.MaxStale = v
+						d.maxStale = v
 					}
 				} else {
-					d.MaxStale = math.MaxInt32 // ~68 years; safe upper bound for *time.Second conversion
+					d.maxStale = math.MaxInt32 // ~68 years; safe upper bound for *time.Second conversion
 				}
 			case "min-fresh":
 				if len(parts) == 2 {
 					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil && v >= 0 {
-						d.MinFresh = v
+						d.minFresh = v
 					}
 				}
 			}
@@ -68,34 +68,34 @@ func parseRequestCacheControl(h http.Header) requestCacheDirectives {
 // Uses Header.Values to handle multiple header lines; matches names
 // case-insensitively per RFC 9111 §5.2.
 func parseCacheControl(h http.Header) cacheDirectives {
-	d := cacheDirectives{MaxAge: -1, SMaxAge: -1}
+	d := cacheDirectives{maxAge: -1, sMaxAge: -1}
 	for _, line := range h.Values("Cache-Control") {
 		for token := range strings.SplitSeq(line, ",") {
 			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
 			directive := strings.ToLower(strings.TrimSpace(parts[0]))
 			switch directive {
 			case "no-store":
-				d.NoStore = true
+				d.noStore = true
 			case "no-cache":
-				d.NoCache = true
+				d.noCache = true
 			case "private":
-				d.Private = true
+				d.private = true
 			case "must-revalidate":
-				d.MustRevalidate = true
+				d.mustRevalidate = true
 			case "proxy-revalidate":
-				d.ProxyRevalidate = true
+				d.proxyRevalidate = true
 			case "public":
-				d.Public = true
+				d.public = true
 			case "max-age":
 				if len(parts) == 2 {
 					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil {
-						d.MaxAge = v
+						d.maxAge = v
 					}
 				}
 			case "s-maxage":
 				if len(parts) == 2 {
 					if v, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil {
-						d.SMaxAge = v
+						d.sMaxAge = v
 					}
 				}
 			}

--- a/filters/cache/cache_control_test.go
+++ b/filters/cache/cache_control_test.go
@@ -46,16 +46,17 @@ func TestParseCacheControl(t *testing.T) {
 		header http.Header
 		want   cacheDirectives
 	}{
-		{"no-store", http.Header{"Cache-Control": {"no-store"}}, cacheDirectives{NoStore: true}},
-		{"no-cache", http.Header{"Cache-Control": {"no-cache"}}, cacheDirectives{NoCache: true}},
-		{"private", http.Header{"Cache-Control": {"private"}}, cacheDirectives{Private: true}},
-		{"must-revalidate", http.Header{"Cache-Control": {"must-revalidate"}}, cacheDirectives{MustRevalidate: true}},
-		{"comma-separated", http.Header{"Cache-Control": {"no-store, must-revalidate"}}, cacheDirectives{NoStore: true, MustRevalidate: true}},
-		{"multiple lines", http.Header{"Cache-Control": {"no-cache", "must-revalidate"}}, cacheDirectives{NoCache: true, MustRevalidate: true}},
-		{"case-insensitive", http.Header{"Cache-Control": {"NO-STORE"}}, cacheDirectives{NoStore: true}},
-		{"value suffix stripped", http.Header{"Cache-Control": {`no-cache="x-private"`}}, cacheDirectives{NoCache: true}},
-		{"empty", http.Header{}, cacheDirectives{}},
-		{"unrelated directive", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{}},
+		{"no-store", http.Header{"Cache-Control": {"no-store"}}, cacheDirectives{NoStore: true, MaxAge: -1, SMaxAge: -1}},
+		{"no-cache", http.Header{"Cache-Control": {"no-cache"}}, cacheDirectives{NoCache: true, MaxAge: -1, SMaxAge: -1}},
+		{"private", http.Header{"Cache-Control": {"private"}}, cacheDirectives{Private: true, MaxAge: -1, SMaxAge: -1}},
+		{"must-revalidate", http.Header{"Cache-Control": {"must-revalidate"}}, cacheDirectives{MustRevalidate: true, MaxAge: -1, SMaxAge: -1}},
+		{"comma-separated", http.Header{"Cache-Control": {"no-store, must-revalidate"}}, cacheDirectives{NoStore: true, MustRevalidate: true, MaxAge: -1, SMaxAge: -1}},
+		{"multiple lines", http.Header{"Cache-Control": {"no-cache", "must-revalidate"}}, cacheDirectives{NoCache: true, MustRevalidate: true, MaxAge: -1, SMaxAge: -1}},
+		{"case-insensitive", http.Header{"Cache-Control": {"NO-STORE"}}, cacheDirectives{NoStore: true, MaxAge: -1, SMaxAge: -1}},
+		{"value suffix stripped", http.Header{"Cache-Control": {`no-cache="x-private"`}}, cacheDirectives{NoCache: true, MaxAge: -1, SMaxAge: -1}},
+		{"empty", http.Header{}, cacheDirectives{MaxAge: -1, SMaxAge: -1}},
+		{"max-age=3600", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{MaxAge: 3600, SMaxAge: -1}},
+		{"s-maxage=60", http.Header{"Cache-Control": {"s-maxage=60"}}, cacheDirectives{MaxAge: -1, SMaxAge: 60}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/filters/cache/cache_control_test.go
+++ b/filters/cache/cache_control_test.go
@@ -1,0 +1,67 @@
+package cache
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestParseRequestCacheControl(t *testing.T) {
+	cases := []struct {
+		header       string
+		noStore      bool
+		noCache      bool
+		onlyIfCached bool
+	}{
+		{"no-store", true, false, false},
+		{"no-cache", false, true, false},
+		{"max-age=0", false, true, false},
+		{"only-if-cached", false, false, true},
+		{"no-cache, no-store", true, true, false},
+		{"max-stale=60", false, false, false},
+		{"", false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			h := http.Header{}
+			if tc.header != "" {
+				h.Set("Cache-Control", tc.header)
+			}
+			d := parseRequestCacheControl(h)
+			if d.NoStore != tc.noStore {
+				t.Errorf("NoStore: want %v got %v", tc.noStore, d.NoStore)
+			}
+			if d.NoCache != tc.noCache {
+				t.Errorf("NoCache: want %v got %v", tc.noCache, d.NoCache)
+			}
+			if d.OnlyIfCached != tc.onlyIfCached {
+				t.Errorf("OnlyIfCached: want %v got %v", tc.onlyIfCached, d.OnlyIfCached)
+			}
+		})
+	}
+}
+
+func TestParseCacheControl(t *testing.T) {
+	cases := []struct {
+		name   string
+		header http.Header
+		want   cacheDirectives
+	}{
+		{"no-store", http.Header{"Cache-Control": {"no-store"}}, cacheDirectives{NoStore: true}},
+		{"no-cache", http.Header{"Cache-Control": {"no-cache"}}, cacheDirectives{NoCache: true}},
+		{"private", http.Header{"Cache-Control": {"private"}}, cacheDirectives{Private: true}},
+		{"must-revalidate", http.Header{"Cache-Control": {"must-revalidate"}}, cacheDirectives{MustRevalidate: true}},
+		{"comma-separated", http.Header{"Cache-Control": {"no-store, must-revalidate"}}, cacheDirectives{NoStore: true, MustRevalidate: true}},
+		{"multiple lines", http.Header{"Cache-Control": {"no-cache", "must-revalidate"}}, cacheDirectives{NoCache: true, MustRevalidate: true}},
+		{"case-insensitive", http.Header{"Cache-Control": {"NO-STORE"}}, cacheDirectives{NoStore: true}},
+		{"value suffix stripped", http.Header{"Cache-Control": {`no-cache="x-private"`}}, cacheDirectives{NoCache: true}},
+		{"empty", http.Header{}, cacheDirectives{}},
+		{"unrelated directive", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseCacheControl(tc.header); got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/filters/cache/cache_control_test.go
+++ b/filters/cache/cache_control_test.go
@@ -22,7 +22,7 @@ func TestParseRequestCacheControl(t *testing.T) {
 		{"no-cache, no-store", true, true, false, -1, -1},
 		{"max-stale=60", false, false, false, 60, -1},
 		{"max-stale", false, false, false, math.MaxInt32, -1},
-		{"max-stale=3.4", false, false, false, -1, -1},  // malformed: ParseInt fails, sentinel unchanged
+		{"max-stale=3.4", false, false, false, -1, -1}, // malformed: ParseInt fails, sentinel unchanged
 		{"min-fresh=30", false, false, false, -1, 30},
 		{"max-age=0,max-age=5", false, true, false, -1, -1}, // =0 sets noCache; =5 ignored (only =0 handled)
 		{"", false, false, false, -1, -1},
@@ -70,7 +70,7 @@ func TestParseCacheControl(t *testing.T) {
 		{"empty", http.Header{}, cacheDirectives{maxAge: -1, sMaxAge: -1}},
 		{"max-age=3600", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{maxAge: 3600, sMaxAge: -1}},
 		{"s-maxage=60", http.Header{"Cache-Control": {"s-maxage=60"}}, cacheDirectives{maxAge: -1, sMaxAge: 60}},
-		{"max-age=3.4", http.Header{"Cache-Control": {"max-age=3.4"}}, cacheDirectives{maxAge: -1, sMaxAge: -1}},           // malformed: ParseInt fails, sentinel unchanged
+		{"max-age=3.4", http.Header{"Cache-Control": {"max-age=3.4"}}, cacheDirectives{maxAge: -1, sMaxAge: -1}}, // malformed: ParseInt fails, sentinel unchanged
 		{"max-age=0,max-age=5", http.Header{"Cache-Control": {"max-age=0, max-age=5"}}, cacheDirectives{maxAge: 5, sMaxAge: -1}}, // last-write-wins; no duplicate guard
 	}
 	for _, tc := range cases {

--- a/filters/cache/cache_control_test.go
+++ b/filters/cache/cache_control_test.go
@@ -27,14 +27,14 @@ func TestParseRequestCacheControl(t *testing.T) {
 				h.Set("Cache-Control", tc.header)
 			}
 			d := parseRequestCacheControl(h)
-			if d.NoStore != tc.noStore {
-				t.Errorf("NoStore: want %v got %v", tc.noStore, d.NoStore)
+			if d.noStore != tc.noStore {
+				t.Errorf("noStore: want %v got %v", tc.noStore, d.noStore)
 			}
-			if d.NoCache != tc.noCache {
-				t.Errorf("NoCache: want %v got %v", tc.noCache, d.NoCache)
+			if d.noCache != tc.noCache {
+				t.Errorf("noCache: want %v got %v", tc.noCache, d.noCache)
 			}
-			if d.OnlyIfCached != tc.onlyIfCached {
-				t.Errorf("OnlyIfCached: want %v got %v", tc.onlyIfCached, d.OnlyIfCached)
+			if d.onlyIfCached != tc.onlyIfCached {
+				t.Errorf("onlyIfCached: want %v got %v", tc.onlyIfCached, d.onlyIfCached)
 			}
 		})
 	}
@@ -46,17 +46,17 @@ func TestParseCacheControl(t *testing.T) {
 		header http.Header
 		want   cacheDirectives
 	}{
-		{"no-store", http.Header{"Cache-Control": {"no-store"}}, cacheDirectives{NoStore: true, MaxAge: -1, SMaxAge: -1}},
-		{"no-cache", http.Header{"Cache-Control": {"no-cache"}}, cacheDirectives{NoCache: true, MaxAge: -1, SMaxAge: -1}},
-		{"private", http.Header{"Cache-Control": {"private"}}, cacheDirectives{Private: true, MaxAge: -1, SMaxAge: -1}},
-		{"must-revalidate", http.Header{"Cache-Control": {"must-revalidate"}}, cacheDirectives{MustRevalidate: true, MaxAge: -1, SMaxAge: -1}},
-		{"comma-separated", http.Header{"Cache-Control": {"no-store, must-revalidate"}}, cacheDirectives{NoStore: true, MustRevalidate: true, MaxAge: -1, SMaxAge: -1}},
-		{"multiple lines", http.Header{"Cache-Control": {"no-cache", "must-revalidate"}}, cacheDirectives{NoCache: true, MustRevalidate: true, MaxAge: -1, SMaxAge: -1}},
-		{"case-insensitive", http.Header{"Cache-Control": {"NO-STORE"}}, cacheDirectives{NoStore: true, MaxAge: -1, SMaxAge: -1}},
-		{"value suffix stripped", http.Header{"Cache-Control": {`no-cache="x-private"`}}, cacheDirectives{NoCache: true, MaxAge: -1, SMaxAge: -1}},
-		{"empty", http.Header{}, cacheDirectives{MaxAge: -1, SMaxAge: -1}},
-		{"max-age=3600", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{MaxAge: 3600, SMaxAge: -1}},
-		{"s-maxage=60", http.Header{"Cache-Control": {"s-maxage=60"}}, cacheDirectives{MaxAge: -1, SMaxAge: 60}},
+		{"no-store", http.Header{"Cache-Control": {"no-store"}}, cacheDirectives{noStore: true, maxAge: -1, sMaxAge: -1}},
+		{"no-cache", http.Header{"Cache-Control": {"no-cache"}}, cacheDirectives{noCache: true, maxAge: -1, sMaxAge: -1}},
+		{"private", http.Header{"Cache-Control": {"private"}}, cacheDirectives{private: true, maxAge: -1, sMaxAge: -1}},
+		{"must-revalidate", http.Header{"Cache-Control": {"must-revalidate"}}, cacheDirectives{mustRevalidate: true, maxAge: -1, sMaxAge: -1}},
+		{"comma-separated", http.Header{"Cache-Control": {"no-store, must-revalidate"}}, cacheDirectives{noStore: true, mustRevalidate: true, maxAge: -1, sMaxAge: -1}},
+		{"multiple lines", http.Header{"Cache-Control": {"no-cache", "must-revalidate"}}, cacheDirectives{noCache: true, mustRevalidate: true, maxAge: -1, sMaxAge: -1}},
+		{"case-insensitive", http.Header{"Cache-Control": {"NO-STORE"}}, cacheDirectives{noStore: true, maxAge: -1, sMaxAge: -1}},
+		{"value suffix stripped", http.Header{"Cache-Control": {`no-cache="x-private"`}}, cacheDirectives{noCache: true, maxAge: -1, sMaxAge: -1}},
+		{"empty", http.Header{}, cacheDirectives{maxAge: -1, sMaxAge: -1}},
+		{"max-age=3600", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{maxAge: 3600, sMaxAge: -1}},
+		{"s-maxage=60", http.Header{"Cache-Control": {"s-maxage=60"}}, cacheDirectives{maxAge: -1, sMaxAge: 60}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/filters/cache/cache_control_test.go
+++ b/filters/cache/cache_control_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"math"
 	"net/http"
 	"testing"
 )
@@ -11,14 +12,20 @@ func TestParseRequestCacheControl(t *testing.T) {
 		noStore      bool
 		noCache      bool
 		onlyIfCached bool
+		maxStale     int64
+		minFresh     int64
 	}{
-		{"no-store", true, false, false},
-		{"no-cache", false, true, false},
-		{"max-age=0", false, true, false},
-		{"only-if-cached", false, false, true},
-		{"no-cache, no-store", true, true, false},
-		{"max-stale=60", false, false, false},
-		{"", false, false, false},
+		{"no-store", true, false, false, -1, -1},
+		{"no-cache", false, true, false, -1, -1},
+		{"max-age=0", false, true, false, -1, -1},
+		{"only-if-cached", false, false, true, -1, -1},
+		{"no-cache, no-store", true, true, false, -1, -1},
+		{"max-stale=60", false, false, false, 60, -1},
+		{"max-stale", false, false, false, math.MaxInt32, -1},
+		{"max-stale=3.4", false, false, false, -1, -1},  // malformed: ParseInt fails, sentinel unchanged
+		{"min-fresh=30", false, false, false, -1, 30},
+		{"max-age=0,max-age=5", false, true, false, -1, -1}, // =0 sets noCache; =5 ignored (only =0 handled)
+		{"", false, false, false, -1, -1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.header, func(t *testing.T) {
@@ -35,6 +42,12 @@ func TestParseRequestCacheControl(t *testing.T) {
 			}
 			if d.onlyIfCached != tc.onlyIfCached {
 				t.Errorf("onlyIfCached: want %v got %v", tc.onlyIfCached, d.onlyIfCached)
+			}
+			if d.maxStale != tc.maxStale {
+				t.Errorf("maxStale: want %v got %v", tc.maxStale, d.maxStale)
+			}
+			if d.minFresh != tc.minFresh {
+				t.Errorf("minFresh: want %v got %v", tc.minFresh, d.minFresh)
 			}
 		})
 	}
@@ -57,6 +70,8 @@ func TestParseCacheControl(t *testing.T) {
 		{"empty", http.Header{}, cacheDirectives{maxAge: -1, sMaxAge: -1}},
 		{"max-age=3600", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{maxAge: 3600, sMaxAge: -1}},
 		{"s-maxage=60", http.Header{"Cache-Control": {"s-maxage=60"}}, cacheDirectives{maxAge: -1, sMaxAge: 60}},
+		{"max-age=3.4", http.Header{"Cache-Control": {"max-age=3.4"}}, cacheDirectives{maxAge: -1, sMaxAge: -1}},           // malformed: ParseInt fails, sentinel unchanged
+		{"max-age=0,max-age=5", http.Header{"Cache-Control": {"max-age=0, max-age=5"}}, cacheDirectives{maxAge: 5, sMaxAge: -1}}, // last-write-wins; no duplicate guard
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/filters/cache/cache_control_test.go
+++ b/filters/cache/cache_control_test.go
@@ -70,7 +70,7 @@ func TestParseCacheControl(t *testing.T) {
 		{"empty", http.Header{}, cacheDirectives{maxAge: -1, sMaxAge: -1}},
 		{"max-age=3600", http.Header{"Cache-Control": {"max-age=3600"}}, cacheDirectives{maxAge: 3600, sMaxAge: -1}},
 		{"s-maxage=60", http.Header{"Cache-Control": {"s-maxage=60"}}, cacheDirectives{maxAge: -1, sMaxAge: 60}},
-		{"max-age=3.4", http.Header{"Cache-Control": {"max-age=3.4"}}, cacheDirectives{maxAge: -1, sMaxAge: -1}}, // malformed: ParseInt fails, sentinel unchanged
+		{"max-age=3.4", http.Header{"Cache-Control": {"max-age=3.4"}}, cacheDirectives{maxAge: -1, sMaxAge: -1}},                 // malformed: ParseInt fails, sentinel unchanged
 		{"max-age=0,max-age=5", http.Header{"Cache-Control": {"max-age=0, max-age=5"}}, cacheDirectives{maxAge: 5, sMaxAge: -1}}, // last-write-wins; no duplicate guard
 	}
 	for _, tc := range cases {

--- a/filters/cache/doc.go
+++ b/filters/cache/doc.go
@@ -1,0 +1,2 @@
+// Package cache implements an HTTP response caching filter for Skipper.
+package cache

--- a/filters/cache/doc.go
+++ b/filters/cache/doc.go
@@ -1,2 +1,2 @@
-// Package cache implements an HTTP response caching filter for Skipper.
+// Package cache implements a caching family of filters.
 package cache

--- a/filters/cache/filter.go
+++ b/filters/cache/filter.go
@@ -1,0 +1,579 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/metrics"
+	sknet "github.com/zalando/skipper/net"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	Name        = "cache"
+	filterName  = Name
+	stateBagKey = "cache:key"
+
+	// revalidateHeader is set on background revalidation requests so the cache
+	// filter skips the cache lookup and lets the response populate a fresh entry.
+	revalidateHeader = "X-Cache-Revalidate"
+)
+
+// NewCacheFilter returns a Spec for the cache() filter. maxBytes is the L1
+// in-memory storage budget per route, derived from cgroup memory limits in skipper.go.
+// listenAddr is Skipper's own listener address (e.g. ":9090"); revalidation requests
+// are sent back through Skipper so the full filter chain runs.
+//
+// Route usage:
+//
+//	-> cache("5m", "15s", "30s") -> "https://example.org"
+func NewCacheFilter(maxBytes int64, listenAddr string) filters.Spec {
+	storage := NewLRUStorage(maxBytes)
+	for i := range storage.lru.shards {
+		storage.lru.shards[i].onEvict = func() {
+			// lru_eviction fires outside a request context, so metrics.Default is correct here.
+			metrics.Default.IncCounter("lru_eviction")
+		}
+	}
+	return &cacheSpec{
+		storage:    storage,
+		listenAddr: listenAddr,
+		client:     sknet.NewClient(sknet.Options{}),
+	}
+}
+
+type cacheSpec struct {
+	storage    *LRUStorage
+	listenAddr string
+	client     *sknet.Client
+}
+
+func (s *cacheSpec) Name() string { return filterName }
+
+func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
+	if len(args) < 3 || len(args) > 4 {
+		return nil, fmt.Errorf("cache: expected 3 or 4 args (ttl, errorTTL, swrWindow[, keyHeaders]), got %d", len(args))
+	}
+
+	ttl, err := toDuration(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("cache: arg 0 (ttl): %w", err)
+	}
+
+	errorTTL, err := toDuration(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("cache: arg 1 (errorTTL): %w", err)
+	}
+
+	swr, err := toDuration(args[2])
+	if err != nil {
+		return nil, fmt.Errorf("cache: arg 2 (swrWindow): %w", err)
+	}
+
+	var keyHeaders []string
+	if len(args) == 4 {
+		raw, ok := args[3].(string)
+		if !ok {
+			return nil, fmt.Errorf("cache: arg 3 (keyHeaders): expected string, got %T", args[3])
+		}
+		for _, h := range strings.Split(raw, ",") {
+			if name := strings.TrimSpace(h); name != "" {
+				keyHeaders = append(keyHeaders, http.CanonicalHeaderKey(name))
+			}
+		}
+	}
+
+	cf := &cacheFilter{
+		storage:    s.storage,
+		listenAddr: s.listenAddr,
+		ttl:        ttl,
+		errorTTL:   errorTTL,
+		swrWindow:  swr,
+		keyHeaders: keyHeaders,
+	}
+	cf.fetch = s.client.Do
+	return cf, nil
+}
+
+type cacheFilter struct {
+	storage    Storage
+	listenAddr string
+	ttl        time.Duration
+	errorTTL   time.Duration
+	swrWindow  time.Duration
+	keyHeaders []string           // request headers folded into the base cache key
+	sf         singleflight.Group // cold-miss coalescing
+	revalSF    singleflight.Group // background revalidation coalescing
+	fetch      func(*http.Request) (*http.Response, error)
+}
+
+// Request checks the cache. On a hit it calls ctx.Serve() to short-circuit the
+// backend roundtrip. On a stale hit it serves stale and fires a background
+// revalidation. On a miss it stores the computed key in the state bag so
+// Response() can populate the cache.
+func (f *cacheFilter) Request(ctx filters.FilterContext) {
+	baseKey := cacheKey(ctx.Request(), f.keyHeaders)
+	key := baseKey
+	if sentinel, _ := f.storage.Get(ctx.Request().Context(), "vary:"+baseKey); sentinel != nil && len(sentinel.VaryHeaders) > 0 {
+		key = varyKey(baseKey, ctx.Request(), sentinel.VaryHeaders)
+	}
+	ctx.StateBag()[stateBagKey] = key
+	ctx.StateBag()["cache:base-key"] = baseKey
+
+	// Unsafe methods skip cache lookup; Response() will invalidate the entry.
+	if isUnsafeMethod(ctx.Request().Method) {
+		return
+	}
+
+	// Revalidation requests bypass the cache lookup so Response() can store a
+	// fresh entry. Strip the header so it never reaches the upstream.
+	if ctx.Request().Header.Get(revalidateHeader) != "" {
+		ctx.Request().Header.Del(revalidateHeader)
+		return
+	}
+
+	reqDir := parseRequestCacheControl(ctx.Request().Header)
+	if reqDir.OnlyIfCached {
+		entry, err := f.storage.Get(ctx.Request().Context(), key)
+		if err != nil || entry == nil || entry.IsStale(time.Now()) {
+			ctx.Serve(&http.Response{
+				StatusCode: http.StatusGatewayTimeout,
+				Header:     http.Header{"X-Cache-Status": {"MISS"}},
+				Body:       http.NoBody,
+			})
+			return
+		}
+		f.serveEntry(ctx, key, entry)
+		return
+	} else if reqDir.NoCache || reqDir.NoStore {
+		if reqDir.NoStore {
+			ctx.StateBag()["cache:no-store"] = true
+		}
+		return
+	}
+
+	entry, err := f.storage.Get(ctx.Request().Context(), key)
+	if err != nil || entry == nil {
+		f.coalesce(ctx, key)
+		return
+	}
+
+	f.serveEntry(ctx, key, entry)
+}
+
+// serveEntry serves entry from cache, handling the stale and fresh cases.
+func (f *cacheFilter) serveEntry(ctx filters.FilterContext, key string, entry *Entry) {
+	rsp := &http.Response{
+		StatusCode: entry.StatusCode,
+		Header:     entry.Header.Clone(),
+		Body:       io.NopCloser(bytes.NewReader(entry.Payload)),
+	}
+
+	if entry.IsStale(time.Now()) {
+		d := parseCacheControl(entry.Header)
+		applySMaxAge(entry.TTL, &d)
+		if d.MustRevalidate {
+			f.coalesce(ctx, key)
+			return
+		}
+		rsp.Header.Set("X-Cache-Status", "STALE")
+		setAgeHeader(rsp, entry, time.Now())
+		ctx.Metrics().IncCounter("stale")
+		ctx.Serve(rsp)
+		go f.revalidate(key, ctx.Request(), ctx.Metrics())
+		return
+	}
+
+	rsp.Header.Set("X-Cache-Status", "HIT")
+	setAgeHeader(rsp, entry, time.Now())
+	ctx.Metrics().IncCounter("hit")
+	ctx.Serve(rsp)
+}
+
+// coalesce gates concurrent cold misses for the same key behind a single
+// upstream fetch. All waiters block until the leader's fetch completes, then
+// all are served the same response. This prevents the thundering herd on a
+// cache miss.
+func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
+	req := ctx.Request().Clone(context.Background())
+
+	ch := f.sf.DoChan(key, func() (interface{}, error) {
+		resp, err := f.fetch(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		ttl := capTTLByExpires(f.ttlForStatus(resp.StatusCode), resp.Header)
+		directives := parseCacheControl(resp.Header)
+		ttl = applySMaxAge(ttl, &directives)
+		swr := f.swrWindow
+		if resp.StatusCode != http.StatusOK {
+			swr = 0
+		}
+		entry := &Entry{
+			StatusCode:           resp.StatusCode,
+			Header:               resp.Header.Clone(),
+			Payload:              body,
+			CreatedAt:            time.Now(),
+			TTL:                  ttl,
+			StaleWhileRevalidate: swr,
+			ETag:                 resp.Header.Get("ETag"),
+			LastModified:         resp.Header.Get("Last-Modified"),
+		}
+		if ttl > 0 && !directives.NoStore && !directives.Private && !directives.NoCache {
+			_ = f.storage.Set(context.Background(), key, entry)
+		}
+		return entry, nil
+	})
+
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			ctx.Metrics().IncCounter("fetch_error")
+			return
+		}
+		if res.Val == nil {
+			return
+		}
+		entry := res.Val.(*Entry)
+		rsp := &http.Response{
+			StatusCode: entry.StatusCode,
+			Header:     entry.Header.Clone(),
+			Body:       io.NopCloser(bytes.NewReader(entry.Payload)),
+		}
+		rsp.Header.Set("X-Cache-Status", "MISS")
+		ctx.Metrics().IncCounter("miss")
+		ctx.Serve(rsp)
+	case <-ctx.Request().Context().Done():
+		// Client disconnected. Remaining waiters still receive their result.
+	}
+}
+
+// Response populates the cache on a miss.
+func (f *cacheFilter) Response(ctx filters.FilterContext) {
+	rsp := ctx.Response()
+	key := ctx.StateBag()[stateBagKey].(string)
+
+	// Hit or stale path: already served from cache in Request(); nothing to do.
+	if ctx.Served() {
+		return
+	}
+
+	// RFC 9111 §4.4: invalidate cached entry on successful unsafe method.
+	if isUnsafeMethod(ctx.Request().Method) && rsp.StatusCode < 400 {
+		_ = f.storage.Delete(ctx.Request().Context(), key)
+		return
+	}
+
+	// Only cache responses to GET requests. HEAD/OPTIONS/CONNECT/TRACE must not be stored.
+	if ctx.Request().Method != http.MethodGet {
+		return
+	}
+
+	// RFC 9111 §3: MUST NOT store partial content (206) without Range support.
+	if rsp.StatusCode == http.StatusPartialContent {
+		return
+	}
+
+	if ctx.StateBag()["cache:no-store"] == true {
+		rsp.Header.Set("X-Cache-Status", "MISS")
+		ctx.Metrics().IncCounter("miss")
+		return
+	}
+
+	rsp.Header.Set("X-Cache-Status", "MISS")
+	ctx.Metrics().IncCounter("miss")
+
+	// Vary: * means every response is unique — never cache.
+	varyHeader := rsp.Header.Get("Vary")
+	if varyHeader == "*" {
+		return
+	}
+
+	ttl := capTTLByExpires(f.ttlForStatus(rsp.StatusCode), rsp.Header)
+	directives := parseCacheControl(rsp.Header)
+	ttl = applySMaxAge(ttl, &directives)
+	if ttl == 0 {
+		return
+	}
+
+	if directives.NoStore || directives.Private || directives.NoCache {
+		return
+	}
+
+	if ctx.Request().Header.Get("Authorization") != "" && !directives.Public && !directives.MustRevalidate {
+		return
+	}
+
+	body, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"method": ctx.Request().Method,
+			"url":    ctx.Request().URL.String(),
+		}).WithError(err).Warn("cache: failed to read response body, skipping cache storage")
+		return
+	}
+
+	rsp.Body = io.NopCloser(bytes.NewReader(body))
+
+	// Resolve Vary-aware storage key.
+	baseKey, _ := ctx.StateBag()["cache:base-key"].(string)
+	if baseKey == "" {
+		baseKey = key
+	}
+	varyNames := parseVaryNames(varyHeader)
+	storeKey := key
+	if len(varyNames) > 0 {
+		storeKey = varyKey(baseKey, ctx.Request(), varyNames)
+		sentinel := &Entry{
+			CreatedAt:   time.Now(),
+			TTL:         ttl,
+			VaryHeaders: varyNames,
+		}
+		_ = f.storage.Set(ctx.Request().Context(), "vary:"+baseKey, sentinel)
+	}
+
+	swr := f.swrWindow
+	if rsp.StatusCode != http.StatusOK {
+		swr = 0
+	}
+	entry := &Entry{
+		StatusCode:           rsp.StatusCode,
+		Header:               rsp.Header.Clone(),
+		Payload:              body,
+		CreatedAt:            time.Now(),
+		TTL:                  ttl,
+		StaleWhileRevalidate: swr,
+		ETag:                 rsp.Header.Get("ETag"),
+		LastModified:         rsp.Header.Get("Last-Modified"),
+		VaryHeaders:          varyNames,
+	}
+	_ = f.storage.Set(ctx.Request().Context(), storeKey, entry)
+}
+
+// revalidate fetches the upstream resource in the background and refreshes the
+// cache entry. Uses singleflight to coalesce concurrent revalidations for the
+// same key. Uses a detached context so the fetch outlives the current request.
+func (f *cacheFilter) revalidate(key string, orig *http.Request, m filters.Metrics) {
+	f.revalSF.Do(key, func() (interface{}, error) {
+		req := orig.Clone(context.Background())
+		req.Header.Set(revalidateHeader, "1")
+		req.URL.Scheme = "http"
+		req.URL.Host = f.listenAddr
+		req.RequestURI = ""
+
+		if stored, err := f.storage.Get(context.Background(), key); err == nil && stored != nil {
+			if stored.ETag != "" {
+				req.Header.Set("If-None-Match", stored.ETag)
+			}
+			if stored.LastModified != "" {
+				req.Header.Set("If-Modified-Since", stored.LastModified)
+			}
+		}
+
+		resp, err := f.fetch(req)
+		if err != nil {
+			m.IncCounter("reval_error")
+			log.WithFields(log.Fields{
+				"url": orig.URL.String(),
+			}).WithError(err).Warn("cache: background revalidation fetch failed")
+			return nil, nil
+		}
+		defer resp.Body.Close()
+
+		var body []byte
+		var responseHeader http.Header
+		var statusCode int
+
+		if resp.StatusCode == http.StatusNotModified {
+			// Reuse stored payload and merge any updated headers from 304.
+			if stored, serr := f.storage.Get(context.Background(), key); serr == nil && stored != nil {
+				body = stored.Payload
+				responseHeader = stored.Header.Clone()
+				for k, vv := range resp.Header {
+					responseHeader[k] = vv
+				}
+			} else {
+				log.WithField("key", key).Debug("cache: revalidation received 304 but entry was evicted, skipping refresh")
+				return nil, nil
+			}
+			statusCode = http.StatusOK
+		} else {
+			var rerr error
+			body, rerr = io.ReadAll(resp.Body)
+			if rerr != nil {
+				m.IncCounter("reval_error")
+				log.WithFields(log.Fields{
+					"url": orig.URL.String(),
+				}).WithError(rerr).Warn("cache: failed to read response body during background revalidation")
+				return nil, nil
+			}
+			responseHeader = resp.Header.Clone()
+			statusCode = resp.StatusCode
+		}
+
+		ttl := capTTLByExpires(f.ttlForStatus(statusCode), responseHeader)
+		directives := parseCacheControl(responseHeader)
+		ttl = applySMaxAge(ttl, &directives)
+		if ttl == 0 {
+			return nil, nil
+		}
+
+		if directives.NoStore || directives.Private || directives.NoCache {
+			return nil, nil
+		}
+
+		entry := &Entry{
+			StatusCode:           statusCode,
+			Header:               responseHeader,
+			Payload:              body,
+			CreatedAt:            time.Now(),
+			TTL:                  ttl,
+			StaleWhileRevalidate: f.swrWindow,
+			ETag:                 responseHeader.Get("ETag"),
+			LastModified:         responseHeader.Get("Last-Modified"),
+		}
+		_ = f.storage.Set(context.Background(), key, entry)
+		return nil, nil
+	})
+}
+
+func (f *cacheFilter) ttlForStatus(status int) time.Duration {
+	switch {
+	case status == http.StatusOK:
+		return f.ttl
+	case status == http.StatusNotFound || (status >= 500 && status < 600):
+		return f.errorTTL
+	default:
+		return 0
+	}
+}
+
+// cacheKey builds a deterministic, URL-safe cache key from the request.
+// SHA-256 is used for uniform distribution and to satisfy the lru.go requirement
+// that keys passed to ShardedByteLRU are pre-hashed by the caller.
+// keyHeaders is an optional list of request header names whose values are folded
+// into the key, allowing per-header cache isolation (e.g. "Authorization").
+func cacheKey(r *http.Request, keyHeaders []string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s://%s%s?%s", r.URL.Scheme, r.Host, r.URL.Path, r.URL.RawQuery)
+	for _, name := range keyHeaders {
+		fmt.Fprintf(h, "\n%s: %s", name, r.Header.Get(name))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// setAgeHeader computes and sets the Age header per RFC 9111 §5.1.
+// If the stored response already carries an Age value from an upstream cache, the two are summed.
+func setAgeHeader(rsp *http.Response, entry *Entry, now time.Time) {
+	elapsed := int64(now.Sub(entry.CreatedAt).Seconds())
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	if existing := rsp.Header.Get("Age"); existing != "" {
+		if v, err := strconv.ParseInt(existing, 10, 64); err == nil {
+			elapsed += v
+		}
+	}
+	rsp.Header.Set("Age", strconv.FormatInt(elapsed, 10))
+}
+
+// applySMaxAge returns the effective TTL after applying s-maxage (RFC 9111 §5.2.2.10).
+// s-maxage overrides Expires and the operator TTL for shared caches.
+// It also sets MustRevalidate on the directives struct because s-maxage implies proxy-revalidate.
+func applySMaxAge(ttl time.Duration, d *cacheDirectives) time.Duration {
+	if d.SMaxAge == nil {
+		return ttl
+	}
+	d.MustRevalidate = true
+	if *d.SMaxAge < ttl {
+		return *d.SMaxAge
+	}
+	return ttl
+}
+
+func capTTLByExpires(ttl time.Duration, header http.Header) time.Duration {
+	exp := header.Get("Expires")
+	if exp == "" {
+		return ttl
+	}
+	t, err := http.ParseTime(exp)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"expires": exp,
+		}).Warn("cache: unparseable Expires header, ignoring")
+		return ttl
+	}
+	remaining := time.Until(t)
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining < ttl {
+		return remaining
+	}
+	return ttl
+}
+
+func isUnsafeMethod(method string) bool {
+	switch method {
+	case http.MethodPut, http.MethodPost, http.MethodDelete, http.MethodPatch:
+		return true
+	}
+	return false
+}
+
+func parseVaryNames(varyHeader string) []string {
+	if varyHeader == "" {
+		return nil
+	}
+	parts := strings.Split(varyHeader, ",")
+	names := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if name := strings.TrimSpace(p); name != "" {
+			names = append(names, http.CanonicalHeaderKey(name))
+		}
+	}
+	return names
+}
+
+func varyKey(base string, r *http.Request, varyHeaders []string) string {
+	if len(varyHeaders) == 0 {
+		return base
+	}
+	h := sha256.New()
+	fmt.Fprintf(h, "%s", base)
+	for _, name := range varyHeaders {
+		fmt.Fprintf(h, "\n%s: %s", name, r.Header.Get(name))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func toDuration(v interface{}) (time.Duration, error) {
+	s, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("expected string, got %T", v)
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("duration must be positive, got %s", s)
+	}
+	return d, nil
+}

--- a/filters/cache/filter.go
+++ b/filters/cache/filter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -29,62 +30,83 @@ const (
 	revalidateHeader = "X-Cache-Revalidate"
 )
 
-// NewCacheFilter returns a Spec for the cache() filter. maxBytes is the L1
-// in-memory storage budget per route, derived from cgroup memory limits in skipper.go.
-// listenAddr is Skipper's own listener address (e.g. ":9090"); revalidation requests
-// are sent back through Skipper so the full filter chain runs.
+// NewCacheFilter returns a Spec for the cache() filter. maxBytes is the
+// in-memory storage budget for the shared LRU cache backing all filter
+// instances created from this Spec.
+// listenAddr is Skipper's own listener address (e.g. ":9090"); revalidation
+// requests are sent back through Skipper so the full filter chain runs.
 //
-// Route usage:
+// Route usage (RFC mode — upstream Cache-Control is fully authoritative):
+//
+//	-> cache() -> "https://example.org"
+//
+// Route usage (force mode — operator TTL is authoritative, upstream directives ignored):
 //
 //	-> cache("5m", "15s", "30s") -> "https://example.org"
+//
+// Combining force mode with stale-if-error:
+//
+//	-> cache("5m", "15s", "30s", "60s") -> "https://example.org"
 func NewCacheFilter(maxBytes int64, listenAddr string) filters.Spec {
-	storage := NewLRUStorage(maxBytes)
-	for i := range storage.lru.shards {
-		storage.lru.shards[i].onEvict = func() {
-			// lru_eviction fires outside a request context, so metrics.Default is correct here.
-			metrics.Default.IncCounter("lru_eviction")
-		}
-	}
 	return &cacheSpec{
-		storage:    storage,
+		maxBytes:   maxBytes,
 		listenAddr: listenAddr,
 		client:     sknet.NewClient(sknet.Options{}),
+		storage:    NewLRUStorage(maxBytes, func() { metrics.Default.IncCounter("lru_eviction") }),
 	}
 }
 
 type cacheSpec struct {
-	storage    *LRUStorage
+	maxBytes   int64
 	listenAddr string
 	client     *sknet.Client
+	storage    Storage // shared across all filter instances
 }
 
 func (s *cacheSpec) Name() string { return filterName }
 
 func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
-	if len(args) < 3 || len(args) > 4 {
-		return nil, fmt.Errorf("cache: expected 3 or 4 args (ttl, errorTTL, swrWindow[, keyHeaders]), got %d", len(args))
+	if len(args) != 0 && (len(args) < 3 || len(args) > 5) {
+		return nil, fmt.Errorf("cache: expected 0 or 3-5 args (ttl, errorTTL, swrWindow[, staleIfError[, keyHeaders]]), got %d", len(args))
 	}
 
-	ttl, err := toDuration(args[0])
-	if err != nil {
-		return nil, fmt.Errorf("cache: arg 0 (ttl): %w", err)
-	}
+	var ttl, errorTTL, swr, staleIfError time.Duration
+	rfcMode := len(args) == 0 // zero args → pure RFC mode
 
-	errorTTL, err := toDuration(args[1])
-	if err != nil {
-		return nil, fmt.Errorf("cache: arg 1 (errorTTL): %w", err)
-	}
+	if len(args) >= 3 {
+		var err error
+		ttl, err = toDuration(args[0])
+		if err != nil {
+			return nil, fmt.Errorf("cache: arg 0 (ttl): %w", err)
+		}
 
-	swr, err := toDuration(args[2])
-	if err != nil {
-		return nil, fmt.Errorf("cache: arg 2 (swrWindow): %w", err)
+		errorTTL, err = toDuration(args[1])
+		if err != nil {
+			return nil, fmt.Errorf("cache: arg 1 (errorTTL): %w", err)
+		}
+
+		swr, err = toDuration(args[2])
+		if err != nil {
+			return nil, fmt.Errorf("cache: arg 2 (swrWindow): %w", err)
+		}
+
+		if len(args) >= 4 {
+			s, ok := args[3].(string)
+			if !ok {
+				return nil, fmt.Errorf("cache: arg 3 (staleIfError): expected string, got %T", args[3])
+			}
+			staleIfError, err = time.ParseDuration(s)
+			if err != nil {
+				return nil, fmt.Errorf("cache: arg 3 (staleIfError): %w", err)
+			}
+		}
 	}
 
 	var keyHeaders []string
-	if len(args) == 4 {
-		raw, ok := args[3].(string)
+	if len(args) == 5 {
+		raw, ok := args[4].(string)
 		if !ok {
-			return nil, fmt.Errorf("cache: arg 3 (keyHeaders): expected string, got %T", args[3])
+			return nil, fmt.Errorf("cache: arg 4 (keyHeaders): expected string, got %T", args[4])
 		}
 		for _, h := range strings.Split(raw, ",") {
 			if name := strings.TrimSpace(h); name != "" {
@@ -93,28 +115,37 @@ func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 		}
 	}
 
+	m := metrics.Default
 	cf := &cacheFilter{
-		storage:    s.storage,
-		listenAddr: s.listenAddr,
-		ttl:        ttl,
-		errorTTL:   errorTTL,
-		swrWindow:  swr,
-		keyHeaders: keyHeaders,
+		storage:      s.storage,
+		listenAddr:   s.listenAddr,
+		ttl:          ttl,
+		errorTTL:     errorTTL,
+		swrWindow:    swr,
+		staleIfError: staleIfError,
+		rfcMode:      rfcMode,
+		metrics:      m,
+		keyHeaders:   keyHeaders,
 	}
 	cf.fetch = s.client.Do
 	return cf, nil
 }
 
 type cacheFilter struct {
-	storage    Storage
-	listenAddr string
-	ttl        time.Duration
-	errorTTL   time.Duration
-	swrWindow  time.Duration
-	keyHeaders []string           // request headers folded into the base cache key
-	sf         singleflight.Group // cold-miss coalescing
-	revalSF    singleflight.Group // background revalidation coalescing
-	fetch      func(*http.Request) (*http.Response, error)
+	storage      Storage
+	listenAddr   string
+	ttl          time.Duration
+	errorTTL     time.Duration
+	swrWindow    time.Duration
+	staleIfError time.Duration
+	keyHeaders   []string // request headers folded into the base cache key
+	// rfcMode true: upstream Cache-Control is authoritative (cache()).
+	// false: operator ttl/errorTTL/swrWindow are authoritative (force mode).
+	rfcMode bool
+	sf      singleflight.Group // cold-miss coalescing
+	revalSF singleflight.Group // background revalidation coalescing
+	fetch   func(*http.Request) (*http.Response, error)
+	metrics metrics.Metrics
 }
 
 // Request checks the cache. On a hit it calls ctx.Serve() to short-circuit the
@@ -122,13 +153,14 @@ type cacheFilter struct {
 // revalidation. On a miss it stores the computed key in the state bag so
 // Response() can populate the cache.
 func (f *cacheFilter) Request(ctx filters.FilterContext) {
-	baseKey := cacheKey(ctx.Request(), f.keyHeaders)
+	baseKey := cacheKey(ctx.RouteId(), ctx.Request(), f.keyHeaders)
 	key := baseKey
 	if sentinel, _ := f.storage.Get(ctx.Request().Context(), "vary:"+baseKey); sentinel != nil && len(sentinel.VaryHeaders) > 0 {
 		key = varyKey(baseKey, ctx.Request(), sentinel.VaryHeaders)
 	}
 	ctx.StateBag()[stateBagKey] = key
 	ctx.StateBag()["cache:base-key"] = baseKey
+	ctx.StateBag()["cache:request-time"] = time.Now()
 
 	// Unsafe methods skip cache lookup; Response() will invalidate the entry.
 	if isUnsafeMethod(ctx.Request().Method) {
@@ -153,8 +185,6 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 			})
 			return
 		}
-		f.serveEntry(ctx, key, entry)
-		return
 	} else if reqDir.NoCache || reqDir.NoStore {
 		if reqDir.NoStore {
 			ctx.StateBag()["cache:no-store"] = true
@@ -168,36 +198,80 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 		return
 	}
 
-	f.serveEntry(ctx, key, entry)
-}
-
-// serveEntry serves entry from cache, handling the stale and fresh cases.
-func (f *cacheFilter) serveEntry(ctx filters.FilterContext, key string, entry *Entry) {
 	rsp := &http.Response{
 		StatusCode: entry.StatusCode,
 		Header:     entry.Header.Clone(),
 		Body:       io.NopCloser(bytes.NewReader(entry.Payload)),
 	}
 
-	if entry.IsStale(time.Now()) {
+	now := time.Now()
+	pastTTL := now.After(entry.CreatedAt.Add(entry.TTL))
+	if entry.IsStale(now) {
 		d := parseCacheControl(entry.Header)
-		applySMaxAge(entry.TTL, &d)
-		if d.MustRevalidate {
+		if d.MustRevalidate || d.ProxyRevalidate || d.NoCache || d.SMaxAge >= 0 {
 			f.coalesce(ctx, key)
 			return
 		}
+		// RFC 9111 §5.2.1 max-stale.
+		if reqDir.MaxStale >= 0 {
+			staleness := time.Since(entry.CreatedAt) - entry.TTL
+			if staleness > time.Duration(reqDir.MaxStale)*time.Second {
+				f.coalesce(ctx, key)
+				return
+			}
+		}
 		rsp.Header.Set("X-Cache-Status", "STALE")
-		setAgeHeader(rsp, entry, time.Now())
+		setAgeHeader(rsp, entry, now)
 		ctx.Metrics().IncCounter("stale")
-		ctx.Serve(rsp)
-		go f.revalidate(key, ctx.Request(), ctx.Metrics())
+		method := ctx.Request().Method
+		if (method == http.MethodGet || method == http.MethodHead) && evaluateConditionals(ctx.Request(), entry) {
+			notModified := &http.Response{
+				StatusCode: http.StatusNotModified,
+				Header:     rsp.Header.Clone(),
+				Body:       http.NoBody,
+				Request:    ctx.Request(), // link response to originating request per net/http convention
+			}
+			ctx.Serve(notModified)
+			go f.revalidate(key, ctx.Request())
+			return
+		}
+		ctx.Serve(headBodyOmitted(method, rsp))
+		go f.revalidate(key, ctx.Request())
 		return
+	}
+
+	// Entry is past TTL+SWR but still in storage (kept alive by stale-if-error window).
+	// Treat as a miss so the upstream is hit; Response() will apply stale-if-error on 5xx.
+	if pastTTL {
+		f.coalesce(ctx, key)
+		return
+	}
+
+	// RFC 9111 §5.2.1 min-fresh.
+	if reqDir.MinFresh >= 0 {
+		elapsed := time.Since(entry.CreatedAt)
+		remaining := entry.TTL - elapsed
+		if remaining < time.Duration(reqDir.MinFresh)*time.Second {
+			f.coalesce(ctx, key)
+			return
+		}
 	}
 
 	rsp.Header.Set("X-Cache-Status", "HIT")
 	setAgeHeader(rsp, entry, time.Now())
 	ctx.Metrics().IncCounter("hit")
-	ctx.Serve(rsp)
+	method := ctx.Request().Method
+	if (method == http.MethodGet || method == http.MethodHead) && evaluateConditionals(ctx.Request(), entry) {
+		notModified := &http.Response{
+			StatusCode: http.StatusNotModified,
+			Header:     rsp.Header.Clone(),
+			Body:       http.NoBody,
+			Request:    ctx.Request(), // link response to originating request per net/http convention
+		}
+		ctx.Serve(notModified)
+		return
+	}
+	ctx.Serve(headBodyOmitted(method, rsp))
 }
 
 // coalesce gates concurrent cold misses for the same key behind a single
@@ -208,34 +282,56 @@ func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
 	req := ctx.Request().Clone(context.Background())
 
 	ch := f.sf.DoChan(key, func() (interface{}, error) {
+		requestTime := time.Now()
 		resp, err := f.fetch(req)
 		if err != nil {
 			return nil, err
 		}
+		responseTime := time.Now()
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
 
-		ttl := capTTLByExpires(f.ttlForStatus(resp.StatusCode), resp.Header)
 		directives := parseCacheControl(resp.Header)
-		ttl = applySMaxAge(ttl, &directives)
+		// RFC mode only: no-store and private are semantic blockers (RFC 9111 §5.2.2).
+		if f.rfcMode && (directives.NoStore || directives.Private) {
+			cia := correctedInitialAge(requestTime, responseTime, resp.Header)
+			coalescedHeader := resp.Header.Clone()
+			stripHopByHop(coalescedHeader)
+			return &Entry{
+				StatusCode:          resp.StatusCode,
+				Header:              coalescedHeader,
+				Payload:             body,
+				CreatedAt:           responseTime,
+				TTL:                 0,
+				CorrectedInitialAge: cia,
+				ResponseTime:        responseTime,
+			}, nil
+		}
+		ttl, shouldStore := f.resolveTTL(resp.StatusCode, resp.Header, directives)
 		swr := f.swrWindow
 		if resp.StatusCode != http.StatusOK {
 			swr = 0
 		}
+		cia := correctedInitialAge(requestTime, responseTime, resp.Header)
+		coalescedHeader := resp.Header.Clone()
+		stripHopByHop(coalescedHeader)
 		entry := &Entry{
 			StatusCode:           resp.StatusCode,
-			Header:               resp.Header.Clone(),
+			Header:               coalescedHeader,
 			Payload:              body,
-			CreatedAt:            time.Now(),
+			CreatedAt:            responseTime,
 			TTL:                  ttl,
 			StaleWhileRevalidate: swr,
+			StaleIfError:         f.staleIfError,
 			ETag:                 resp.Header.Get("ETag"),
 			LastModified:         resp.Header.Get("Last-Modified"),
+			CorrectedInitialAge:  cia,
+			ResponseTime:         responseTime,
 		}
-		if ttl > 0 && !directives.NoStore && !directives.Private && !directives.NoCache {
+		if shouldStore {
 			_ = f.storage.Set(context.Background(), key, entry)
 		}
 		return entry, nil
@@ -243,11 +339,8 @@ func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
 
 	select {
 	case res := <-ch:
-		if res.Err != nil {
-			ctx.Metrics().IncCounter("fetch_error")
-			return
-		}
-		if res.Val == nil {
+		if res.Err != nil || res.Val == nil {
+			ctx.Metrics().IncCounter("coalesce_error")
 			return
 		}
 		entry := res.Val.(*Entry)
@@ -258,16 +351,57 @@ func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
 		}
 		rsp.Header.Set("X-Cache-Status", "MISS")
 		ctx.Metrics().IncCounter("miss")
-		ctx.Serve(rsp)
+		ctx.Serve(headBodyOmitted(ctx.Request().Method, rsp))
 	case <-ctx.Request().Context().Done():
 		// Client disconnected. Remaining waiters still receive their result.
 	}
 }
 
-// Response populates the cache on a miss.
+// Response stores the upstream response in the cache, freshens HEAD entries,
+// invalidates on unsafe methods, and applies stale-if-error on 5xx.
 func (f *cacheFilter) Response(ctx filters.FilterContext) {
 	rsp := ctx.Response()
 	key := ctx.StateBag()[stateBagKey].(string)
+
+	// RFC 5861 §4.
+	if f.staleIfError > 0 && rsp.StatusCode >= 500 {
+		if stored, err := f.storage.Get(ctx.Request().Context(), key); err == nil && stored != nil {
+			staleAge := time.Since(stored.CreatedAt) - stored.TTL
+			if staleAge <= f.staleIfError {
+				staleRsp := &http.Response{
+					StatusCode: stored.StatusCode,
+					Header:     stored.Header.Clone(),
+					Body:       io.NopCloser(bytes.NewReader(stored.Payload)),
+				}
+				staleRsp.Header.Set("X-Cache-Status", "STALE")
+				setAgeHeader(staleRsp, stored, time.Now())
+				ctx.Serve(headBodyOmitted(ctx.Request().Method, staleRsp))
+				return
+			}
+		}
+	}
+
+	// RFC 9111 §4.3.5: HEAD 200 freshens the stored GET entry's headers.
+	// This block runs before ctx.Served() so freshening happens even when
+	// Request() already served the HEAD from cache.
+	if ctx.Request().Method == http.MethodHead && rsp.StatusCode == http.StatusOK {
+		if stored, err := f.storage.Get(ctx.Request().Context(), key); err == nil && stored != nil {
+			for k, vv := range rsp.Header {
+				if bodyRelatedHeaders[k] {
+					continue
+				}
+				stored.Header[k] = vv
+			}
+			if etag := rsp.Header.Get("ETag"); etag != "" {
+				stored.ETag = etag
+			}
+			if lm := rsp.Header.Get("Last-Modified"); lm != "" {
+				stored.LastModified = lm
+			}
+			_ = f.storage.Set(ctx.Request().Context(), key, stored)
+		}
+		return
+	}
 
 	// Hit or stale path: already served from cache in Request(); nothing to do.
 	if ctx.Served() {
@@ -275,18 +409,17 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 	}
 
 	// RFC 9111 §4.4: invalidate cached entry on successful unsafe method.
+	// Also invalidate same-origin Location/Content-Location URIs.
 	if isUnsafeMethod(ctx.Request().Method) && rsp.StatusCode < 400 {
 		_ = f.storage.Delete(ctx.Request().Context(), key)
-		return
-	}
-
-	// Only cache responses to GET requests. HEAD/OPTIONS/CONNECT/TRACE must not be stored.
-	if ctx.Request().Method != http.MethodGet {
-		return
-	}
-
-	// RFC 9111 §3: MUST NOT store partial content (206) without Range support.
-	if rsp.StatusCode == http.StatusPartialContent {
+		for _, hdrName := range []string{"Location", "Content-Location"} {
+			if loc := rsp.Header.Get(hdrName); loc != "" && sameOrigin(ctx.Request(), loc) {
+				if locKey := cacheKeyForURL(ctx.RouteId(), ctx.Request(), loc, f.keyHeaders); locKey != "" {
+					_ = f.storage.Delete(ctx.Request().Context(), locKey)
+					_ = f.storage.Delete(ctx.Request().Context(), "vary:"+locKey)
+				}
+			}
+		}
 		return
 	}
 
@@ -305,14 +438,14 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 		return
 	}
 
-	ttl := capTTLByExpires(f.ttlForStatus(rsp.StatusCode), rsp.Header)
 	directives := parseCacheControl(rsp.Header)
-	ttl = applySMaxAge(ttl, &directives)
-	if ttl == 0 {
+	// RFC mode only: no-store and private are semantic blockers (RFC 9111 §5.2.2).
+	if f.rfcMode && (directives.NoStore || directives.Private) {
 		return
 	}
 
-	if directives.NoStore || directives.Private || directives.NoCache {
+	ttl, shouldStore := f.resolveTTL(rsp.StatusCode, rsp.Header, directives)
+	if !shouldStore {
 		return
 	}
 
@@ -331,7 +464,6 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 
 	rsp.Body = io.NopCloser(bytes.NewReader(body))
 
-	// Resolve Vary-aware storage key.
 	baseKey, _ := ctx.StateBag()["cache:base-key"].(string)
 	if baseKey == "" {
 		baseKey = key
@@ -341,9 +473,10 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 	if len(varyNames) > 0 {
 		storeKey = varyKey(baseKey, ctx.Request(), varyNames)
 		sentinel := &Entry{
-			CreatedAt:   time.Now(),
-			TTL:         ttl,
-			VaryHeaders: varyNames,
+			CreatedAt:            time.Now(),
+			TTL:                  ttl,
+			StaleWhileRevalidate: f.swrWindow,
+			VaryHeaders:          varyNames,
 		}
 		_ = f.storage.Set(ctx.Request().Context(), "vary:"+baseKey, sentinel)
 	}
@@ -352,16 +485,29 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 	if rsp.StatusCode != http.StatusOK {
 		swr = 0
 	}
+	responseTime := time.Now()
+	var requestTime time.Time
+	if rt, ok := ctx.StateBag()["cache:request-time"].(time.Time); ok {
+		requestTime = rt
+	} else {
+		requestTime = responseTime
+	}
+	cia := correctedInitialAge(requestTime, responseTime, rsp.Header)
+	storedHeader := rsp.Header.Clone()
+	stripHopByHop(storedHeader)
 	entry := &Entry{
 		StatusCode:           rsp.StatusCode,
-		Header:               rsp.Header.Clone(),
+		Header:               storedHeader,
 		Payload:              body,
-		CreatedAt:            time.Now(),
+		CreatedAt:            responseTime,
 		TTL:                  ttl,
 		StaleWhileRevalidate: swr,
+		StaleIfError:         f.staleIfError,
 		ETag:                 rsp.Header.Get("ETag"),
 		LastModified:         rsp.Header.Get("Last-Modified"),
 		VaryHeaders:          varyNames,
+		CorrectedInitialAge:  cia,
+		ResponseTime:         responseTime,
 	}
 	_ = f.storage.Set(ctx.Request().Context(), storeKey, entry)
 }
@@ -369,7 +515,7 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 // revalidate fetches the upstream resource in the background and refreshes the
 // cache entry. Uses singleflight to coalesce concurrent revalidations for the
 // same key. Uses a detached context so the fetch outlives the current request.
-func (f *cacheFilter) revalidate(key string, orig *http.Request, m filters.Metrics) {
+func (f *cacheFilter) revalidate(key string, orig *http.Request) {
 	f.revalSF.Do(key, func() (interface{}, error) {
 		req := orig.Clone(context.Background())
 		req.Header.Set(revalidateHeader, "1")
@@ -386,14 +532,16 @@ func (f *cacheFilter) revalidate(key string, orig *http.Request, m filters.Metri
 			}
 		}
 
+		requestTime := time.Now()
 		resp, err := f.fetch(req)
 		if err != nil {
-			m.IncCounter("reval_error")
+			f.metrics.IncCounter("reval_error")
 			log.WithFields(log.Fields{
 				"url": orig.URL.String(),
 			}).WithError(err).Warn("cache: background revalidation fetch failed")
 			return nil, nil
 		}
+		responseTime := time.Now()
 		defer resp.Body.Close()
 
 		var body []byte
@@ -405,7 +553,9 @@ func (f *cacheFilter) revalidate(key string, orig *http.Request, m filters.Metri
 			if stored, serr := f.storage.Get(context.Background(), key); serr == nil && stored != nil {
 				body = stored.Payload
 				responseHeader = stored.Header.Clone()
-				for k, vv := range resp.Header {
+				mergeHeaders := resp.Header.Clone()
+				stripHopByHop(mergeHeaders)
+				for k, vv := range mergeHeaders {
 					responseHeader[k] = vv
 				}
 			} else {
@@ -417,36 +567,40 @@ func (f *cacheFilter) revalidate(key string, orig *http.Request, m filters.Metri
 			var rerr error
 			body, rerr = io.ReadAll(resp.Body)
 			if rerr != nil {
-				m.IncCounter("reval_error")
+				f.metrics.IncCounter("reval_error")
 				log.WithFields(log.Fields{
 					"url": orig.URL.String(),
 				}).WithError(rerr).Warn("cache: failed to read response body during background revalidation")
 				return nil, nil
 			}
 			responseHeader = resp.Header.Clone()
+			stripHopByHop(responseHeader)
 			statusCode = resp.StatusCode
 		}
 
-		ttl := capTTLByExpires(f.ttlForStatus(statusCode), responseHeader)
 		directives := parseCacheControl(responseHeader)
-		ttl = applySMaxAge(ttl, &directives)
-		if ttl == 0 {
+		// RFC mode only: no-store and private are semantic blockers (RFC 9111 §5.2.2).
+		if f.rfcMode && (directives.NoStore || directives.Private) {
+			return nil, nil
+		}
+		ttl, shouldStore := f.resolveTTL(statusCode, responseHeader, directives)
+		if !shouldStore {
 			return nil, nil
 		}
 
-		if directives.NoStore || directives.Private || directives.NoCache {
-			return nil, nil
-		}
-
+		cia := correctedInitialAge(requestTime, responseTime, responseHeader)
 		entry := &Entry{
 			StatusCode:           statusCode,
 			Header:               responseHeader,
 			Payload:              body,
-			CreatedAt:            time.Now(),
+			CreatedAt:            responseTime,
 			TTL:                  ttl,
 			StaleWhileRevalidate: f.swrWindow,
+			StaleIfError:         f.staleIfError,
 			ETag:                 responseHeader.Get("ETag"),
 			LastModified:         responseHeader.Get("Last-Modified"),
+			CorrectedInitialAge:  cia,
+			ResponseTime:         responseTime,
 		}
 		_ = f.storage.Set(context.Background(), key, entry)
 		return nil, nil
@@ -464,66 +618,228 @@ func (f *cacheFilter) ttlForStatus(status int) time.Duration {
 	}
 }
 
-// cacheKey builds a deterministic, URL-safe cache key from the request.
+// resolveTTL decides the TTL to use for a stored entry.
+//
+// Force mode (rfcMode==false): operator ttl/errorTTL is authoritative; upstream
+// freshness directives are ignored. Semantic blockers (no-store, private) are
+// ignored too — callers must gate those in RFC mode only.
+//
+// RFC mode (rfcMode==true): upstream Cache-Control drives TTL per RFC 9111.
+// Heuristic freshness (§4.2.2) applies when no explicit directive is present.
+//
+// Returns (ttl, store) where store==false means the response must not be cached
+// (only possible in RFC mode when no directive and heuristic yields nothing).
+func (f *cacheFilter) resolveTTL(statusCode int, header http.Header, directives cacheDirectives) (ttl time.Duration, store bool) {
+	if !f.rfcMode {
+		// no-cache: store with TTL=0 so ETag/Last-Modified survive for conditional revalidation.
+		if directives.NoCache {
+			return 0, true
+		}
+		baseTTL := f.ttlForStatus(statusCode)
+		return baseTTL, baseTTL > 0
+	}
+
+	if directives.NoCache {
+		return 0, true
+	}
+	hasExplicitDirective := directives.MaxAge >= 0 || directives.SMaxAge >= 0 || header.Get("Expires") != ""
+	if !hasExplicitDirective {
+		if h := heuristicTTL(header, directives, time.Now()); h > 0 {
+			return h, true
+		}
+		return 0, false
+	}
+	// s-maxage takes precedence over max-age (RFC 9111 §5.2.2.10), then Expires.
+	if directives.SMaxAge >= 0 {
+		ttl = time.Duration(directives.SMaxAge) * time.Second
+	} else if directives.MaxAge >= 0 {
+		ttl = time.Duration(directives.MaxAge) * time.Second
+	} else {
+		ttl = capTTLByExpires(0, header, directives) // 0 = uncapped
+	}
+	// Store even when TTL=0 (expired/invalid Expires or max-age=0) so
+	// ETag/Last-Modified are preserved for conditional revalidation (§5.2.2.4).
+	return ttl, true
+}
+
+// cacheKey builds a deterministic cache key from the route ID and request.
+// routeID is included so entries from different routes never collide when all
+// routes share the same LRUStorage instance.
 // SHA-256 is used for uniform distribution and to satisfy the lru.go requirement
 // that keys passed to ShardedByteLRU are pre-hashed by the caller.
 // keyHeaders is an optional list of request header names whose values are folded
 // into the key, allowing per-header cache isolation (e.g. "Authorization").
-func cacheKey(r *http.Request, keyHeaders []string) string {
+func cacheKey(routeID string, r *http.Request, keyHeaders []string) string {
 	h := sha256.New()
-	fmt.Fprintf(h, "%s://%s%s?%s", r.URL.Scheme, r.Host, r.URL.Path, r.URL.RawQuery)
+	fmt.Fprintf(h, "%s\n%s://%s%s?%s", routeID, r.URL.Scheme, r.Host, r.URL.Path, r.URL.RawQuery)
 	for _, name := range keyHeaders {
 		fmt.Fprintf(h, "\n%s: %s", name, r.Header.Get(name))
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// setAgeHeader computes and sets the Age header per RFC 9111 §5.1.
-// If the stored response already carries an Age value from an upstream cache, the two are summed.
-func setAgeHeader(rsp *http.Response, entry *Entry, now time.Time) {
-	elapsed := int64(now.Sub(entry.CreatedAt).Seconds())
-	if elapsed < 0 {
-		elapsed = 0
+// parseHTTPTime parses an HTTP date per RFC 9111 §4.2.
+// Rejects dates with non-GMT zone abbreviations that http.ParseTime would silently
+// accept with a wrong offset (RFC 850 format only; RFC 1123 already rejects non-GMT).
+func parseHTTPTime(s string) (time.Time, error) {
+	t, err := http.ParseTime(s)
+	if err != nil {
+		return time.Time{}, err
 	}
-	if existing := rsp.Header.Get("Age"); existing != "" {
-		if v, err := strconv.ParseInt(existing, 10, 64); err == nil {
-			elapsed += v
+	name, offset := t.Zone()
+	if offset != 0 || (name != "UTC" && name != "GMT") {
+		return time.Time{}, fmt.Errorf("cache: non-GMT date %q rejected", s)
+	}
+	return t, nil
+}
+
+// correctedInitialAge computes the corrected_initial_age per RFC 9111 §4.2.3.
+// It is called once at cache-entry-creation time and stored in Entry.CorrectedInitialAge.
+func correctedInitialAge(requestTime, responseTime time.Time, rspHeader http.Header) time.Duration {
+	var apparentAge time.Duration
+	if dateStr := rspHeader.Get("Date"); dateStr != "" {
+		if dateVal, err := parseHTTPTime(dateStr); err == nil {
+			if diff := responseTime.Sub(dateVal); diff > 0 {
+				apparentAge = diff
+			}
 		}
 	}
-	rsp.Header.Set("Age", strconv.FormatInt(elapsed, 10))
+	var ageValue time.Duration
+	if ageStr := rspHeader.Get("Age"); ageStr != "" {
+		if v, err := strconv.ParseInt(ageStr, 10, 64); err == nil && v >= 0 {
+			ageValue = time.Duration(v) * time.Second
+		}
+	}
+	responseDelay := responseTime.Sub(requestTime)
+	if responseDelay < 0 {
+		responseDelay = 0
+	}
+	correctedAgeValue := ageValue + responseDelay
+	if correctedAgeValue > apparentAge {
+		return correctedAgeValue
+	}
+	return apparentAge
 }
 
-// applySMaxAge returns the effective TTL after applying s-maxage (RFC 9111 §5.2.2.10).
-// s-maxage overrides Expires and the operator TTL for shared caches.
-// It also sets MustRevalidate on the directives struct because s-maxage implies proxy-revalidate.
-func applySMaxAge(ttl time.Duration, d *cacheDirectives) time.Duration {
-	if d.SMaxAge == nil {
-		return ttl
+// setAgeHeader computes and sets the Age header per RFC 9111 §4.2.3.
+// For new entries (ResponseTime set), uses precise corrected_initial_age formula.
+// For legacy entries (ResponseTime zero), falls back to the elapsed-time formula.
+func setAgeHeader(rsp *http.Response, entry *Entry, now time.Time) {
+	var age int64
+	if !entry.ResponseTime.IsZero() {
+		// RFC 9111 §4.2.3 precise formula.
+		residentTime := now.Sub(entry.ResponseTime)
+		if residentTime < 0 {
+			residentTime = 0
+		}
+		secs := int64((entry.CorrectedInitialAge + residentTime).Seconds())
+		if secs < 0 {
+			secs = 0
+		}
+		age = secs
+	} else {
+		elapsed := int64(now.Sub(entry.CreatedAt).Seconds())
+		if elapsed < 0 {
+			elapsed = 0
+		}
+		if existing := rsp.Header.Get("Age"); existing != "" {
+			if v, err := strconv.ParseInt(existing, 10, 64); err == nil {
+				elapsed += v
+			}
+		}
+		age = elapsed
 	}
-	d.MustRevalidate = true
-	if *d.SMaxAge < ttl {
-		return *d.SMaxAge
-	}
-	return ttl
+	rsp.Header.Set("Age", strconv.FormatInt(age, 10))
 }
 
-func capTTLByExpires(ttl time.Duration, header http.Header) time.Duration {
+// evaluateConditionals checks client If-None-Match / If-Modified-Since against
+// a cached entry per RFC 9111 §4.3.2 / RFC 9110 §13. Returns true when the
+// client condition is "not modified" (cache should respond 304).
+// Only call for GET and HEAD requests.
+func evaluateConditionals(req *http.Request, entry *Entry) bool {
+	if inm := req.Header.Get("If-None-Match"); inm != "" {
+		return matchesETag(inm, entry.ETag)
+	}
+	if ims := req.Header.Get("If-Modified-Since"); ims != "" && entry.LastModified != "" {
+		imsTime, err := parseHTTPTime(ims)
+		if err != nil {
+			return false
+		}
+		lmTime, err := parseHTTPTime(entry.LastModified)
+		if err != nil {
+			return false
+		}
+		return !lmTime.After(imsTime)
+	}
+	return false
+}
+
+// matchesETag reports whether the If-None-Match header value matches etag
+// using weak comparison per RFC 9110 §8.8.3.2.
+func matchesETag(ifNoneMatch, etag string) bool {
+	if etag == "" {
+		return false
+	}
+	if ifNoneMatch == "*" {
+		return true
+	}
+	normalise := func(e string) string {
+		return strings.TrimPrefix(strings.TrimSpace(e), "W/")
+	}
+	normEtag := normalise(etag)
+	for _, token := range strings.Split(ifNoneMatch, ",") {
+		if normalise(token) == normEtag {
+			return true
+		}
+	}
+	return false
+}
+
+// heuristicTTL returns a heuristic freshness lifetime per RFC 9111 §4.2.2:
+// ttl = 0.1 * (Date - Last-Modified). Returns 0 when any explicit freshness
+// directive is present, when Last-Modified is absent, or when inapplicable.
+func heuristicTTL(header http.Header, d cacheDirectives, now time.Time) time.Duration {
+	if d.MaxAge >= 0 || d.SMaxAge >= 0 || header.Get("Expires") != "" {
+		return 0
+	}
+	lmStr := header.Get("Last-Modified")
+	if lmStr == "" {
+		return 0
+	}
+	lm, err := parseHTTPTime(lmStr)
+	if err != nil {
+		return 0
+	}
+	ref := now
+	if dateStr := header.Get("Date"); dateStr != "" {
+		if t, err := parseHTTPTime(dateStr); err == nil {
+			ref = t
+		}
+	}
+	age := ref.Sub(lm)
+	if age <= 0 {
+		return 0
+	}
+	return time.Duration(float64(age) * 0.1)
+}
+
+func capTTLByExpires(ttl time.Duration, header http.Header, d cacheDirectives) time.Duration {
+	if d.MaxAge >= 0 || d.SMaxAge >= 0 {
+		return ttl // RFC 9111 §5.3: Expires ignored when max-age or s-maxage present
+	}
 	exp := header.Get("Expires")
 	if exp == "" {
 		return ttl
 	}
-	t, err := http.ParseTime(exp)
+	t, err := parseHTTPTime(exp)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"expires": exp,
-		}).Warn("cache: unparseable Expires header, ignoring")
-		return ttl
+		return 0 // RFC 9111 §5.3: invalid date (incl. "0") = already expired
 	}
 	remaining := time.Until(t)
 	if remaining <= 0 {
 		return 0
 	}
-	if remaining < ttl {
+	if ttl == 0 || remaining < ttl { // ttl==0 means uncapped (pure RFC mode)
 		return remaining
 	}
 	return ttl
@@ -535,6 +851,51 @@ func isUnsafeMethod(method string) bool {
 		return true
 	}
 	return false
+}
+
+// headBodyOmitted returns rsp with an empty body when method is HEAD.
+// RFC 9110 §9.3.2: HEAD responses must not include a message body.
+func headBodyOmitted(method string, rsp *http.Response) *http.Response {
+	if method != http.MethodHead {
+		return rsp
+	}
+	out := *rsp
+	out.Body = http.NoBody
+	out.ContentLength = 0
+	return &out
+}
+
+// bodyRelatedHeaders are omitted when freshening a GET entry from a HEAD response
+// (RFC 9111 §4.3.5). These headers describe the body and are meaningless from HEAD.
+var bodyRelatedHeaders = map[string]bool{
+	"Content-Length":    true,
+	"Content-Range":     true,
+	"Transfer-Encoding": true,
+}
+
+// hopByHopHeaders are never stored in a cache entry per RFC 9111 §3.1 / RFC 9110 §7.6.1.
+var hopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+// stripHopByHop removes hop-by-hop headers from h in-place.
+// Also removes any header named in the Connection value per RFC 9110 §7.6.1.
+func stripHopByHop(h http.Header) {
+	for _, name := range h.Values("Connection") {
+		for _, field := range strings.Split(name, ",") {
+			h.Del(strings.TrimSpace(field))
+		}
+	}
+	for name := range hopByHopHeaders {
+		h.Del(name)
+	}
 }
 
 func parseVaryNames(varyHeader string) []string {
@@ -576,4 +937,35 @@ func toDuration(v interface{}) (time.Duration, error) {
 		return 0, fmt.Errorf("duration must be positive, got %s", s)
 	}
 	return d, nil
+}
+
+// sameOrigin reports whether rawTarget is same-origin as base.
+// Relative URIs (no host) are always treated as same-origin.
+func sameOrigin(base *http.Request, rawTarget string) bool {
+	u, err := url.Parse(rawTarget)
+	if err != nil || u.Host == "" {
+		return true
+	}
+	return u.Scheme == base.URL.Scheme && u.Host == base.URL.Host
+}
+
+// cacheKeyForURL builds the cache key for rawTarget resolved against base.
+// routeID must match the routeID used when the entry was originally stored.
+// Returns "" if rawTarget cannot be parsed.
+func cacheKeyForURL(routeID string, base *http.Request, rawTarget string, keyHeaders []string) string {
+	u, err := url.Parse(rawTarget)
+	if err != nil {
+		return ""
+	}
+	if u.Host == "" {
+		host := base.Host
+		if host == "" {
+			host = base.URL.Host
+		}
+		u.Host = host
+		u.Scheme = base.URL.Scheme
+	}
+	// Synthesise a minimal *http.Request so we can reuse cacheKey.
+	synthetic := &http.Request{URL: u, Host: u.Host, Header: base.Header}
+	return cacheKey(routeID, synthetic, keyHeaders)
 }

--- a/filters/cache/filter.go
+++ b/filters/cache/filter.go
@@ -221,8 +221,10 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 	}
 
 	reqDir := parseRequestCacheControl(ctx.Request().Header)
+	var entry *Entry
+	var err error
 	if reqDir.onlyIfCached {
-		entry, err := f.storage.Get(ctx.Request().Context(), key)
+		entry, err = f.storage.Get(ctx.Request().Context(), key)
 		if err != nil || entry == nil || entry.IsStale(time.Now()) {
 			ctx.Serve(&http.Response{
 				StatusCode: http.StatusGatewayTimeout,
@@ -236,9 +238,9 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 			ctx.StateBag()[stateBagNoStore] = true
 		}
 		return
+	} else {
+		entry, err = f.storage.Get(ctx.Request().Context(), key)
 	}
-
-	entry, err := f.storage.Get(ctx.Request().Context(), key)
 	if err != nil || entry == nil {
 		f.coalesce(ctx, key)
 		return

--- a/filters/cache/filter.go
+++ b/filters/cache/filter.go
@@ -16,18 +16,34 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/metrics"
-	sknet "github.com/zalando/skipper/net"
+	skpnet "github.com/zalando/skipper/net"
 	"golang.org/x/sync/singleflight"
 )
 
 const (
-	Name        = "cache"
-	filterName  = Name
-	stateBagKey = "cache:key"
+	Name       = filters.CacheName
+	filterName = Name
+
+	// State bag keys.
+	stateBagKey         = "cache:key"
+	stateBagBaseKey     = "cache:base-key"
+	stateBagRequestTime = "cache:request-time"
+	stateBagNoStore     = "cache:no-store"
 
 	// revalidateHeader is set on background revalidation requests so the cache
 	// filter skips the cache lookup and lets the response populate a fresh entry.
 	revalidateHeader = "X-Cache-Revalidate"
+
+	// X-Cache-Status header values.
+	cacheStatusHeader = "X-Cache-Status"
+	cacheStatusHit    = "HIT"
+	cacheStatusMiss   = "MISS"
+	cacheStatusStale  = "STALE"
+
+	// revalQueueSize is the capacity of the per-filter revalidation job queue.
+	// Sized to absorb short bursts; jobs are dropped (with reval_dropped metric)
+	// if the worker cannot keep up.
+	revalQueueSize = 256
 )
 
 // NewCacheFilter returns a Spec for the cache() filter. maxBytes is the
@@ -47,19 +63,24 @@ const (
 // Combining force mode with stale-if-error:
 //
 //	-> cache("5m", "15s", "30s", "60s") -> "https://example.org"
-func NewCacheFilter(maxBytes int64, listenAddr string) filters.Spec {
+func NewCacheFilter(maxBytes int64, listenAddr string, netOpts skpnet.Options) filters.Spec {
+	var store *LRUStorage
+	store = NewLRUStorage(maxBytes, func() {
+		metrics.Default.IncCounter("lru_eviction")
+		metrics.Default.UpdateGauge("lru_bytes", float64(store.lru.Bytes()))
+	})
 	return &cacheSpec{
 		maxBytes:   maxBytes,
 		listenAddr: listenAddr,
-		client:     sknet.NewClient(sknet.Options{}),
-		storage:    NewLRUStorage(maxBytes, func() { metrics.Default.IncCounter("lru_eviction") }),
+		client:     skpnet.NewClient(netOpts),
+		storage:    store,
 	}
 }
 
 type cacheSpec struct {
 	maxBytes   int64
 	listenAddr string
-	client     *sknet.Client
+	client     *skpnet.Client
 	storage    Storage // shared across all filter instances
 }
 
@@ -67,37 +88,36 @@ func (s *cacheSpec) Name() string { return filterName }
 
 func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 	if len(args) != 0 && (len(args) < 3 || len(args) > 5) {
-		return nil, fmt.Errorf("cache: expected 0 or 3-5 args (ttl, errorTTL, swrWindow[, staleIfError[, keyHeaders]]), got %d", len(args))
+		return nil, fmt.Errorf("cache: expected 0 or 3-5 args (ttl, errorTTL, swrWindow[, staleIfError[, keyHeaders]]), got %d: %w", len(args), filters.ErrInvalidFilterParameters)
 	}
 
-	var ttl, errorTTL, swr, staleIfError time.Duration
 	rfcMode := len(args) == 0 // zero args → pure RFC mode
 
+	var ttl, errorTTL, swr, staleIfError time.Duration
 	if len(args) >= 3 {
 		var err error
 		ttl, err = toDuration(args[0])
 		if err != nil {
-			return nil, fmt.Errorf("cache: arg 0 (ttl): %w", err)
+			return nil, fmt.Errorf("cache: arg 0 (ttl): %v: %w", err, filters.ErrInvalidFilterParameters)
 		}
 
 		errorTTL, err = toDuration(args[1])
 		if err != nil {
-			return nil, fmt.Errorf("cache: arg 1 (errorTTL): %w", err)
+			return nil, fmt.Errorf("cache: arg 1 (errorTTL): %v: %w", err, filters.ErrInvalidFilterParameters)
 		}
 
 		swr, err = toDuration(args[2])
 		if err != nil {
-			return nil, fmt.Errorf("cache: arg 2 (swrWindow): %w", err)
+			return nil, fmt.Errorf("cache: arg 2 (swrWindow): %v: %w", err, filters.ErrInvalidFilterParameters)
 		}
 
 		if len(args) >= 4 {
-			s, ok := args[3].(string)
-			if !ok {
-				return nil, fmt.Errorf("cache: arg 3 (staleIfError): expected string, got %T", args[3])
+			if _, ok := args[3].(string); !ok {
+				return nil, fmt.Errorf("cache: arg 3 (staleIfError): expected string, got %T: %w", args[3], filters.ErrInvalidFilterParameters)
 			}
-			staleIfError, err = time.ParseDuration(s)
+			staleIfError, err = time.ParseDuration(args[3].(string))
 			if err != nil {
-				return nil, fmt.Errorf("cache: arg 3 (staleIfError): %w", err)
+				return nil, fmt.Errorf("cache: arg 3 (staleIfError): %v: %w", err, filters.ErrInvalidFilterParameters)
 			}
 		}
 	}
@@ -106,7 +126,7 @@ func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 	if len(args) == 5 {
 		raw, ok := args[4].(string)
 		if !ok {
-			return nil, fmt.Errorf("cache: arg 4 (keyHeaders): expected string, got %T", args[4])
+			return nil, fmt.Errorf("cache: arg 4 (keyHeaders): expected string, got %T: %w", args[4], filters.ErrInvalidFilterParameters)
 		}
 		for _, h := range strings.Split(raw, ",") {
 			if name := strings.TrimSpace(h); name != "" {
@@ -115,7 +135,6 @@ func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 		}
 	}
 
-	m := metrics.Default
 	cf := &cacheFilter{
 		storage:      s.storage,
 		listenAddr:   s.listenAddr,
@@ -124,11 +143,34 @@ func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 		swrWindow:    swr,
 		staleIfError: staleIfError,
 		rfcMode:      rfcMode,
-		metrics:      m,
+		metrics:      metrics.Default,
 		keyHeaders:   keyHeaders,
+		revalJobs:    make(chan revalJob, revalQueueSize),
 	}
+
 	cf.fetch = s.client.Do
+	go cf.revalidationWorker()
 	return cf, nil
+}
+
+// Close shuts down the background revalidation worker. Must be called when the
+// filter is no longer in use (e.g. in tests via t.Cleanup).
+func (f *cacheFilter) Close() {
+	close(f.revalJobs)
+}
+
+// revalidationWorker is the single background goroutine per filter that
+// processes revalidation jobs sequentially. It exits when revalJobs is closed.
+func (f *cacheFilter) revalidationWorker() {
+	for job := range f.revalJobs {
+		f.doRevalidate(job.key, job.req)
+	}
+	log.Debug("cache: revalidation worker stopped")
+}
+
+type revalJob struct {
+	key string
+	req *http.Request // pre-cloned, safe to use after the originating request ends
 }
 
 type cacheFilter struct {
@@ -139,13 +181,15 @@ type cacheFilter struct {
 	swrWindow    time.Duration
 	staleIfError time.Duration
 	keyHeaders   []string // request headers folded into the base cache key
+
 	// rfcMode true: upstream Cache-Control is authoritative (cache()).
 	// false: operator ttl/errorTTL/swrWindow are authoritative (force mode).
-	rfcMode bool
-	sf      singleflight.Group // cold-miss coalescing
-	revalSF singleflight.Group // background revalidation coalescing
-	fetch   func(*http.Request) (*http.Response, error)
-	metrics metrics.Metrics
+	rfcMode   bool
+	coldSF    singleflight.Group // cold-miss coalescing
+	revalSF   singleflight.Group // coalesces concurrent background revalidations per key
+	revalJobs chan revalJob      // background revalidation queue; worker drains this
+	fetch     func(*http.Request) (*http.Response, error)
+	metrics   metrics.Metrics
 }
 
 // Request checks the cache. On a hit it calls ctx.Serve() to short-circuit the
@@ -153,16 +197,18 @@ type cacheFilter struct {
 // revalidation. On a miss it stores the computed key in the state bag so
 // Response() can populate the cache.
 func (f *cacheFilter) Request(ctx filters.FilterContext) {
+	// Key is built from the already-filtered request: mutations by earlier filters
+	// (e.g. header stripping by auth) are intentionally reflected in the cache key.
 	baseKey := cacheKey(ctx.RouteId(), ctx.Request(), f.keyHeaders)
 	key := baseKey
 	if sentinel, _ := f.storage.Get(ctx.Request().Context(), "vary:"+baseKey); sentinel != nil && len(sentinel.VaryHeaders) > 0 {
 		key = varyKey(baseKey, ctx.Request(), sentinel.VaryHeaders)
 	}
 	ctx.StateBag()[stateBagKey] = key
-	ctx.StateBag()["cache:base-key"] = baseKey
-	ctx.StateBag()["cache:request-time"] = time.Now()
+	ctx.StateBag()[stateBagBaseKey] = baseKey
+	ctx.StateBag()[stateBagRequestTime] = time.Now()
 
-	// Unsafe methods skip cache lookup; Response() will invalidate the entry.
+	// Unsafe methods skip the cache lookup; Response() will invalidate using the key above.
 	if isUnsafeMethod(ctx.Request().Method) {
 		return
 	}
@@ -175,19 +221,19 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 	}
 
 	reqDir := parseRequestCacheControl(ctx.Request().Header)
-	if reqDir.OnlyIfCached {
+	if reqDir.onlyIfCached {
 		entry, err := f.storage.Get(ctx.Request().Context(), key)
 		if err != nil || entry == nil || entry.IsStale(time.Now()) {
 			ctx.Serve(&http.Response{
 				StatusCode: http.StatusGatewayTimeout,
-				Header:     http.Header{"X-Cache-Status": {"MISS"}},
+				Header:     http.Header{cacheStatusHeader: {cacheStatusMiss}},
 				Body:       http.NoBody,
 			})
 			return
 		}
-	} else if reqDir.NoCache || reqDir.NoStore {
-		if reqDir.NoStore {
-			ctx.StateBag()["cache:no-store"] = true
+	} else if reqDir.noCache || reqDir.noStore {
+		if reqDir.noStore {
+			ctx.StateBag()[stateBagNoStore] = true
 		}
 		return
 	}
@@ -208,19 +254,19 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 	pastTTL := now.After(entry.CreatedAt.Add(entry.TTL))
 	if entry.IsStale(now) {
 		d := parseCacheControl(entry.Header)
-		if d.MustRevalidate || d.ProxyRevalidate || d.NoCache || d.SMaxAge >= 0 {
+		if d.mustRevalidate || d.proxyRevalidate || d.noCache || d.sMaxAge >= 0 {
 			f.coalesce(ctx, key)
 			return
 		}
 		// RFC 9111 §5.2.1 max-stale.
-		if reqDir.MaxStale >= 0 {
+		if reqDir.maxStale >= 0 {
 			staleness := time.Since(entry.CreatedAt) - entry.TTL
-			if staleness > time.Duration(reqDir.MaxStale)*time.Second {
+			if staleness > time.Duration(reqDir.maxStale)*time.Second {
 				f.coalesce(ctx, key)
 				return
 			}
 		}
-		rsp.Header.Set("X-Cache-Status", "STALE")
+		rsp.Header.Set(cacheStatusHeader, cacheStatusStale)
 		setAgeHeader(rsp, entry, now)
 		ctx.Metrics().IncCounter("stale")
 		method := ctx.Request().Method
@@ -232,11 +278,11 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 				Request:    ctx.Request(), // link response to originating request per net/http convention
 			}
 			ctx.Serve(notModified)
-			go f.revalidate(key, ctx.Request())
+			f.enqueueRevalidation(key, ctx.Request())
 			return
 		}
 		ctx.Serve(headBodyOmitted(method, rsp))
-		go f.revalidate(key, ctx.Request())
+		f.enqueueRevalidation(key, ctx.Request())
 		return
 	}
 
@@ -248,16 +294,16 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 	}
 
 	// RFC 9111 §5.2.1 min-fresh.
-	if reqDir.MinFresh >= 0 {
+	if reqDir.minFresh >= 0 {
 		elapsed := time.Since(entry.CreatedAt)
 		remaining := entry.TTL - elapsed
-		if remaining < time.Duration(reqDir.MinFresh)*time.Second {
+		if remaining < time.Duration(reqDir.minFresh)*time.Second {
 			f.coalesce(ctx, key)
 			return
 		}
 	}
 
-	rsp.Header.Set("X-Cache-Status", "HIT")
+	rsp.Header.Set(cacheStatusHeader, cacheStatusHit)
 	setAgeHeader(rsp, entry, time.Now())
 	ctx.Metrics().IncCounter("hit")
 	method := ctx.Request().Method
@@ -281,7 +327,7 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
 	req := ctx.Request().Clone(context.Background())
 
-	ch := f.sf.DoChan(key, func() (interface{}, error) {
+	ch := f.coldSF.DoChan(key, func() (interface{}, error) {
 		requestTime := time.Now()
 		resp, err := f.fetch(req)
 		if err != nil {
@@ -296,7 +342,7 @@ func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
 
 		directives := parseCacheControl(resp.Header)
 		// RFC mode only: no-store and private are semantic blockers (RFC 9111 §5.2.2).
-		if f.rfcMode && (directives.NoStore || directives.Private) {
+		if f.rfcMode && (directives.noStore || directives.private) {
 			cia := correctedInitialAge(requestTime, responseTime, resp.Header)
 			coalescedHeader := resp.Header.Clone()
 			stripHopByHop(coalescedHeader)
@@ -349,7 +395,7 @@ func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
 			Header:     entry.Header.Clone(),
 			Body:       io.NopCloser(bytes.NewReader(entry.Payload)),
 		}
-		rsp.Header.Set("X-Cache-Status", "MISS")
+		rsp.Header.Set(cacheStatusHeader, cacheStatusMiss)
 		ctx.Metrics().IncCounter("miss")
 		ctx.Serve(headBodyOmitted(ctx.Request().Method, rsp))
 	case <-ctx.Request().Context().Done():
@@ -362,24 +408,6 @@ func (f *cacheFilter) coalesce(ctx filters.FilterContext, key string) {
 func (f *cacheFilter) Response(ctx filters.FilterContext) {
 	rsp := ctx.Response()
 	key := ctx.StateBag()[stateBagKey].(string)
-
-	// RFC 5861 §4.
-	if f.staleIfError > 0 && rsp.StatusCode >= 500 {
-		if stored, err := f.storage.Get(ctx.Request().Context(), key); err == nil && stored != nil {
-			staleAge := time.Since(stored.CreatedAt) - stored.TTL
-			if staleAge <= f.staleIfError {
-				staleRsp := &http.Response{
-					StatusCode: stored.StatusCode,
-					Header:     stored.Header.Clone(),
-					Body:       io.NopCloser(bytes.NewReader(stored.Payload)),
-				}
-				staleRsp.Header.Set("X-Cache-Status", "STALE")
-				setAgeHeader(staleRsp, stored, time.Now())
-				ctx.Serve(headBodyOmitted(ctx.Request().Method, staleRsp))
-				return
-			}
-		}
-	}
 
 	// RFC 9111 §4.3.5: HEAD 200 freshens the stored GET entry's headers.
 	// This block runs before ctx.Served() so freshening happens even when
@@ -423,13 +451,31 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 		return
 	}
 
-	if ctx.StateBag()["cache:no-store"] == true {
-		rsp.Header.Set("X-Cache-Status", "MISS")
+	// RFC 5861 §4.
+	if f.staleIfError > 0 && rsp.StatusCode >= 500 {
+		if stored, err := f.storage.Get(ctx.Request().Context(), key); err == nil && stored != nil {
+			staleAge := time.Since(stored.CreatedAt) - stored.TTL
+			if staleAge <= f.staleIfError {
+				staleRsp := &http.Response{
+					StatusCode: stored.StatusCode,
+					Header:     stored.Header.Clone(),
+					Body:       io.NopCloser(bytes.NewReader(stored.Payload)),
+				}
+				staleRsp.Header.Set(cacheStatusHeader, cacheStatusStale)
+				setAgeHeader(staleRsp, stored, time.Now())
+				ctx.Serve(headBodyOmitted(ctx.Request().Method, staleRsp))
+				return
+			}
+		}
+	}
+
+	if ctx.StateBag()[stateBagNoStore] == true {
+		rsp.Header.Set(cacheStatusHeader, cacheStatusMiss)
 		ctx.Metrics().IncCounter("miss")
 		return
 	}
 
-	rsp.Header.Set("X-Cache-Status", "MISS")
+	rsp.Header.Set(cacheStatusHeader, cacheStatusMiss)
 	ctx.Metrics().IncCounter("miss")
 
 	// Vary: * means every response is unique — never cache.
@@ -440,7 +486,7 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 
 	directives := parseCacheControl(rsp.Header)
 	// RFC mode only: no-store and private are semantic blockers (RFC 9111 §5.2.2).
-	if f.rfcMode && (directives.NoStore || directives.Private) {
+	if f.rfcMode && (directives.noStore || directives.private) {
 		return
 	}
 
@@ -449,7 +495,7 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 		return
 	}
 
-	if ctx.Request().Header.Get("Authorization") != "" && !directives.Public && !directives.MustRevalidate {
+	if ctx.Request().Header.Get("Authorization") != "" && !directives.public && !directives.mustRevalidate {
 		return
 	}
 
@@ -464,7 +510,7 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 
 	rsp.Body = io.NopCloser(bytes.NewReader(body))
 
-	baseKey, _ := ctx.StateBag()["cache:base-key"].(string)
+	baseKey, _ := ctx.StateBag()[stateBagBaseKey].(string)
 	if baseKey == "" {
 		baseKey = key
 	}
@@ -487,7 +533,7 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 	}
 	responseTime := time.Now()
 	var requestTime time.Time
-	if rt, ok := ctx.StateBag()["cache:request-time"].(time.Time); ok {
+	if rt, ok := ctx.StateBag()[stateBagRequestTime].(time.Time); ok {
 		requestTime = rt
 	} else {
 		requestTime = responseTime
@@ -512,12 +558,23 @@ func (f *cacheFilter) Response(ctx filters.FilterContext) {
 	_ = f.storage.Set(ctx.Request().Context(), storeKey, entry)
 }
 
-// revalidate fetches the upstream resource in the background and refreshes the
-// cache entry. Uses singleflight to coalesce concurrent revalidations for the
-// same key. Uses a detached context so the fetch outlives the current request.
-func (f *cacheFilter) revalidate(key string, orig *http.Request) {
-	f.revalSF.Do(key, func() (interface{}, error) {
-		req := orig.Clone(context.Background())
+// enqueueRevalidation clones the request before sending a job to the background
+// revalidation worker so there is no data race: the clone happens in the calling
+// goroutine while orig is still live, and the worker receives a fully independent copy.
+// Non-blocking send: if the queue is full the revalidation is dropped rather than
+// blocking the request goroutine.
+func (f *cacheFilter) enqueueRevalidation(key string, orig *http.Request) {
+	cloned := orig.Clone(context.Background())
+	select {
+	case f.revalJobs <- revalJob{key: key, req: cloned}:
+	default:
+		f.metrics.IncCounter("reval_dropped")
+	}
+}
+
+// doRevalidate fetches the upstream resource and refreshes the cache entry.
+func (f *cacheFilter) doRevalidate(key string, req *http.Request) {
+	f.revalSF.Do(key, func() (interface{}, error) { //nolint:errcheck
 		req.Header.Set(revalidateHeader, "1")
 		req.URL.Scheme = "http"
 		req.URL.Host = f.listenAddr
@@ -537,7 +594,7 @@ func (f *cacheFilter) revalidate(key string, orig *http.Request) {
 		if err != nil {
 			f.metrics.IncCounter("reval_error")
 			log.WithFields(log.Fields{
-				"url": orig.URL.String(),
+				"url": req.URL.String(),
 			}).WithError(err).Warn("cache: background revalidation fetch failed")
 			return nil, nil
 		}
@@ -569,7 +626,7 @@ func (f *cacheFilter) revalidate(key string, orig *http.Request) {
 			if rerr != nil {
 				f.metrics.IncCounter("reval_error")
 				log.WithFields(log.Fields{
-					"url": orig.URL.String(),
+					"url": req.URL.String(),
 				}).WithError(rerr).Warn("cache: failed to read response body during background revalidation")
 				return nil, nil
 			}
@@ -580,7 +637,7 @@ func (f *cacheFilter) revalidate(key string, orig *http.Request) {
 
 		directives := parseCacheControl(responseHeader)
 		// RFC mode only: no-store and private are semantic blockers (RFC 9111 §5.2.2).
-		if f.rfcMode && (directives.NoStore || directives.Private) {
+		if f.rfcMode && (directives.noStore || directives.private) {
 			return nil, nil
 		}
 		ttl, shouldStore := f.resolveTTL(statusCode, responseHeader, directives)
@@ -632,17 +689,17 @@ func (f *cacheFilter) ttlForStatus(status int) time.Duration {
 func (f *cacheFilter) resolveTTL(statusCode int, header http.Header, directives cacheDirectives) (ttl time.Duration, store bool) {
 	if !f.rfcMode {
 		// no-cache: store with TTL=0 so ETag/Last-Modified survive for conditional revalidation.
-		if directives.NoCache {
+		if directives.noCache {
 			return 0, true
 		}
 		baseTTL := f.ttlForStatus(statusCode)
 		return baseTTL, baseTTL > 0
 	}
 
-	if directives.NoCache {
+	if directives.noCache {
 		return 0, true
 	}
-	hasExplicitDirective := directives.MaxAge >= 0 || directives.SMaxAge >= 0 || header.Get("Expires") != ""
+	hasExplicitDirective := directives.maxAge >= 0 || directives.sMaxAge >= 0 || header.Get("Expires") != ""
 	if !hasExplicitDirective {
 		if h := heuristicTTL(header, directives, time.Now()); h > 0 {
 			return h, true
@@ -650,10 +707,10 @@ func (f *cacheFilter) resolveTTL(statusCode int, header http.Header, directives 
 		return 0, false
 	}
 	// s-maxage takes precedence over max-age (RFC 9111 §5.2.2.10), then Expires.
-	if directives.SMaxAge >= 0 {
-		ttl = time.Duration(directives.SMaxAge) * time.Second
-	} else if directives.MaxAge >= 0 {
-		ttl = time.Duration(directives.MaxAge) * time.Second
+	if directives.sMaxAge >= 0 {
+		ttl = time.Duration(directives.sMaxAge) * time.Second
+	} else if directives.maxAge >= 0 {
+		ttl = time.Duration(directives.maxAge) * time.Second
 	} else {
 		ttl = capTTLByExpires(0, header, directives) // 0 = uncapped
 	}
@@ -799,7 +856,7 @@ func matchesETag(ifNoneMatch, etag string) bool {
 // ttl = 0.1 * (Date - Last-Modified). Returns 0 when any explicit freshness
 // directive is present, when Last-Modified is absent, or when inapplicable.
 func heuristicTTL(header http.Header, d cacheDirectives, now time.Time) time.Duration {
-	if d.MaxAge >= 0 || d.SMaxAge >= 0 || header.Get("Expires") != "" {
+	if d.maxAge >= 0 || d.sMaxAge >= 0 || header.Get("Expires") != "" {
 		return 0
 	}
 	lmStr := header.Get("Last-Modified")
@@ -824,7 +881,7 @@ func heuristicTTL(header http.Header, d cacheDirectives, now time.Time) time.Dur
 }
 
 func capTTLByExpires(ttl time.Duration, header http.Header, d cacheDirectives) time.Duration {
-	if d.MaxAge >= 0 || d.SMaxAge >= 0 {
+	if d.maxAge >= 0 || d.sMaxAge >= 0 {
 		return ttl // RFC 9111 §5.3: Expires ignored when max-age or s-maxage present
 	}
 	exp := header.Get("Expires")

--- a/filters/cache/filter.go
+++ b/filters/cache/filter.go
@@ -239,6 +239,9 @@ func (f *cacheFilter) Request(ctx filters.FilterContext) {
 		}
 		return
 	} else {
+		if ctx.Request().Context().Err() != nil {
+			return
+		}
 		entry, err = f.storage.Get(ctx.Request().Context(), key)
 	}
 	if err != nil || entry == nil {

--- a/filters/cache/filter.go
+++ b/filters/cache/filter.go
@@ -128,7 +128,7 @@ func (s *cacheSpec) CreateFilter(args []interface{}) (filters.Filter, error) {
 		if !ok {
 			return nil, fmt.Errorf("cache: arg 4 (keyHeaders): expected string, got %T: %w", args[4], filters.ErrInvalidFilterParameters)
 		}
-		for _, h := range strings.Split(raw, ",") {
+		for h := range strings.SplitSeq(raw, ",") {
 			if name := strings.TrimSpace(h); name != "" {
 				keyHeaders = append(keyHeaders, http.CanonicalHeaderKey(name))
 			}
@@ -951,7 +951,7 @@ var hopByHopHeaders = map[string]bool{
 // Also removes any header named in the Connection value per RFC 9110 §7.6.1.
 func stripHopByHop(h http.Header) {
 	for _, name := range h.Values("Connection") {
-		for _, field := range strings.Split(name, ",") {
+		for field := range strings.SplitSeq(name, ",") {
 			h.Del(strings.TrimSpace(field))
 		}
 	}

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -1,0 +1,1166 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/metrics/metricstest"
+)
+
+func newTestFilter(t *testing.T, ttl, errorTTL, swrWindow time.Duration) *cacheFilter {
+	t.Helper()
+	spec := NewCacheFilter(1<<20, "localhost:9090")
+	f, err := spec.CreateFilter([]interface{}{
+		ttl.String(),
+		errorTTL.String(),
+		swrWindow.String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf := f.(*cacheFilter)
+	// Panic if fetch is called without a stub — tests must set cf.fetch
+	// if they exercise the cold-miss path.
+	cf.fetch = func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("no fetch stub set")
+	}
+	return cf
+}
+
+func newCtx(method, rawURL string, authHeader string) *filtertest.Context {
+	req, _ := http.NewRequest(method, rawURL, nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	return &filtertest.Context{
+		FRequest:  req,
+		FStateBag: make(map[string]interface{}),
+		FMetrics:  &metricstest.MockMetrics{},
+	}
+}
+
+func upstreamResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func upstreamResponseCC(status int, body, cacheControl string) *http.Response {
+	r := upstreamResponse(status, body)
+	r.Header.Set("Cache-Control", cacheControl)
+	return r
+}
+
+func TestCacheFilter_MissAndHit(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+
+	// First request: miss
+	ctx1 := newCtx("GET", "https://cdn.contentful.com/spaces/abc/entries", "Bearer token1")
+	f.Request(ctx1)
+	if ctx1.FServed {
+		t.Fatal("first request should not be served from cache")
+	}
+
+	ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"items":[]}`, "public, max-age=300")
+	f.Response(ctx1)
+
+	if ctx1.FResponse.Header.Get("X-Cache-Status") != "MISS" {
+		t.Fatalf("expected MISS, got %q", ctx1.FResponse.Header.Get("X-Cache-Status"))
+	}
+
+	// Second request: hit
+	ctx2 := newCtx("GET", "https://cdn.contentful.com/spaces/abc/entries", "Bearer token1")
+	f.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("second request should be served from cache")
+	}
+	if ctx2.FResponse.Header.Get("X-Cache-Status") != "HIT" {
+		t.Fatalf("expected HIT, got %q", ctx2.FResponse.Header.Get("X-Cache-Status"))
+	}
+
+	body, _ := io.ReadAll(ctx2.FResponse.Body)
+	if string(body) != `{"items":[]}` {
+		t.Fatalf("unexpected body: %q", body)
+	}
+}
+
+func TestCacheFilter_KeyIsolationByAuthToken(t *testing.T) {
+	spec := NewCacheFilter(1<<20, "localhost:9090")
+	fi, err := spec.CreateFilter([]interface{}{"1m", "15s", "1m", "Authorization"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := fi.(*cacheFilter)
+	f.fetch = func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("no fetch stub set")
+	}
+	url := "https://cdn.contentful.com/spaces/abc/entries"
+
+	// Populate cache with token A.
+	ctxA := newCtx("GET", url, "Bearer token-delivery")
+	f.Request(ctxA)
+	ctxA.FResponse = upstreamResponseCC(http.StatusOK, `{"env":"production"}`, "public, max-age=300")
+	f.Response(ctxA)
+
+	// Populate cache with token B (preview).
+	ctxB := newCtx("GET", url, "Bearer token-preview")
+	f.Request(ctxB)
+	ctxB.FResponse = upstreamResponseCC(http.StatusOK, `{"env":"preview"}`, "public, max-age=300")
+	f.Response(ctxB)
+
+	// Token A hit must return production payload.
+	hitA := newCtx("GET", url, "Bearer token-delivery")
+	f.Request(hitA)
+	if !hitA.FServed {
+		t.Fatal("expected cache hit for token-delivery")
+	}
+	bodyA, _ := io.ReadAll(hitA.FResponse.Body)
+	if string(bodyA) != `{"env":"production"}` {
+		t.Fatalf("token-delivery got wrong payload: %q", bodyA)
+	}
+
+	// Token B hit must return preview payload.
+	hitB := newCtx("GET", url, "Bearer token-preview")
+	f.Request(hitB)
+	if !hitB.FServed {
+		t.Fatal("expected cache hit for token-preview")
+	}
+	bodyB, _ := io.ReadAll(hitB.FResponse.Body)
+	if string(bodyB) != `{"env":"preview"}` {
+		t.Fatalf("token-preview got wrong payload: %q", bodyB)
+	}
+}
+
+func TestCacheFilter_404CachedWithErrorTTL(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/missing"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusNotFound, `{"message":"not found"}`)
+	f.Response(ctx1)
+
+	// Second request: 404 should be served from cache.
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("expected 404 to be served from cache")
+	}
+	if ctx2.FResponse.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", ctx2.FResponse.StatusCode)
+	}
+}
+
+func TestCacheFilter_NonCacheableStatusNotStored(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/redirect"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusFound, "")
+	f.Response(ctx1)
+
+	// Second request: 302 must not be cached; should be a miss.
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("302 response should not be cached")
+	}
+}
+
+func TestCacheFilter_TTLExpiry(t *testing.T) {
+	// swrWindow=1ms so hard expiry is at TTL+1ms; advancing 2min exceeds both.
+	// Filter created outside the bubble so sknet.Client's transport goroutine
+	// does not get trapped inside the synctest bubble.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries"
+
+	synctest.Test(t, func(t *testing.T) {
+		// Populate cache.
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":1}`)
+		f.Response(ctx1)
+
+		// Still within TTL — must be a HIT.
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected HIT within TTL")
+		}
+
+		// Advance past TTL+SWR (swrWindow=1ms, so 2min exceeds both).
+		time.Sleep(2 * time.Minute)
+
+		// After TTL+SWR — must be a hard-expired MISS.
+		ctx3 := newCtx("GET", url, "")
+		f.Request(ctx3)
+		if ctx3.FServed {
+			t.Fatal("expected MISS after TTL+SWR expired")
+		}
+	})
+}
+
+func TestCreateFilter_InvalidArgs(t *testing.T) {
+	spec := NewCacheFilter(1<<20, "localhost:9090")
+	cases := []struct {
+		name string
+		args []interface{}
+	}{
+		{"too few args", []interface{}{"5m", "15s"}},
+		{"bad ttl", []interface{}{"bad", "15s", "30s"}},
+		{"zero ttl", []interface{}{"0s", "15s", "30s"}},
+		{"non-string ttl", []interface{}{300, "15s", "30s"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := spec.CreateFilter(tc.args); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestCacheFilter_ErrorStatus_NoSWR(t *testing.T) {
+	// 404 entries must hard-expire at errorTTL with no SWR window
+	f := newTestFilter(t, time.Minute, time.Millisecond, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/missing"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponse(http.StatusNotFound, `{"message":"not found"}`)
+		f.Response(ctx1)
+
+		// Advance past errorTTL — must be a hard miss, not STALE (SWR is 0 for errors).
+		time.Sleep(10 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if ctx2.FServed {
+			t.Fatal("404 entry must not be served as stale after errorTTL; SWR window must be 0")
+		}
+	})
+}
+
+func TestCacheFilter_SWR_StaleServedAndRevalidated(t *testing.T) {
+	// ttl=1ms, swrWindow=1h — entry expires quickly but SWR window is huge.
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/swr"
+
+	synctest.Test(t, func(t *testing.T) {
+		// Populate cache.
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"fresh"}`)
+		f.Response(ctx1)
+
+		// Advance past TTL but inside SWR window.
+		time.Sleep(2 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		synctest.Wait()
+
+		if !ctx2.FServed {
+			t.Fatal("expected stale entry to be served")
+		}
+		if ctx2.FResponse.Header.Get("X-Cache-Status") != "STALE" {
+			t.Fatalf("expected STALE, got %q", ctx2.FResponse.Header.Get("X-Cache-Status"))
+		}
+		body, _ := io.ReadAll(ctx2.FResponse.Body)
+		if string(body) != `{"data":"fresh"}` {
+			t.Fatalf("unexpected stale body: %q", body)
+		}
+	})
+}
+
+func TestCacheFilter_SWR_HardExpiry_Miss(t *testing.T) {
+	// ttl=1ms, swrWindow=1ms — hard expiry at 2ms.
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries/hard-expired"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"old"}`)
+		f.Response(ctx1)
+
+		// Advance past TTL + SWR window (2ms combined).
+		time.Sleep(10 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+
+		if ctx2.FServed {
+			t.Fatal("expected hard-expired entry to result in a miss, not served")
+		}
+	})
+}
+
+func TestCacheFilter_ColdMissCoalescing(t *testing.T) {
+	// Hold the upstream fetch until all N goroutines have checked in, proving
+	// that exactly 1 fetch fires for the whole cohort.
+	const N = 50
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+
+	var fetchStarted sync.Once
+	fetchStartedCh := make(chan struct{})
+	releaseAll := make(chan struct{})
+	var fetchCount int64
+
+	// The leader waits for all N goroutines to signal (wgIn.Done) before the
+	// fetch returns. Each goroutine signals just before calling f.Request so
+	// it is either already in DoChan's wait list or about to enter it while
+	// the leader is still blocked on <-releaseAll.
+	var wgIn sync.WaitGroup
+	wgIn.Add(N)
+
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt64(&fetchCount, 1)
+		fetchStarted.Do(func() { close(fetchStartedCh) })
+		wgIn.Wait()
+		<-releaseAll
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"coalesced":true}`)),
+		}, nil
+	}
+
+	url := "https://cdn.contentful.com/spaces/abc/entries/coalesce"
+	results := make([]*filtertest.Context, N)
+	var wg sync.WaitGroup
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			ctx := newCtx("GET", url, "")
+			wgIn.Done()
+			f.Request(ctx)
+			results[i] = ctx
+		}()
+	}
+
+	<-fetchStartedCh
+	close(releaseAll)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&fetchCount); got != 1 {
+		t.Fatalf("expected 1 upstream fetch, got %d", got)
+	}
+
+	// Every goroutine must have been served (either as MISS from the coalesced
+	// fetch, or as HIT if they raced past storage.Get after the entry was stored).
+	for i, ctx := range results {
+		if !ctx.FServed {
+			t.Errorf("goroutine %d: expected ctx to be served", i)
+			continue
+		}
+		status := ctx.FResponse.Header.Get("X-Cache-Status")
+		if status != "MISS" && status != "HIT" {
+			t.Errorf("goroutine %d: expected MISS or HIT, got %q", i, status)
+		}
+		body, _ := io.ReadAll(ctx.FResponse.Body)
+		if string(body) != `{"coalesced":true}` {
+			t.Errorf("goroutine %d: unexpected body: %q", i, body)
+		}
+	}
+
+	// Subsequent request must be a HIT (entry was stored by the leader).
+	hit := newCtx("GET", url, "")
+	f.Request(hit)
+	if !hit.FServed {
+		t.Fatal("expected HIT after coalesced miss")
+	}
+	if got := hit.FResponse.Header.Get("X-Cache-Status"); got != "HIT" {
+		t.Fatalf("expected HIT, got %q", got)
+	}
+}
+
+func TestCacheFilter_ColdMissCoalescing_NonCacheable(t *testing.T) {
+	// 302 responses are served to waiters but not stored; each new request must
+	// fetch again (fetchCount grows with each miss wave).
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+
+	var fetchCount int64
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt64(&fetchCount, 1)
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+
+	url := "https://cdn.contentful.com/spaces/abc/redirect"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+
+	if got := atomic.LoadInt64(&fetchCount); got != 2 {
+		t.Fatalf("non-cacheable 302: expected 2 upstream fetches, got %d", got)
+	}
+}
+
+func TestCacheFilter_ColdMissCoalescing_UpstreamError(t *testing.T) {
+	// When the upstream fetch fails, coalesce must not call ctx.Serve so the
+	// proxy can fall back to its own backend fetch.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream unavailable")
+	}
+
+	ctx := newCtx("GET", "https://cdn.contentful.com/spaces/abc/entries/err", "")
+	f.Request(ctx)
+
+	if ctx.FServed {
+		t.Fatal("on upstream error, ctx must not be served; proxy should fall back")
+	}
+}
+
+func TestCacheFilter_ColdMissCoalescing_UpstreamError_FetchErrorMetric(t *testing.T) {
+	// fetch_error counter must be incremented when the upstream fetch fails during coalescing.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	mockMetrics := &metricstest.MockMetrics{}
+
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream unavailable")
+	}
+
+	ctx := newCtx("GET", "https://cdn.contentful.com/spaces/abc/entries/fetch-err-metric", "")
+	ctx.FMetrics = mockMetrics
+	f.Request(ctx)
+
+	mockMetrics.WithCounters(func(counters map[string]int64) {
+		if counters["fetch_error"] != 1 {
+			t.Errorf("expected fetch_error==1, got %d", counters["fetch_error"])
+		}
+	})
+}
+
+func TestCacheFilter_RequestNoStore_NotCached(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/nostoreReq"
+
+	ctx1 := newCtx("GET", url, "")
+	ctx1.FRequest.Header.Set("Cache-Control", "no-store")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"fresh"}`)
+	f.Response(ctx1)
+
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("response should not have been stored when request had no-store")
+	}
+}
+
+func TestCacheFilter_RequestNoCache_BypassesCache(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/nocacheReq"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+	f.Response(ctx1)
+
+	ctx2 := newCtx("GET", url, "")
+	ctx2.FRequest.Header.Set("Cache-Control", "no-cache")
+	f.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("no-cache request must bypass cache even on HIT")
+	}
+}
+
+func TestCacheFilter_RequestOnlyIfCached_Miss_Returns504(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/onlyifcachedMiss"
+
+	ctx := newCtx("GET", url, "")
+	ctx.FRequest.Header.Set("Cache-Control", "only-if-cached")
+	f.Request(ctx)
+
+	if !ctx.FServed {
+		t.Fatal("only-if-cached with cold cache must call ctx.Serve")
+	}
+	if ctx.FResponse.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504, got %d", ctx.FResponse.StatusCode)
+	}
+}
+
+func TestCacheFilter_RequestOnlyIfCached_Hit_ServesFromCache(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/onlyifcachedHit"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"cached"}`)
+	f.Response(ctx1)
+
+	ctx2 := newCtx("GET", url, "")
+	ctx2.FRequest.Header.Set("Cache-Control", "only-if-cached")
+	f.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("only-if-cached must serve cached entry on hit")
+	}
+	if ctx2.FResponse.Header.Get("X-Cache-Status") != "HIT" {
+		t.Fatalf("expected HIT, got %q", ctx2.FResponse.Header.Get("X-Cache-Status"))
+	}
+}
+
+func TestCacheFilter_AgeHeader_HIT(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/age"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		f.Response(ctx1)
+
+		time.Sleep(10 * time.Second)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected HIT")
+		}
+		age := ctx2.FResponse.Header.Get("Age")
+		if age == "" {
+			t.Fatal("Age header must be present on HIT")
+		}
+		if age != "10" {
+			t.Fatalf("expected Age: 10, got %q", age)
+		}
+	})
+}
+
+func TestCacheFilter_AgeHeader_STALE(t *testing.T) {
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/age-stale"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"old"}`)
+		f.Response(ctx1)
+
+		time.Sleep(5 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		synctest.Wait()
+		if !ctx2.FServed {
+			t.Fatal("expected STALE")
+		}
+		if ctx2.FResponse.Header.Get("Age") == "" {
+			t.Fatal("Age header must be present on STALE")
+		}
+	})
+}
+
+func TestCacheFilter_AgeHeader_UpstreamAgeAdded(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/upstream-age"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		rsp.Header.Set("Age", "30")
+		ctx1.FResponse = rsp
+		f.Response(ctx1)
+
+		time.Sleep(10 * time.Second)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected HIT")
+		}
+		age := ctx2.FResponse.Header.Get("Age")
+		if age != "40" {
+			t.Fatalf("expected Age: 40 (30 upstream + 10 elapsed), got %q", age)
+		}
+	})
+}
+
+func TestCacheFilter_Metrics(t *testing.T) {
+	// ttl=1ms, swrWindow=1h — entry expires quickly, SWR window is huge.
+	// Filter created outside the bubble so sknet.Client's transport goroutine
+	// does not get trapped inside the synctest bubble.
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/metrics"
+
+	synctest.Test(t, func(t *testing.T) {
+
+		// MISS: populate via Response() path
+		miss := newCtx("GET", url, "")
+		f.Request(miss)
+		miss.FResponse = upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		f.Response(miss)
+
+		miss.FMetrics.(*metricstest.MockMetrics).WithCounters(func(counters map[string]int64) {
+			if counters["miss"] != 1 {
+				t.Errorf("after MISS: expected miss==1, got %d", counters["miss"])
+			}
+			if counters["hit"] != 0 {
+				t.Errorf("after MISS: expected hit==0, got %d", counters["hit"])
+			}
+		})
+
+		// HIT: within TTL
+		hit := newCtx("GET", url, "")
+		f.Request(hit)
+		if !hit.FServed {
+			t.Fatal("expected HIT within TTL")
+		}
+		hit.FMetrics.(*metricstest.MockMetrics).WithCounters(func(counters map[string]int64) {
+			if counters["hit"] != 1 {
+				t.Errorf("after HIT: expected hit==1, got %d", counters["hit"])
+			}
+			if counters["stale"] != 0 {
+				t.Errorf("after HIT: expected stale==0, got %d", counters["stale"])
+			}
+		})
+
+		// STALE: advance past TTL but inside SWR window
+		f.fetch = func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader(`{"data":"v2"}`)),
+			}, nil
+		}
+		time.Sleep(2 * time.Millisecond)
+
+		stale := newCtx("GET", url, "")
+		f.Request(stale)
+		synctest.Wait()
+
+		if !stale.FServed {
+			t.Fatal("expected STALE to be served")
+		}
+		if stale.FResponse.Header.Get("X-Cache-Status") != "STALE" {
+			t.Fatalf("expected STALE header, got %q", stale.FResponse.Header.Get("X-Cache-Status"))
+		}
+		stale.FMetrics.(*metricstest.MockMetrics).WithCounters(func(counters map[string]int64) {
+			if counters["stale"] != 1 {
+				t.Errorf("after STALE: expected stale==1, got %d", counters["stale"])
+			}
+			if counters["hit"] != 0 {
+				t.Errorf("after STALE: expected hit==0, got %d", counters["hit"])
+			}
+		})
+	})
+}
+
+func TestCacheFilter_Vary_Isolation(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/vary"
+
+	ctxEN := newCtx("GET", url, "")
+	ctxEN.FRequest.Header.Set("Accept-Language", "en-US")
+	f.Request(ctxEN)
+	rspEN := upstreamResponse(http.StatusOK, `{"lang":"en-US"}`)
+	rspEN.Header.Set("Vary", "Accept-Language")
+	ctxEN.FResponse = rspEN
+	f.Response(ctxEN)
+
+	ctxDE := newCtx("GET", url, "")
+	ctxDE.FRequest.Header.Set("Accept-Language", "de-DE")
+	f.Request(ctxDE)
+	rspDE := upstreamResponse(http.StatusOK, `{"lang":"de-DE"}`)
+	rspDE.Header.Set("Vary", "Accept-Language")
+	ctxDE.FResponse = rspDE
+	f.Response(ctxDE)
+
+	hitEN := newCtx("GET", url, "")
+	hitEN.FRequest.Header.Set("Accept-Language", "en-US")
+	f.Request(hitEN)
+	if !hitEN.FServed {
+		t.Fatal("expected HIT for en-US")
+	}
+	body, _ := io.ReadAll(hitEN.FResponse.Body)
+	if string(body) != `{"lang":"en-US"}` {
+		t.Fatalf("en-US got wrong payload: %q", body)
+	}
+
+	hitDE := newCtx("GET", url, "")
+	hitDE.FRequest.Header.Set("Accept-Language", "de-DE")
+	f.Request(hitDE)
+	if !hitDE.FServed {
+		t.Fatal("expected HIT for de-DE")
+	}
+	bodyDE, _ := io.ReadAll(hitDE.FResponse.Body)
+	if string(bodyDE) != `{"lang":"de-DE"}` {
+		t.Fatalf("de-DE got wrong payload: %q", bodyDE)
+	}
+}
+
+func TestCacheFilter_Vary_Star_NotCached(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/vary-star"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+	rsp.Header.Set("Vary", "*")
+	ctx1.FResponse = rsp
+	f.Response(ctx1)
+
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("Vary: * response must not be cached")
+	}
+}
+
+func TestCacheFilter_ConditionalRevalidation_ETag_304(t *testing.T) {
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/etag"
+
+	var revalReq *http.Request
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		rsp.Header.Set("ETag", `"abc123"`)
+		ctx1.FResponse = rsp
+		f.Response(ctx1)
+
+		f.fetch = func(req *http.Request) (*http.Response, error) {
+			revalReq = req
+			return &http.Response{
+				StatusCode: http.StatusNotModified,
+				Header:     http.Header{"ETag": {`"abc123"`}},
+				Body:       http.NoBody,
+			}, nil
+		}
+
+		time.Sleep(2 * time.Millisecond)
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		synctest.Wait()
+
+		if revalReq == nil {
+			t.Fatal("expected a revalidation request")
+		}
+		if revalReq.Header.Get("If-None-Match") != `"abc123"` {
+			t.Fatalf("expected If-None-Match: \"abc123\", got %q", revalReq.Header.Get("If-None-Match"))
+		}
+
+		// After 304 revalidation, subsequent GET must be a fresh HIT.
+		time.Sleep(0)
+		ctx3 := newCtx("GET", url, "")
+		f.Request(ctx3)
+		if !ctx3.FServed {
+			t.Fatal("expected HIT after 304 revalidation")
+		}
+		body, _ := io.ReadAll(ctx3.FResponse.Body)
+		if string(body) != `{"data":"v1"}` {
+			t.Fatalf("body changed unexpectedly: %q", body)
+		}
+	})
+}
+
+func TestCacheFilter_ConditionalRevalidation_LastModified_304(t *testing.T) {
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/lastmod"
+
+	var revalReq *http.Request
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		rsp.Header.Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+		ctx1.FResponse = rsp
+		f.Response(ctx1)
+
+		f.fetch = func(req *http.Request) (*http.Response, error) {
+			revalReq = req
+			return &http.Response{
+				StatusCode: http.StatusNotModified,
+				Header:     http.Header{},
+				Body:       http.NoBody,
+			}, nil
+		}
+
+		time.Sleep(2 * time.Millisecond)
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		synctest.Wait()
+
+		if revalReq == nil {
+			t.Fatal("expected revalidation request")
+		}
+		if revalReq.Header.Get("If-Modified-Since") != "Wed, 21 Oct 2015 07:28:00 GMT" {
+			t.Fatalf("expected If-Modified-Since, got %q", revalReq.Header.Get("If-Modified-Since"))
+		}
+	})
+}
+
+func TestCacheFilter_RevalidationError_MetricIncremented(t *testing.T) {
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/reval-err"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "public, max-age=300")
+		ctx1.FResponse = rsp
+		f.Response(ctx1)
+
+		f.fetch = func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("upstream down")
+		}
+
+		time.Sleep(2 * time.Millisecond)
+
+		mockMetrics := &metricstest.MockMetrics{}
+		ctx2 := newCtx("GET", url, "")
+		ctx2.FMetrics = mockMetrics
+		f.Request(ctx2)
+		synctest.Wait()
+
+		if !ctx2.FServed {
+			t.Fatal("expected STALE to be served")
+		}
+		mockMetrics.WithCounters(func(counters map[string]int64) {
+			if counters["reval_error"] != 1 {
+				t.Errorf("expected reval_error==1, got %d", counters["reval_error"])
+			}
+		})
+	})
+}
+
+func TestCacheFilter_ExpiresHeader_CapsOperatorTTL(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries/expires"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"expires-soon"}`, "public, max-age=300")
+		rsp.Header.Set("Expires", time.Now().Add(5*time.Second).UTC().Format(http.TimeFormat))
+		ctx1.FResponse = rsp
+		f.Response(ctx1)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected HIT within Expires window")
+		}
+
+		time.Sleep(6 * time.Second)
+
+		ctx3 := newCtx("GET", url, "")
+		f.Request(ctx3)
+		if ctx3.FServed {
+			t.Fatal("expected MISS after Expires time passed")
+		}
+	})
+}
+
+func TestCacheFilter_UnsafeMethod_InvalidatesCache(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/item"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "public, max-age=300")
+	ctx1.FResponse = rsp
+	f.Response(ctx1)
+
+	hit := newCtx("GET", url, "")
+	f.Request(hit)
+	if !hit.FServed {
+		t.Fatal("expected HIT before invalidation")
+	}
+
+	postCtx := newCtx("POST", url, "")
+	f.Request(postCtx)
+	postCtx.FResponse = &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+	}
+	f.Response(postCtx)
+
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("cache must be invalidated after POST")
+	}
+}
+
+func TestCacheFilter_SafeMethod_DoesNotInvalidate(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/safe"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"safe"}`, "public, max-age=300")
+	ctx1.FResponse = rsp
+	f.Response(ctx1)
+
+	headCtx := newCtx("HEAD", url, "")
+	f.Request(headCtx)
+	headCtx.FResponse = &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}
+	f.Response(headCtx)
+
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("HEAD must not invalidate cache")
+	}
+}
+
+func TestCacheFilter_PartialContent_NotStored(t *testing.T) {
+	// 206 Partial Content must never be stored — storing it as a full 200 is data corruption.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/partial"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	ctx1.FResponse = &http.Response{
+		StatusCode: http.StatusPartialContent,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(`partial`)),
+	}
+	f.Response(ctx1)
+
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("206 Partial Content must not be stored in cache")
+	}
+}
+
+func TestCacheFilter_NonGetMethod_NotStored(t *testing.T) {
+	// HEAD and OPTIONS responses must not be stored even if the status is 200.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/non-get"
+
+	for _, method := range []string{http.MethodHead, http.MethodOptions} {
+		ctx1 := newCtx(method, url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		f.Response(ctx1)
+
+		ctx2 := newCtx(http.MethodGet, url, "")
+		f.Request(ctx2)
+		if ctx2.FServed {
+			t.Fatalf("%s response must not be stored in cache", method)
+		}
+	}
+}
+
+func TestCacheFilter_AuthorizationSafety_BlockedWithoutPermission(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/auth-safety"
+
+	ctx1 := newCtx("GET", url, "Bearer secret")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"private"}`)
+	f.Response(ctx1)
+
+	ctx2 := newCtx("GET", url, "Bearer secret")
+	f.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("response to Auth request without Cache-Control: public must not be cached")
+	}
+}
+
+func TestCacheFilter_AuthorizationSafety_AllowedWithPublic(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/auth-public"
+
+	ctx1 := newCtx("GET", url, "Bearer delivery-token")
+	f.Request(ctx1)
+	rsp := upstreamResponse(http.StatusOK, `{"data":"public-content"}`)
+	rsp.Header.Set("Cache-Control", "public, max-age=300")
+	ctx1.FResponse = rsp
+	f.Response(ctx1)
+
+	ctx2 := newCtx("GET", url, "Bearer delivery-token")
+	f.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("Cache-Control: public must allow caching for authorized requests")
+	}
+}
+
+// evictAfterFirstGetStorage wraps a Storage and deletes the entry after the
+// first successful Get, simulating eviction between two consecutive Get calls.
+type evictAfterFirstGetStorage struct {
+	Storage
+	mu      sync.Mutex
+	evicted map[string]bool
+}
+
+func (s *evictAfterFirstGetStorage) Get(ctx context.Context, key string) (*Entry, error) {
+	entry, err := s.Storage.Get(ctx, key)
+	if entry != nil && err == nil {
+		s.mu.Lock()
+		already := s.evicted[key]
+		if !already {
+			s.evicted[key] = true
+		}
+		s.mu.Unlock()
+		if !already {
+			// Evict after returning — next Get will miss.
+			_ = s.Storage.Delete(ctx, key)
+		}
+	}
+	return entry, err
+}
+
+// TestCacheFilter_OnlyIfCached_NoSecondGet proves that a valid only-if-cached hit
+// is served from the entry found on the first Get, without a second Get that
+// could race with eviction.
+func TestCacheFilter_OnlyIfCached_NoSecondGet(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, 30*time.Second)
+	url := "https://cdn.contentful.com/spaces/abc/entries/oic-evict"
+
+	// Populate the cache normally.
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"id":"oic"}`)
+	f.Response(ctx1)
+
+	// Swap in a storage that evicts the entry after the first Get.
+	f.storage = &evictAfterFirstGetStorage{
+		Storage: f.storage,
+		evicted: make(map[string]bool),
+	}
+
+	// The only-if-cached path must reuse the entry from the first Get rather than
+	// issuing a second Get that could race with eviction.
+	ctx2 := newCtx("GET", url, "")
+	ctx2.FRequest.Header.Set("Cache-Control", "only-if-cached")
+	f.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("only-if-cached hit must be served using the entry from the first Get, not a second Get that can race with eviction")
+	}
+}
+
+// TestCacheSpec_SharedStorage proves that two filter instances created from the
+// same spec share one LRU. A response stored via f1 must be a HIT when f2
+// serves the same URL.
+// TestCacheFilter_SMaxAge_CapsRouteTTL verifies that s-maxage in the upstream
+// response overrides the operator-configured TTL for shared caches.
+func TestCacheFilter_SMaxAge_CapsRouteTTL(t *testing.T) {
+	// Route TTL is 10 minutes; upstream says s-maxage=2s.
+	// Filter created outside bubble so sknet transport goroutines don't get trapped.
+	f := newTestFilter(t, 10*time.Minute, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/smaxage"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"ok":true}`, "s-maxage=2")
+		f.Response(ctx1)
+
+		// Immediately after storage: should be a HIT.
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected HIT immediately after storage")
+		}
+
+		// Advance past s-maxage=2s; entry must have expired.
+		time.Sleep(3 * time.Second)
+
+		ctx3 := newCtx("GET", url, "")
+		f.Request(ctx3)
+		if ctx3.FServed {
+			t.Fatal("expected MISS after s-maxage expired — route TTL must not override s-maxage")
+		}
+	})
+}
+
+// TestCacheFilter_SMaxAge_ImpliesProxyRevalidate verifies that s-maxage implies
+// proxy-revalidate: once stale the cache must not serve stale and must revalidate.
+func TestCacheFilter_SMaxAge_ImpliesProxyRevalidate(t *testing.T) {
+	// Route TTL=1ms (minimal), SWR=10s; upstream has s-maxage=2s.
+	// After 3s the entry is stale (TTL=1ms gone) but inside SWR=10s.
+	// Without s-maxage support: serveEntry would return STALE.
+	// With s-maxage=2s + implied proxy-revalidate: STALE must be blocked.
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, 10*time.Second)
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		return upstreamResponseCC(http.StatusOK, `{"v":2}`, "s-maxage=2"), nil
+	}
+	url := "https://cdn.contentful.com/spaces/abc/smaxage-reval"
+
+	synctest.Test(t, func(t *testing.T) {
+		// Prime the cache.
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"v":1}`, "s-maxage=2")
+		f.Response(ctx1)
+
+		// Advance past route TTL (1ms) but inside SWR (10s) — stale territory.
+		time.Sleep(3 * time.Second)
+
+		// s-maxage implies proxy-revalidate — must NOT serve STALE.
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+
+		if ctx2.FServed && ctx2.FResponse.Header.Get("X-Cache-Status") == "STALE" {
+			t.Fatal("s-maxage implies proxy-revalidate — must not serve stale")
+		}
+	})
+}
+
+func TestCacheSpec_SharedStorage(t *testing.T) {
+	spec := NewCacheFilter(1<<20, "localhost:9090")
+	url := "https://cdn.contentful.com/spaces/abc/entries/shared"
+
+	mustFilter := func() *cacheFilter {
+		f, err := spec.CreateFilter([]interface{}{"1m", "15s", "30s"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		cf := f.(*cacheFilter)
+		cf.fetch = func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("no fetch stub")
+		}
+		return cf
+	}
+
+	f1 := mustFilter()
+	f2 := mustFilter()
+
+	// Populate cache through f1.
+	ctx1 := newCtx("GET", url, "")
+	f1.Request(ctx1)
+	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"id":"shared"}`)
+	f1.Response(ctx1)
+
+	// f2 must find the entry stored by f1.
+	ctx2 := newCtx("GET", url, "")
+	f2.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("f2 did not get a HIT for an entry stored by f1 — storage is not shared")
+	}
+}

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,20 +17,43 @@ import (
 	"github.com/zalando/skipper/metrics/metricstest"
 )
 
-func newTestFilter(t *testing.T, ttl, errorTTL, swrWindow time.Duration) *cacheFilter {
+func newTestFilter(t *testing.T, ttl, errorTTL, swrWindow time.Duration, extra ...time.Duration) *cacheFilter {
 	t.Helper()
 	spec := NewCacheFilter(1<<20, "localhost:9090")
-	f, err := spec.CreateFilter([]interface{}{
+	args := []interface{}{
 		ttl.String(),
 		errorTTL.String(),
 		swrWindow.String(),
-	})
+	}
+	if len(extra) > 0 {
+		args = append(args, extra[0].String())
+	}
+	f, err := spec.CreateFilter(args)
 	if err != nil {
 		t.Fatal(err)
 	}
 	cf := f.(*cacheFilter)
 	// Panic if fetch is called without a stub — tests must set cf.fetch
 	// if they exercise the cold-miss path.
+	cf.fetch = func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("no fetch stub set")
+	}
+	return cf
+}
+
+// newTestFilterRFC creates a filter in pure RFC mode (zero args). Upstream
+// Cache-Control is fully authoritative. Use this for tests that exercise
+// Expires capping, heuristic freshness, or other RFC 9111 TTL logic.
+// The ttl/errorTTL/swrWindow args are accepted for call-site compatibility
+// but are ignored — pure RFC mode has no operator TTL.
+func newTestFilterRFC(t *testing.T, _, _, _ time.Duration, _ ...time.Duration) *cacheFilter {
+	t.Helper()
+	spec := NewCacheFilter(1<<20, "localhost:9090")
+	f, err := spec.CreateFilter([]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf := f.(*cacheFilter)
 	cf.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("no fetch stub set")
 	}
@@ -46,6 +70,12 @@ func newCtx(method, rawURL string, authHeader string) *filtertest.Context {
 		FStateBag: make(map[string]interface{}),
 		FMetrics:  &metricstest.MockMetrics{},
 	}
+}
+
+func newCtxWithRoute(method, rawURL, authHeader, routeID string) *filtertest.Context {
+	ctx := newCtx(method, rawURL, authHeader)
+	ctx.FRouteId = routeID
+	return ctx
 }
 
 func upstreamResponse(status int, body string) *http.Response {
@@ -97,7 +127,7 @@ func TestCacheFilter_MissAndHit(t *testing.T) {
 
 func TestCacheFilter_KeyIsolationByAuthToken(t *testing.T) {
 	spec := NewCacheFilter(1<<20, "localhost:9090")
-	fi, err := spec.CreateFilter([]interface{}{"1m", "15s", "1m", "Authorization"})
+	fi, err := spec.CreateFilter([]interface{}{"1m", "15s", "1m", "0s", "Authorization"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +178,7 @@ func TestCacheFilter_404CachedWithErrorTTL(t *testing.T) {
 
 	ctx1 := newCtx("GET", url, "")
 	f.Request(ctx1)
-	ctx1.FResponse = upstreamResponse(http.StatusNotFound, `{"message":"not found"}`)
+	ctx1.FResponse = upstreamResponseCC(http.StatusNotFound, `{"message":"not found"}`, "max-age=300")
 	f.Response(ctx1)
 
 	// Second request: 404 should be served from cache.
@@ -190,7 +220,7 @@ func TestCacheFilter_TTLExpiry(t *testing.T) {
 		// Populate cache.
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":1}`)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":1}`, "max-age=300")
 		f.Response(ctx1)
 
 		// Still within TTL — must be a HIT.
@@ -263,7 +293,7 @@ func TestCacheFilter_SWR_StaleServedAndRevalidated(t *testing.T) {
 		// Populate cache.
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"fresh"}`)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"fresh"}`, "max-age=300")
 		f.Response(ctx1)
 
 		// Advance past TTL but inside SWR window.
@@ -334,7 +364,7 @@ func TestCacheFilter_ColdMissCoalescing(t *testing.T) {
 		<-releaseAll
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": {"application/json"}},
+			Header:     http.Header{"Content-Type": {"application/json"}, "Cache-Control": {"max-age=300"}},
 			Body:       io.NopCloser(strings.NewReader(`{"coalesced":true}`)),
 		}, nil
 	}
@@ -436,22 +466,21 @@ func TestCacheFilter_ColdMissCoalescing_UpstreamError(t *testing.T) {
 	}
 }
 
-func TestCacheFilter_ColdMissCoalescing_UpstreamError_FetchErrorMetric(t *testing.T) {
-	// fetch_error counter must be incremented when the upstream fetch fails during coalescing.
+func TestCacheFilter_ColdMissCoalescing_FetchError_CoalesceErrorMetric(t *testing.T) {
+	// coalesce_error must be incremented when the upstream fetch fails during coalescing.
 	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
-	mockMetrics := &metricstest.MockMetrics{}
-
-	f.fetch = func(req *http.Request) (*http.Response, error) {
+	f.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("upstream unavailable")
 	}
 
-	ctx := newCtx("GET", "https://cdn.contentful.com/spaces/abc/entries/fetch-err-metric", "")
+	mockMetrics := &metricstest.MockMetrics{}
+	ctx := newCtx("GET", "https://cdn.contentful.com/spaces/abc/entries/coalesce-err", "")
 	ctx.FMetrics = mockMetrics
 	f.Request(ctx)
 
 	mockMetrics.WithCounters(func(counters map[string]int64) {
-		if counters["fetch_error"] != 1 {
-			t.Errorf("expected fetch_error==1, got %d", counters["fetch_error"])
+		if counters["coalesce_error"] != 1 {
+			t.Errorf("expected coalesce_error==1, got %d", counters["coalesce_error"])
 		}
 	})
 }
@@ -512,7 +541,7 @@ func TestCacheFilter_RequestOnlyIfCached_Hit_ServesFromCache(t *testing.T) {
 
 	ctx1 := newCtx("GET", url, "")
 	f.Request(ctx1)
-	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"cached"}`)
+	ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"cached"}`, "max-age=300")
 	f.Response(ctx1)
 
 	ctx2 := newCtx("GET", url, "")
@@ -533,7 +562,7 @@ func TestCacheFilter_AgeHeader_HIT(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
 		f.Response(ctx1)
 
 		time.Sleep(10 * time.Second)
@@ -560,7 +589,7 @@ func TestCacheFilter_AgeHeader_STALE(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"old"}`)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"old"}`, "max-age=300")
 		f.Response(ctx1)
 
 		time.Sleep(5 * time.Millisecond)
@@ -584,7 +613,7 @@ func TestCacheFilter_AgeHeader_UpstreamAgeAdded(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
 		rsp.Header.Set("Age", "30")
 		ctx1.FResponse = rsp
 		f.Response(ctx1)
@@ -615,7 +644,7 @@ func TestCacheFilter_Metrics(t *testing.T) {
 		// MISS: populate via Response() path
 		miss := newCtx("GET", url, "")
 		f.Request(miss)
-		miss.FResponse = upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		miss.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
 		f.Response(miss)
 
 		miss.FMetrics.(*metricstest.MockMetrics).WithCounters(func(counters map[string]int64) {
@@ -680,7 +709,7 @@ func TestCacheFilter_Vary_Isolation(t *testing.T) {
 	ctxEN := newCtx("GET", url, "")
 	ctxEN.FRequest.Header.Set("Accept-Language", "en-US")
 	f.Request(ctxEN)
-	rspEN := upstreamResponse(http.StatusOK, `{"lang":"en-US"}`)
+	rspEN := upstreamResponseCC(http.StatusOK, `{"lang":"en-US"}`, "max-age=300")
 	rspEN.Header.Set("Vary", "Accept-Language")
 	ctxEN.FResponse = rspEN
 	f.Response(ctxEN)
@@ -688,7 +717,7 @@ func TestCacheFilter_Vary_Isolation(t *testing.T) {
 	ctxDE := newCtx("GET", url, "")
 	ctxDE.FRequest.Header.Set("Accept-Language", "de-DE")
 	f.Request(ctxDE)
-	rspDE := upstreamResponse(http.StatusOK, `{"lang":"de-DE"}`)
+	rspDE := upstreamResponseCC(http.StatusOK, `{"lang":"de-DE"}`, "max-age=300")
 	rspDE.Header.Set("Vary", "Accept-Language")
 	ctxDE.FResponse = rspDE
 	f.Response(ctxDE)
@@ -743,7 +772,7 @@ func TestCacheFilter_ConditionalRevalidation_ETag_304(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
 		rsp.Header.Set("ETag", `"abc123"`)
 		ctx1.FResponse = rsp
 		f.Response(ctx1)
@@ -792,7 +821,7 @@ func TestCacheFilter_ConditionalRevalidation_LastModified_304(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
 		rsp.Header.Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
 		ctx1.FResponse = rsp
 		f.Response(ctx1)
@@ -822,6 +851,8 @@ func TestCacheFilter_ConditionalRevalidation_LastModified_304(t *testing.T) {
 
 func TestCacheFilter_RevalidationError_MetricIncremented(t *testing.T) {
 	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	mockMetrics := &metricstest.MockMetrics{}
+	f.metrics = mockMetrics
 	url := "https://cdn.contentful.com/spaces/abc/entries/reval-err"
 
 	synctest.Test(t, func(t *testing.T) {
@@ -837,9 +868,7 @@ func TestCacheFilter_RevalidationError_MetricIncremented(t *testing.T) {
 
 		time.Sleep(2 * time.Millisecond)
 
-		mockMetrics := &metricstest.MockMetrics{}
 		ctx2 := newCtx("GET", url, "")
-		ctx2.FMetrics = mockMetrics
 		f.Request(ctx2)
 		synctest.Wait()
 
@@ -855,13 +884,17 @@ func TestCacheFilter_RevalidationError_MetricIncremented(t *testing.T) {
 }
 
 func TestCacheFilter_ExpiresHeader_CapsOperatorTTL(t *testing.T) {
-	f := newTestFilter(t, time.Minute, 15*time.Second, time.Millisecond)
+	// Expires without max-age/s-maxage: TTL must be capped by Expires (RFC 9111 §5.3).
+	// No Cache-Control so max-age/s-maxage are absent; Expires must be honoured.
+	// Also need Last-Modified for the heuristic branch to not short-circuit storage.
+	// RFC mode required: force mode ignores Expires and uses operator TTL directly.
+	f := newTestFilterRFC(t, time.Minute, 15*time.Second, time.Millisecond)
 	url := "https://cdn.contentful.com/spaces/abc/entries/expires"
 
 	synctest.Test(t, func(t *testing.T) {
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		rsp := upstreamResponseCC(http.StatusOK, `{"data":"expires-soon"}`, "public, max-age=300")
+		rsp := upstreamResponse(http.StatusOK, `{"data":"expires-soon"}`)
 		rsp.Header.Set("Expires", time.Now().Add(5*time.Second).UTC().Format(http.TimeFormat))
 		ctx1.FResponse = rsp
 		f.Response(ctx1)
@@ -936,46 +969,6 @@ func TestCacheFilter_SafeMethod_DoesNotInvalidate(t *testing.T) {
 	}
 }
 
-func TestCacheFilter_PartialContent_NotStored(t *testing.T) {
-	// 206 Partial Content must never be stored — storing it as a full 200 is data corruption.
-	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
-	url := "https://cdn.contentful.com/spaces/abc/entries/partial"
-
-	ctx1 := newCtx("GET", url, "")
-	f.Request(ctx1)
-	ctx1.FResponse = &http.Response{
-		StatusCode: http.StatusPartialContent,
-		Header:     http.Header{},
-		Body:       io.NopCloser(strings.NewReader(`partial`)),
-	}
-	f.Response(ctx1)
-
-	ctx2 := newCtx("GET", url, "")
-	f.Request(ctx2)
-	if ctx2.FServed {
-		t.Fatal("206 Partial Content must not be stored in cache")
-	}
-}
-
-func TestCacheFilter_NonGetMethod_NotStored(t *testing.T) {
-	// HEAD and OPTIONS responses must not be stored even if the status is 200.
-	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
-	url := "https://cdn.contentful.com/spaces/abc/entries/non-get"
-
-	for _, method := range []string{http.MethodHead, http.MethodOptions} {
-		ctx1 := newCtx(method, url, "")
-		f.Request(ctx1)
-		ctx1.FResponse = upstreamResponse(http.StatusOK, `{"data":"v1"}`)
-		f.Response(ctx1)
-
-		ctx2 := newCtx(http.MethodGet, url, "")
-		f.Request(ctx2)
-		if ctx2.FServed {
-			t.Fatalf("%s response must not be stored in cache", method)
-		}
-	}
-}
-
 func TestCacheFilter_AuthorizationSafety_BlockedWithoutPermission(t *testing.T) {
 	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
 	url := "https://cdn.contentful.com/spaces/abc/entries/auth-safety"
@@ -1010,157 +1003,1536 @@ func TestCacheFilter_AuthorizationSafety_AllowedWithPublic(t *testing.T) {
 	}
 }
 
-// evictAfterFirstGetStorage wraps a Storage and deletes the entry after the
-// first successful Get, simulating eviction between two consecutive Get calls.
-type evictAfterFirstGetStorage struct {
-	Storage
-	mu      sync.Mutex
-	evicted map[string]bool
-}
+func TestCacheFilter_NoCacheResponse_StoredWithZeroTTL(t *testing.T) {
+	// Response Cache-Control: no-cache means: store the entry with TTL=0 (immediately
+	// stale) so ETag/Last-Modified are preserved for conditional revalidation
+	// (RFC 9111 §5.2.2.4). The entry must be in storage after the first fetch.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/nc-stored"
 
-func (s *evictAfterFirstGetStorage) Get(ctx context.Context, key string) (*Entry, error) {
-	entry, err := s.Storage.Get(ctx, key)
-	if entry != nil && err == nil {
-		s.mu.Lock()
-		already := s.evicted[key]
-		if !already {
-			s.evicted[key] = true
-		}
-		s.mu.Unlock()
-		if !already {
-			// Evict after returning — next Get will miss.
-			_ = s.Storage.Delete(ctx, key)
-		}
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		// Use http.Header.Set to ensure canonical header key normalization.
+		hdr := http.Header{}
+		hdr.Set("Cache-Control", "no-cache")
+		hdr.Set("ETag", `"etag-v1"`)
+		hdr.Set("Content-Type", "application/json")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     hdr,
+			Body:       io.NopCloser(strings.NewReader(`{"v":1}`)),
+		}, nil
 	}
-	return entry, err
-}
 
-// TestCacheFilter_OnlyIfCached_NoSecondGet proves that a valid only-if-cached hit
-// is served from the entry found on the first Get, without a second Get that
-// could race with eviction.
-func TestCacheFilter_OnlyIfCached_NoSecondGet(t *testing.T) {
-	f := newTestFilter(t, time.Minute, 15*time.Second, 30*time.Second)
-	url := "https://cdn.contentful.com/spaces/abc/entries/oic-evict"
-
-	// Populate the cache normally.
+	// First request: cold miss → fetch → must store with TTL=0.
 	ctx1 := newCtx("GET", url, "")
 	f.Request(ctx1)
-	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"id":"oic"}`)
-	f.Response(ctx1)
-
-	// Swap in a storage that evicts the entry after the first Get.
-	f.storage = &evictAfterFirstGetStorage{
-		Storage: f.storage,
-		evicted: make(map[string]bool),
+	if !ctx1.FServed {
+		t.Fatal("expected first request to be served via coalesce")
 	}
 
-	// The only-if-cached path must reuse the entry from the first Get rather than
-	// issuing a second Get that could race with eviction.
-	ctx2 := newCtx("GET", url, "")
-	ctx2.FRequest.Header.Set("Cache-Control", "only-if-cached")
-	f.Request(ctx2)
-	if !ctx2.FServed {
-		t.Fatal("only-if-cached hit must be served using the entry from the first Get, not a second Get that can race with eviction")
+	// Verify entry is stored in the cache with TTL=0 and ETag preserved.
+	key := cacheKey(ctx1.FRouteId, ctx1.FRequest, nil)
+	entry, err := f.storage.Get(ctx1.FRequest.Context(), key)
+	if err != nil {
+		t.Fatalf("storage.Get error: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("no-cache response must be stored in cache (TTL=0) so ETag is preserved for revalidation")
+	}
+	if entry.TTL != 0 {
+		t.Fatalf("no-cache entry must have TTL=0 (immediately stale), got %v", entry.TTL)
+	}
+	if entry.ETag != `"etag-v1"` {
+		t.Fatalf("no-cache entry must preserve ETag, got %q", entry.ETag)
 	}
 }
 
-// TestCacheSpec_SharedStorage proves that two filter instances created from the
-// same spec share one LRU. A response stored via f1 must be a HIT when f2
-// serves the same URL.
-// TestCacheFilter_SMaxAge_CapsRouteTTL verifies that s-maxage in the upstream
-// response overrides the operator-configured TTL for shared caches.
-func TestCacheFilter_SMaxAge_CapsRouteTTL(t *testing.T) {
-	// Route TTL is 10 minutes; upstream says s-maxage=2s.
-	// Filter created outside bubble so sknet transport goroutines don't get trapped.
-	f := newTestFilter(t, 10*time.Minute, 15*time.Second, time.Millisecond)
-	url := "https://cdn.contentful.com/spaces/abc/smaxage"
+func TestCacheFilter_NoCacheResponse_ForceRevalidation(t *testing.T) {
+	// Response Cache-Control: no-cache means: store the entry (for ETag reuse) but
+	// MUST revalidate before every serve. TTL is effectively 0 (RFC 9111 §5.2.2.4).
+	// The second request must trigger an upstream fetch (not be served from stored body).
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/nc"
 
-	synctest.Test(t, func(t *testing.T) {
-		ctx1 := newCtx("GET", url, "")
-		f.Request(ctx1)
-		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"ok":true}`, "s-maxage=2")
-		f.Response(ctx1)
-
-		// Immediately after storage: should be a HIT.
-		ctx2 := newCtx("GET", url, "")
-		f.Request(ctx2)
-		if !ctx2.FServed {
-			t.Fatal("expected HIT immediately after storage")
-		}
-
-		// Advance past s-maxage=2s; entry must have expired.
-		time.Sleep(3 * time.Second)
-
-		ctx3 := newCtx("GET", url, "")
-		f.Request(ctx3)
-		if ctx3.FServed {
-			t.Fatal("expected MISS after s-maxage expired — route TTL must not override s-maxage")
-		}
-	})
-}
-
-// TestCacheFilter_SMaxAge_ImpliesProxyRevalidate verifies that s-maxage implies
-// proxy-revalidate: once stale the cache must not serve stale and must revalidate.
-func TestCacheFilter_SMaxAge_ImpliesProxyRevalidate(t *testing.T) {
-	// Route TTL=1ms (minimal), SWR=10s; upstream has s-maxage=2s.
-	// After 3s the entry is stale (TTL=1ms gone) but inside SWR=10s.
-	// Without s-maxage support: serveEntry would return STALE.
-	// With s-maxage=2s + implied proxy-revalidate: STALE must be blocked.
-	f := newTestFilter(t, time.Millisecond, 15*time.Second, 10*time.Second)
+	fetchCount := 0
 	f.fetch = func(req *http.Request) (*http.Response, error) {
-		return upstreamResponseCC(http.StatusOK, `{"v":2}`, "s-maxage=2"), nil
+		fetchCount++
+		hdr := http.Header{}
+		hdr.Set("Cache-Control", "no-cache")
+		hdr.Set("ETag", `"etag-v1"`)
+		hdr.Set("Content-Type", "application/json")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     hdr,
+			Body:       io.NopCloser(strings.NewReader(`{"v":1}`)),
+		}, nil
 	}
-	url := "https://cdn.contentful.com/spaces/abc/smaxage-reval"
+
+	// First request: cold miss → fetch.
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	if !ctx1.FServed {
+		t.Fatal("expected first request to be served via coalesce")
+	}
+	if ctx1.FResponse.Header.Get("X-Cache-Status") != "MISS" {
+		t.Fatalf("expected MISS, got %q", ctx1.FResponse.Header.Get("X-Cache-Status"))
+	}
+
+	// Second request: entry exists with no-cache → must fetch upstream again (not serve from cache).
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
+	if fetchCount < 2 {
+		t.Fatalf("no-cache must force upstream fetch on next request; fetchCount=%d", fetchCount)
+	}
+}
+
+func TestCacheFilter_ProxyRevalidate_BlocksStale(t *testing.T) {
+	// proxy-revalidate has the same effect as must-revalidate for shared caches:
+	// stale entries MUST NOT be served without revalidation (RFC 9111 §5.2.2.8).
+	f := newTestFilter(t, 100*time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/pr"
+
+	fetchCount := 0
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		fetchCount++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Cache-Control": {"proxy-revalidate"}, "Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"v":1}`)),
+		}, nil
+	}
 
 	synctest.Test(t, func(t *testing.T) {
-		// Prime the cache.
+		// First request: cold miss → fetch → store.
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
-		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"v":1}`, "s-maxage=2")
-		f.Response(ctx1)
+		if !ctx1.FServed {
+			t.Fatal("expected cold miss to be served via coalesce")
+		}
+		if ctx1.FResponse.Header.Get("X-Cache-Status") != "MISS" {
+			t.Fatalf("expected MISS, got %q", ctx1.FResponse.Header.Get("X-Cache-Status"))
+		}
 
-		// Advance past route TTL (1ms) but inside SWR (10s) — stale territory.
-		time.Sleep(3 * time.Second)
+		// Advance into stale window (past TTL=100ms, within SWR=1h).
+		time.Sleep(200 * time.Millisecond)
 
-		// s-maxage implies proxy-revalidate — must NOT serve STALE.
+		// Second request: entry is stale + proxy-revalidate → must NOT serve stale.
+		// coalesce() will call fetch again.
 		ctx2 := newCtx("GET", url, "")
 		f.Request(ctx2)
-
-		if ctx2.FServed && ctx2.FResponse.Header.Get("X-Cache-Status") == "STALE" {
-			t.Fatal("s-maxage implies proxy-revalidate — must not serve stale")
+		synctest.Wait()
+		if fetchCount < 2 {
+			t.Fatalf("proxy-revalidate must block stale serve and trigger upstream fetch; fetchCount=%d", fetchCount)
 		}
 	})
 }
 
-func TestCacheSpec_SharedStorage(t *testing.T) {
-	spec := NewCacheFilter(1<<20, "localhost:9090")
-	url := "https://cdn.contentful.com/spaces/abc/entries/shared"
+func TestCacheFilter_SMaxAge_ImpliesProxyRevalidate(t *testing.T) {
+	// RFC 9111 §5.2.2.10: s-maxage implies proxy-revalidate for shared caches.
+	// Stale entries stored under s-maxage MUST NOT be served without revalidation.
+	f := newTestFilter(t, 100*time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/smaxage-pr"
 
-	mustFilter := func() *cacheFilter {
-		f, err := spec.CreateFilter([]interface{}{"1m", "15s", "30s"})
+	fetchCount := 0
+	f.fetch = func(req *http.Request) (*http.Response, error) {
+		fetchCount++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Cache-Control": {"s-maxage=1"}, "Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"v":1}`)),
+		}, nil
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		if ctx1.FResponse.Header.Get("X-Cache-Status") != "MISS" {
+			t.Fatalf("expected MISS, got %q", ctx1.FResponse.Header.Get("X-Cache-Status"))
+		}
+
+		// Advance past TTL=100ms (operator), within SWR=1h.
+		time.Sleep(200 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		synctest.Wait()
+		if fetchCount < 2 {
+			t.Fatalf("s-maxage must imply proxy-revalidate: stale must not be served; fetchCount=%d", fetchCount)
+		}
+	})
+}
+
+func TestCacheFilter_SharedStorage_RouteIsolation(t *testing.T) {
+	spec := NewCacheFilter(1<<20, "localhost:9090")
+
+	makeFilter := func(t *testing.T) *cacheFilter {
+		t.Helper()
+		f, err := spec.CreateFilter([]interface{}{"5m", "15s", "30s"})
 		if err != nil {
 			t.Fatal(err)
 		}
 		cf := f.(*cacheFilter)
+		// Default fetch stub returns an error so coalesce does not serve the
+		// request; this allows the test to distinguish a true cache HIT from a
+		// coalesced upstream fetch.
 		cf.fetch = func(*http.Request) (*http.Response, error) {
-			return nil, errors.New("no fetch stub")
+			return nil, errors.New("no fetch stub set")
 		}
 		return cf
 	}
 
-	f1 := mustFilter()
-	f2 := mustFilter()
+	f1 := makeFilter(t)
+	f2 := makeFilter(t)
 
-	// Populate cache through f1.
-	ctx1 := newCtx("GET", url, "")
+	// Both filter instances must share the same storage.
+	if f1.storage != f2.storage {
+		t.Fatal("expected shared storage: f1.storage and f2.storage must be the same pointer")
+	}
+
+	url := "https://cdn.contentful.com/spaces/abc/entries/shared"
+
+	// Populate cache via f1 with route "route-a" using the Response() path.
+	ctx1 := newCtxWithRoute("GET", url, "", "route-a")
 	f1.Request(ctx1)
-	ctx1.FResponse = upstreamResponse(http.StatusOK, `{"id":"shared"}`)
+	ctx1.FResponse = &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Cache-Control": {"public, max-age=300"}},
+		Body:       io.NopCloser(strings.NewReader(`{"route":"a"}`)),
+	}
 	f1.Response(ctx1)
 
-	// f2 must find the entry stored by f1.
-	ctx2 := newCtx("GET", url, "")
+	// f2 with a different route ID must not see f1's entry.
+	ctx2 := newCtxWithRoute("GET", url, "", "route-b")
 	f2.Request(ctx2)
+	if ctx2.FServed {
+		t.Fatal("route-b must not see route-a's cached entry (cross-route collision)")
+	}
+
+	// f1 with the same route ID must hit.
+	ctx3 := newCtxWithRoute("GET", url, "", "route-a")
+	f1.Request(ctx3)
+	if !ctx3.FServed {
+		t.Fatal("route-a must hit its own cached entry")
+	}
+	body, _ := io.ReadAll(ctx3.FResponse.Body)
+	if string(body) != `{"route":"a"}` {
+		t.Fatalf("unexpected body: %q", body)
+	}
+}
+
+func TestCacheFilter_UnsafeMethod_SameOriginLocation_Invalidates(t *testing.T) {
+	// RFC 9111 §4.4: a successful unsafe-method response with a same-origin Location
+	// header must also invalidate the cached entry for that URI.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	base := "https://cdn.contentful.com"
+
+	// Populate cache for /entries/other.
+	ctxGet := newCtx("GET", base+"/entries/other", "")
+	f.Request(ctxGet)
+	ctxGet.FResponse = upstreamResponseCC(http.StatusOK, `{"id":"other"}`, "public, max-age=300")
+	f.Response(ctxGet)
+	if ctxGet.FResponse.Header.Get("X-Cache-Status") != "MISS" {
+		t.Fatal("expected MISS on first GET")
+	}
+
+	// Verify /entries/other is cached.
+	ctxHit := newCtx("GET", base+"/entries/other", "")
+	f.Request(ctxHit)
+	if !ctxHit.FServed {
+		t.Fatal("expected /entries/other to be cached before POST")
+	}
+
+	// POST to /entries — response has Location: /entries/other (same-origin, relative).
+	ctxPost := newCtx("POST", base+"/entries", "")
+	f.Request(ctxPost)
+	postResp := upstreamResponse(http.StatusCreated, "")
+	postResp.Header.Set("Location", "/entries/other")
+	ctxPost.FResponse = postResp
+	f.Response(ctxPost)
+
+	// /entries/other cache must now be invalidated.
+	ctxAfter := newCtx("GET", base+"/entries/other", "")
+	f.Request(ctxAfter)
+	if ctxAfter.FServed {
+		t.Fatal("expected /entries/other cache to be invalidated by POST Location header")
+	}
+}
+
+func TestCacheFilter_UnsafeMethod_ContentLocation_Invalidates(t *testing.T) {
+	// RFC 9111 §4.4: a successful unsafe-method response with a same-origin Content-Location
+	// header must also invalidate the cached entry for that URI.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+	base := "https://cdn.contentful.com"
+
+	// Populate cache for /resource.
+	ctxGet := newCtx("GET", base+"/resource", "")
+	f.Request(ctxGet)
+	ctxGet.FResponse = upstreamResponseCC(http.StatusOK, `{"id":"resource"}`, "public, max-age=300")
+	f.Response(ctxGet)
+	if ctxGet.FResponse.Header.Get("X-Cache-Status") != "MISS" {
+		t.Fatal("expected MISS on first GET")
+	}
+
+	// Verify /resource is cached.
+	ctxHit := newCtx("GET", base+"/resource", "")
+	f.Request(ctxHit)
+	if !ctxHit.FServed {
+		t.Fatal("expected /resource to be cached before POST")
+	}
+
+	// POST to /resource — response has Content-Location: /resource.
+	ctxPost := newCtx("POST", base+"/resource", "")
+	f.Request(ctxPost)
+	postResp := upstreamResponse(http.StatusOK, "")
+	postResp.Header.Set("Content-Location", "/resource")
+	ctxPost.FResponse = postResp
+	f.Response(ctxPost)
+
+	// /resource cache must now be invalidated.
+	ctxAfter := newCtx("GET", base+"/resource", "")
+	f.Request(ctxAfter)
+	if ctxAfter.FServed {
+		t.Fatal("expected /resource cache to be invalidated by POST Content-Location header")
+	}
+}
+
+func TestCacheFilter_AgeHeader_RFC9111_CorrectFormula(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/age-rfc9111"
+
+	synctest.Test(t, func(t *testing.T) {
+		now := time.Now()
+		ctx1 := newCtx("GET", url, "")
+		// NOTE: for this test we need the response to go through the coalesce
+		// path (f.fetch stub), NOT the Response() path. Set up f.fetch to return
+		// a response with Date=now-20s and Age=5.
+		f.fetch = func(r *http.Request) (*http.Response, error) {
+			rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+			rsp.Header.Set("Cache-Control", "public, max-age=300")
+			rsp.Header.Set("Date", now.Add(-20*time.Second).UTC().Format(http.TimeFormat))
+			rsp.Header.Set("Age", "5")
+			return rsp, nil
+		}
+		f.Request(ctx1) // triggers coalesce -> f.fetch
+		// ctx1 is served by coalesce; advance time 10s
+		time.Sleep(10 * time.Second)
+		// Second request hits the cache
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected cache HIT")
+		}
+		age := ctx2.FResponse.Header.Get("Age")
+		if age != "30" {
+			t.Fatalf("expected Age 30, got %q", age)
+		}
+	})
+}
+
+func TestCacheFilter_AgeHeader_RFC9111_ResponseDelay(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/age-delay"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.fetch = func(r *http.Request) (*http.Response, error) {
+			// Simulate 5s of response delay (inside synctest, time.Sleep is instant).
+			time.Sleep(5 * time.Second)
+			now := time.Now()
+			rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+			rsp.Header.Set("Cache-Control", "public, max-age=300")
+			rsp.Header.Set("Date", now.UTC().Format(http.TimeFormat))
+			return rsp, nil
+		}
+		f.Request(ctx1) // triggers coalesce -> f.fetch (5s delay simulated)
+		// Serve immediately after, no additional time sleep
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected cache HIT")
+		}
+		age := ctx2.FResponse.Header.Get("Age")
+		if age != "5" {
+			t.Fatalf("expected Age 5 (response_delay), got %q", age)
+		}
+	})
+}
+
+func TestCacheFilter_UnsafeMethod_CrossOriginLocation_DoesNotInvalidate(t *testing.T) {
+	// RFC 9111 §4.4: cross-origin Location headers must NOT trigger cache invalidation.
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
+
+	// Populate cache for https://cdn.contentful.com/entries/safe.
+	ctxGet := newCtx("GET", "https://cdn.contentful.com/entries/safe", "")
+	f.Request(ctxGet)
+	ctxGet.FResponse = upstreamResponseCC(http.StatusOK, `{"id":"safe"}`, "public, max-age=300")
+	f.Response(ctxGet)
+
+	// Verify it's cached.
+	ctxHit := newCtx("GET", "https://cdn.contentful.com/entries/safe", "")
+	f.Request(ctxHit)
+	if !ctxHit.FServed {
+		t.Fatal("expected /entries/safe to be cached")
+	}
+
+	// POST — response has a cross-origin Location.
+	ctxPost := newCtx("POST", "https://cdn.contentful.com/entries", "")
+	f.Request(ctxPost)
+	postResp := upstreamResponse(http.StatusCreated, "")
+	postResp.Header.Set("Location", "https://evil.example.com/entries/safe")
+	ctxPost.FResponse = postResp
+	f.Response(ctxPost)
+
+	// /entries/safe must still be in cache (cross-origin Location must be ignored).
+	ctxAfter := newCtx("GET", "https://cdn.contentful.com/entries/safe", "")
+	f.Request(ctxAfter)
+	if !ctxAfter.FServed {
+		t.Fatal("cross-origin Location must not invalidate same-origin cache entry")
+	}
+}
+
+func TestCacheFilter_HEAD_ServedWithEmptyBody(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/head-empty"
+
+	// Populate via GET (goes through coalesce path).
+	ctx1 := newCtx("GET", url, "")
+	f.fetch = func(r *http.Request) (*http.Response, error) {
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "public, max-age=300")
+		return rsp, nil
+	}
+	f.Request(ctx1)
+
+	// HEAD request must be served from cache with empty body.
+	headCtx := newCtx("HEAD", url, "")
+	f.Request(headCtx)
+	if !headCtx.FServed {
+		t.Fatal("HEAD request must be served from cache when GET entry exists")
+	}
+	if headCtx.FResponse.Header.Get("X-Cache-Status") != "HIT" {
+		t.Fatalf("expected HIT status, got %q", headCtx.FResponse.Header.Get("X-Cache-Status"))
+	}
+	body, _ := io.ReadAll(headCtx.FResponse.Body)
+	if len(body) != 0 {
+		t.Fatalf("HEAD response must have empty body, got %d bytes", len(body))
+	}
+	if headCtx.FResponse.ContentLength != 0 {
+		t.Fatalf("HEAD response ContentLength must be 0, got %d", headCtx.FResponse.ContentLength)
+	}
+}
+
+func TestCacheFilter_HEAD_200_FreshensStoredEntry(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/head-freshen"
+
+	// Populate via GET with ETag "v1".
+	ctx1 := newCtx("GET", url, "")
+	f.fetch = func(r *http.Request) (*http.Response, error) {
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "public, max-age=300")
+		rsp.Header.Set("ETag", `"v1"`)
+		return rsp, nil
+	}
+	f.Request(ctx1)
+
+	// HEAD request: served from cache (FServed=true), but we also call Response()
+	// with a HEAD 200 containing updated ETag "v2". Freshening must update the entry.
+	headCtx := newCtx("HEAD", url, "")
+	f.Request(headCtx) // serves from cache, sets FServed=true
+	// Simulate upstream returning a HEAD 200 with updated headers.
+	headCtx.FResponse = &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Etag":          {`"v2"`},
+			"Cache-Control": {"public, max-age=300"},
+		},
+		Body: http.NoBody,
+	}
+	f.Response(headCtx) // must freshen even though FServed=true
+
+	// Stored GET entry must now have ETag "v2".
+	key := cacheKey(headCtx.FRouteId, headCtx.FRequest, nil)
+	entry, err := f.storage.Get(headCtx.FRequest.Context(), key)
+	if err != nil || entry == nil {
+		t.Fatal("expected stored entry after freshening")
+	}
+	if entry.ETag != `"v2"` {
+		t.Fatalf("expected ETag %q after freshening, got %q", `"v2"`, entry.ETag)
+	}
+	if got := entry.Header.Get("Cache-Control"); got != "public, max-age=300" {
+		t.Fatalf("expected freshened Cache-Control header, got %q", got)
+	}
+
+	// Subsequent GET must still serve from cache with the original body.
+	ctx2 := newCtx("GET", url, "")
+	f.Request(ctx2)
 	if !ctx2.FServed {
-		t.Fatal("f2 did not get a HIT for an entry stored by f1 — storage is not shared")
+		t.Fatal("expected GET HIT after HEAD freshening")
+	}
+	body, _ := io.ReadAll(ctx2.FResponse.Body)
+	if string(body) != `{"data":"v1"}` {
+		t.Fatalf("body must not change after HEAD freshening, got %q", body)
+	}
+}
+
+func TestCacheFilter_HeuristicFreshness_NoExplicitTTL(t *testing.T) {
+	// f.ttl=5m; heuristic TTL = 0.1 * 1000s = 100s < 5m so not capped.
+	// RFC mode required: force mode ignores Last-Modified and uses operator TTL directly.
+	f := newTestFilterRFC(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries/heuristic"
+
+	synctest.Test(t, func(t *testing.T) {
+		now := time.Now()
+		ctx1 := newCtx("GET", url, "")
+		f.fetch = func(r *http.Request) (*http.Response, error) {
+			rsp := upstreamResponse(http.StatusOK, `{"data":"heuristic"}`)
+			// No Cache-Control, no Expires. Last-Modified = 1000s ago.
+			rsp.Header.Set("Last-Modified", now.Add(-1000*time.Second).UTC().Format(http.TimeFormat))
+			return rsp, nil
+		}
+		f.Request(ctx1)
+
+		// Entry must be stored with heuristic TTL ~= 100s.
+		key := cacheKey(ctx1.FRouteId, ctx1.FRequest, nil)
+		entry, err := f.storage.Get(ctx1.FRequest.Context(), key)
+		if err != nil || entry == nil {
+			t.Fatal("heuristic TTL response must be stored in cache")
+		}
+		if entry.TTL < 90*time.Second || entry.TTL > 110*time.Second {
+			t.Fatalf("expected heuristic TTL ~100s, got %v", entry.TTL)
+		}
+
+		// HIT within heuristic window.
+		time.Sleep(50 * time.Second)
+		ctx2 := newCtx("GET", url, "")
+		f.Request(ctx2)
+		if !ctx2.FServed {
+			t.Fatal("expected HIT within heuristic TTL window")
+		}
+
+		// After heuristic TTL + SWR (swrWindow=1ms), entry must be hard-expired.
+		// We check storage directly rather than via f.Request to avoid coalesce
+		// fetching and re-storing the entry.
+		time.Sleep(60 * time.Second)
+		entry2, err2 := f.storage.Get(ctx1.FRequest.Context(), key)
+		if err2 != nil {
+			t.Fatalf("storage.Get error: %v", err2)
+		}
+		if entry2 != nil {
+			t.Fatal("expected entry expired after heuristic TTL + SWR")
+		}
+	})
+}
+
+func TestCacheFilter_HeuristicFreshness_ExplicitMaxAge_NoHeuristic(t *testing.T) {
+	f := newTestFilter(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries/heuristic-maxage"
+
+	now := time.Now()
+	ctx1 := newCtx("GET", url, "")
+	f.fetch = func(r *http.Request) (*http.Response, error) {
+		// max-age=300 present: heuristic must NOT apply.
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"explicit"}`, "max-age=300")
+		rsp.Header.Set("Last-Modified", now.Add(-1000*time.Second).UTC().Format(http.TimeFormat))
+		return rsp, nil
+	}
+	f.Request(ctx1)
+
+	key := cacheKey(ctx1.FRouteId, ctx1.FRequest, nil)
+	entry, err := f.storage.Get(ctx1.FRequest.Context(), key)
+	if err != nil || entry == nil {
+		t.Fatal("entry with explicit max-age must be stored")
+	}
+	// TTL must be the operator f.ttl (5m), not the heuristic 100s.
+	if entry.TTL != 5*time.Minute {
+		t.Fatalf("expected operator TTL 5m, got %v (heuristic must not apply with explicit max-age)", entry.TTL)
+	}
+}
+
+func TestCacheFilter_HeuristicFreshness_NoLastModified_NotCached(t *testing.T) {
+	// RFC mode required: in force mode a response with no CC/Expires/Last-Modified
+	// is still cached using the operator TTL.
+	f := newTestFilterRFC(t, time.Minute, 15*time.Second, time.Minute)
+	url := "https://cdn.contentful.com/spaces/abc/entries/heuristic-nolm"
+
+	ctx1 := newCtx("GET", url, "")
+	f.fetch = func(r *http.Request) (*http.Response, error) {
+		// No CC, no Expires, no Last-Modified → must not be cached.
+		return upstreamResponse(http.StatusOK, `{"data":"nolm"}`), nil
+	}
+	f.Request(ctx1)
+
+	// Reset fetch to error stub: entry must not be in storage (heuristic returned 0
+	// for no-Last-Modified response), so ctx2 goes to coalesce which will fail.
+	f.fetch = func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("no fetch stub: expected cache miss, not upstream call")
+	}
+
+	key := cacheKey(ctx1.FRouteId, ctx1.FRequest, nil)
+	entry, err := f.storage.Get(ctx1.FRequest.Context(), key)
+	if err != nil {
+		t.Fatalf("storage.Get error: %v", err)
+	}
+	if entry != nil {
+		t.Fatal("response without Last-Modified and no explicit TTL must not be cached")
+	}
+}
+
+func TestCacheFilter_HeuristicFreshness_Capped(t *testing.T) {
+	// f.ttl=5m; heuristic = 0.1 * 36000s = 3600s, but capped to 5m.
+	f := newTestFilter(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries/heuristic-cap"
+
+	synctest.Test(t, func(t *testing.T) {
+		now := time.Now()
+		ctx1 := newCtx("GET", url, "")
+		f.fetch = func(r *http.Request) (*http.Response, error) {
+			rsp := upstreamResponse(http.StatusOK, `{"data":"cap"}`)
+			// Last-Modified = 10h ago → heuristic = 0.1 * 36000s = 3600s.
+			rsp.Header.Set("Last-Modified", now.Add(-10*time.Hour).UTC().Format(http.TimeFormat))
+			return rsp, nil
+		}
+		f.Request(ctx1)
+
+		key := cacheKey(ctx1.FRouteId, ctx1.FRequest, nil)
+		entry, err := f.storage.Get(ctx1.FRequest.Context(), key)
+		if err != nil || entry == nil {
+			t.Fatal("expected stored entry")
+		}
+		// Must be capped to f.ttl = 5m, not 3600s.
+		if entry.TTL != 5*time.Minute {
+			t.Fatalf("expected TTL capped to 5m, got %v", entry.TTL)
+		}
+	})
+}
+
+func TestCacheFilter_HEAD_NoStoredEntry_NoFreshen(t *testing.T) {
+	f := newTestFilter(t, time.Minute, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/head-no-entry"
+
+	// HEAD arrives cold (no prior GET). Response() should not create a new entry.
+	headCtx := newCtx("HEAD", url, "")
+	f.Request(headCtx) // no entry, not served from cache
+	headCtx.FResponse = &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Etag": {`"v1"`}},
+		Body:       http.NoBody,
+	}
+	f.Response(headCtx)
+
+	key := cacheKey(headCtx.FRouteId, headCtx.FRequest, nil)
+	entry, err := f.storage.Get(headCtx.FRequest.Context(), key)
+	if err != nil {
+		t.Fatalf("storage.Get error: %v", err)
+	}
+	if entry != nil {
+		t.Fatal("HEAD 200 with no existing entry must not create a new entry")
+	}
+}
+
+func TestCacheFilter_Expires_InvalidDate_TreatedAsExpired(t *testing.T) {
+	// RFC 9111 §5.3: invalid Expires date (including "0") must be treated as already
+	// expired. capTTLByExpires returns 0. The entry is stored with TTL=0 (immediately
+	// stale, preserved for conditional revalidation).
+	// Use the Response() path (not coalesce) to store the TTL=0 entry;
+	// coalesce only stores entries with NoCache==true or TTL>0.
+	// f.fetch returns an error so coalesce resolves immediately without serving,
+	// leaving ctx unserved so Response() can run and store the entry.
+	// RFC mode required: force mode ignores Expires and always uses operator TTL.
+	f := newTestFilterRFC(t, 5*time.Minute, 10*time.Second, time.Second)
+	// f.fetch is already set to the error stub by newTestFilter; coalesce resolves
+	// with an error, leaving ctx unserved so Response() will run.
+	ctx := newCtx(http.MethodGet, "http://example.com/invalid-expires", "")
+	f.Request(ctx) // sets state-bag key; coalesce resolves (error), ctx not served
+
+	rsp := upstreamResponse(http.StatusOK, "body")
+	rsp.Header.Set("Expires", "0")
+	ctx.FResponse = rsp
+	f.Response(ctx) // stores entry with TTL=0 via the Response() path
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("expected entry to be stored with TTL=0 (invalid Expires treated as expired)")
+	}
+	if entry.TTL != 0 {
+		t.Errorf("expected TTL=0 for invalid Expires, got %v", entry.TTL)
+	}
+}
+
+func TestCacheFilter_HopByHop_NotStored(t *testing.T) {
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, time.Second)
+	rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+	rsp.Header.Set("Connection", "Keep-Alive")
+	rsp.Header.Set("Keep-Alive", "timeout=5")
+	f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+	ctx := newCtx(http.MethodGet, "http://example.com/path", "")
+	f.Request(ctx)
+
+	// Read stored entry directly
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("expected entry to be stored")
+	}
+	if entry.Header.Get("Connection") != "" {
+		t.Errorf("Connection header should not be stored, got %q", entry.Header.Get("Connection"))
+	}
+	if entry.Header.Get("Keep-Alive") != "" {
+		t.Errorf("Keep-Alive header should not be stored, got %q", entry.Header.Get("Keep-Alive"))
+	}
+	// Positive assertion: a non-hop-by-hop header must still be present.
+	if entry.Header.Get("Cache-Control") == "" {
+		t.Errorf("Cache-Control header should still be present in stored entry")
+	}
+}
+
+func TestCacheFilter_304Merge_HopByHop_NotMerged(t *testing.T) {
+	// filter created OUTSIDE synctest bubble
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, 10*time.Minute)
+
+	synctest.Test(t, func(t *testing.T) {
+		// 1. First request populates cache
+		rsp1 := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+		rsp1.Header.Set("ETag", `"v1"`)
+		f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp1, nil }
+		ctx1 := newCtx(http.MethodGet, "http://example.com/path", "")
+		f.Request(ctx1)
+
+		// 2. Sleep past TTL to make entry stale
+		time.Sleep(6 * time.Minute)
+
+		// 3. Second request triggers STALE serve + background revalidation
+		rsp304 := &http.Response{
+			StatusCode: http.StatusNotModified,
+			Header:     http.Header{},
+			Body:       http.NoBody,
+		}
+		rsp304.Header.Set("ETag", `"v2"`)
+		rsp304.Header.Set("Connection", "close")
+		f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp304, nil }
+		ctx2 := newCtx(http.MethodGet, "http://example.com/path", "")
+		f.Request(ctx2)
+
+		synctest.Wait() // wait for background revalidation goroutine
+
+		// 4. Read stored entry and check
+		key := ctx1.StateBag()[stateBagKey].(string)
+		entry, err := f.storage.Get(context.Background(), key)
+		if err != nil || entry == nil {
+			t.Fatal("expected entry after revalidation")
+		}
+		if entry.Header.Get("Connection") != "" {
+			t.Errorf("Connection should not be in stored entry after 304 merge")
+		}
+		if entry.ETag != `"v2"` {
+			t.Errorf("ETag should be updated to v2, got %q", entry.ETag)
+		}
+	})
+}
+
+func TestCacheFilter_Revalidate200_HopByHop_NotStored(t *testing.T) {
+	// filter created OUTSIDE synctest bubble
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, 10*time.Minute)
+
+	synctest.Test(t, func(t *testing.T) {
+		// 1. First request populates cache
+		rsp1 := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+		rsp1.Header.Set("ETag", `"v1"`)
+		f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp1, nil }
+		ctx1 := newCtx(http.MethodGet, "http://example.com/path200", "")
+		f.Request(ctx1)
+
+		// 2. Sleep past TTL to make entry stale (within SWR window)
+		time.Sleep(6 * time.Minute)
+
+		// 3. Set fetch stub to return a 200 with hop-by-hop headers
+		rsp200 := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("newbody")),
+		}
+		rsp200.Header.Set("Cache-Control", "max-age=300")
+		rsp200.Header.Set("Connection", "Keep-Alive")
+		rsp200.Header.Set("Keep-Alive", "timeout=5")
+		f.fetch = func(_ *http.Request) (*http.Response, error) {
+			return rsp200, nil
+		}
+
+		// 4. Second request: served stale + background revalidation fired
+		ctx2 := newCtx(http.MethodGet, "http://example.com/path200", "")
+		f.Request(ctx2)
+
+		synctest.Wait() // wait for background revalidation goroutine
+
+		// 5. Read stored entry and assert hop-by-hop headers are absent
+		key := ctx1.StateBag()[stateBagKey].(string)
+		entry, err := f.storage.Get(context.Background(), key)
+		if err != nil || entry == nil {
+			t.Fatal("expected entry after 200 revalidation")
+		}
+		if entry.Header.Get("Connection") != "" {
+			t.Errorf("Connection should not be stored after 200 revalidation, got %q", entry.Header.Get("Connection"))
+		}
+		if entry.Header.Get("Keep-Alive") != "" {
+			t.Errorf("Keep-Alive should not be stored after 200 revalidation, got %q", entry.Header.Get("Keep-Alive"))
+		}
+		// Positive assertion: non-hop-by-hop header must still be present.
+		if entry.Header.Get("Cache-Control") == "" {
+			t.Errorf("Cache-Control should be present in stored entry after 200 revalidation")
+		}
+		// Body and status must be correct.
+		if entry.StatusCode != http.StatusOK {
+			t.Errorf("expected StatusCode 200, got %d", entry.StatusCode)
+		}
+		if string(entry.Payload) != "newbody" {
+			t.Errorf("expected payload %q, got %q", "newbody", string(entry.Payload))
+		}
+	})
+}
+
+func TestCacheFilter_CacheControl_PassedThrough(t *testing.T) {
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, time.Second)
+	rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300, must-revalidate")
+	f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+	ctx := newCtx(http.MethodGet, "http://example.com/path", "")
+	f.Request(ctx)
+
+	// The filter must not strip or modify Cache-Control on the response.
+	got := ctx.FResponse.Header.Get("Cache-Control")
+	if got != "max-age=300, must-revalidate" {
+		t.Errorf("Cache-Control not passed through: got %q", got)
+	}
+}
+
+func TestCacheFilter_Expires_IgnoredWhenMaxAgePresent(t *testing.T) {
+	// RFC 9111 §5.3: Expires MUST be ignored when max-age is present.
+	// max-age=300 present and Expires is a past date. Without the fix, the past
+	// Expires would cap TTL to 0. With the fix, Expires is ignored and entry is
+	// stored with TTL = f.ttl = 5m.
+	// Use the fetch stub pattern (like TestCacheFilter_MissAndHit) so coalesce
+	// handles storage — max-age=300 means ttl=5m>0, so coalesce will store it.
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, time.Second)
+	url := "http://example.com/expires-ignored"
+
+	f.fetch = func(r *http.Request) (*http.Response, error) {
+		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
+		rsp.Header.Set("Expires", "Mon, 01 Jan 2024 00:00:00 GMT") // past date: must be ignored
+		return rsp, nil
+	}
+
+	// First request: cold miss → coalesce → fetch → store (max-age wins over Expires).
+	ctx1 := newCtx(http.MethodGet, url, "")
+	f.Request(ctx1)
+	if !ctx1.FServed {
+		t.Fatal("expected first request to be served via coalesce")
+	}
+
+	key := ctx1.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("expected entry to be stored (Expires ignored when max-age present)")
+	}
+
+	// Second request must be a HIT.
+	ctx2 := newCtx(http.MethodGet, url, "")
+	f.Request(ctx2)
+	if !ctx2.FServed {
+		t.Fatal("expected HIT: Expires must be ignored when max-age is present")
+	}
+	if ctx2.FResponse.Header.Get("X-Cache-Status") != "HIT" {
+		t.Fatalf("expected HIT status, got %q", ctx2.FResponse.Header.Get("X-Cache-Status"))
+	}
+}
+
+func TestCacheFilter_Expires_NonGMT_TreatedAsInvalid(t *testing.T) {
+	// RFC 9111 §4.2 / §5.3: RFC 850 date with non-GMT zone (EST) must be rejected by
+	// parseHTTPTime and treated as an invalid date — capTTLByExpires returns 0.
+	// The entry is stored with TTL=0 (immediately stale, preserved for conditional
+	// revalidation), mirroring the behaviour of TestCacheFilter_Expires_InvalidDate_TreatedAsExpired.
+	// RFC mode required: force mode ignores Expires and always uses operator TTL.
+	f := newTestFilterRFC(t, 5*time.Minute, 10*time.Second, time.Second)
+	// f.fetch is already set to the error stub by newTestFilter; coalesce resolves
+	// with an error, leaving ctx unserved so Response() will run.
+	ctx := newCtx(http.MethodGet, "http://example.com/nonGMT-expires", "")
+	f.Request(ctx) // sets state-bag key; coalesce resolves (error), ctx not served
+
+	rsp := upstreamResponseCC(http.StatusOK, "body", "")
+	rsp.Header.Set("Expires", "Monday, 01-Jan-24 12:00:00 EST")
+	rsp.Header.Del("Cache-Control") // no Cache-Control
+	ctx.FResponse = rsp
+	f.Response(ctx) // stores entry with TTL=0 via the Response() path
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("expected entry to be stored with TTL=0 (non-GMT Expires treated as invalid)")
+	}
+	if entry.TTL != 0 {
+		t.Errorf("expected TTL=0 for non-GMT Expires, got %v", entry.TTL)
+	}
+}
+
+func TestCacheFilter_AgeHeader_NonGMT_Date_Ignored(t *testing.T) {
+	// RFC 9111 §4.2: RFC 850 date with non-GMT zone (EST) in Date header must be
+	// rejected. apparent_age falls back to 0. After 10s resident time, Age must be
+	// ~10 (from ResponseTime only), not inflated by a wrong apparent_age.
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, time.Second)
+	synctest.Test(t, func(t *testing.T) {
+		rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+		rsp.Header.Set("Date", "Monday, 01-Jan-24 12:00:00 EST")
+		f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+		ctx1 := newCtx(http.MethodGet, "http://example.com/nonGMT-date", "")
+		f.Request(ctx1)
+
+		time.Sleep(10 * time.Second)
+
+		ctx2 := newCtx(http.MethodGet, "http://example.com/nonGMT-date", "")
+		f.Request(ctx2)
+		if ctx2.FResponse == nil {
+			t.Fatal("expected HIT")
+		}
+		age := ctx2.FResponse.Header.Get("Age")
+		// Age should be ~10, not inflated by a wrong apparent_age from EST offset
+		v, _ := strconv.ParseInt(age, 10, 64)
+		if v < 9 || v > 12 {
+			t.Errorf("expected Age ~10 when non-GMT Date is ignored, got %q", age)
+		}
+	})
+}
+
+func TestCacheFilter_AgeHeader_InvalidAge_Ignored(t *testing.T) {
+	// RFC 9111 §5.1: invalid Age field value must be ignored; only resident time
+	// should contribute to the Age header on a HIT response.
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, time.Second)
+	synctest.Test(t, func(t *testing.T) {
+		rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+		rsp.Header.Set("Age", "bogus")
+		f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+		ctx1 := newCtx(http.MethodGet, "http://example.com/invalid-age", "")
+		f.Request(ctx1)
+
+		time.Sleep(10 * time.Second)
+
+		ctx2 := newCtx(http.MethodGet, "http://example.com/invalid-age", "")
+		f.Request(ctx2)
+		if ctx2.FResponse == nil {
+			t.Fatal("expected HIT")
+		}
+		age := ctx2.FResponse.Header.Get("Age")
+		v, err := strconv.ParseInt(age, 10, 64)
+		if err != nil {
+			t.Fatalf("Age header not a valid integer: %q", age)
+		}
+		if v < 9 || v > 12 {
+			t.Errorf("expected Age ~10 when invalid upstream Age is ignored, got %q", age)
+		}
+	})
+}
+
+func TestCacheFilter_AgeHeader_Zero_IsValid(t *testing.T) {
+	// RFC 9111 §5.1: Age: 0 is a valid non-negative integer and must be accepted
+	// (not discarded by a v > 0 guard). ageValue = 0 so corrected_initial_age
+	// is unchanged, but the field must not cause a parse error.
+	f := newTestFilter(t, 5*time.Minute, 10*time.Second, time.Second)
+	synctest.Test(t, func(t *testing.T) {
+		rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+		rsp.Header.Set("Age", "0")
+		f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+		ctx1 := newCtx(http.MethodGet, "http://example.com/age-zero", "")
+		f.Request(ctx1)
+
+		time.Sleep(10 * time.Second)
+
+		ctx2 := newCtx(http.MethodGet, "http://example.com/age-zero", "")
+		f.Request(ctx2)
+		if ctx2.FResponse == nil {
+			t.Fatal("expected HIT")
+		}
+		age := ctx2.FResponse.Header.Get("Age")
+		v, err := strconv.ParseInt(age, 10, 64)
+		if err != nil {
+			t.Fatalf("Age header not a valid integer: %q", age)
+		}
+		// Age: 0 upstream contributes ageValue=0; resident time of 10s dominates.
+		if v < 9 || v > 12 {
+			t.Errorf("expected Age ~10 with Age: 0 upstream, got %q", age)
+		}
+	})
+}
+
+func TestCacheFilter_ConditionalRequest_IfNoneMatch_304(t *testing.T) {
+	f := newTestFilter(t, 5*time.Minute, time.Second, time.Second)
+	rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+	rsp.Header.Set("ETag", `"v1"`)
+	f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+	ctx1 := newCtx(http.MethodGet, "http://example.com/cond-inm", "")
+	f.Request(ctx1)
+
+	ctx2 := newCtx(http.MethodGet, "http://example.com/cond-inm", "")
+	ctx2.FRequest.Header.Set("If-None-Match", `"v1"`)
+	f.Request(ctx2)
+	if ctx2.FResponse == nil {
+		t.Fatal("expected response")
+	}
+	if ctx2.FResponse.StatusCode != http.StatusNotModified {
+		t.Errorf("expected 304, got %d", ctx2.FResponse.StatusCode)
+	}
+	body, _ := io.ReadAll(ctx2.FResponse.Body)
+	if len(body) != 0 {
+		t.Errorf("expected empty body on 304, got %q", body)
+	}
+}
+
+func TestCacheFilter_ConditionalRequest_IfNoneMatch_Wildcard_304(t *testing.T) {
+	f := newTestFilter(t, 5*time.Minute, time.Second, time.Second)
+	rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+	rsp.Header.Set("ETag", `"abc"`)
+	f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+	ctx1 := newCtx(http.MethodGet, "http://example.com/cond-inm-wildcard", "")
+	f.Request(ctx1)
+
+	ctx2 := newCtx(http.MethodGet, "http://example.com/cond-inm-wildcard", "")
+	ctx2.FRequest.Header.Set("If-None-Match", "*")
+	f.Request(ctx2)
+	if ctx2.FResponse == nil {
+		t.Fatal("expected response")
+	}
+	if ctx2.FResponse.StatusCode != http.StatusNotModified {
+		t.Errorf("expected 304, got %d", ctx2.FResponse.StatusCode)
+	}
+}
+
+func TestCacheFilter_ConditionalRequest_IfModifiedSince_304(t *testing.T) {
+	f := newTestFilter(t, 5*time.Minute, time.Second, time.Second)
+	rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+	rsp.Header.Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+	f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+	ctx1 := newCtx(http.MethodGet, "http://example.com/cond-ims", "")
+	f.Request(ctx1)
+
+	ctx2 := newCtx(http.MethodGet, "http://example.com/cond-ims", "")
+	ctx2.FRequest.Header.Set("If-Modified-Since", "Wed, 21 Oct 2015 07:28:00 GMT")
+	f.Request(ctx2)
+	if ctx2.FResponse == nil {
+		t.Fatal("expected response")
+	}
+	if ctx2.FResponse.StatusCode != http.StatusNotModified {
+		t.Errorf("expected 304, got %d", ctx2.FResponse.StatusCode)
+	}
+}
+
+func TestCacheFilter_ConditionalRequest_IfModifiedSince_200(t *testing.T) {
+	f := newTestFilter(t, 5*time.Minute, time.Second, time.Second)
+	rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+	rsp.Header.Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+	f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+	ctx1 := newCtx(http.MethodGet, "http://example.com/cond-ims-200", "")
+	f.Request(ctx1)
+
+	ctx2 := newCtx(http.MethodGet, "http://example.com/cond-ims-200", "")
+	// Earlier date: the resource HAS been modified since this date, so serve 200.
+	ctx2.FRequest.Header.Set("If-Modified-Since", "Wed, 20 Oct 2015 07:28:00 GMT")
+	f.Request(ctx2)
+	if ctx2.FResponse == nil {
+		t.Fatal("expected response")
+	}
+	if ctx2.FResponse.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", ctx2.FResponse.StatusCode)
+	}
+}
+
+func TestCacheFilter_ConditionalRequest_INM_Precedence_Over_IMS(t *testing.T) {
+	// RFC 9110 §13.1.3: If-None-Match takes precedence over If-Modified-Since.
+	// Even when IMS would yield 200 (resource modified), INM match must win → 304.
+	f := newTestFilter(t, 5*time.Minute, time.Second, time.Second)
+	rsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+	rsp.Header.Set("ETag", `"v1"`)
+	rsp.Header.Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+	f.fetch = func(_ *http.Request) (*http.Response, error) { return rsp, nil }
+
+	ctx1 := newCtx(http.MethodGet, "http://example.com/cond-precedence", "")
+	f.Request(ctx1)
+
+	ctx2 := newCtx(http.MethodGet, "http://example.com/cond-precedence", "")
+	ctx2.FRequest.Header.Set("If-None-Match", `"v1"`)
+	// IMS is earlier than Last-Modified — IMS alone would yield 200.
+	ctx2.FRequest.Header.Set("If-Modified-Since", "Wed, 20 Oct 2015 07:28:00 GMT")
+	f.Request(ctx2)
+	if ctx2.FResponse == nil {
+		t.Fatal("expected response")
+	}
+	if ctx2.FResponse.StatusCode != http.StatusNotModified {
+		t.Errorf("expected 304 (INM wins over IMS), got %d", ctx2.FResponse.StatusCode)
+	}
+}
+
+func TestCacheFilter_ConditionalRequest_Stale_IfNoneMatch_304_AndRevalidates(t *testing.T) {
+	// Stale entries must also honour client If-None-Match per RFC 9111 §4.3.2.
+	// Background revalidation must still fire even when a 304 is served to the client.
+	f := newTestFilter(t, 100*time.Millisecond, time.Second, 500*time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		var revalFired atomic.Bool
+
+		// Prime the cache via Request+Response so the entry is stored with ETag "v1".
+		ctx1 := newCtx(http.MethodGet, "http://example.com/stale-cond", "")
+		f.Request(ctx1)
+		primeRsp := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
+		primeRsp.Header.Set("ETag", `"v1"`)
+		ctx1.FResponse = primeRsp
+		f.Response(ctx1)
+
+		// Switch fetch to the revalidation stub (fires after the entry goes stale).
+		f.fetch = func(_ *http.Request) (*http.Response, error) {
+			revalFired.Store(true)
+			return upstreamResponseCC(http.StatusOK, "body2", "max-age=300"), nil
+		}
+
+		// Advance past TTL into SWR window (TTL=100ms, SWR=500ms).
+		time.Sleep(200 * time.Millisecond)
+
+		// Conditional request against stale entry.
+		ctx2 := newCtx(http.MethodGet, "http://example.com/stale-cond", "")
+		ctx2.FRequest.Header.Set("If-None-Match", `"v1"`)
+		f.Request(ctx2)
+		if ctx2.FResponse == nil {
+			t.Fatal("expected response")
+		}
+		if ctx2.FResponse.StatusCode != http.StatusNotModified {
+			t.Errorf("expected 304 for stale conditional, got %d", ctx2.FResponse.StatusCode)
+		}
+
+		// Background revalidation must have fired.
+		synctest.Wait()
+		if !revalFired.Load() {
+			t.Error("expected background revalidation to fire even when 304 served")
+		}
+	})
+}
+
+// RFC 9111 §5.2.1 max-stale and min-fresh request directive tests.
+
+func TestCacheFilter_MaxStale_ExceedsWindow_Bypasses(t *testing.T) {
+	// ttl=1ms, swrWindow=1h — entry expires immediately, SWR keeps it alive in storage.
+	// max-stale=0: even 2ms of staleness exceeds the 0s window → bypass (miss).
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/max-stale-exceed"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=0")
+		f.Response(ctx1)
+
+		// Advance 2ms — entry is now 2ms past its 1ms TTL (stale), within 1h SWR.
+		time.Sleep(2 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		ctx2.FRequest.Header.Set("Cache-Control", "max-stale=0")
+		f.Request(ctx2)
+
+		if ctx2.FServed {
+			t.Fatal("want bypass (max-stale=0 exceeded by 2ms staleness), got stale served")
+		}
+	})
+}
+
+func TestCacheFilter_MaxStale_WithinWindow_ServesStale(t *testing.T) {
+	// ttl=1ms, swrWindow=1h — entry is stale after 1ms, SWR keeps it.
+	// max-stale=1 (1000ms): 2ms stale < 1000ms window → serve stale.
+	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+	url := "https://cdn.contentful.com/spaces/abc/entries/max-stale-within"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=0")
+		f.Response(ctx1)
+
+		// Advance 2ms — entry is 2ms past its 1ms TTL.
+		time.Sleep(2 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		ctx2.FRequest.Header.Set("Cache-Control", "max-stale=1")
+		f.Request(ctx2)
+
+		if !ctx2.FServed {
+			t.Fatal("want stale served (2ms < 1000ms max-stale window), got miss")
+		}
+	})
+}
+
+func TestCacheFilter_MinFresh_SufficientFreshness_HIT(t *testing.T) {
+	// Fresh entry with 5m TTL remaining; min-fresh=1 (1s required) → serve from cache.
+	f := newTestFilter(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries/min-fresh-hit"
+
+	ctx1 := newCtx("GET", url, "")
+	f.Request(ctx1)
+	ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
+	f.Response(ctx1)
+
+	// Fresh entry, 5m TTL remaining (entry stored just now). min-fresh=1 (1s required).
+	// 5m >> 1s → HIT.
+	ctx2 := newCtx("GET", url, "")
+	ctx2.FRequest.Header.Set("Cache-Control", "min-fresh=1")
+	f.Request(ctx2)
+
+	if !ctx2.FServed {
+		t.Fatal("want HIT (5m remaining > 1s min-fresh), got bypass")
+	}
+}
+
+func TestCacheFilter_MinFresh_InsufficientFreshness_Bypasses(t *testing.T) {
+	// ttl=100ms, swrWindow=1ms — after 80ms only 20ms remain.
+	// min-fresh=1 (1000ms required): 20ms remaining < 1000ms → bypass.
+	f := newTestFilter(t, 100*time.Millisecond, 15*time.Second, time.Millisecond)
+	url := "https://cdn.contentful.com/spaces/abc/entries/min-fresh-bypass"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx1 := newCtx("GET", url, "")
+		f.Request(ctx1)
+		ctx1.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
+		f.Response(ctx1)
+
+		// Advance 80ms — only 20ms of freshness remain.
+		time.Sleep(80 * time.Millisecond)
+
+		ctx2 := newCtx("GET", url, "")
+		ctx2.FRequest.Header.Set("Cache-Control", "min-fresh=1")
+		f.Request(ctx2)
+
+		if ctx2.FServed {
+			t.Fatal("want bypass (20ms remaining < 1s min-fresh), got HIT")
+		}
+	})
+}
+
+func TestCacheFilter_StaleIfError_Serves_On_5xx(t *testing.T) {
+	// ttl=1ms, errorTTL=10s, swrWindow=1ms, staleIfError=60s
+	// Entry expires after 1ms; staleIfError=60s keeps it in storage.
+	// A 503 upstream should cause the stale entry to be served.
+	f := newTestFilter(t, time.Millisecond, 10*time.Second, time.Millisecond, 60*time.Second)
+	url := "http://example.com/sie-5xx"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx := newCtx(http.MethodGet, url, "")
+		f.Request(ctx)
+		ctx.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"cached"}`, "max-age=0")
+		f.Response(ctx)
+
+		// Advance past TTL+SWR (SWR=0) so the entry is stale, but within staleIfError window.
+		time.Sleep(50 * time.Millisecond)
+
+		ctx2 := newCtx(http.MethodGet, url, "")
+		f.Request(ctx2)
+		// ctx2 is a MISS (past TTL+SWR); upstream returns 503.
+		ctx2.FResponse = upstreamResponse(http.StatusServiceUnavailable, "")
+		f.Response(ctx2)
+
+		if ctx2.FResponse.StatusCode != http.StatusOK {
+			t.Fatalf("want 200 from stale-if-error, got %d", ctx2.FResponse.StatusCode)
+		}
+		if ctx2.FResponse.Header.Get("X-Cache-Status") != "STALE" {
+			t.Fatalf("want X-Cache-Status: STALE, got %s", ctx2.FResponse.Header.Get("X-Cache-Status"))
+		}
+	})
+}
+
+func TestCacheFilter_StaleIfError_Expired_NotServed(t *testing.T) {
+	// ttl=1ms, errorTTL=10s, swrWindow=1ms, staleIfError=100ms
+	// Sleep 200ms — past TTL + staleIfError window. Entry too old for stale-if-error.
+	f := newTestFilter(t, time.Millisecond, 10*time.Second, time.Millisecond, 100*time.Millisecond)
+	url := "http://example.com/sie-expired"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx := newCtx(http.MethodGet, url, "")
+		f.Request(ctx)
+		ctx.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"cached"}`, "max-age=0")
+		f.Response(ctx)
+
+		// Advance past TTL (1ms) + staleIfError (100ms) = well beyond 200ms.
+		time.Sleep(200 * time.Millisecond)
+
+		ctx2 := newCtx(http.MethodGet, url, "")
+		f.Request(ctx2)
+		ctx2.FResponse = upstreamResponse(http.StatusServiceUnavailable, "")
+		f.Response(ctx2)
+
+		if ctx2.FResponse.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("want 503 (SIE window expired), got %d", ctx2.FResponse.StatusCode)
+		}
+	})
+}
+
+func TestCacheFilter_StaleIfError_Disabled_When_Zero(t *testing.T) {
+	// No 4th arg — staleIfError defaults to 0. Upstream 503 must pass through.
+	f := newTestFilter(t, time.Millisecond, 10*time.Second, time.Millisecond)
+	url := "http://example.com/sie-disabled"
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx := newCtx(http.MethodGet, url, "")
+		f.Request(ctx)
+		ctx.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"cached"}`, "max-age=0")
+		f.Response(ctx)
+
+		time.Sleep(50 * time.Millisecond)
+
+		ctx2 := newCtx(http.MethodGet, url, "")
+		f.Request(ctx2)
+		ctx2.FResponse = upstreamResponse(http.StatusServiceUnavailable, "")
+		f.Response(ctx2)
+
+		if ctx2.FResponse.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("want 503 (SIE disabled), got %d", ctx2.FResponse.StatusCode)
+		}
+	})
+}
+
+// --- Option C: force mode vs RFC mode ---
+
+func TestCacheFilter_ForceMode_IgnoresUpstreamMaxAge(t *testing.T) {
+	// Force mode (default): operator TTL=5m is used even when upstream says max-age=1.
+	f := newTestFilter(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "http://example.com/force-ttl"
+
+	ctx := newCtx(http.MethodGet, url, "")
+	f.Request(ctx)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "public, max-age=1")
+	ctx.FResponse = rsp
+	f.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("expected entry to be stored in force mode")
+	}
+	if entry.TTL != 5*time.Minute {
+		t.Errorf("force mode: expected TTL=5m, got %v", entry.TTL)
+	}
+}
+
+func TestCacheFilter_ForceMode_CachesWhenUpstreamSaysPrivate(t *testing.T) {
+	// Force mode: operator TTL is authoritative; upstream `private` is NOT a blocker.
+	// This is the Contentful use-case: CDN returns private/no-store but we're a
+	// shared proxy that owns the caching decision.
+	f := newTestFilter(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "http://example.com/force-private"
+
+	ctx := newCtx(http.MethodGet, url, "")
+	f.Request(ctx)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"contentful"}`, "private, max-age=0")
+	ctx.FResponse = rsp
+	f.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("force mode: expected entry stored despite upstream private")
+	}
+	if entry.TTL != 5*time.Minute {
+		t.Errorf("force mode: expected TTL=5m, got %v", entry.TTL)
+	}
+}
+
+func TestCacheFilter_ForceMode_CachesWhenUpstreamSaysNoStore(t *testing.T) {
+	// Force mode: operator TTL is authoritative; upstream `no-store` is NOT a blocker.
+	f := newTestFilter(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "http://example.com/force-nostore"
+
+	ctx := newCtx(http.MethodGet, url, "")
+	f.Request(ctx)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"no-store"}`, "no-store")
+	ctx.FResponse = rsp
+	f.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("force mode: expected entry stored despite upstream no-store")
+	}
+}
+
+func TestCacheFilter_RFCMode_RespectsUpstreamPrivate(t *testing.T) {
+	// RFC mode: upstream `private` must block storage (RFC 9111 §5.2.2.7).
+	f := newTestFilterRFC(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "http://example.com/rfc-private"
+
+	ctx := newCtx(http.MethodGet, url, "")
+	f.Request(ctx)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"private"}`, "private, max-age=300")
+	ctx.FResponse = rsp
+	f.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, _ := f.storage.Get(context.Background(), key)
+	if entry != nil {
+		t.Fatal("RFC mode: upstream private must not be cached")
+	}
+}
+
+func TestCacheFilter_RFCMode_RespectsUpstreamNoStore(t *testing.T) {
+	// RFC mode: upstream `no-store` must block storage (RFC 9111 §5.2.2.5).
+	f := newTestFilterRFC(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "http://example.com/rfc-nostore"
+
+	ctx := newCtx(http.MethodGet, url, "")
+	f.Request(ctx)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"no-store"}`, "no-store")
+	ctx.FResponse = rsp
+	f.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, _ := f.storage.Get(context.Background(), key)
+	if entry != nil {
+		t.Fatal("RFC mode: upstream no-store must not be cached")
+	}
+}
+
+func TestCacheFilter_RFCMode_UpstreamMaxAgeIsAuthoritative(t *testing.T) {
+	// Pure RFC mode: upstream max-age=10 is the TTL exactly (no operator ceiling).
+	f := newTestFilterRFC(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "http://example.com/rfc-maxage"
+
+	ctx := newCtx(http.MethodGet, url, "")
+	f.Request(ctx)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"maxage"}`, "public, max-age=10")
+	ctx.FResponse = rsp
+	f.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("RFC mode: expected entry stored with upstream max-age")
+	}
+	if entry.TTL != 10*time.Second {
+		t.Errorf("RFC mode: expected TTL=10s (upstream max-age), got %v", entry.TTL)
+	}
+}
+
+func TestCacheFilter_SMaxAge_CapsRouteTTL(t *testing.T) {
+	// RFC 9111 §5.2.2.10: s-maxage takes precedence over max-age for shared caches.
+	f := newTestFilterRFC(t, 5*time.Minute, 15*time.Second, time.Millisecond)
+	url := "http://example.com/smaxage-caps"
+
+	ctx := newCtx(http.MethodGet, url, "")
+	f.Request(ctx)
+	ctx.FResponse = upstreamResponseCC(http.StatusOK, `{"data":"smaxage"}`, "public, max-age=300, s-maxage=5")
+	f.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := f.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("RFC mode: expected entry stored")
+	}
+	if entry.TTL != 5*time.Second {
+		t.Errorf("RFC mode: expected TTL=5s (s-maxage), got %v", entry.TTL)
+	}
+}
+
+func TestCacheFilter_CreateFilter_RFCArgParsing(t *testing.T) {
+	spec := NewCacheFilter(1<<20, ":9090")
+
+	cases := []struct {
+		name    string
+		args    []interface{}
+		wantRFC bool
+		wantSIE time.Duration
+		wantErr bool
+	}{
+		{"0 args pure rfc mode", []interface{}{}, true, 0, false},
+		{"3 args force mode", []interface{}{"5m", "15s", "30s"}, false, 0, false},
+		{"4 args staleIfError", []interface{}{"5m", "15s", "30s", "60s"}, false, 60 * time.Second, false},
+		{"1 arg invalid", []interface{}{"5m"}, false, 0, true},
+		{"2 args invalid", []interface{}{"5m", "15s"}, false, 0, true},
+		{"6 args too many", []interface{}{"5m", "15s", "30s", "60s", "Authorization", "extra"}, false, 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := spec.CreateFilter(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cf := f.(*cacheFilter)
+			if cf.rfcMode != tc.wantRFC {
+				t.Errorf("rfcMode: got %v, want %v", cf.rfcMode, tc.wantRFC)
+			}
+			if cf.staleIfError != tc.wantSIE {
+				t.Errorf("staleIfError: got %v, want %v", cf.staleIfError, tc.wantSIE)
+			}
+		})
+	}
+}
+
+func TestCacheFilter_PureRFCMode_ZeroArgs_UsesUpstreamMaxAge(t *testing.T) {
+	// cache() with no args: pure RFC mode, upstream max-age is fully authoritative,
+	// no operator ceiling. TTL should equal upstream max-age exactly.
+	spec := NewCacheFilter(1<<20, ":9090")
+	f, err := spec.CreateFilter([]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cf := f.(*cacheFilter)
+	cf.fetch = func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("no fetch stub")
+	}
+
+	url := "http://example.com/pure-rfc"
+	ctx := newCtx(http.MethodGet, url, "")
+	cf.Request(ctx)
+	rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "public, max-age=120")
+	ctx.FResponse = rsp
+	cf.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, err := cf.storage.Get(context.Background(), key)
+	if err != nil || entry == nil {
+		t.Fatal("pure RFC mode: expected entry stored")
+	}
+	if entry.TTL != 120*time.Second {
+		t.Errorf("pure RFC mode: expected TTL=120s (from upstream max-age), got %v", entry.TTL)
+	}
+}
+
+func TestCacheFilter_PureRFCMode_ZeroArgs_NoUpstreamDirective_NotCached(t *testing.T) {
+	// cache() with no args: when upstream sends no Cache-Control, no Expires,
+	// and no Last-Modified, nothing should be cached (no heuristic without Last-Modified).
+	spec := NewCacheFilter(1<<20, ":9090")
+	f, err := spec.CreateFilter([]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cf := f.(*cacheFilter)
+	cf.fetch = func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("no fetch stub")
+	}
+
+	url := "http://example.com/pure-rfc-nocache"
+	ctx := newCtx(http.MethodGet, url, "")
+	cf.Request(ctx)
+	rsp := upstreamResponse(http.StatusOK, `{"data":"v1"}`)
+	rsp.Header.Del("Cache-Control")
+	ctx.FResponse = rsp
+	cf.Response(ctx)
+
+	key := ctx.StateBag()[stateBagKey].(string)
+	entry, _ := cf.storage.Get(context.Background(), key)
+	if entry != nil {
+		t.Fatal("pure RFC mode: response with no freshness directives must not be cached")
 	}
 }

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -137,6 +137,7 @@ func TestCacheFilter_KeyIsolationByAuthToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	f := fi.(*cacheFilter)
+	t.Cleanup(f.Close)
 	f.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("no fetch stub set")
 	}
@@ -1177,6 +1178,7 @@ func TestCacheFilter_SharedStorage_RouteIsolation(t *testing.T) {
 			t.Fatal(err)
 		}
 		cf := f.(*cacheFilter)
+		t.Cleanup(cf.Close)
 		// Default fetch stub returns an error so coalesce does not serve the
 		// request; this allows the test to distinguish a true cache HIT from a
 		// coalesced upstream fetch.
@@ -2470,6 +2472,7 @@ func TestCacheFilter_CreateFilter_RFCArgParsing(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			cf := f.(*cacheFilter)
+			t.Cleanup(cf.Close)
 			if cf.rfcMode != tc.wantRFC {
 				t.Errorf("rfcMode: got %v, want %v", cf.rfcMode, tc.wantRFC)
 			}
@@ -2489,6 +2492,7 @@ func TestCacheFilter_PureRFCMode_ZeroArgs_UsesUpstreamMaxAge(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cf := f.(*cacheFilter)
+	t.Cleanup(cf.Close)
 	cf.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("no fetch stub")
 	}
@@ -2519,6 +2523,7 @@ func TestCacheFilter_PureRFCMode_ZeroArgs_NoUpstreamDirective_NotCached(t *testi
 		t.Fatalf("unexpected error: %v", err)
 	}
 	cf := f.(*cacheFilter)
+	t.Cleanup(cf.Close)
 	cf.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("no fetch stub")
 	}

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -138,6 +138,7 @@ func TestCacheFilter_KeyIsolationByAuthToken(t *testing.T) {
 	}
 	f := fi.(*cacheFilter)
 	t.Cleanup(f.Close)
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 	f.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("no fetch stub set")
 	}
@@ -250,6 +251,7 @@ func TestCacheFilter_TTLExpiry(t *testing.T) {
 
 func TestCreateFilter_InvalidArgs(t *testing.T) {
 	spec := NewCacheFilter(1<<20, "localhost:9090", skpnet.Options{})
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 	cases := []struct {
 		name string
 		args []interface{}
@@ -1170,6 +1172,7 @@ func TestCacheFilter_SMaxAge_ImpliesProxyRevalidate(t *testing.T) {
 
 func TestCacheFilter_SharedStorage_RouteIsolation(t *testing.T) {
 	spec := NewCacheFilter(1<<20, "localhost:9090", skpnet.Options{})
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 
 	makeFilter := func(t *testing.T) *cacheFilter {
 		t.Helper()
@@ -2443,6 +2446,7 @@ func TestCacheFilter_SMaxAge_CapsRouteTTL(t *testing.T) {
 
 func TestCacheFilter_CreateFilter_RFCArgParsing(t *testing.T) {
 	spec := NewCacheFilter(1<<20, ":9090", skpnet.Options{})
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 
 	cases := []struct {
 		name    string
@@ -2487,6 +2491,7 @@ func TestCacheFilter_PureRFCMode_ZeroArgs_UsesUpstreamMaxAge(t *testing.T) {
 	// cache() with no args: pure RFC mode, upstream max-age is fully authoritative,
 	// no operator ceiling. TTL should equal upstream max-age exactly.
 	spec := NewCacheFilter(1<<20, ":9090", skpnet.Options{})
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 	f, err := spec.CreateFilter([]interface{}{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2518,6 +2523,7 @@ func TestCacheFilter_PureRFCMode_ZeroArgs_NoUpstreamDirective_NotCached(t *testi
 	// cache() with no args: when upstream sends no Cache-Control, no Expires,
 	// and no Last-Modified, nothing should be cached (no heuristic without Last-Modified).
 	spec := NewCacheFilter(1<<20, ":9090", skpnet.Options{})
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 	f, err := spec.CreateFilter([]interface{}{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -15,11 +15,12 @@ import (
 
 	"github.com/zalando/skipper/filters/filtertest"
 	"github.com/zalando/skipper/metrics/metricstest"
+	skpnet "github.com/zalando/skipper/net"
 )
 
 func newTestFilter(t *testing.T, ttl, errorTTL, swrWindow time.Duration, extra ...time.Duration) *cacheFilter {
 	t.Helper()
-	spec := NewCacheFilter(1<<20, "localhost:9090")
+	spec := NewCacheFilter(1<<20, "localhost:9090", skpnet.Options{})
 	args := []interface{}{
 		ttl.String(),
 		errorTTL.String(),
@@ -38,6 +39,8 @@ func newTestFilter(t *testing.T, ttl, errorTTL, swrWindow time.Duration, extra .
 	cf.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("no fetch stub set")
 	}
+	t.Cleanup(cf.Close)
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 	return cf
 }
 
@@ -48,7 +51,7 @@ func newTestFilter(t *testing.T, ttl, errorTTL, swrWindow time.Duration, extra .
 // but are ignored — pure RFC mode has no operator TTL.
 func newTestFilterRFC(t *testing.T, _, _, _ time.Duration, _ ...time.Duration) *cacheFilter {
 	t.Helper()
-	spec := NewCacheFilter(1<<20, "localhost:9090")
+	spec := NewCacheFilter(1<<20, "localhost:9090", skpnet.Options{})
 	f, err := spec.CreateFilter([]interface{}{})
 	if err != nil {
 		t.Fatal(err)
@@ -57,6 +60,8 @@ func newTestFilterRFC(t *testing.T, _, _, _ time.Duration, _ ...time.Duration) *
 	cf.fetch = func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("no fetch stub set")
 	}
+	t.Cleanup(cf.Close)
+	t.Cleanup(spec.(*cacheSpec).client.Close)
 	return cf
 }
 
@@ -126,7 +131,7 @@ func TestCacheFilter_MissAndHit(t *testing.T) {
 }
 
 func TestCacheFilter_KeyIsolationByAuthToken(t *testing.T) {
-	spec := NewCacheFilter(1<<20, "localhost:9090")
+	spec := NewCacheFilter(1<<20, "localhost:9090", skpnet.Options{})
 	fi, err := spec.CreateFilter([]interface{}{"1m", "15s", "1m", "0s", "Authorization"})
 	if err != nil {
 		t.Fatal(err)
@@ -243,7 +248,7 @@ func TestCacheFilter_TTLExpiry(t *testing.T) {
 }
 
 func TestCreateFilter_InvalidArgs(t *testing.T) {
-	spec := NewCacheFilter(1<<20, "localhost:9090")
+	spec := NewCacheFilter(1<<20, "localhost:9090", skpnet.Options{})
 	cases := []struct {
 		name string
 		args []interface{}
@@ -764,12 +769,12 @@ func TestCacheFilter_Vary_Star_NotCached(t *testing.T) {
 }
 
 func TestCacheFilter_ConditionalRevalidation_ETag_304(t *testing.T) {
-	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
 	url := "https://cdn.contentful.com/spaces/abc/entries/etag"
 
 	var revalReq *http.Request
 
 	synctest.Test(t, func(t *testing.T) {
+		f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
 		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
@@ -813,12 +818,12 @@ func TestCacheFilter_ConditionalRevalidation_ETag_304(t *testing.T) {
 }
 
 func TestCacheFilter_ConditionalRevalidation_LastModified_304(t *testing.T) {
-	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
 	url := "https://cdn.contentful.com/spaces/abc/entries/lastmod"
 
 	var revalReq *http.Request
 
 	synctest.Test(t, func(t *testing.T) {
+		f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
 		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "max-age=300")
@@ -850,12 +855,12 @@ func TestCacheFilter_ConditionalRevalidation_LastModified_304(t *testing.T) {
 }
 
 func TestCacheFilter_RevalidationError_MetricIncremented(t *testing.T) {
-	f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
-	mockMetrics := &metricstest.MockMetrics{}
-	f.metrics = mockMetrics
 	url := "https://cdn.contentful.com/spaces/abc/entries/reval-err"
 
 	synctest.Test(t, func(t *testing.T) {
+		f := newTestFilter(t, time.Millisecond, 15*time.Second, time.Hour)
+		mockMetrics := &metricstest.MockMetrics{}
+		f.metrics = mockMetrics
 		ctx1 := newCtx("GET", url, "")
 		f.Request(ctx1)
 		rsp := upstreamResponseCC(http.StatusOK, `{"data":"v1"}`, "public, max-age=300")
@@ -1163,7 +1168,7 @@ func TestCacheFilter_SMaxAge_ImpliesProxyRevalidate(t *testing.T) {
 }
 
 func TestCacheFilter_SharedStorage_RouteIsolation(t *testing.T) {
-	spec := NewCacheFilter(1<<20, "localhost:9090")
+	spec := NewCacheFilter(1<<20, "localhost:9090", skpnet.Options{})
 
 	makeFilter := func(t *testing.T) *cacheFilter {
 		t.Helper()
@@ -1688,10 +1693,8 @@ func TestCacheFilter_HopByHop_NotStored(t *testing.T) {
 }
 
 func TestCacheFilter_304Merge_HopByHop_NotMerged(t *testing.T) {
-	// filter created OUTSIDE synctest bubble
-	f := newTestFilter(t, 5*time.Minute, 10*time.Second, 10*time.Minute)
-
 	synctest.Test(t, func(t *testing.T) {
+		f := newTestFilter(t, 5*time.Minute, 10*time.Second, 10*time.Minute)
 		// 1. First request populates cache
 		rsp1 := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
 		rsp1.Header.Set("ETag", `"v1"`)
@@ -1732,10 +1735,8 @@ func TestCacheFilter_304Merge_HopByHop_NotMerged(t *testing.T) {
 }
 
 func TestCacheFilter_Revalidate200_HopByHop_NotStored(t *testing.T) {
-	// filter created OUTSIDE synctest bubble
-	f := newTestFilter(t, 5*time.Minute, 10*time.Second, 10*time.Minute)
-
 	synctest.Test(t, func(t *testing.T) {
+		f := newTestFilter(t, 5*time.Minute, 10*time.Second, 10*time.Minute)
 		// 1. First request populates cache
 		rsp1 := upstreamResponseCC(http.StatusOK, "body", "max-age=300")
 		rsp1.Header.Set("ETag", `"v1"`)
@@ -2078,8 +2079,8 @@ func TestCacheFilter_ConditionalRequest_INM_Precedence_Over_IMS(t *testing.T) {
 func TestCacheFilter_ConditionalRequest_Stale_IfNoneMatch_304_AndRevalidates(t *testing.T) {
 	// Stale entries must also honour client If-None-Match per RFC 9111 §4.3.2.
 	// Background revalidation must still fire even when a 304 is served to the client.
-	f := newTestFilter(t, 100*time.Millisecond, time.Second, 500*time.Millisecond)
 	synctest.Test(t, func(t *testing.T) {
+		f := newTestFilter(t, 100*time.Millisecond, time.Second, 500*time.Millisecond)
 		var revalFired atomic.Bool
 
 		// Prime the cache via Request+Response so the entry is stored with ETag "v1".
@@ -2439,7 +2440,7 @@ func TestCacheFilter_SMaxAge_CapsRouteTTL(t *testing.T) {
 }
 
 func TestCacheFilter_CreateFilter_RFCArgParsing(t *testing.T) {
-	spec := NewCacheFilter(1<<20, ":9090")
+	spec := NewCacheFilter(1<<20, ":9090", skpnet.Options{})
 
 	cases := []struct {
 		name    string
@@ -2482,7 +2483,7 @@ func TestCacheFilter_CreateFilter_RFCArgParsing(t *testing.T) {
 func TestCacheFilter_PureRFCMode_ZeroArgs_UsesUpstreamMaxAge(t *testing.T) {
 	// cache() with no args: pure RFC mode, upstream max-age is fully authoritative,
 	// no operator ceiling. TTL should equal upstream max-age exactly.
-	spec := NewCacheFilter(1<<20, ":9090")
+	spec := NewCacheFilter(1<<20, ":9090", skpnet.Options{})
 	f, err := spec.CreateFilter([]interface{}{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2512,7 +2513,7 @@ func TestCacheFilter_PureRFCMode_ZeroArgs_UsesUpstreamMaxAge(t *testing.T) {
 func TestCacheFilter_PureRFCMode_ZeroArgs_NoUpstreamDirective_NotCached(t *testing.T) {
 	// cache() with no args: when upstream sends no Cache-Control, no Expires,
 	// and no Last-Modified, nothing should be cached (no heuristic without Last-Modified).
-	spec := NewCacheFilter(1<<20, ":9090")
+	spec := NewCacheFilter(1<<20, ":9090", skpnet.Options{})
 	f, err := spec.CreateFilter([]interface{}{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/filters/cache/lru.go
+++ b/filters/cache/lru.go
@@ -1,0 +1,161 @@
+package cache
+
+import (
+	"container/list"
+	"hash/fnv"
+	"sync"
+)
+
+// shardCount is set to 256 to balance lock contention with baseline memory overhead.
+// As a power of 2, it allows Go compiler to optimize modulo operations into
+// fast bitwise AND operations.
+const shardCount = 256
+
+// lruItem holds raw []byte instead of Go struct pointers.
+// This eliminates Garbage Collector (GC) scanning overhead and allows us to
+// enforce strict immutability of cached responses.
+type lruItem struct {
+	key  string
+	data []byte
+	size int64
+}
+
+// lruShard is a bounded LRU cache protected by a single mutex.
+type lruShard struct {
+	maxBytes     int64
+	currentBytes int64
+	ll           *list.List
+	cache        map[string]*list.Element
+	onEvict      func() // called once per evicted item; nil = no-op
+
+	// mu is a standard Mutex (not RWMutex) because LRU reads (Get)
+	// modify linked list. Contention is mitigated by sharding.
+	mu sync.Mutex
+}
+
+func newLRUShard(maxBytes int64) *lruShard {
+	return &lruShard{
+		maxBytes: maxBytes,
+		ll:       list.New(),
+		cache:    make(map[string]*list.Element),
+	}
+}
+
+func (s *lruShard) set(key string, data []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	size := int64(len(data))
+
+	// If item exceeds shard's capacity, we cannot cache it.
+	// We must also remove any existing smaller version of this key
+	// to prevent serving stale or inconsistent data.
+	if size > s.maxBytes {
+		if ele, ok := s.cache[key]; ok {
+			s.ll.Remove(ele)
+			item := ele.Value.(*lruItem)
+			delete(s.cache, key)
+			s.currentBytes -= item.size
+		}
+		return
+	}
+
+	if ele, ok := s.cache[key]; ok {
+		s.ll.MoveToFront(ele)
+		item := ele.Value.(*lruItem)
+		s.currentBytes -= item.size
+		item.data = data
+		item.size = size
+		s.currentBytes += size
+	} else {
+		ele := s.ll.PushFront(&lruItem{key, data, size})
+		s.cache[key] = ele
+		s.currentBytes += size
+	}
+
+	for s.currentBytes > s.maxBytes {
+		s.removeOldest()
+	}
+}
+
+func (s *lruShard) get(key string) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if ele, ok := s.cache[key]; ok {
+		s.ll.MoveToFront(ele)
+		item := ele.Value.(*lruItem)
+
+		dst := make([]byte, len(item.data))
+		copy(dst, item.data)
+		return dst, true
+	}
+	return nil, false
+}
+
+func (s *lruShard) delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if ele, ok := s.cache[key]; ok {
+		s.ll.Remove(ele)
+		item := ele.Value.(*lruItem)
+		delete(s.cache, key)
+		s.currentBytes -= item.size
+	}
+}
+
+func (s *lruShard) removeOldest() {
+	ele := s.ll.Back()
+	if ele != nil {
+		s.ll.Remove(ele)
+		item := ele.Value.(*lruItem)
+		delete(s.cache, item.key)
+		s.currentBytes -= item.size
+		if s.onEvict != nil {
+			s.onEvict()
+		}
+	}
+}
+
+// ShardedByteLRU manages an array of LRU shards to reduce lock contention
+// in highly concurrent reverse proxy environments.
+type ShardedByteLRU struct {
+	shards [shardCount]*lruShard
+}
+
+// NewShardedByteLRU distributes total allowed memory evenly across all shards.
+func NewShardedByteLRU(totalMaxBytes int64) *ShardedByteLRU {
+	s := &ShardedByteLRU{}
+	bytesPerShard := totalMaxBytes / int64(shardCount)
+
+	for i := 0; i < shardCount; i++ {
+		s.shards[i] = newLRUShard(bytesPerShard)
+	}
+	return s
+}
+
+// getShard routes a key to its shard via FNV-1a. Keys are expected to be
+// pre-hashed (e.g. SHA-256) by the caller.
+func (s *ShardedByteLRU) getShard(key string) *lruShard {
+	h := fnv.New32a()
+	h.Write([]byte(key))
+	return s.shards[h.Sum32()%shardCount]
+}
+
+// ExceedsShard reports whether data is too large to fit in any shard.
+func (s *ShardedByteLRU) ExceedsShard(data []byte) bool {
+	return int64(len(data)) > s.shards[0].maxBytes
+}
+
+func (s *ShardedByteLRU) Set(key string, data []byte) {
+	s.getShard(key).set(key, data)
+}
+
+func (s *ShardedByteLRU) Get(key string) ([]byte, bool) {
+	return s.getShard(key).get(key)
+}
+
+func (s *ShardedByteLRU) Delete(key string) {
+	s.getShard(key).delete(key)
+}

--- a/filters/cache/lru.go
+++ b/filters/cache/lru.go
@@ -33,11 +33,12 @@ type lruShard struct {
 	mu sync.Mutex
 }
 
-func newLRUShard(maxBytes int64) *lruShard {
+func newLRUShard(maxBytes int64, onEvict func()) *lruShard {
 	return &lruShard{
 		maxBytes: maxBytes,
 		ll:       list.New(),
 		cache:    make(map[string]*list.Element),
+		onEvict:  onEvict,
 	}
 }
 
@@ -125,12 +126,12 @@ type ShardedByteLRU struct {
 }
 
 // NewShardedByteLRU distributes total allowed memory evenly across all shards.
-func NewShardedByteLRU(totalMaxBytes int64) *ShardedByteLRU {
+func NewShardedByteLRU(totalMaxBytes int64, onEvict func()) *ShardedByteLRU {
 	s := &ShardedByteLRU{}
 	bytesPerShard := totalMaxBytes / int64(shardCount)
 
 	for i := 0; i < shardCount; i++ {
-		s.shards[i] = newLRUShard(bytesPerShard)
+		s.shards[i] = newLRUShard(bytesPerShard, onEvict)
 	}
 	return s
 }

--- a/filters/cache/lru.go
+++ b/filters/cache/lru.go
@@ -2,8 +2,9 @@ package cache
 
 import (
 	"container/list"
-	"hash/fnv"
 	"sync"
+
+	"github.com/cespare/xxhash/v2"
 )
 
 // shardCount is set to 256 to balance lock contention with baseline memory overhead.
@@ -21,16 +22,17 @@ type lruItem struct {
 }
 
 // lruShard is a bounded LRU cache protected by a single mutex.
+// mu is a standard Mutex (not RWMutex) because LRU reads (Get) modify the
+// linked list. Contention is mitigated by sharding.
 type lruShard struct {
-	maxBytes     int64
+	// Immutable after construction; not protected by mu.
+	maxBytes int64
+	onEvict  func() // called once per evicted item; nil = no-op
+
+	mu           sync.Mutex
 	currentBytes int64
 	ll           *list.List
 	cache        map[string]*list.Element
-	onEvict      func() // called once per evicted item; nil = no-op
-
-	// mu is a standard Mutex (not RWMutex) because LRU reads (Get)
-	// modify linked list. Contention is mitigated by sharding.
-	mu sync.Mutex
 }
 
 func newLRUShard(maxBytes int64, onEvict func()) *lruShard {
@@ -136,12 +138,10 @@ func NewShardedByteLRU(totalMaxBytes int64, onEvict func()) *ShardedByteLRU {
 	return s
 }
 
-// getShard routes a key to its shard via FNV-1a. Keys are expected to be
+// getShard routes a key to its shard via xxhash. Keys are expected to be
 // pre-hashed (e.g. SHA-256) by the caller.
 func (s *ShardedByteLRU) getShard(key string) *lruShard {
-	h := fnv.New32a()
-	h.Write([]byte(key))
-	return s.shards[h.Sum32()%shardCount]
+	return s.shards[xxhash.Sum64String(key)%shardCount]
 }
 
 // ExceedsShard reports whether data is too large to fit in any shard.
@@ -159,4 +159,15 @@ func (s *ShardedByteLRU) Get(key string) ([]byte, bool) {
 
 func (s *ShardedByteLRU) Delete(key string) {
 	s.getShard(key).delete(key)
+}
+
+// Bytes returns the total number of bytes currently stored across all shards.
+func (s *ShardedByteLRU) Bytes() int64 {
+	var total int64
+	for _, shard := range s.shards {
+		shard.mu.Lock()
+		total += shard.currentBytes
+		shard.mu.Unlock()
+	}
+	return total
 }

--- a/filters/cache/lru_storage.go
+++ b/filters/cache/lru_storage.go
@@ -17,9 +17,9 @@ type LRUStorage struct {
 }
 
 // NewLRUStorage returns an LRUStorage backed by a ShardedByteLRU sized to totalMaxBytes.
-func NewLRUStorage(totalMaxBytes int64) *LRUStorage {
+func NewLRUStorage(totalMaxBytes int64, onEvict func()) *LRUStorage {
 	return &LRUStorage{
-		lru: NewShardedByteLRU(totalMaxBytes),
+		lru: NewShardedByteLRU(totalMaxBytes, onEvict),
 	}
 }
 
@@ -34,10 +34,14 @@ func (s *LRUStorage) Get(_ context.Context, key string) (*Entry, error) {
 		return nil, fmt.Errorf("cache: decode entry: %w", err)
 	}
 
-	hardExpiry := e.CreatedAt.Add(e.TTL + e.StaleWhileRevalidate)
-	if time.Now().After(hardExpiry) {
-		s.lru.Delete(key)
-		return nil, nil
+	// TTL==0 means "always stale but keep for conditional revalidation" (no-cache entries).
+	// Only hard-evict when TTL>0 and the entry has passed its full retention window.
+	if e.TTL > 0 {
+		sieWindow := max(e.StaleIfError, e.StaleWhileRevalidate)
+		if time.Now().After(e.CreatedAt.Add(e.TTL + sieWindow)) {
+			s.lru.Delete(key)
+			return nil, nil
+		}
 	}
 
 	return &e, nil

--- a/filters/cache/lru_storage.go
+++ b/filters/cache/lru_storage.go
@@ -1,0 +1,65 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// LRUStorage wraps ShardedByteLRU and implements Storage.
+// It owns all cache semantics (serialisation, TTL expiry); ShardedByteLRU
+// remains a pure byte store.
+type LRUStorage struct {
+	lru *ShardedByteLRU
+}
+
+// NewLRUStorage returns an LRUStorage backed by a ShardedByteLRU sized to totalMaxBytes.
+func NewLRUStorage(totalMaxBytes int64) *LRUStorage {
+	return &LRUStorage{
+		lru: NewShardedByteLRU(totalMaxBytes),
+	}
+}
+
+func (s *LRUStorage) Get(_ context.Context, key string) (*Entry, error) {
+	data, ok := s.lru.Get(key)
+	if !ok {
+		return nil, nil
+	}
+
+	var e Entry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return nil, fmt.Errorf("cache: decode entry: %w", err)
+	}
+
+	hardExpiry := e.CreatedAt.Add(e.TTL + e.StaleWhileRevalidate)
+	if time.Now().After(hardExpiry) {
+		s.lru.Delete(key)
+		return nil, nil
+	}
+
+	return &e, nil
+}
+
+func (s *LRUStorage) Set(_ context.Context, key string, entry *Entry) error {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("cache: encode entry: %w", err)
+	}
+	if s.lru.ExceedsShard(data) {
+		log.WithFields(log.Fields{
+			"key":        key,
+			"size_bytes": len(data),
+			"shard_max":  s.lru.shards[0].maxBytes,
+		}).Warn("cache: entry exceeds shard capacity and will not be stored")
+	}
+	s.lru.Set(key, data)
+	return nil
+}
+
+func (s *LRUStorage) Delete(_ context.Context, key string) error {
+	s.lru.Delete(key)
+	return nil
+}

--- a/filters/cache/lru_storage.go
+++ b/filters/cache/lru_storage.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/zalando/skipper/metrics"
 )
 
 // LRUStorage wraps ShardedByteLRU and implements Storage.
@@ -58,6 +59,8 @@ func (s *LRUStorage) Set(_ context.Context, key string, entry *Entry) error {
 			"size_bytes": len(data),
 			"shard_max":  s.lru.shards[0].maxBytes,
 		}).Warn("cache: entry exceeds shard capacity and will not be stored")
+		metrics.Default.IncCounter("lru_oversized")
+		return nil
 	}
 	s.lru.Set(key, data)
 	return nil

--- a/filters/cache/lru_test.go
+++ b/filters/cache/lru_test.go
@@ -1,0 +1,158 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func makeEntry(payload string, ttl time.Duration) *Entry {
+	return &Entry{
+		StatusCode: http.StatusOK,
+		Payload:    []byte(payload),
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		CreatedAt:  time.Now(),
+		TTL:        ttl,
+	}
+}
+
+func TestLRUStorage_HitAndMiss(t *testing.T) {
+	s := NewLRUStorage(1 << 20) // 1 MB
+	ctx := context.Background()
+
+	got, err := s.Get(ctx, "missing")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil, nil) for missing key, got (%v, %v)", got, err)
+	}
+
+	want := makeEntry(`{"id":1}`, time.Minute)
+	if err := s.Set(ctx, "k1", want); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = s.Get(ctx, "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("payload mismatch: got %q, want %q", got.Payload, want.Payload)
+	}
+	if got.StatusCode != want.StatusCode {
+		t.Fatalf("status mismatch: got %d, want %d", got.StatusCode, want.StatusCode)
+	}
+}
+
+func TestLRUStorage_HardExpiry(t *testing.T) {
+	s := NewLRUStorage(1 << 20)
+	ctx := context.Background()
+
+	entry := makeEntry("stale", time.Millisecond)
+	// Back-date CreatedAt so the entry is already expired.
+	entry.CreatedAt = time.Now().Add(-time.Second)
+
+	if err := s.Set(ctx, "expired", entry); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get(ctx, "expired")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for expired entry, got %+v", got)
+	}
+
+	// Confirm the key was evicted and a second Get is also nil.
+	got, err = s.Get(ctx, "expired")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil, nil) after eviction, got (%v, %v)", got, err)
+	}
+}
+
+func TestLRUStorage_Delete(t *testing.T) {
+	s := NewLRUStorage(1 << 20)
+	ctx := context.Background()
+
+	if err := s.Set(ctx, "del", makeEntry("x", time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(ctx, "del"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get(ctx, "del")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil, nil) after delete, got (%v, %v)", got, err)
+	}
+}
+
+func TestLRUStorage_InPlaceUpdate(t *testing.T) {
+	sample, _ := json.Marshal(makeEntry("v1", time.Minute))
+	entrySize := int64(len(sample)) + 20
+	s := NewLRUStorage(entrySize * shardCount)
+	ctx := context.Background()
+
+	// Overwrite an existing key — Get must return the new payload.
+	if err := s.Set(ctx, "k", makeEntry("v1", time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set(ctx, "k", makeEntry("v2", time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get(ctx, "k")
+	if err != nil || got == nil {
+		t.Fatalf("expected entry after overwrite, got (%v, %v)", got, err)
+	}
+	if string(got.Payload) != "v2" {
+		t.Fatalf("expected updated payload %q, got %q", "v2", got.Payload)
+	}
+}
+
+func TestLRUStorage_ImmutabilityAfterSet(t *testing.T) {
+	s := NewLRUStorage(1 << 20)
+	ctx := context.Background()
+
+	entry := makeEntry("original", time.Minute)
+	if err := s.Set(ctx, "imm", entry); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutate the original after storing; cached copy must be unaffected.
+	entry.Payload = []byte("mutated")
+
+	got, err := s.Get(ctx, "imm")
+	if err != nil || got == nil {
+		t.Fatal(err)
+	}
+	if string(got.Payload) != "original" {
+		t.Fatalf("cache was mutated: got %q", got.Payload)
+	}
+}
+
+func TestLRUShard_CrossKeyEviction(t *testing.T) {
+	// Test lruShard directly to make eviction deterministic — no hash routing.
+	dataA := []byte("aaaa")
+	dataB := []byte("bbbb")
+	// maxBytes fits exactly one entry; writing a second must evict the first.
+	shard := newLRUShard(int64(len(dataA)))
+
+	shard.set("a", dataA)
+	if _, ok := shard.get("a"); !ok {
+		t.Fatal("expected key a to be present after set")
+	}
+
+	shard.set("b", dataB)
+
+	if _, ok := shard.get("a"); ok {
+		t.Fatal("expected key a to be evicted after key b filled the shard")
+	}
+	if _, ok := shard.get("b"); !ok {
+		t.Fatal("expected key b to be present after set")
+	}
+}

--- a/filters/cache/lru_test.go
+++ b/filters/cache/lru_test.go
@@ -19,7 +19,7 @@ func makeEntry(payload string, ttl time.Duration) *Entry {
 }
 
 func TestLRUStorage_HitAndMiss(t *testing.T) {
-	s := NewLRUStorage(1 << 20) // 1 MB
+	s := NewLRUStorage(1<<20, nil) // 1 MB
 	ctx := context.Background()
 
 	got, err := s.Get(ctx, "missing")
@@ -48,7 +48,7 @@ func TestLRUStorage_HitAndMiss(t *testing.T) {
 }
 
 func TestLRUStorage_HardExpiry(t *testing.T) {
-	s := NewLRUStorage(1 << 20)
+	s := NewLRUStorage(1<<20, nil)
 	ctx := context.Background()
 
 	entry := makeEntry("stale", time.Millisecond)
@@ -75,7 +75,7 @@ func TestLRUStorage_HardExpiry(t *testing.T) {
 }
 
 func TestLRUStorage_Delete(t *testing.T) {
-	s := NewLRUStorage(1 << 20)
+	s := NewLRUStorage(1<<20, nil)
 	ctx := context.Background()
 
 	if err := s.Set(ctx, "del", makeEntry("x", time.Minute)); err != nil {
@@ -94,7 +94,7 @@ func TestLRUStorage_Delete(t *testing.T) {
 func TestLRUStorage_InPlaceUpdate(t *testing.T) {
 	sample, _ := json.Marshal(makeEntry("v1", time.Minute))
 	entrySize := int64(len(sample)) + 20
-	s := NewLRUStorage(entrySize * shardCount)
+	s := NewLRUStorage(entrySize*shardCount, nil)
 	ctx := context.Background()
 
 	// Overwrite an existing key — Get must return the new payload.
@@ -115,7 +115,7 @@ func TestLRUStorage_InPlaceUpdate(t *testing.T) {
 }
 
 func TestLRUStorage_ImmutabilityAfterSet(t *testing.T) {
-	s := NewLRUStorage(1 << 20)
+	s := NewLRUStorage(1<<20, nil)
 	ctx := context.Background()
 
 	entry := makeEntry("original", time.Minute)
@@ -140,7 +140,7 @@ func TestLRUShard_CrossKeyEviction(t *testing.T) {
 	dataA := []byte("aaaa")
 	dataB := []byte("bbbb")
 	// maxBytes fits exactly one entry; writing a second must evict the first.
-	shard := newLRUShard(int64(len(dataA)))
+	shard := newLRUShard(int64(len(dataA)), nil)
 
 	shard.set("a", dataA)
 	if _, ok := shard.get("a"); !ok {

--- a/filters/cache/main_test.go
+++ b/filters/cache/main_test.go
@@ -1,0 +1,12 @@
+package cache
+
+import (
+	"os"
+	"testing"
+
+	"github.com/AlexanderYastrebov/noleak"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(noleak.CheckMain(m))
+}

--- a/filters/cache/storage.go
+++ b/filters/cache/storage.go
@@ -1,0 +1,33 @@
+package cache
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type Entry struct {
+	StatusCode           int
+	Payload              []byte
+	Header               http.Header
+	CreatedAt            time.Time
+	TTL                  time.Duration
+	StaleWhileRevalidate time.Duration
+	ETag                 string
+	LastModified         string
+	VaryHeaders          []string
+}
+
+// IsStale returns true when the entry is past its TTL but still within the SWR window.
+func (e *Entry) IsStale(now time.Time) bool {
+	return now.After(e.CreatedAt.Add(e.TTL)) && now.Before(e.CreatedAt.Add(e.TTL+e.StaleWhileRevalidate))
+}
+
+type Storage interface {
+	// Should return (nil, nil) if the key is not found
+	Get(ctx context.Context, key string) (*Entry, error)
+
+	Set(ctx context.Context, key string, entry *Entry) error
+
+	Delete(ctx context.Context, key string) error
+}

--- a/filters/cache/storage.go
+++ b/filters/cache/storage.go
@@ -16,6 +16,13 @@ type Entry struct {
 	ETag                 string
 	LastModified         string
 	VaryHeaders          []string
+	// RFC 9111 §4.2.3 Age fields. Zero-value safe: setAgeHeader falls back to
+	// legacy formula when ResponseTime.IsZero().
+	CorrectedInitialAge time.Duration
+	ResponseTime        time.Time
+	// StaleIfError is used by storage to extend the hard-expiry window; the filter
+	// uses f.staleIfError directly for the SIE window check.
+	StaleIfError time.Duration
 }
 
 // IsStale returns true when the entry is past its TTL but still within the SWR window.

--- a/filters/cache/storage.go
+++ b/filters/cache/storage.go
@@ -6,35 +6,58 @@ import (
 	"time"
 )
 
+// Entry holds a cached HTTP response and the metadata required for freshness
+// evaluation, conditional revalidation, and Age header calculation.
 type Entry struct {
-	StatusCode           int
-	Payload              []byte
-	Header               http.Header
-	CreatedAt            time.Time
-	TTL                  time.Duration
+	// StatusCode is the HTTP status code of the cached response.
+	StatusCode int
+	// Payload is the serialised response body.
+	Payload []byte
+	// Header contains the response headers as stored at cache time.
+	Header http.Header
+	// CreatedAt is the wall-clock time at which this entry was stored.
+	CreatedAt time.Time
+	// TTL is the freshness lifetime of the entry.
+	TTL time.Duration
+	// StaleWhileRevalidate is the window after TTL expiry during which a stale
+	// response may be served while a background revalidation is in flight.
 	StaleWhileRevalidate time.Duration
-	ETag                 string
-	LastModified         string
-	VaryHeaders          []string
-	// RFC 9111 §4.2.3 Age fields. Zero-value safe: setAgeHeader falls back to
-	// legacy formula when ResponseTime.IsZero().
+	// ETag is the entity tag from the upstream response, used for conditional
+	// revalidation (If-None-Match).
+	ETag string
+	// LastModified is the Last-Modified value from the upstream response, used
+	// for conditional revalidation (If-Modified-Since).
+	LastModified string
+	// VaryHeaders lists the request header names captured from the original
+	// request that were used to derive the cache key, matching the upstream
+	// Vary response header.
+	VaryHeaders []string
+	// CorrectedInitialAge is the age correction term defined in RFC 9111 §4.2.3.
+	// When zero, setAgeHeader falls back to the legacy elapsed-time formula.
 	CorrectedInitialAge time.Duration
-	ResponseTime        time.Time
-	// StaleIfError is used by storage to extend the hard-expiry window; the filter
-	// uses f.staleIfError directly for the SIE window check.
+	// ResponseTime is the local time at which the upstream response was received,
+	// used together with CorrectedInitialAge for RFC 9111 §4.2.3 age calculation.
+	ResponseTime time.Time
+	// StaleIfError extends the hard-expiry retention window so the entry remains
+	// retrievable during upstream error periods (RFC 5861 stale-if-error).
 	StaleIfError time.Duration
 }
 
-// IsStale returns true when the entry is past its TTL but still within the SWR window.
+// IsStale reports whether the entry is past its TTL but still within the
+// stale-while-revalidate window relative to now.
 func (e *Entry) IsStale(now time.Time) bool {
 	return now.After(e.CreatedAt.Add(e.TTL)) && now.Before(e.CreatedAt.Add(e.TTL+e.StaleWhileRevalidate))
 }
 
+// Storage is the backing store abstraction for cached entries. Implementations
+// must be safe for concurrent use.
 type Storage interface {
-	// Should return (nil, nil) if the key is not found
+	// Get returns the entry for key, or (nil, nil) if the key is not found.
 	Get(ctx context.Context, key string) (*Entry, error)
 
+	// Set stores or overwrites the entry for key.
 	Set(ctx context.Context, key string, entry *Entry) error
 
+	// Delete removes the entry for key. It is not an error if the key does not exist.
 	Delete(ctx context.Context, key string) error
 }

--- a/filters/cache/storage.go
+++ b/filters/cache/storage.go
@@ -49,8 +49,8 @@ func (e *Entry) IsStale(now time.Time) bool {
 	return now.After(e.CreatedAt.Add(e.TTL)) && now.Before(e.CreatedAt.Add(e.TTL+e.StaleWhileRevalidate))
 }
 
-// Storage is the backing store abstraction for cached entries. Implementations
-// must be safe for concurrent use.
+// Storage is the backing store abstraction for cached entries.
+// Implementations must be safe for concurrent use.
 type Storage interface {
 	// Get returns the entry for key, or (nil, nil) if the key is not found.
 	Get(ctx context.Context, key string) (*Entry, error)

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -379,6 +379,7 @@ const (
 	TLSName                                    = "tlsPassClientCertificates"
 	AWSSigV4Name                               = "awsSigv4"
 	LoopbackIfStatus                           = "loopbackIfStatus"
+	CacheName                                  = "cache"
 
 	// Undocumented filters
 	HealthCheckName        = "healthcheck"

--- a/skipper.go
+++ b/skipper.go
@@ -37,6 +37,7 @@ import (
 	"github.com/zalando/skipper/filters/auth"
 	"github.com/zalando/skipper/filters/block"
 	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/filters/cache"
 	"github.com/zalando/skipper/filters/fadein"
 	logfilter "github.com/zalando/skipper/filters/log"
 	"github.com/zalando/skipper/filters/openpolicyagent"
@@ -138,6 +139,16 @@ type Options struct {
 	// EnableCopyStreamPoolExperimental if set to true the Proxy will use a
 	// sync.Pool to reduce memory garbage in copy stream.
 	EnableCopyStreamPoolExperimental bool
+
+	// ResponseCacheMaxMemoryBytes sets the in-memory budget for the cache()
+	// filter. When zero, the budget is derived from the cgroup memory limit
+	// using a fixed 25% fraction. Set explicitly to override that behaviour.
+	ResponseCacheMaxMemoryBytes int64
+
+	// ReadMemoryLimit, when set, is called by the cache() filter initialiser
+	// to determine the container memory limit. Defaults to reading cgroup files.
+	// Override in tests or on non-standard platforms.
+	ReadMemoryLimit func() (int64, error)
 
 	// List of custom filter specifications.
 	CustomFilters []filters.Spec
@@ -1300,6 +1311,52 @@ func initLog(o Options) (*logging.AccessLogger, error) {
 	return lg, nil
 }
 
+// readCgroupMemoryLimit reads the container memory limit from the cgroup
+// filesystem (v2 path first, v1 fallback).
+func readCgroupMemoryLimit() (int64, error) {
+	const (
+		memoryLimitFileV2 = "/sys/fs/cgroup/memory.max"
+		memoryLimitFileV1 = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	)
+	data, err := os.ReadFile(memoryLimitFileV2)
+	if err != nil {
+		data, err = os.ReadFile(memoryLimitFileV1)
+	}
+	if err != nil {
+		return 0, err
+	}
+	limit, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return limit, nil
+}
+
+// cacheBudget returns the in-memory byte budget for the cache() filter.
+// If ResponseCacheMaxMemoryBytes is set it is used directly. Otherwise the
+// budget is derived from ReadMemoryLimit (defaults to readCgroupMemoryLimit)
+// at 25% of the reported limit. Falls back to 2 GB if the limit is
+// unavailable.
+func (o *Options) cacheBudget() int64 {
+	const (
+		// 2 << 30 shifts the bits to represent 2 * 1024 * 1024 * 1024 bytes (2 GB)
+		defaultBudget  = 2 << 30
+		cgroupFraction = 4
+	)
+	if o.ResponseCacheMaxMemoryBytes > 0 {
+		return o.ResponseCacheMaxMemoryBytes
+	}
+	readLimit := o.ReadMemoryLimit
+	if readLimit == nil {
+		readLimit = readCgroupMemoryLimit
+	}
+	limit, _ := readLimit()
+	if limit <= 0 {
+		return defaultBudget
+	}
+	return limit / cgroupFraction
+}
+
 // filterRegistry creates a filter registry with the builtin and
 // custom filter specs registered excluding disabled filters.
 // If [Options.RegisterFilters] callback is set, it will be called.
@@ -1315,6 +1372,10 @@ func (o *Options) filterRegistry() filters.Registry {
 		if _, ok := disabledFilters[f.Name()]; !ok {
 			registry.Register(f)
 		}
+	}
+
+	if _, ok := disabledFilters[cache.Name]; !ok {
+		registry.Register(cache.NewCacheFilter(o.cacheBudget(), o.Address))
 	}
 
 	for _, f := range o.CustomFilters {
@@ -1404,32 +1465,17 @@ func listen(o *Options, address string, mtr metrics.Metrics) (net.Listener, erro
 
 	var memoryLimit int64
 	if o.MaxTCPListenerConcurrency <= 0 {
-		// cgroup v1: https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
-		// cgroup v2: https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 		// Note that in containers this will be the container limit.
 		// Runtimes without these files will use defaults defined in `queuelistener` package.
-		const (
-			memoryLimitFileV1 = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-			memoryLimitFileV2 = "/sys/fs/cgroup/memory.max"
-		)
-		memoryLimitBytes, err := os.ReadFile(memoryLimitFileV2)
+		var err error
+		memoryLimit, err = readCgroupMemoryLimit()
 		if err != nil {
-			memoryLimitBytes, err = os.ReadFile(memoryLimitFileV1)
-			if err != nil {
-				log.Errorf("Failed to read memory limits, fall back to defaults: %v", err)
-			}
+			log.Errorf("Failed to read memory limits, fall back to defaults: %v", err)
 		}
-		if err == nil {
-			memoryLimitString := strings.TrimSpace(string(memoryLimitBytes))
-			memoryLimit, err = strconv.ParseInt(memoryLimitString, 10, 64)
-			if err != nil {
-				log.Errorf("Failed to convert memory limits, fall back to defaults: %v", err)
-			}
 
-			// 4GB, temporarily, as a tested magic number until a better mechanism is in place:
-			if memoryLimit > 1<<32 {
-				memoryLimit = 1 << 32
-			}
+		// 4GB, temporarily, as a tested magic number until a better mechanism is in place:
+		if memoryLimit > 1<<32 {
+			memoryLimit = 1 << 32
 		}
 	}
 

--- a/skipper.go
+++ b/skipper.go
@@ -1374,10 +1374,6 @@ func (o *Options) filterRegistry() filters.Registry {
 		}
 	}
 
-	if _, ok := disabledFilters[cache.Name]; !ok {
-		registry.Register(cache.NewCacheFilter(o.cacheBudget(), o.Address))
-	}
-
 	for _, f := range o.CustomFilters {
 		if _, ok := disabledFilters[f.Name()]; !ok {
 			registry.Register(f)
@@ -1868,6 +1864,23 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			OpenTracingClientTraceByTag: o.OpenTracingClientTraceByTag,
 		}),
 	)
+
+	// cache() filter registered here (not in filterRegistry) so the resolved tracer
+	// and connection options from skipper.Options can be wired through.
+	if _, ok := disabledFilters[cache.Name]; !ok {
+		o.CustomFilters = append(o.CustomFilters, cache.NewCacheFilter(
+			o.cacheBudget(),
+			o.Address,
+			skpnet.Options{
+				IdleConnTimeout:         o.CloseIdleConnsPeriod,
+				MaxIdleConnsPerHost:     o.IdleConnectionsPerHost,
+				Tracer:                  tracer,
+				OpentracingComponentTag: "skipper",
+				OpentracingSpanName:     "cache_revalidation",
+				OpentracingEventsByTag:  o.OpenTracingClientTraceByTag,
+			},
+		))
+	}
 
 	if o.OAuthTokeninfoURL != "" {
 		tio := auth.TokeninfoOptions{

--- a/skipper.go
+++ b/skipper.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1867,7 +1868,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	// cache() filter registered here (not in filterRegistry) so the resolved tracer
 	// and connection options from skipper.Options can be wired through.
-	if _, ok := disabledFilters[cache.Name]; !ok {
+	if !slices.Contains(o.DisabledFilters, cache.Name) {
 		o.CustomFilters = append(o.CustomFilters, cache.NewCacheFilter(
 			o.cacheBudget(),
 			o.Address,


### PR DESCRIPTION
# Summary

Adds a new `cache()` filter providing proxy-layer HTTP response caching backed by a shared in-memory LRU store.

## Two operating modes

- `cache()` - RFC mode: upstream `Cache-Control` is fully authoritative (freshness, `no-store`, `private`, `Vary`, `s-maxage`, heuristic TTL, conditional revalidation)
- `cache("5m", "15s", "30s"[, "60s"[, "X-Header"]])` - force mode: operator sets TTL, error TTL, and SWR window directly; upstream freshness directives are ignored        

## Behaviours                                                                                                                                                     
                              
- Stale-while-revalidate: serves stale immediately, refreshes in background
- Cold-miss coalescing: concurrent requests for the same uncached key share a single upstream fetch
- Unsafe method invalidation: `POST`/`PUT`/`DELETE`/`PATCH` success invalidates the cached entry and any same-origin `Location`/`Content-Location` URIs
- `HEAD 200` freshens stored headers without replacing the cached body
- Stale-if-error (RFC 5861): serves stale during upstream 5xx within a configurable window                                                                                                                                                      
- Per-header key namespacing via optional `keyHeaders` argument

**RFC 9111 compliance:** `s-maxage` correctly implies proxy-revalidate (§5.2.2.10), `Vary` header support, heuristic freshness (§4.2.2), corrected initial age (§4.2.3).

### Revalidation worker sizing

Single-worker + 256-slot queue design is intentional and sufficient for our target workload driving the need for this implementation.

<img width="1295" height="413" alt="Screenshot 2026-05-21 at 07 35 05" src="https://github.com/user-attachments/assets/02c0c4df-6cbb-470a-9158-b060565cd832" />

At ~1.36ms average upstream latency (CURRENT_CACHING_SOLUTION_TO_BE_REPLACED, production, last 7 days),  worker can process ~735 revalidations/sec ceiling, well within capacity. Against a ~267 req/s baseline, the queue will not back up under normal or burst conditions. The `reval_dropped` metric provides visibility if this assumption breaks in a different deployment context.

<details>
<summary>Math</summary>
1000ms / 1.36ms ≈ 735 revals/sec
735 revals/sec capacity vs ~267 req/s demand - that's ~2.75x headroom. 
Even if 100% of requests hit a stale entry simultaneously, the worker clears the queue faster than it fills.
256 slots / 735 revals/sec ≈ 0.35 seconds of burst absorption at full capacity.
</details>

### Demo

Covers MISS→HIT→STALE→HIT, error caching, coalescing, `Age` header, and `no-cache`/`no-store` bypass against a live mockapi backend. Run against a local Skipper on `:9090`.

<details>
<summary>demo-route.eskip + demo.sh</summary>

```eskip
demoBanners:
  Path("/api/v1/banners")
  -> cache("5s", "3s", "5s")
  -> "http://localhost:8888";

demoBanners404:
  Path("/api/v1/banners/0")
  -> cache("5s", "3s", "5s")
  -> "http://localhost:8888";
```

```bash
#!/usr/bin/env bash
set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
SKIPPER_DIR="${SCRIPT_DIR}/skipper"
MOCK_DIR="${SCRIPT_DIR}/mock-upstream"

BASE="http://localhost:9090"
MOCK_ADDR="http://localhost:8888"
N=0  # global request counter
MOCK_PID=""
SKIPPER_PID=""
SKIPPER_LOG="${SCRIPT_DIR}/skipper-demo.log"

# Extract X-Cache-Status from a response; never fails the script.
xcache() {
  grep -i "^x-cache-status:" | tr -d '\r' | awk '{print $2}'
}

req() {
  local path="$1"
  local raw status
  raw=$(curl -si --max-time 10 "${BASE}${path}" 2>/dev/null) || true
  status=$(printf '%s' "$raw" | xcache) || true
  N=$((N + 1))
  printf "[%d] %s\n" "$N" "${status:-NO_HEADER}"
}

cleanup() {
  echo ""
  echo "Stopping mock upstream and Skipper..."
  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
  [[ -n "$SKIPPER_PID" ]] && kill "$SKIPPER_PID" 2>/dev/null || true
  echo "Skipper logs saved to: ${SKIPPER_LOG}"
}
trap cleanup EXIT

echo "============================================"
echo " Cache Demo: MISS -> HIT -> STALE -> HIT"
echo "============================================"
echo ""

# Build and start the mock upstream.
echo "Building mock upstream..."
cd "${MOCK_DIR}"
go build -o mock-upstream . 2>/dev/null
./mock-upstream -addr :8888 > /tmp/mock-upstream.log 2>&1 &
MOCK_PID=$!
cd "${SCRIPT_DIR}"

# Build and start Skipper.
echo "Building Skipper..."
cd "${SKIPPER_DIR}"
go build -o skipper ./cmd/skipper 2>/dev/null
./skipper -routes-file ../demo-route.eskip -address :9090 > "${SKIPPER_LOG}" 2>&1 &
SKIPPER_PID=$!
cd "${SCRIPT_DIR}"

# Wait for both to be ready.
# Use /__health for Skipper (avoids warming the cache) and a direct hit for mock.
echo "Starting services..."
for i in $(seq 1 20); do
  if curl -s --max-time 1 "${MOCK_ADDR}/api/v1/banners" > /dev/null 2>&1 && \
     curl -s --max-time 1 "${BASE}/__health" > /dev/null 2>&1; then
    break
  fi
  sleep 0.5
done

echo "Services ready."
echo ""

# -- Section 1: MISS -> HIT -> STALE -> revalidation HIT ---------------------
# TTL=5s, SWR=5s, hard expiry=10s
echo "--- Section 1: Happy path (TTL=5s, SWR=5s) ---"
echo ""

echo "Request 1 -- cold cache, expect MISS"
req "/api/v1/banners"                          # T+0: MISS, CreatedAt=T+0

echo "Request 2 -- within TTL, expect HIT"
req "/api/v1/banners"                          # T+0: HIT

echo "Sleeping 6s (past TTL=5s, inside SWR window)..."
sleep 6                               # now T+6

echo "Request 3 -- past TTL, inside SWR window, expect STALE"
req "/api/v1/banners"                          # T+6: STALE, revalidation fires, new CreatedAt=T+6

echo "Sleeping 3s (background revalidation should complete)..."
sleep 3                               # now T+9; revalidated entry is 3s old (< TTL=5s)

echo "Request 4 -- revalidated entry, expect HIT"
req "/api/v1/banners"                          # T+9: HIT (3s old, inside TTL=5s)

echo ""

# -- Section 2: Error caching (404, no SWR) -----------------------------------
# errorTTL=3s, hard expiry=3s (SWR=0 for errors)
echo "--- Section 2: Error caching (errorTTL=3s, no SWR) ---"
echo ""

echo "Request 5 -- cold cache for /api/v1/banners/0, expect MISS (404 stored)"
req "/api/v1/banners/0"                        # T+9: MISS, 404 stored

echo "Request 6 -- within errorTTL, expect HIT (cached 404)"
req "/api/v1/banners/0"                        # T+9: HIT

echo "Sleeping 4s (past errorTTL=3s, no SWR for errors)..."
sleep 4                               # now T+13

echo "Request 7 -- errorTTL expired, expect MISS"
req "/api/v1/banners/0"                        # T+13: MISS

echo ""

# -- Section 3: Thundering herd / coalescing ----------------------------------
# The /api/v1/banners entry was last revalidated during Section 1 (background
# revalidation from the STALE request). With TTL=5s and SWR=5s the hard expiry
# is CreatedAt + 10s. We are at T+13 here; sleep 8s to ensure we are safely
# past even a late revalidation (hard expiry window is at most 10s from T+9).
echo "--- Section 3: Coalescing (5 parallel cold-miss requests) ---"
echo ""

echo "Sleeping 8s for /api/v1/banners to hard-expire..."
sleep 8                               # ensures we are past hard expiry

echo "Firing 5 parallel requests against cold cache -- all should show MISS"
echo "(Typically 1-2 upstream fetches occur; singleflight coalesces the rest)"
echo ""

tmpdir=$(mktemp -d)
pids=()
for i in 1 2 3 4 5; do
  (
    raw=$(curl -si --max-time 10 "${BASE}/api/v1/banners" 2>/dev/null) || true
    xcstat=$(printf '%s' "$raw" | xcache) || true
    printf '%s' "${xcstat:-NO_HEADER}" > "${tmpdir}/result_${i}"
  ) &
  pids+=($!)
done
wait "${pids[@]}"

for i in 1 2 3 4 5; do
  N=$((N + 1))
  printf "[%d] %s\n" "$N" "$(cat "${tmpdir}/result_${i}")"
done
rm -rf "$tmpdir"

echo ""
echo "Request $((N + 1)) -- after coalescing, expect HIT (entry stored by coalesced fetch)"
req "/api/v1/banners"

echo ""

# -- Section 4: Age header -----------------------------------------------------
echo "--- Section 4: Age header ---"
echo ""

echo "Sleeping 11s to hard-expire /api/v1/banners (TTL=5s + SWR=5s = 10s)..."
sleep 11

echo "Request $((N + 1)) -- cold cache, expect MISS"
req "/api/v1/banners"

echo "Sleeping 2s..."
sleep 2

echo "Request $((N + 1)) -- within TTL, expect HIT with Age >= 2"
raw=$(curl -si --max-time 10 "${BASE}/api/v1/banners" 2>/dev/null) || true
age_val=$(printf '%s' "$raw" | grep -i "^age:" | tr -d '\r' | awk '{print $2}') || true
N=$((N + 1))
printf "[%d] Age: %s (expected >= 2)\n" "$N" "${age_val:-MISSING}"
echo ""

# -- Section 5: Request no-cache bypass ----------------------------------------
echo "--- Section 5: Request no-cache bypass ---"
echo ""

echo "Cache should be warm from Section 4."
echo "Request $((N + 1)) -- Cache-Control: no-cache, expect MISS even on warm cache"
raw=$(curl -si --max-time 10 -H "Cache-Control: no-cache" "${BASE}/api/v1/banners" 2>/dev/null) || true
xcstat=$(printf '%s' "$raw" | xcache) || true
N=$((N + 1))
printf "[%d] %s (expected MISS)\n" "$N" "${xcstat:-NO_HEADER}"
echo ""

# -- Section 6: Request no-store -----------------------------------------------
echo "--- Section 6: Request no-store ---"
echo ""

echo "Sleeping 11s to hard-expire cache..."
sleep 11

echo "Request $((N + 1)) -- no-store, expect MISS (and nothing stored)"
raw=$(curl -si --max-time 10 -H "Cache-Control: no-store" "${BASE}/api/v1/banners" 2>/dev/null) || true
xcstat=$(printf '%s' "$raw" | xcache) || true
N=$((N + 1))
printf "[%d] %s (expected MISS)\n" "$N" "${xcstat:-NO_HEADER}"

echo "Request $((N + 1)) -- normal GET after no-store, expect MISS (entry stored now)"
req "/api/v1/banners"
echo ""

# -- Section 7: min-fresh bypass -----------------------------------------------
# Cache is warm from Section 6 Request 18 (stored just above).
# TTL=5s so freshness decays over the next 5s.
echo "--- Section 7: min-fresh (RFC 9111 §5.2.1) ---"
echo ""

echo "Cache is warm from Section 6. Request $((N + 1)) -- min-fresh=1 with plenty of TTL, expect HIT"
raw=$(curl -si --max-time 10 -H "Cache-Control: min-fresh=1" "${BASE}/api/v1/banners" 2>/dev/null) || true
xcstat=$(printf '%s' "$raw" | xcache) || true
N=$((N + 1))
printf "[%d] %s (expected HIT)\n" "$N" "${xcstat:-NO_HEADER}"

echo "Sleeping 4s (TTL=5s, ~1s freshness remaining)..."
sleep 4

echo "Request $((N + 1)) -- min-fresh=2 with ~1s left, expect MISS (2s required, ~1s left)"
raw=$(curl -si --max-time 10 -H "Cache-Control: min-fresh=2" "${BASE}/api/v1/banners" 2>/dev/null) || true
xcstat=$(printf '%s' "$raw" | xcache) || true
N=$((N + 1))
printf "[%d] %s (expected MISS)\n" "$N" "${xcstat:-NO_HEADER}"
echo ""

echo "============================================"
echo " Demo complete."
echo "============================================"

```

</details>


<img width="10326" height="4745" alt="Caching Layer for Contentful - Frame 4" src="https://github.com/user-attachments/assets/8fa09f76-99f0-457a-a59b-83f229b41b90" />


