### PR TITLE
fix: client metrics name cache and unknown path handling (#3999)

### DIFF
--- a/filters/apiusagemonitoring/filter.go
+++ b/filters/apiusagemonitoring/filter.go
@@ -108,8 +108,8 @@ func (f *apiUsageMonitoringFilter) Response(c filters.FilterContext) {
 
 func getClientMetricsNames(realmClientKey string, path *pathInfo) *clientMetricNames {
 	if value, ok := path.metricPrefixedPerClient.Load(realmClientKey); ok {
-		if prefixes, ok := value.(clientMetricNames); ok {
-			return &prefixes
+		if prefixes, ok := value.(*clientMetricNames); ok {
+			return prefixes
 		}
 	}
 

--- a/filters/apiusagemonitoring/filter_clientmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_clientmetrics_test.go
@@ -57,8 +57,8 @@ func Test_Filter_ClientMetrics_NoMatchingPath_RealmIsKnown(t *testing.T) {
 		realmsTrackingPattern:        "services",
 		header:                       headerUsersJoe,
 		url:                          "https://www.example.com/non/configured/path/template",
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.*.*.users.{all}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{no-tag}.my_api.GET.{no-match}.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{no-tag}.my_api.*.*.users.{all}.",
 	})
 }
 
@@ -69,8 +69,8 @@ func Test_Filter_ClientMetrics_NoMatchingPath_RealmIsUnknown(t *testing.T) {
 		clientTrackingPattern:        s(".*"),
 		header:                       headerUsersJoe,
 		url:                          "https://www.example.com/non/configured/path/template",
-		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*.",
-		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.*.*.{unknown}.{unknown}.",
+		expectedEndpointMetricPrefix: "apiUsageMonitoring.custom.my_app.{no-tag}.my_api.GET.{no-match}.*.*.",
+		expectedClientMetricPrefix:   "apiUsageMonitoring.custom.my_app.{no-tag}.my_api.*.*.{unknown}.{unknown}.",
 	})
 }
 

--- a/filters/apiusagemonitoring/filter_endpointmetrics_test.go
+++ b/filters/apiusagemonitoring/filter_endpointmetrics_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/zalando/skipper/metrics/metricstest"
 )
 
+func Test_Filter_HandleErrorResponse(t *testing.T) {
+	filter, err := createFilterForTest()
+	assert.NoError(t, err)
+	f := filter.(*apiUsageMonitoringFilter)
+	assert.True(t, f.HandleErrorResponse())
+}
+
 func Test_Filter_NoPathTemplate(t *testing.T) {
 	testWithFilter(
 		t,
@@ -21,7 +28,7 @@ func Test_Filter_NoPathTemplate(t *testing.T) {
 		"https://www.example.org/a/b/c",
 		299,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.{no-tag}.my_api.GET.{no-match}.*.*."
 			// no path matching: tracked as unknown
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
@@ -219,7 +226,7 @@ func Test_Filter_NonConfiguredPathTrackedUnderNoMatch(t *testing.T) {
 		"https://www.example.org/lapin/malin",
 		200,
 		func(pass int, m *metricstest.MockMetrics) {
-			pre := "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*."
+			pre := "apiUsageMonitoring.custom.my_app.{no-tag}.my_api.GET.{no-match}.*.*."
 			m.WithCounters(func(counters map[string]int64) {
 				assert.Equal(t,
 					map[string]int64{
@@ -261,7 +268,7 @@ func Test_Filter_AllHttpMethodsAreSupported(t *testing.T) {
 				200,
 				func(pass int, m *metricstest.MockMetrics) {
 					pre := fmt.Sprintf(
-						"apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.%s.{no-match}.*.*.",
+						"apiUsageMonitoring.custom.my_app.{no-tag}.my_api.%s.{no-match}.*.*.",
 						testCase.expectedMethodInMetric)
 					m.WithCounters(func(counters map[string]int64) {
 						assert.Equal(t,
@@ -403,6 +410,75 @@ func Test_Filter_PathTemplateMatchesPathFromRequestChain(t *testing.T) {
 					})
 					m.WithMeasures(func(measures map[string][]time.Duration) {
 						assert.Contains(t, measures, pre+"latency")
+					})
+				})
+		})
+	}
+}
+
+var multiApiArgs = []interface{}{
+	`{
+		"application_id": "my_app",
+		"api_id": "orders_api",
+		"path_templates": [
+			"foo/orders/{order-id}"
+		]
+	}`,
+	`{
+		"application_id": "my_app",
+		"api_id": "customers_api",
+		"path_templates": [
+			"foo/customers/{customer-id}"
+		]
+	}`,
+}
+
+func createMultiApiFilter() (filters.Filter, error) {
+	spec := NewApiUsageMonitoring(true, "", "", "")
+	return spec.CreateFilter(multiApiArgs)
+}
+
+func Test_Filter_MultipleApisAsMultipleArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		url         string
+		expectedPre string
+	}{
+		{
+			name:        "orders_api",
+			url:         "https://www.example.org/foo/orders/1234",
+			expectedPre: "apiUsageMonitoring.custom.my_app.{no-tag}.orders_api.GET.foo/orders/{order-id}.*.*.",
+		},
+		{
+			name:        "customers_api",
+			url:         "https://www.example.org/foo/customers/loremipsum",
+			expectedPre: "apiUsageMonitoring.custom.my_app.{no-tag}.customers_api.GET.foo/customers/{customer-id}.*.*.",
+		},
+		{
+			name:        "no_match",
+			url:         "https://www.example.org/foo/unknown",
+			expectedPre: "apiUsageMonitoring.custom.my_app.{no-tag}.{unknown}.GET.{no-match}.*.*.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testWithFilter(
+				t,
+				createMultiApiFilter,
+				http.MethodGet,
+				tc.url,
+				200,
+				func(pass int, m *metricstest.MockMetrics) {
+					m.WithCounters(func(counters map[string]int64) {
+						assert.Equal(t,
+							map[string]int64{
+								tc.expectedPre + "http_count":    int64(pass),
+								tc.expectedPre + "http2xx_count": int64(pass),
+							},
+							counters,
+						)
+					})
+					m.WithMeasures(func(measures map[string][]time.Duration) {
+						assert.Contains(t, measures, tc.expectedPre+"latency")
 					})
 				})
 		})

--- a/filters/apiusagemonitoring/spec.go
+++ b/filters/apiusagemonitoring/spec.go
@@ -75,10 +75,12 @@ func NewApiUsageMonitoring(
 	realmsTrackingMatcher, err := loadOrCompileRegex(realmsTrackingPattern)
 	if err != nil {
 		log.Errorf(
-			"api-usage-monitoring-realmsTrackingPattern-tracking-pattern (global config) ignored: error compiling regular expression %q: %v",
+			"api-usage-monitoring-realmsTrackingPattern-tracking-pattern"+
+				" (global config) ignored: error compiling regular expression %q: %v",
 			realmsTrackingPattern, err)
 		realmsTrackingMatcher = regexp.MustCompile("services")
-		log.Warn("defaulting to 'services' as api-usage-monitoring-realmsTrackingPattern-tracking-pattern (global config)")
+		log.Warn("defaulting to 'services' as api-usage-monitoring-" +
+			"realmsTrackingPattern-tracking-pattern (global config)")
 	}
 
 	// Create the filter Spec
@@ -253,24 +255,31 @@ func (s *apiUsageMonitoringSpec) parseJsonConfiguration(args []interface{}) []*a
 }
 
 func (s *apiUsageMonitoringSpec) buildUnknownPathInfo(paths []*pathInfo) *pathInfo {
-	var applicationId *string
-	for i := range paths {
-		path := paths[i]
-		if applicationId != nil && *applicationId != path.ApplicationId {
-			return s.unknownPath
-		}
-		applicationId = &path.ApplicationId
+	if len(paths) == 0 {
+		return s.unknownPath
 	}
 
-	if applicationId != nil && *applicationId != "" {
-		return newPathInfo(
-			*applicationId,
-			s.unknownPath.Tag,
-			s.unknownPath.ApiId,
-			s.unknownPath.PathTemplate,
-			s.unknownPath.ClientTracking)
+	var applicationId, apiId *string
+	for i := range paths {
+		path := paths[i]
+		if applicationId == nil {
+			applicationId = &path.ApplicationId
+		} else if *applicationId != path.ApplicationId {
+			applicationId = &s.unknownPath.ApplicationId
+		}
+		if apiId == nil {
+			apiId = &path.ApiId
+		} else if *apiId != path.ApiId {
+			apiId = &s.unknownPath.ApiId
+		}
 	}
-	return s.unknownPath
+
+	return newPathInfo(
+		*applicationId,
+		s.unknownPath.Tag,
+		*apiId,
+		s.unknownPath.PathTemplate,
+		s.unknownPath.ClientTracking)
 }
 
 func (s *apiUsageMonitoringSpec) buildPathInfoListFromConfiguration(apis []*apiConfig) []*pathInfo {
@@ -328,20 +337,20 @@ func (s *apiUsageMonitoringSpec) buildPathInfoListFromConfiguration(apis []*apiC
 			// Detect regular expression duplicates
 			if existingMatcher, ok := existingPathPattern[pathPattern]; ok {
 				s.warnf(
-					"args[%d].path_templates[%d] ignored: two path templates yielded the same regular expression %q (%q and %q)",
-					apiIndex, templateIndex, pathPattern, info.PathTemplate, existingMatcher.PathTemplate)
+					"args[%d].path_templates[%d] ignored: two path templates"+
+						" yielded the same regular expression %q (%q and %q)",
+					apiIndex, templateIndex, pathPattern, info.PathTemplate,
+					existingMatcher.PathTemplate)
 				continue
 			}
 			existingPathPattern[pathPattern] = info
 
 			pathPatternMatcher, err := loadOrCompileRegex(pathPattern)
-			if err != nil {
+			if err != nil || pathPatternMatcher == nil {
 				s.warnf(
-					"args[%d].path_templates[%d] ignored: error compiling regular expression %q for path %q: %v",
+					"args[%d].path_templates[%d] ignored: error compiling regular"+
+						" expression %q for path %q: %v",
 					apiIndex, templateIndex, pathPattern, info.PathTemplate, err)
-				continue
-			}
-			if pathPatternMatcher == nil {
 				continue
 			}
 
@@ -358,34 +367,34 @@ func (s *apiUsageMonitoringSpec) buildPathInfoListFromConfiguration(apis []*apiC
 	return paths
 }
 
-func (s *apiUsageMonitoringSpec) buildClientTrackingInfo(apiIndex int, api *apiConfig, realmsTrackingMatcher *regexp.Regexp) *clientTrackingInfo {
+func (s *apiUsageMonitoringSpec) buildClientTrackingInfo(
+	apiIndex int, api *apiConfig, realmsTrackingMatcher *regexp.Regexp,
+) *clientTrackingInfo {
 	if len(s.realmKeys) == 0 {
 		s.infof(
-			`args[%d]: skipper wide configuration "api-usage-monitoring-realm-keys" not provided, not tracking client metrics`,
-			apiIndex)
+			`args[%d]: skipper wide configuration "api-usage-monitoring-realm-keys"`+
+				` not provided, not tracking client metrics`, apiIndex)
 		return nil
 	}
 	if len(s.clientKeys) == 0 {
 		s.infof(
-			`args[%d]: skipper wide configuration "api-usage-monitoring-client-keys" not provided, not tracking client metrics`,
-			apiIndex)
+			`args[%d]: skipper wide configuration "api-usage-monitoring-client-keys"`+
+				` not provided, not tracking client metrics`, apiIndex)
 		return nil
 	}
 	if api.ClientTrackingPattern == "" {
 		s.debugf(
-			`args[%d]: empty client_tracking_pattern disables the client metrics for its endpoints`,
-			apiIndex)
+			`args[%d]: empty client_tracking_pattern disables the client metrics for`+
+				` its endpoints`, apiIndex)
 		return nil
 	}
 
 	clientTrackingMatcher, err := loadOrCompileRegex(api.ClientTrackingPattern)
-	if err != nil {
+	if err != nil || clientTrackingMatcher == nil {
 		s.errorf(
-			"args[%d].client_tracking_pattern ignored (no client tracking): error compiling regular expression %q: %v",
+			"args[%d].client_tracking_pattern ignored (no client tracking): error"+
+				" compiling regular expression %q: %v",
 			apiIndex, api.ClientTrackingPattern, err)
-		return nil
-	}
-	if clientTrackingMatcher == nil {
 		return nil
 	}
 

--- a/filters/apiusagemonitoring/spec_test.go
+++ b/filters/apiusagemonitoring/spec_test.go
@@ -25,6 +25,34 @@ func Test_FeatureDisableCreateNilFilters(t *testing.T) {
 	assert.Equal(t, filter, &noopFilter{})
 }
 
+func Test_NewApiUsageMonitoring_InvalidRealmsTrackingPattern(t *testing.T) {
+	// An invalid regex for realmsTrackingPattern should log an error and default
+	// to "services" instead of failing.
+	spec := NewApiUsageMonitoring(true, "realm", "client", "[invalid")
+	assert.IsType(t, new(apiUsageMonitoringSpec), spec)
+	s := spec.(*apiUsageMonitoringSpec)
+	assert.Equal(t, "services", s.realmsTrackingMatcher.String())
+}
+
+func Test_Close_ClosesSpec(t *testing.T) {
+	spec := NewApiUsageMonitoring(true, "", "", "")
+	s := spec.(*apiUsageMonitoringSpec)
+	assert.NoError(t, s.Close())
+}
+
+func Test_CreateFilter_CacheHit(t *testing.T) {
+	spec := NewApiUsageMonitoring(true, "", "", "")
+
+	filter1, err := spec.CreateFilter(defaultArgs)
+	assert.NoError(t, err)
+	assert.NotNil(t, filter1)
+
+	// Second call with identical args must return the cached filter instance.
+	filter2, err := spec.CreateFilter(defaultArgs)
+	assert.NoError(t, err)
+	assert.Same(t, filter1.(*apiUsageMonitoringFilter), filter2.(*apiUsageMonitoringFilter))
+}
+
 type pathMatcher struct {
 	ApplicationId string
 	Tag           string
@@ -33,12 +61,12 @@ type pathMatcher struct {
 	Matcher       *string
 }
 
-func unknownPath(applicationId string) pathMatcher {
+func unknownPath(applicationId, apiId string) pathMatcher {
 	return pathMatcher{
 		PathTemplate:  "{no-match}",
 		ApplicationId: applicationId,
 		Tag:           "{no-tag}",
-		ApiId:         "{unknown}",
+		ApiId:         apiId,
 		Matcher:       nil,
 	}
 }
@@ -201,7 +229,7 @@ func Test_CreateFilter_NonParsableParametersShouldBeLoggedAndIgnored(t *testing.
 			Matcher:       matcher("^/*test/*$"),
 		},
 	})
-	assertPath(t, filter.UnknownPath, unknownPath("my_app"))
+	assertPath(t, filter.UnknownPath, unknownPath("my_app", "my_api"))
 }
 
 func Test_CreateFilter_FullConfigSingleApi(t *testing.T) {
@@ -250,7 +278,7 @@ func Test_CreateFilter_FullConfigSingleApi(t *testing.T) {
 			Matcher:       matcher("^/*foo/+order-items/+.+:.+/*$"),
 		},
 	})
-	assertPath(t, filter.UnknownPath, unknownPath("my_app"))
+	assertPath(t, filter.UnknownPath, unknownPath("my_app", "my_api"))
 }
 
 func Test_CreateFilter_NoApplicationId_ShouldReturnNoopFilter(t *testing.T) {
@@ -347,7 +375,87 @@ func Test_CreateFilter_FullConfigMultipleApis(t *testing.T) {
 			Matcher:       matcher("^/*foo/+customers/*$"),
 		},
 	})
-	assertPath(t, filter.UnknownPath, unknownPath("my_app"))
+	assertPath(t, filter.UnknownPath, unknownPath("my_app", "{unknown}"))
+}
+
+func Test_CreateFilter_MultipleApisAsMultipleArgs(t *testing.T) {
+	args := []interface{}{
+		`{
+			"application_id": "my_app",
+			"api_id": "orders_api",
+			"path_templates": [
+				"foo/orders/{order-id}"
+			]
+		}`,
+		`{
+			"application_id": "my_app",
+			"api_id": "customers_api",
+			"path_templates": [
+				"foo/customers/{customer-id}"
+			]
+		}`,
+	}
+	spec := NewApiUsageMonitoring(true, "", "", "")
+
+	rawFilter, err := spec.CreateFilter(args)
+	assert.NoError(t, err)
+	assert.NotNil(t, rawFilter)
+
+	filter := rawFilter.(*apiUsageMonitoringFilter)
+	assertPaths(t, filter.Paths, []pathMatcher{
+		{
+			ApplicationId: "my_app",
+			Tag:           "{no-tag}",
+			ApiId:         "orders_api",
+			PathTemplate:  "foo/orders/{order-id}",
+			Matcher:       matcher("^/*foo/+orders/+.+/*$"),
+		},
+		{
+			ApplicationId: "my_app",
+			Tag:           "{no-tag}",
+			ApiId:         "customers_api",
+			PathTemplate:  "foo/customers/{customer-id}",
+			Matcher:       matcher("^/*foo/+customers/+.+/*$"),
+		},
+	})
+	assertPath(t, filter.UnknownPath, unknownPath("my_app", "{unknown}"))
+}
+
+func Test_CreateFilter_TwoApplicationIds(t *testing.T) {
+	// Two different application_ids both producing paths — unknown path falls
+	// back to the global {unknown}.{unknown} because application_id is mixed.
+	args := []interface{}{
+		`{
+			"application_id": "app_a",
+			"api_id": "orders_api",
+			"path_templates": [
+				"foo/orders/{order-id}"
+			]
+		}`,
+		`{
+			"application_id": "app_b",
+			"api_id": "customers_api",
+			"path_templates": [
+				"foo/customers/{customer-id}"
+			]
+		}`,
+	}
+	spec := NewApiUsageMonitoring(true, "", "", "")
+
+	rawFilter, err := spec.CreateFilter(args)
+	assert.NoError(t, err)
+	assert.NotNil(t, rawFilter)
+
+	filter := rawFilter.(*apiUsageMonitoringFilter)
+	assertPath(t, filter.UnknownPath, unknownPath("{unknown}", "{unknown}"))
+}
+
+func Test_BuildUnknownPathInfo_NoPaths(t *testing.T) {
+	// buildUnknownPathInfo is guarded by len(paths)==0 so it always returns
+	// s.unknownPath when called with an empty slice.
+	spec := NewApiUsageMonitoring(true, "", "", "").(*apiUsageMonitoringSpec)
+	result := spec.buildUnknownPathInfo([]*pathInfo{})
+	assert.Same(t, spec.unknownPath, result)
 }
 
 func Test_CreateFilter_FullConfigWithApisWithoutPaths(t *testing.T) {
@@ -391,7 +499,7 @@ func Test_CreateFilter_FullConfigWithApisWithoutPaths(t *testing.T) {
 			Matcher:       matcher("^/*foo/+orders/*$"),
 		},
 	})
-	assertPath(t, filter.UnknownPath, unknownPath("my_order_app"))
+	assertPath(t, filter.UnknownPath, unknownPath("my_order_app", "orders_api"))
 }
 
 func Test_CreateFilter_DuplicatePathTemplatesAreIgnored(t *testing.T) {
@@ -421,7 +529,7 @@ func Test_CreateFilter_DuplicatePathTemplatesAreIgnored(t *testing.T) {
 			Matcher:       matcher("^/*foo/*$"),
 		},
 	})
-	assertPath(t, filter.UnknownPath, unknownPath("my_app"))
+	assertPath(t, filter.UnknownPath, unknownPath("my_app", "orders_api"))
 }
 
 func Test_CreateFilter_DuplicateMatchersAreIgnored(t *testing.T) {
@@ -451,7 +559,7 @@ func Test_CreateFilter_DuplicateMatchersAreIgnored(t *testing.T) {
 			Matcher:       matcher("^/*foo/+.+/*$"),
 		},
 	})
-	assertPath(t, filter.UnknownPath, unknownPath("my_app"))
+	assertPath(t, filter.UnknownPath, unknownPath("my_app", "orders_api"))
 }
 
 type identPathHandler struct{}
@@ -482,7 +590,7 @@ func Test_CreateFilter_RegExCompileFailureIgnoresPath(t *testing.T) {
 
 	filter := rawFilter.(*apiUsageMonitoringFilter)
 	assert.Equal(t, 1, len(filter.Paths))
-	assertPath(t, filter.UnknownPath, unknownPath("my_app"))
+	assertPath(t, filter.UnknownPath, unknownPath("my_app", "orders_api"))
 }
 
 func Test_NormalizePathTemplate(t *testing.T) {
@@ -583,6 +691,75 @@ func Test_CreatePathPattern(t *testing.T) {
 		actualPathPattern := unit.createPathPattern(path.originalPath)
 		assert.Equalf(t, path.expectedPathPattern, actualPathPattern, message)
 	}
+}
+
+func Test_CreateFilter_PartnerClientManagement(t *testing.T) {
+	// Two API configs are passed as separate arguments, one per API.
+	// This is the canonical multi-API usage of the filter.
+	spec := NewApiUsageMonitoring(true, "", "", "")
+
+	args := []interface{}{
+		`{
+			"api_id": "partner-client-management-api-0.0.1",
+			"application_id": "corporate-single-sign-on",
+			"path_templates": [
+				"/domains/partner/pfa/{partner_facing_application}/applications/{application_name}",
+				"/domains/partner/pfa/{partner_facing_application}/applications/{application_name}/migrate",
+				"/domains/partner/pfa/{partner_facing_application}/applications/{application_name}/secrets"
+			]
+		}`,
+		`{
+			"api_id": "partner-client-management-internal-api-0.0.1",
+			"application_id": "corporate-single-sign-on",
+			"path_templates": [
+				"/domains/partner/applications"
+			]
+		}`,
+	}
+
+	rawFilter, err := spec.CreateFilter(args)
+	assert.NoError(t, err)
+	assert.NotNil(t, rawFilter)
+
+	filter, ok := rawFilter.(*apiUsageMonitoringFilter)
+	if !assert.True(t, ok, "expected *apiUsageMonitoringFilter, got %T", rawFilter) {
+		return
+	}
+
+	// Paths must be sorted by regex in reverse alphabetical order so that
+	// more specific path templates (migrate, secrets) are evaluated before
+	// the more general base template.
+	assertPaths(t, filter.Paths, []pathMatcher{
+		{
+			ApplicationId: "corporate-single-sign-on",
+			Tag:           "{no-tag}",
+			ApiId:         "partner-client-management-api-0.0.1",
+			PathTemplate:  "domains/partner/pfa/{partner_facing_application}/applications/{application_name}/secrets",
+			Matcher:       matcher(`^/*domains/+partner/+pfa/+.+/+applications/+.+/+secrets/*$`),
+		},
+		{
+			ApplicationId: "corporate-single-sign-on",
+			Tag:           "{no-tag}",
+			ApiId:         "partner-client-management-api-0.0.1",
+			PathTemplate:  "domains/partner/pfa/{partner_facing_application}/applications/{application_name}/migrate",
+			Matcher:       matcher(`^/*domains/+partner/+pfa/+.+/+applications/+.+/+migrate/*$`),
+		},
+		{
+			ApplicationId: "corporate-single-sign-on",
+			Tag:           "{no-tag}",
+			ApiId:         "partner-client-management-api-0.0.1",
+			PathTemplate:  "domains/partner/pfa/{partner_facing_application}/applications/{application_name}",
+			Matcher:       matcher(`^/*domains/+partner/+pfa/+.+/+applications/+.+/*$`),
+		},
+		{
+			ApplicationId: "corporate-single-sign-on",
+			Tag:           "{no-tag}",
+			ApiId:         "partner-client-management-internal-api-0.0.1",
+			PathTemplate:  "domains/partner/applications",
+			Matcher:       matcher(`^/*domains/+partner/+applications/*$`),
+		},
+	})
+	assertPath(t, filter.UnknownPath, unknownPath("corporate-single-sign-on", "{unknown}"))
 }
 
 func Benchmark_CreateFilter_FullConfigSingleApiNakadi(b *testing.B) {


### PR DESCRIPTION
### Description

This pull request is fixing two small bugs in the `apiUsageMonitoring` filter as well as improving the general test coverage of this filter:

1. It removes a small bug that prevented the caching of client metric names, which speeds up monitoring by 1.5us removing also 13 allocs per request as intended, and 
2. It fixes the originally intended discovery of application and API IDs in edge cases improving the api and application visible while making the code more transparent and readable.

### Related Issue(s)

fixes #3999.


### Testing

Run `make test`, since the code is highly unit tested.


### Checklist

- [x] I have reviewed and tested the changes thoroughly.
- [x] I have added appropriate documentation to the code for clarity.
- [x] I have communicated the consequences of the updates to customers.

Signed-off-by: Tronje Krop <tronje.krop@jactors.de>