### PR TITLE
shortcheck: fix some testcases

### DIFF
--- a/secrets/file_test.go
+++ b/secrets/file_test.go
@@ -53,7 +53,10 @@ func TestSecretPaths(t *testing.T) {
 	})
 
 	t.Run("errors when path is not a file or directory", func(t *testing.T) {
-		path := t.TempDir() + "/foo"
+		dir, err := os.MkdirTemp("", "sp")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		path := dir + "/foo"
 
 		l, err := net.Listen("unix", path)
 		require.NoError(t, err)


### PR DESCRIPTION
Use os.MkdirTemp with a short path to avoid hitting the Unix socket path length limit (104 chars on macOS) when t.TempDir() produces a long path.