### PR TITLE
Async decision logging for OPA

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -345,7 +345,7 @@ type Config struct {
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool          `yaml:"enable-open-policy-agent-data-preprocessing-optimization"`
 	EnableOpenPolicyAgentPreloading                    bool          `yaml:"enable-open-policy-agent-preloading"`
 	EnableOpenPolicyAgentAsyncDecisionLogging          bool          `yaml:"enable-open-policy-agent-async-decision-logging"`
-	OpenPolicyAgentDecisionLogBufferSize               int           `yaml:"open-policy-agent-decision-log-buffer-size"`
+	OpenPolicyAgentDecisionLogQueueSize                int           `yaml:"open-policy-agent-decision-log-queue-size"`
 	EnableOpenPolicyAgentPrintTracing                  bool          `yaml:"enable-open-policy-agent-print-tracing"`
 	OpenPolicyAgentConfigTemplate                      string        `yaml:"open-policy-agent-config-template"`
 	OpenPolicyAgentEnvoyMetadata                       string        `yaml:"open-policy-agent-envoy-metadata"`
@@ -615,7 +615,7 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentCustomControlLoop, "enable-open-policy-agent-custom-control-loop", false, "when enabled skipper will use a custom control loop to orchestrate certain opa behaviour (like the download of new bundles) instead of relying on periodic plugin triggers")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentPreloading, "enable-open-policy-agent-preloading", false, "EXPERIMENTAL: when enabled, OPA instances will be pre-loaded during route processing instead of during filter creation, making filter creation non-blocking")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentAsyncDecisionLogging, "enable-open-policy-agent-async-decision-logging", false, "when enabled, decision log events are offloaded to a background goroutine so that slow decision log plugins (e.g. eopa_dl with S3 output) do not delay HTTP responses")
-	flag.IntVar(&cfg.OpenPolicyAgentDecisionLogBufferSize, "open-policy-agent-decision-log-buffer-size", openpolicyagent.DefaultDecisionLogChannelSize, "number of decision log events that can be queued before new ones are dropped; only applies when async decision logging is enabled")
+	flag.IntVar(&cfg.OpenPolicyAgentDecisionLogQueueSize, "open-policy-agent-decision-log-queue-size", openpolicyagent.DefaultDecisionLogQueueSize, "number of decision log events that can be queued before new ones are dropped; only applies when async decision logging is enabled")
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopInterval, "open-policy-agent-control-loop-interval", openpolicyagent.DefaultControlLoopInterval, "Interval between the execution of the control loop. Only applies if the custom control loop is enabled")
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopMaxJitter, "open-policy-agent-control-loop-max-jitter", openpolicyagent.DefaultControlLoopMaxJitter, "Maximum jitter to add to the control loop interval. Only applies if the custom control loop is enabled")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentDataPreProcessingOptimization, "enable-open-policy-agent-data-preprocessing-optimization", false, "As a latency optimization, open policy agent will read values from in-memory storage as pre converted ASTs, removing conversion overhead at evaluation time. Currently experimental and if successful will be enabled by default")
@@ -1147,7 +1147,7 @@ func (c *Config) ToOptions() skipper.Options {
 		EnableOpenPolicyAgentDataPreProcessingOptimization: c.EnableOpenPolicyAgentDataPreProcessingOptimization,
 		EnableOpenPolicyAgentPreloading:                    c.EnableOpenPolicyAgentPreloading,
 		EnableOpenPolicyAgentAsyncDecisionLogging:          c.EnableOpenPolicyAgentAsyncDecisionLogging,
-		OpenPolicyAgentDecisionLogChannelSize:              c.OpenPolicyAgentDecisionLogBufferSize,
+		OpenPolicyAgentDecisionLogQueueSize:                c.OpenPolicyAgentDecisionLogQueueSize,
 		EnableOpenPolicyAgentPrintTracing:                  c.EnableOpenPolicyAgentPrintTracing,
 		OpenPolicyAgentConfigTemplate:                      c.OpenPolicyAgentConfigTemplate,
 		OpenPolicyAgentEnvoyMetadata:                       c.OpenPolicyAgentEnvoyMetadata,

--- a/config/config.go
+++ b/config/config.go
@@ -345,7 +345,6 @@ type Config struct {
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool          `yaml:"enable-open-policy-agent-data-preprocessing-optimization"`
 	EnableOpenPolicyAgentPreloading                    bool          `yaml:"enable-open-policy-agent-preloading"`
 	EnableOpenPolicyAgentAsyncDecisionLogging          bool          `yaml:"enable-open-policy-agent-async-decision-logging"`
-	OpenPolicyAgentDecisionLogQueueSize                int           `yaml:"open-policy-agent-decision-log-queue-size"`
 	EnableOpenPolicyAgentPrintTracing                  bool          `yaml:"enable-open-policy-agent-print-tracing"`
 	OpenPolicyAgentConfigTemplate                      string        `yaml:"open-policy-agent-config-template"`
 	OpenPolicyAgentEnvoyMetadata                       string        `yaml:"open-policy-agent-envoy-metadata"`
@@ -615,7 +614,6 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentCustomControlLoop, "enable-open-policy-agent-custom-control-loop", false, "when enabled skipper will use a custom control loop to orchestrate certain opa behaviour (like the download of new bundles) instead of relying on periodic plugin triggers")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentPreloading, "enable-open-policy-agent-preloading", false, "EXPERIMENTAL: when enabled, OPA instances will be pre-loaded during route processing instead of during filter creation, making filter creation non-blocking")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentAsyncDecisionLogging, "enable-open-policy-agent-async-decision-logging", false, "when enabled, decision log events are offloaded to a background goroutine so that slow decision log plugins (e.g. eopa_dl with S3 output) do not delay HTTP responses")
-	flag.IntVar(&cfg.OpenPolicyAgentDecisionLogQueueSize, "open-policy-agent-decision-log-queue-size", openpolicyagent.DefaultDecisionLogQueueSize, "number of decision log events that can be queued before new ones are dropped; only applies when async decision logging is enabled")
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopInterval, "open-policy-agent-control-loop-interval", openpolicyagent.DefaultControlLoopInterval, "Interval between the execution of the control loop. Only applies if the custom control loop is enabled")
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopMaxJitter, "open-policy-agent-control-loop-max-jitter", openpolicyagent.DefaultControlLoopMaxJitter, "Maximum jitter to add to the control loop interval. Only applies if the custom control loop is enabled")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentDataPreProcessingOptimization, "enable-open-policy-agent-data-preprocessing-optimization", false, "As a latency optimization, open policy agent will read values from in-memory storage as pre converted ASTs, removing conversion overhead at evaluation time. Currently experimental and if successful will be enabled by default")
@@ -1147,7 +1145,6 @@ func (c *Config) ToOptions() skipper.Options {
 		EnableOpenPolicyAgentDataPreProcessingOptimization: c.EnableOpenPolicyAgentDataPreProcessingOptimization,
 		EnableOpenPolicyAgentPreloading:                    c.EnableOpenPolicyAgentPreloading,
 		EnableOpenPolicyAgentAsyncDecisionLogging:          c.EnableOpenPolicyAgentAsyncDecisionLogging,
-		OpenPolicyAgentDecisionLogQueueSize:                c.OpenPolicyAgentDecisionLogQueueSize,
 		EnableOpenPolicyAgentPrintTracing:                  c.EnableOpenPolicyAgentPrintTracing,
 		OpenPolicyAgentConfigTemplate:                      c.OpenPolicyAgentConfigTemplate,
 		OpenPolicyAgentEnvoyMetadata:                       c.OpenPolicyAgentEnvoyMetadata,

--- a/config/config.go
+++ b/config/config.go
@@ -344,6 +344,8 @@ type Config struct {
 	OpenPolicyAgentControlLoopMaxJitter                time.Duration `yaml:"open-policy-agent-control-loop-max-jitter"`
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool          `yaml:"enable-open-policy-agent-data-preprocessing-optimization"`
 	EnableOpenPolicyAgentPreloading                    bool          `yaml:"enable-open-policy-agent-preloading"`
+	EnableOpenPolicyAgentAsyncDecisionLogging          bool          `yaml:"enable-open-policy-agent-async-decision-logging"`
+	OpenPolicyAgentDecisionLogBufferSize               int           `yaml:"open-policy-agent-decision-log-buffer-size"`
 	EnableOpenPolicyAgentPrintTracing                  bool          `yaml:"enable-open-policy-agent-print-tracing"`
 	OpenPolicyAgentConfigTemplate                      string        `yaml:"open-policy-agent-config-template"`
 	OpenPolicyAgentEnvoyMetadata                       string        `yaml:"open-policy-agent-envoy-metadata"`
@@ -612,6 +614,8 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableOpenPolicyAgent, "enable-open-policy-agent", false, "enables Open Policy Agent filters")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentCustomControlLoop, "enable-open-policy-agent-custom-control-loop", false, "when enabled skipper will use a custom control loop to orchestrate certain opa behaviour (like the download of new bundles) instead of relying on periodic plugin triggers")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentPreloading, "enable-open-policy-agent-preloading", false, "EXPERIMENTAL: when enabled, OPA instances will be pre-loaded during route processing instead of during filter creation, making filter creation non-blocking")
+	flag.BoolVar(&cfg.EnableOpenPolicyAgentAsyncDecisionLogging, "enable-open-policy-agent-async-decision-logging", false, "when enabled, decision log events are offloaded to a background goroutine so that slow decision log plugins (e.g. eopa_dl with S3 output) do not delay HTTP responses")
+	flag.IntVar(&cfg.OpenPolicyAgentDecisionLogBufferSize, "open-policy-agent-decision-log-buffer-size", openpolicyagent.DefaultDecisionLogChannelSize, "number of decision log events that can be queued before new ones are dropped; only applies when async decision logging is enabled")
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopInterval, "open-policy-agent-control-loop-interval", openpolicyagent.DefaultControlLoopInterval, "Interval between the execution of the control loop. Only applies if the custom control loop is enabled")
 	flag.DurationVar(&cfg.OpenPolicyAgentControlLoopMaxJitter, "open-policy-agent-control-loop-max-jitter", openpolicyagent.DefaultControlLoopMaxJitter, "Maximum jitter to add to the control loop interval. Only applies if the custom control loop is enabled")
 	flag.BoolVar(&cfg.EnableOpenPolicyAgentDataPreProcessingOptimization, "enable-open-policy-agent-data-preprocessing-optimization", false, "As a latency optimization, open policy agent will read values from in-memory storage as pre converted ASTs, removing conversion overhead at evaluation time. Currently experimental and if successful will be enabled by default")
@@ -1142,6 +1146,8 @@ func (c *Config) ToOptions() skipper.Options {
 		OpenPolicyAgentControlLoopMaxJitter:                c.OpenPolicyAgentControlLoopMaxJitter,
 		EnableOpenPolicyAgentDataPreProcessingOptimization: c.EnableOpenPolicyAgentDataPreProcessingOptimization,
 		EnableOpenPolicyAgentPreloading:                    c.EnableOpenPolicyAgentPreloading,
+		EnableOpenPolicyAgentAsyncDecisionLogging:          c.EnableOpenPolicyAgentAsyncDecisionLogging,
+		OpenPolicyAgentDecisionLogChannelSize:              c.OpenPolicyAgentDecisionLogBufferSize,
 		EnableOpenPolicyAgentPrintTracing:                  c.EnableOpenPolicyAgentPrintTracing,
 		OpenPolicyAgentConfigTemplate:                      c.OpenPolicyAgentConfigTemplate,
 		OpenPolicyAgentEnvoyMetadata:                       c.OpenPolicyAgentEnvoyMetadata,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -187,7 +187,6 @@ func defaultConfig(with func(*Config)) *Config {
 		OpenPolicyAgentMaxRequestBodySize:       openpolicyagent.DefaultMaxRequestBodySize,
 		OpenPolicyAgentMaxMemoryBodyParsing:     openpolicyagent.DefaultMaxMemoryBodyParsing,
 		OpenPolicyAgentRequestBodyBufferSize:    openpolicyagent.DefaultRequestBodyBufferSize,
-		OpenPolicyAgentDecisionLogQueueSize:     openpolicyagent.DefaultDecisionLogQueueSize,
 		ProxyAllowListCIDRs:                     commaListFlag(),
 		ProxyDenyListCIDRs:                      commaListFlag(),
 		ProxySkipListCIDRs:                      commaListFlag(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -187,6 +187,7 @@ func defaultConfig(with func(*Config)) *Config {
 		OpenPolicyAgentMaxRequestBodySize:       openpolicyagent.DefaultMaxRequestBodySize,
 		OpenPolicyAgentMaxMemoryBodyParsing:     openpolicyagent.DefaultMaxMemoryBodyParsing,
 		OpenPolicyAgentRequestBodyBufferSize:    openpolicyagent.DefaultRequestBodyBufferSize,
+		OpenPolicyAgentDecisionLogQueueSize:     openpolicyagent.DefaultDecisionLogQueueSize,
 		ProxyAllowListCIDRs:                     commaListFlag(),
 		ProxyDenyListCIDRs:                      commaListFlag(),
 		ProxySkipListCIDRs:                      commaListFlag(),

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -53,21 +53,27 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 			return
 		}
 
-		task := decisionLogTask{
-			// Detach from the request context so a client disconnect or timeout
-			// does not silently drop the event inside the OPA plugin.
-			ctx:    context.WithoutCancel(ctx),
-			input:  input,
-			result: result,
-			err:    err,
-		}
-		select {
-		case opa.decisionLogChan <- task:
-		default:
-			// Buffer full: drop the event rather than blocking the request goroutine.
-			opa.Logger().WithFields(map[string]interface{}{
-				"decision_id": result.DecisionID,
-			}).Warn("Decision log dropped: async buffer full.")
+		if opa.decisionLogChan != nil {
+			task := decisionLogTask{
+				// Detach from the request context so a client disconnect or timeout
+				// does not silently drop the event inside the OPA plugin.
+				ctx:    context.WithoutCancel(ctx),
+				input:  input,
+				result: result,
+				err:    err,
+			}
+			select {
+			case opa.decisionLogChan <- task:
+			default:
+				// Buffer full: drop the event rather than blocking the request goroutine.
+				opa.Logger().WithFields(map[string]interface{}{
+					"decision_id": result.DecisionID,
+				}).Warn("Decision log dropped: async buffer full.")
+			}
+		} else {
+			if err := opa.logDecision(ctx, input, result, err); err != nil {
+				opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
+			}
 		}
 	}()
 

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -53,9 +53,21 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 			return
 		}
 
-		err := opa.logDecision(ctx, input, result, err)
-		if err != nil {
-			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
+		task := decisionLogTask{
+			// Detach from the request context so a client disconnect or timeout
+			// does not silently drop the event inside the OPA plugin.
+			ctx:    context.WithoutCancel(ctx),
+			input:  input,
+			result: result,
+			err:    err,
+		}
+		select {
+		case opa.decisionLogChan <- task:
+		default:
+			// Buffer full: drop the event rather than blocking the request goroutine.
+			opa.Logger().WithFields(map[string]interface{}{
+				"decision_id": result.DecisionID,
+			}).Warn("Decision log dropped: async buffer full.")
 		}
 	}()
 

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -55,9 +55,6 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 
 		if opa.decisionLogChan != nil {
 			task := decisionLogTask{
-				// Detach from the request context so a client disconnect or timeout
-				// does not silently drop the event inside the OPA plugin.
-				ctx:    context.WithoutCancel(ctx),
 				input:  input,
 				result: result,
 				err:    err,

--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -53,24 +53,8 @@ func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.
 			return
 		}
 
-		if opa.decisionLogChan != nil {
-			task := decisionLogTask{
-				input:  input,
-				result: result,
-				err:    err,
-			}
-			select {
-			case opa.decisionLogChan <- task:
-			default:
-				// Buffer full: drop the event rather than blocking the request goroutine.
-				opa.Logger().WithFields(map[string]interface{}{
-					"decision_id": result.DecisionID,
-				}).Warn("Decision log dropped: async buffer full.")
-			}
-		} else {
-			if err := opa.logDecision(ctx, input, result, err); err != nil {
-				opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
-			}
+		if err := opa.logDecision(ctx, input, result, err); err != nil {
+			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
 		}
 	}()
 
@@ -131,6 +115,22 @@ func FormOpenPolicyAgentMetaDataObject(decisionId string) (*pbstruct.Struct, err
 }
 
 func (opa *OpenPolicyAgentInstance) logDecision(ctx context.Context, input interface{}, result *envoyauth.EvalResult, err error) error {
+	if opa.decisionLogChan != nil {
+		task := decisionLogTask{input: input, result: result, err: err}
+		select {
+		case opa.decisionLogChan <- task:
+		default:
+			opa.Logger().WithFields(map[string]interface{}{
+				"decision_id": result.DecisionID,
+			}).Warn("Decision log dropped: async buffer full.")
+		}
+		return nil
+	}
+
+	return opa.doLogDecision(ctx, input, result, err)
+}
+
+func (opa *OpenPolicyAgentInstance) doLogDecision(ctx context.Context, input interface{}, result *envoyauth.EvalResult, err error) error {
 	info := &server.Info{
 		Timestamp: time.Now(),
 		Input:     &input,

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -829,6 +829,285 @@ func TestAuthorizeRequestFilterWithS3DecisionLogPlugin(t *testing.T) {
 	}
 }
 
+// TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientResponse
+// verifies that a slow S3 upload does NOT delay the HTTP response to the client.
+//
+// Before the fix: evaluation.go called logDecision synchronously on the request
+// goroutine. With "unbuffered" eopa_dl, every millisecond S3 took to respond was
+// added to the client round-trip.
+//
+// After the fix: logDecision is dispatched to a background goroutine via a bounded
+// channel. The request goroutine returns immediately after enqueuing the task, so
+// S3 latency is fully decoupled from the client response time.
+func TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientResponse(t *testing.T) {
+	const s3Delay = 300 * time.Millisecond
+
+	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(s3Delay)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3Server.Close()
+
+	clientServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Welcome!"))
+	}))
+	defer clientServer.Close()
+
+	opaControlPlane := opasdktest.MustNewServer(
+		opasdktest.MockBundle("/bundles/test", map[string]string{
+			"main.rego": `
+				package envoy.authz
+				default allow = false
+				allow if { input.parsed_path == [ "allow" ] }
+			`,
+		}),
+		opasdktest.MockBundle("/bundles/discovery", map[string]string{
+			"data.json": `{
+			  "discovery": {
+				"bundles": {
+				  "bundles/test": {
+					"persist": false,
+					"resource": "bundles/test",
+					"service": "test"
+				  }
+			}}
+			}`,
+		}),
+	)
+	defer opaControlPlane.Stop()
+
+	// "unbuffered" removes the memory buffer so Consume blocks directly on the S3
+	// output ACK, making the coupling between S3 latency and client latency visible.
+	config := []byte(fmt.Sprintf(`{
+		"services": { "test": { "url": %q } },
+		"discovery": {
+			"name": "discovery",
+			"resource": "/bundles/discovery",
+			"service": "test"
+		},
+		"labels": { "environment": "test" },
+		"decision_logs": { "plugin": "eopa_dl" },
+		"plugins": {
+			"envoy_ext_authz_grpc": {
+				"path": "envoy/authz/allow",
+				"dry-run": false
+			},
+			"eopa_dl": {
+				"buffer": { "type": "unbuffered" },
+				"output": {
+					"type": "s3",
+					"bucket": "slow-s3",
+					"endpoint": %q,
+					"force_path": true,
+					"region": "eu-central-1",
+					"timeout": "10s",
+					"batching": { "at_bytes": 1, "at_period": "1ms" }
+				}
+			}
+		}
+	}`, opaControlPlane.URL(), s3Server.URL))
+
+	fr := make(filters.Registry)
+	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(
+		openpolicyagent.WithTracer(tracingtest.NewTracer()),
+		openpolicyagent.WithOpenPolicyAgentInstanceConfig(
+			openpolicyagent.WithConfigTemplate(config),
+		),
+	)
+	require.NoError(t, err)
+
+	ftSpec := NewOpaAuthorizeRequestSpec(opaFactory)
+	fr.Register(ftSpec)
+	fr.Register(builtin.NewSetPath())
+
+	r := eskip.MustParse(fmt.Sprintf(`* -> opaAuthorizeRequest("test") -> %q`, clientServer.URL))
+	proxy := proxytest.New(fr, r...)
+	defer proxy.Close()
+
+	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/allow", nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	rsp, err := proxy.Client().Do(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	defer rsp.Body.Close()
+	assert.Equal(t, http.StatusOK, rsp.StatusCode)
+
+	// logDecision now runs on a background goroutine, so S3 latency is fully
+	// decoupled from the client round-trip.
+	assert.Less(t, elapsed, s3Delay,
+		"client round-trip (%v) should not be delayed by the S3 upload (%v); "+
+			"logDecision must not run on the request goroutine", elapsed, s3Delay)
+}
+
+// TestFullDecisionLogBufferBlocksClientResponse is the regression test for Issue 1:
+// when the eopa_dl memory buffer is full, decision log processing must not delay
+// the HTTP response to the upstream client.
+//
+// How Benthos memory buffer backpressure works (and why it previously hit clients):
+//
+//  1. prod(ctx, msg) sends on an unbuffered tChan and waits for resChan.
+//  2. The buffer's inputLoop reads tChan, calls WriteBatch(ctx, msg, ackFn).
+//  3. WriteBatch calls ackFn immediately (ACKs upstream), then checks capacity.
+//     If (m.bytes + extraBytes) > m.cap it blocks on cond.Wait().
+//  4. While inputLoop is stuck in WriteBatch, it cannot read the next transaction
+//     from tChan (unbuffered). The next prod() call blocks on "tChan <-".
+//
+// Before the fix: logDecision ran synchronously on the request goroutine, so
+// request N+2's prod() call blocked the HTTP response.
+//
+// After the fix: logDecision is dispatched to a background goroutine. Buffer
+// backpressure stays within the background goroutine and never reaches the client.
+func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
+	// stallDuration must be long enough to be unambiguous, short enough for a fast test.
+	const stallDuration = 300 * time.Millisecond
+
+	// s3Server never responds until the test ends, keeping the buffer occupied.
+	s3Stalled := make(chan struct{})
+	s3Reached := make(chan struct{}, 1)
+	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case s3Reached <- struct{}{}:
+		default:
+		}
+		select {
+		case <-s3Stalled:
+		case <-r.Context().Done():
+		}
+	}))
+	defer func() {
+		close(s3Stalled)
+		s3Server.Close()
+	}()
+
+	clientServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Welcome!"))
+	}))
+	defer clientServer.Close()
+
+	opaControlPlane := opasdktest.MustNewServer(
+		opasdktest.MockBundle("/bundles/test", map[string]string{
+			"main.rego": `
+				package envoy.authz
+				default allow = false
+				allow if { input.parsed_path == [ "allow" ] }
+			`,
+		}),
+		opasdktest.MockBundle("/bundles/discovery", map[string]string{
+			"data.json": `{
+			  "discovery": {
+				"bundles": {
+				  "bundles/test": {
+					"persist": false,
+					"resource": "bundles/test",
+					"service": "test"
+				  }
+			}}
+			}`,
+		}),
+	)
+	defer opaControlPlane.Stop()
+
+	// max_bytes=1200: large enough for one event (~874 bytes, so no ErrMessageTooLarge),
+	// too small for two (1748 > 1200). After event 1 is in the buffer and S3 stalls,
+	// WriteBatch for event 2 blocks in cond.Wait(); inputLoop stops reading tChan;
+	// event 3's prod() call blocks on the unbuffered tChan send.
+	// batching.at_bytes=1 ensures events are flushed to S3 immediately.
+	config := []byte(fmt.Sprintf(`{
+		"services": { "test": { "url": %q } },
+		"discovery": {
+			"name": "discovery",
+			"resource": "/bundles/discovery",
+			"service": "test"
+		},
+		"labels": { "environment": "test" },
+		"decision_logs": { "plugin": "eopa_dl" },
+		"plugins": {
+			"envoy_ext_authz_grpc": {
+				"path": "envoy/authz/allow",
+				"dry-run": false
+			},
+			"eopa_dl": {
+				"buffer": { "type": "memory", "max_bytes": 1200 },
+				"output": {
+					"type": "s3",
+					"bucket": "stalled-s3",
+					"endpoint": %q,
+					"force_path": true,
+					"region": "eu-central-1",
+					"timeout": "60s",
+					"batching": { "at_bytes": 1, "at_period": "1ms" }
+				}
+			}
+		}
+	}`, opaControlPlane.URL(), s3Server.URL))
+
+	fr := make(filters.Registry)
+	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(
+		openpolicyagent.WithTracer(tracingtest.NewTracer()),
+		openpolicyagent.WithOpenPolicyAgentInstanceConfig(
+			openpolicyagent.WithConfigTemplate(config),
+		),
+	)
+	require.NoError(t, err)
+
+	ftSpec := NewOpaAuthorizeRequestSpec(opaFactory)
+	fr.Register(ftSpec)
+
+	r := eskip.MustParse(fmt.Sprintf(`* -> opaAuthorizeRequest("test") -> %q`, clientServer.URL))
+	proxy := proxytest.New(fr, r...)
+	defer proxy.Close()
+
+	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/allow", nil)
+	require.NoError(t, err)
+
+	// Request 1: fills the buffer. S3 receives and stalls on this batch, keeping
+	// the ReadBatch ack pending so m.bytes stays at the event size.
+	rsp1, err := proxy.Client().Do(req)
+	require.NoError(t, err)
+	rsp1.Body.Close()
+	assert.Equal(t, http.StatusOK, rsp1.StatusCode)
+
+	// Wait until S3 is actually blocking so the buffer cannot drain.
+	select {
+	case <-s3Reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("S3 server never received a request — decision log was not flushed")
+	}
+
+	// Request 2: WriteBatch for this event triggers cond.Wait() inside the buffer
+	// (buffer now holds event1 bytes + event2 bytes > max_bytes=1200). WriteBatch
+	// ACKs request 2's producer before blocking, so request 2 itself returns quickly.
+	// But inputLoop is now stuck in WriteBatch and stops reading tChan.
+	rsp2, err := proxy.Client().Do(req)
+	require.NoError(t, err)
+	rsp2.Body.Close()
+	assert.Equal(t, http.StatusOK, rsp2.StatusCode)
+
+	// Request 3: prod() tries to send on tChan (unbuffered). inputLoop is stuck in
+	// WriteBatch and cannot read from tChan, so this send blocks. Since logDecision
+	// runs synchronously on the request goroutine (current behaviour), the client
+	// round-trip is delayed >= stallDuration.
+	// After the fix, logDecision is off the hot path and elapsed < stallDuration.
+	client := proxy.Client()
+	client.Timeout = stallDuration + 2*time.Second
+	start := time.Now()
+	rsp3, err := client.Do(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		rsp3.Body.Close()
+	}
+
+	// After the fix: logDecision runs on a background goroutine, so buffer
+	// backpressure never reaches the request goroutine.
+	assert.Less(t, elapsed, stallDuration,
+		"client round-trip (%v) should not be delayed by the full decision log buffer (%v stall); "+
+			"logDecision must not block the request goroutine", elapsed, stallDuration)
+}
+
 func TestCreateFilterArguments(t *testing.T) {
 	opaRegistry, err := openpolicyagent.NewOpenPolicyAgentRegistry(
 		openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate([]byte(""))))

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -906,6 +906,7 @@ func TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientRespons
 	fr := make(filters.Registry)
 	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(
 		openpolicyagent.WithTracer(tracingtest.NewTracer()),
+		openpolicyagent.WithAsyncDecisionLogging(true),
 		openpolicyagent.WithOpenPolicyAgentInstanceConfig(
 			openpolicyagent.WithConfigTemplate(config),
 		),
@@ -1026,6 +1027,7 @@ func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
 	fr := make(filters.Registry)
 	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(
 		openpolicyagent.WithTracer(tracingtest.NewTracer()),
+		openpolicyagent.WithAsyncDecisionLogging(true),
 		openpolicyagent.WithOpenPolicyAgentInstanceConfig(
 			openpolicyagent.WithConfigTemplate(config),
 		),

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -840,6 +840,9 @@ func TestAuthorizeRequestFilterWithS3DecisionLogPlugin(t *testing.T) {
 // channel. The request goroutine returns immediately after enqueuing the task, so
 // S3 latency is fully decoupled from the client response time.
 func TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientResponse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive test, skipped in short mode")
+	}
 	const s3Delay = 300 * time.Millisecond
 
 	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -961,6 +964,9 @@ func TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientRespons
 // After the fix: logDecision is dispatched to a background goroutine. Buffer
 // backpressure stays within the background goroutine and never reaches the client.
 func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive test, skipped in short mode")
+	}
 	// stallDuration must be long enough to be unambiguous, short enough for a fast test.
 	const stallDuration = 300 * time.Millisecond
 

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -830,15 +830,8 @@ func TestAuthorizeRequestFilterWithS3DecisionLogPlugin(t *testing.T) {
 }
 
 // TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientResponse
-// verifies that a slow S3 upload does NOT delay the HTTP response to the client.
-//
-// Before the fix: evaluation.go called logDecision synchronously on the request
-// goroutine. With "unbuffered" eopa_dl, every millisecond S3 took to respond was
-// added to the client round-trip.
-//
-// After the fix: logDecision is dispatched to a background goroutine via a bounded
-// channel. The request goroutine returns immediately after enqueuing the task, so
-// S3 latency is fully decoupled from the client response time.
+// verifies that a slow S3 upload does NOT delay the HTTP response to the client
+// Even when using the "unbuffered" memory buffer, which directly couples the S3 upload ACK to the client response.
 func TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientResponse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing-sensitive test, skipped in short mode")
@@ -938,31 +931,13 @@ func TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientRespons
 	defer rsp.Body.Close()
 	assert.Equal(t, http.StatusOK, rsp.StatusCode)
 
-	// logDecision now runs on a background goroutine, so S3 latency is fully
-	// decoupled from the client round-trip.
 	assert.Less(t, elapsed, s3Delay,
 		"client round-trip (%v) should not be delayed by the S3 upload (%v); "+
 			"logDecision must not run on the request goroutine", elapsed, s3Delay)
 }
 
-// TestFullDecisionLogBufferBlocksClientResponse is the regression test for Issue 1:
-// when the eopa_dl memory buffer is full, decision log processing must not delay
-// the HTTP response to the upstream client.
-//
-// How Benthos memory buffer backpressure works (and why it previously hit clients):
-//
-//  1. prod(ctx, msg) sends on an unbuffered tChan and waits for resChan.
-//  2. The buffer's inputLoop reads tChan, calls WriteBatch(ctx, msg, ackFn).
-//  3. WriteBatch calls ackFn immediately (ACKs upstream), then checks capacity.
-//     If (m.bytes + extraBytes) > m.cap it blocks on cond.Wait().
-//  4. While inputLoop is stuck in WriteBatch, it cannot read the next transaction
-//     from tChan (unbuffered). The next prod() call blocks on "tChan <-".
-//
-// Before the fix: logDecision ran synchronously on the request goroutine, so
-// request N+2's prod() call blocked the HTTP response.
-//
-// After the fix: logDecision is dispatched to a background goroutine. Buffer
-// backpressure stays within the background goroutine and never reaches the client.
+// TestFullDecisionLogBufferBlocksClientResponse is the regression test for the buffer full scenario when
+// the eopa_dl memory buffer is full, decision log processing must not delay the HTTP response to the upstream client.
 func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing-sensitive test, skipped in short mode")
@@ -1016,10 +991,8 @@ func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
 	)
 	defer opaControlPlane.Stop()
 
-	// max_bytes=1200: large enough for one event (~874 bytes, so no ErrMessageTooLarge),
+	// max_bytes=1200: large enough for one event (~874 bytes),
 	// too small for two (1748 > 1200). After event 1 is in the buffer and S3 stalls,
-	// WriteBatch for event 2 blocks in cond.Wait(); inputLoop stops reading tChan;
-	// event 3's prod() call blocks on the unbuffered tChan send.
 	// batching.at_bytes=1 ensures events are flushed to S3 immediately.
 	config := []byte(fmt.Sprintf(`{
 		"services": { "test": { "url": %q } },
@@ -1069,8 +1042,7 @@ func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/allow", nil)
 	require.NoError(t, err)
 
-	// Request 1: fills the buffer. S3 receives and stalls on this batch, keeping
-	// the ReadBatch ack pending so m.bytes stays at the event size.
+	// Request 1: fills the buffer. S3 receives and stalls on this batch
 	rsp1, err := proxy.Client().Do(req)
 	require.NoError(t, err)
 	rsp1.Body.Close()
@@ -1092,11 +1064,6 @@ func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
 	rsp2.Body.Close()
 	assert.Equal(t, http.StatusOK, rsp2.StatusCode)
 
-	// Request 3: prod() tries to send on tChan (unbuffered). inputLoop is stuck in
-	// WriteBatch and cannot read from tChan, so this send blocks. Since logDecision
-	// runs synchronously on the request goroutine (current behaviour), the client
-	// round-trip is delayed >= stallDuration.
-	// After the fix, logDecision is off the hot path and elapsed < stallDuration.
 	client := proxy.Client()
 	client.Timeout = stallDuration + 2*time.Second
 	start := time.Now()
@@ -1107,8 +1074,6 @@ func TestFullDecisionLogBufferBlocksClientResponse(t *testing.T) {
 		rsp3.Body.Close()
 	}
 
-	// After the fix: logDecision runs on a background goroutine, so buffer
-	// backpressure never reaches the request goroutine.
 	assert.Less(t, elapsed, stallDuration,
 		"client round-trip (%v) should not be delayed by the full decision log buffer (%v stall); "+
 			"logDecision must not block the request goroutine", elapsed, stallDuration)

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -62,7 +62,7 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
-	DefaultDecisionLogChannelSize   = 1000
+	DefaultDecisionLogQueueSize   = 1000
 
 	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
@@ -131,7 +131,7 @@ type OpenPolicyAgentRegistry struct {
 	preloadingEnabled bool
 
 	asyncDecisionLogging   bool
-	decisionLogChannelSize int
+	decisionLogQueueSize int
 
 	// Background task system
 	backgroundTaskChan       chan *BackgroundTask
@@ -283,9 +283,9 @@ func WithAsyncDecisionLogging(enabled bool) func(*OpenPolicyAgentRegistry) error
 	}
 }
 
-func WithDecisionLogChannelSize(size int) func(*OpenPolicyAgentRegistry) error {
+func WithDecisionLogQueueSize(size int) func(*OpenPolicyAgentRegistry) error {
 	return func(cfg *OpenPolicyAgentRegistry) error {
-		cfg.decisionLogChannelSize = size
+		cfg.decisionLogQueueSize = size
 		return nil
 	}
 }
@@ -797,9 +797,9 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 	}
 
 	if registry.asyncDecisionLogging {
-		bufSize := registry.decisionLogChannelSize
+		bufSize := registry.decisionLogQueueSize
 		if bufSize <= 0 {
-			bufSize = DefaultDecisionLogChannelSize
+			bufSize = DefaultDecisionLogQueueSize
 		}
 		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
 		opa.decisionsProcessed = make(chan struct{})

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -62,6 +62,7 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
+	DefaultDecisionLogChannelSize   = 1000
 
 	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
@@ -128,6 +129,9 @@ type OpenPolicyAgentRegistry struct {
 
 	// New fields for pre-loading support
 	preloadingEnabled bool
+
+	asyncDecisionLogging   bool
+	decisionLogChannelSize int
 
 	// Background task system
 	backgroundTaskChan       chan *BackgroundTask
@@ -268,6 +272,20 @@ func (registry *OpenPolicyAgentRegistry) initializeCache() error {
 func WithPreloadingEnabled(enabled bool) func(*OpenPolicyAgentRegistry) error {
 	return func(cfg *OpenPolicyAgentRegistry) error {
 		cfg.preloadingEnabled = enabled
+		return nil
+	}
+}
+
+func WithAsyncDecisionLogging(enabled bool) func(*OpenPolicyAgentRegistry) error {
+	return func(cfg *OpenPolicyAgentRegistry) error {
+		cfg.asyncDecisionLogging = enabled
+		return nil
+	}
+}
+
+func WithDecisionLogChannelSize(size int) func(*OpenPolicyAgentRegistry) error {
+	return func(cfg *OpenPolicyAgentRegistry) error {
+		cfg.decisionLogChannelSize = size
 		return nil
 	}
 }
@@ -608,19 +626,12 @@ func (registry *OpenPolicyAgentRegistry) newOpenPolicyAgentInstance(bundleName s
 }
 
 // decisionLogTask holds everything needed to call logDecision off the hot path.
-// If sync is non-nil it is a flush sentinel: the worker closes it and skips logDecision.
 type decisionLogTask struct {
 	ctx    context.Context
 	input  interface{}
 	result *envoyauth.EvalResult
 	err    error
-	sync   chan struct{}
 }
-
-// defaultDecisionLogBufferSize is the number of pending decision log tasks that
-// can be queued before new ones are dropped. Each entry is a small struct; the
-// real memory cost is the decision payload held by *envoyauth.EvalResult.
-const defaultDecisionLogBufferSize = 1000
 
 type OpenPolicyAgentInstance struct {
 	manager                     *plugins.Manager
@@ -647,8 +658,8 @@ type OpenPolicyAgentInstance struct {
 
 	idGenerator flowid.Generator
 
-	decisionLogChan chan decisionLogTask
-	decisionLogDone chan struct{}
+	decisionLogChan    chan decisionLogTask
+	decisionsProcessed chan struct{}
 }
 
 func envVariablesMap() map[string]string {
@@ -783,12 +794,17 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 
 		idGenerator: uniqueIDGenerator,
 		logger:      logging.Get().WithFields(map[string]any{"bundle-name": bundleName}),
-
-		decisionLogChan: make(chan decisionLogTask, defaultDecisionLogBufferSize),
-		decisionLogDone: make(chan struct{}),
 	}
 
-	go opa.runDecisionLogger()
+	if registry.asyncDecisionLogging {
+		bufSize := registry.decisionLogChannelSize
+		if bufSize <= 0 {
+			bufSize = DefaultDecisionLogChannelSize
+		}
+		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
+		opa.decisionsProcessed = make(chan struct{})
+		go opa.runDecisionLogger()
+	}
 
 	manager.RegisterCompilerTrigger(opa.compilerUpdated)
 	manager.RegisterPluginStatusListener("instance-health-check", func(_ map[string]*plugins.Status) {
@@ -1002,10 +1018,12 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 	opa.closingOnce.Do(func() {
 		opa.Logger().Info("Closing OPA instance...")
 		opa.closing = true
-		close(opa.decisionLogChan)
-		select {
-		case <-opa.decisionLogDone:
-		case <-ctx.Done():
+		if opa.decisionLogChan != nil {
+			close(opa.decisionLogChan)
+			select {
+			case <-opa.decisionsProcessed:
+			case <-ctx.Done():
+			}
 		}
 		opa.manager.Stop(ctx)
 	})
@@ -1013,14 +1031,10 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 
 // runDecisionLogger drains decisionLogChan in the background so that logDecision
 // is never called on the request goroutine. The goroutine exits when the channel
-// is closed (during Close) and signals completion via decisionLogDone.
+// is closed (during Close) and signals completion via decisionsProcessed.
 func (opa *OpenPolicyAgentInstance) runDecisionLogger() {
-	defer close(opa.decisionLogDone)
+	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		if task.sync != nil {
-			close(task.sync) // unblock waitDecisionLogDrained
-			continue
-		}
 		if err := opa.logDecision(task.ctx, task.input, task.result, task.err); err != nil {
 			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
 		}

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -3,6 +3,7 @@ package openpolicyagent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	dl "github.com/open-policy-agent/eopa/pkg/plugins/decision_logs"
+	"github.com/open-policy-agent/opa/v1/plugins/logs"
 	"github.com/open-policy-agent/opa/v1/util"
 
 	"google.golang.org/protobuf/proto"
@@ -62,7 +64,6 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
-	DefaultDecisionLogQueueSize     = 1000
 
 	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
@@ -131,7 +132,6 @@ type OpenPolicyAgentRegistry struct {
 	preloadingEnabled bool
 
 	asyncDecisionLogging bool
-	decisionLogQueueSize int
 
 	// Background task system
 	backgroundTaskChan       chan *BackgroundTask
@@ -279,13 +279,6 @@ func WithPreloadingEnabled(enabled bool) func(*OpenPolicyAgentRegistry) error {
 func WithAsyncDecisionLogging(enabled bool) func(*OpenPolicyAgentRegistry) error {
 	return func(cfg *OpenPolicyAgentRegistry) error {
 		cfg.asyncDecisionLogging = enabled
-		return nil
-	}
-}
-
-func WithDecisionLogQueueSize(size int) func(*OpenPolicyAgentRegistry) error {
-	return func(cfg *OpenPolicyAgentRegistry) error {
-		cfg.decisionLogQueueSize = size
 		return nil
 	}
 }
@@ -796,10 +789,7 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 	}
 
 	if registry.asyncDecisionLogging {
-		bufSize := registry.decisionLogQueueSize
-		if bufSize <= 0 {
-			bufSize = DefaultDecisionLogQueueSize
-		}
+		bufSize := decisionLogBufferSize(opaConfig.DecisionLogs)
 		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
 		opa.decisionsProcessed = make(chan struct{})
 		go opa.runDecisionLogger()
@@ -827,6 +817,21 @@ func allPluginsReady(allPluginsStatus map[string]*plugins.Status, pluginNames ..
 		}
 	}
 	return true
+}
+
+func decisionLogBufferSize(rawConfig json.RawMessage) int {
+	const defaultBufferSize = 1000
+	if rawConfig == nil {
+		return defaultBufferSize
+	}
+	var cfg logs.Config
+	if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+		return defaultBufferSize
+	}
+	if cfg.Reporting.BufferSizeLimitEvents != nil && *cfg.Reporting.BufferSizeLimitEvents > 0 {
+		return int(*cfg.Reporting.BufferSizeLimitEvents)
+	}
+	return defaultBufferSize
 }
 
 func (opa *OpenPolicyAgentInstance) Start() error {
@@ -1034,7 +1039,7 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 func (opa *OpenPolicyAgentInstance) runDecisionLogger() {
 	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		if err := opa.logDecision(context.Background(), task.input, task.result, task.err); err != nil {
+		if err := opa.doLogDecision(context.Background(), task.input, task.result, task.err); err != nil {
 			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
 		}
 	}

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -607,6 +607,21 @@ func (registry *OpenPolicyAgentRegistry) newOpenPolicyAgentInstance(bundleName s
 	return engine, nil
 }
 
+// decisionLogTask holds everything needed to call logDecision off the hot path.
+// If sync is non-nil it is a flush sentinel: the worker closes it and skips logDecision.
+type decisionLogTask struct {
+	ctx    context.Context
+	input  interface{}
+	result *envoyauth.EvalResult
+	err    error
+	sync   chan struct{}
+}
+
+// defaultDecisionLogBufferSize is the number of pending decision log tasks that
+// can be queued before new ones are dropped. Each entry is a small struct; the
+// real memory cost is the decision payload held by *envoyauth.EvalResult.
+const defaultDecisionLogBufferSize = 1000
+
 type OpenPolicyAgentInstance struct {
 	manager                     *plugins.Manager
 	instanceConfig              OpenPolicyAgentInstanceConfig
@@ -631,6 +646,9 @@ type OpenPolicyAgentInstance struct {
 	bodyReadBufferSize int64
 
 	idGenerator flowid.Generator
+
+	decisionLogChan chan decisionLogTask
+	decisionLogDone chan struct{}
 }
 
 func envVariablesMap() map[string]string {
@@ -765,7 +783,12 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 
 		idGenerator: uniqueIDGenerator,
 		logger:      logging.Get().WithFields(map[string]any{"bundle-name": bundleName}),
+
+		decisionLogChan: make(chan decisionLogTask, defaultDecisionLogBufferSize),
+		decisionLogDone: make(chan struct{}),
 	}
+
+	go opa.runDecisionLogger()
 
 	manager.RegisterCompilerTrigger(opa.compilerUpdated)
 	manager.RegisterPluginStatusListener("instance-health-check", func(_ map[string]*plugins.Status) {
@@ -979,8 +1002,29 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 	opa.closingOnce.Do(func() {
 		opa.Logger().Info("Closing OPA instance...")
 		opa.closing = true
+		close(opa.decisionLogChan)
+		select {
+		case <-opa.decisionLogDone:
+		case <-ctx.Done():
+		}
 		opa.manager.Stop(ctx)
 	})
+}
+
+// runDecisionLogger drains decisionLogChan in the background so that logDecision
+// is never called on the request goroutine. The goroutine exits when the channel
+// is closed (during Close) and signals completion via decisionLogDone.
+func (opa *OpenPolicyAgentInstance) runDecisionLogger() {
+	defer close(opa.decisionLogDone)
+	for task := range opa.decisionLogChan {
+		if task.sync != nil {
+			close(task.sync) // unblock waitDecisionLogDrained
+			continue
+		}
+		if err := opa.logDecision(task.ctx, task.input, task.result, task.err); err != nil {
+			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
+		}
+	}
 }
 
 func (opa *OpenPolicyAgentInstance) Logger() logging.Logger {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -627,7 +627,6 @@ func (registry *OpenPolicyAgentRegistry) newOpenPolicyAgentInstance(bundleName s
 
 // decisionLogTask holds everything needed to call logDecision off the hot path.
 type decisionLogTask struct {
-	ctx    context.Context
 	input  interface{}
 	result *envoyauth.EvalResult
 	err    error
@@ -1035,7 +1034,7 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 func (opa *OpenPolicyAgentInstance) runDecisionLogger() {
 	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		if err := opa.logDecision(task.ctx, task.input, task.result, task.err); err != nil {
+		if err := opa.logDecision(context.Background(), task.input, task.result, task.err); err != nil {
 			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
 		}
 	}

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -62,7 +62,7 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
-	DefaultDecisionLogQueueSize   = 1000
+	DefaultDecisionLogQueueSize     = 1000
 
 	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
@@ -130,7 +130,7 @@ type OpenPolicyAgentRegistry struct {
 	// New fields for pre-loading support
 	preloadingEnabled bool
 
-	asyncDecisionLogging   bool
+	asyncDecisionLogging bool
 	decisionLogQueueSize int
 
 	// Background task system

--- a/skipper.go
+++ b/skipper.go
@@ -1055,7 +1055,6 @@ type Options struct {
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool
 	EnableOpenPolicyAgentPreloading                    bool
 	EnableOpenPolicyAgentAsyncDecisionLogging          bool
-	OpenPolicyAgentDecisionLogQueueSize                int
 	EnableOpenPolicyAgentPrintTracing                  bool
 	OpenPolicyAgentConfigTemplate                      string
 	OpenPolicyAgentEnvoyMetadata                       string
@@ -2179,7 +2178,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			openpolicyagent.WithEnableDataPreProcessingOptimization(o.EnableOpenPolicyAgentDataPreProcessingOptimization),
 			openpolicyagent.WithPreloadingEnabled(o.EnableOpenPolicyAgentPreloading),
 			openpolicyagent.WithAsyncDecisionLogging(o.EnableOpenPolicyAgentAsyncDecisionLogging),
-			openpolicyagent.WithDecisionLogQueueSize(o.OpenPolicyAgentDecisionLogQueueSize),
 			openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...),
 		}
 

--- a/skipper.go
+++ b/skipper.go
@@ -1055,7 +1055,7 @@ type Options struct {
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool
 	EnableOpenPolicyAgentPreloading                    bool
 	EnableOpenPolicyAgentAsyncDecisionLogging          bool
-	OpenPolicyAgentDecisionLogChannelSize              int
+	OpenPolicyAgentDecisionLogQueueSize                int
 	EnableOpenPolicyAgentPrintTracing                  bool
 	OpenPolicyAgentConfigTemplate                      string
 	OpenPolicyAgentEnvoyMetadata                       string
@@ -2179,7 +2179,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			openpolicyagent.WithEnableDataPreProcessingOptimization(o.EnableOpenPolicyAgentDataPreProcessingOptimization),
 			openpolicyagent.WithPreloadingEnabled(o.EnableOpenPolicyAgentPreloading),
 			openpolicyagent.WithAsyncDecisionLogging(o.EnableOpenPolicyAgentAsyncDecisionLogging),
-			openpolicyagent.WithDecisionLogChannelSize(o.OpenPolicyAgentDecisionLogChannelSize),
+			openpolicyagent.WithDecisionLogQueueSize(o.OpenPolicyAgentDecisionLogQueueSize),
 			openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...),
 		}
 

--- a/skipper.go
+++ b/skipper.go
@@ -1054,6 +1054,8 @@ type Options struct {
 	OpenPolicyAgentControlLoopMaxJitter                time.Duration
 	EnableOpenPolicyAgentDataPreProcessingOptimization bool
 	EnableOpenPolicyAgentPreloading                    bool
+	EnableOpenPolicyAgentAsyncDecisionLogging          bool
+	OpenPolicyAgentDecisionLogChannelSize              int
 	EnableOpenPolicyAgentPrintTracing                  bool
 	OpenPolicyAgentConfigTemplate                      string
 	OpenPolicyAgentEnvoyMetadata                       string
@@ -2176,6 +2178,8 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			openpolicyagent.WithControlLoopMaxJitter(o.OpenPolicyAgentControlLoopMaxJitter),
 			openpolicyagent.WithEnableDataPreProcessingOptimization(o.EnableOpenPolicyAgentDataPreProcessingOptimization),
 			openpolicyagent.WithPreloadingEnabled(o.EnableOpenPolicyAgentPreloading),
+			openpolicyagent.WithAsyncDecisionLogging(o.EnableOpenPolicyAgentAsyncDecisionLogging),
+			openpolicyagent.WithDecisionLogChannelSize(o.OpenPolicyAgentDecisionLogChannelSize),
 			openpolicyagent.WithOpenPolicyAgentInstanceConfig(opts...),
 		}
 


### PR DESCRIPTION
 ## Async decision logging for OPA

Adds an opt-in async decision logging mode (--enable-open-policy-agent-async-decision-logging) that offloads decision log calls to a background goroutine, preventing slow log plugins (e.g. eopa_dl writing to S3) from adding latency to HTTP responses.

When enabled, each OPA instance maintains a bounded channel. logDecision does a non-blocking send into it; if the buffer is full the event is dropped with a warning rather than blocking the request goroutine. A dedicated runDecisionLogger goroutine drains the channel and performs the actual log call. On shutdown, Close drains the channel to completion before stopping the manager, respecting the context deadline.

The channel buffer size is derived from decision_logs.reporting.buffer_size_limit_events in the OPA config template, keeping it consistent with OPA's own buffer configuration. If not set, it defaults to 1000.