### PR TITLE
Add `decision_log.dropped` counter for async decision logging

### DIFF
--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -18,6 +18,8 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown/print"
 	"github.com/opentracing/opentracing-go"
 	pbstruct "google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/zalando/skipper/metrics"
 )
 
 func (opa *OpenPolicyAgentInstance) Eval(ctx context.Context, req *ext_authz_v3.CheckRequest) (*envoyauth.EvalResult, error) {
@@ -120,6 +122,7 @@ func (opa *OpenPolicyAgentInstance) logDecision(ctx context.Context, input inter
 		select {
 		case opa.decisionLogChan <- task:
 		default:
+			metrics.Default.IncCounter(opa.MetricsKey("decision_log.dropped"))
 			opa.Logger().WithFields(map[string]interface{}{
 				"decision_id": result.DecisionID,
 			}).Warn("Decision log dropped: async buffer full.")

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-policy-agent/opa-envoy-plugin/envoyauth"
 	opaconf "github.com/open-policy-agent/opa/v1/config"
 	"github.com/open-policy-agent/opa/v1/download"
+	"github.com/open-policy-agent/opa/v1/logging"
 	"github.com/open-policy-agent/opa/v1/plugins"
 	"github.com/open-policy-agent/opa/v1/plugins/bundle"
 	"github.com/open-policy-agent/opa/v1/plugins/discovery"
@@ -35,6 +36,7 @@ import (
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/filtertest"
 	"github.com/zalando/skipper/filters/openpolicyagent/internal/envoy"
+	"github.com/zalando/skipper/metrics"
 	"github.com/zalando/skipper/metrics/metricstest"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/tracing/tracingtest"
@@ -1468,4 +1470,33 @@ func TestPrintTracing(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAsyncDecisionLogDroppedCounter verifies the decision_log.dropped counter
+func TestAsyncDecisionLogDroppedCounter(t *testing.T) {
+	mockMetrics := &metricstest.MockMetrics{}
+	origDefault := metrics.Default
+	metrics.Default = mockMetrics
+	t.Cleanup(func() { metrics.Default = origDefault })
+
+	// Buffered cap=1 with no reader: first send fits, every send after drops.
+	opa := &OpenPolicyAgentInstance{
+		registry:        &OpenPolicyAgentRegistry{},
+		bundleName:      "test",
+		logger:          logging.Get().WithFields(map[string]any{"bundle-name": "test"}),
+		decisionLogChan: make(chan decisionLogTask, 1),
+	}
+	result := &envoyauth.EvalResult{DecisionID: "decision-1"}
+
+	require.NoError(t, opa.logDecision(context.Background(), nil, result, nil))
+	mockMetrics.WithCounters(func(counters map[string]int64) {
+		assert.Zero(t, counters["decision_log.dropped.test"], "no drop expected when channel has room")
+	})
+
+	// Channel is now full: subsequent sends drop and increment the counter.
+	require.NoError(t, opa.logDecision(context.Background(), nil, result, nil))
+	require.NoError(t, opa.logDecision(context.Background(), nil, result, nil))
+	mockMetrics.WithCounters(func(counters map[string]int64) {
+		assert.Equal(t, int64(2), counters["decision_log.dropped.test"])
+	})
 }


### PR DESCRIPTION
## What & Why?

Follow-up to #4001, which introduced a bounded async channel in front of `logDecision` so that slow log plugins (e.g. `eopa_dl` writing to S3) don't add latency to HTTP responses. When the channel is full, events are silently dropped.

Currently, those drops are only visible as warn log lines. This PR surfaces the same event as a Prometheus counter so we can:

- **Alert** when drops exceed a threshold (should we decide on one based on operational experience)
- **Tune `buffer_size_limit_events`** based on observed drop rate.

The counter is emitted via skipper's standard `metrics.Default`:

```
skipper_custom_total{key="decision_log.dropped.<bundle>"}
```

to match the existing OPA counter convention (`decision.allow.<bundle>`, `decision.deny.<bundle>`, `decision.err.<bundle>`). 

_Given naming is hard, please feel free to suggest a better name for the metric._