### PR TITLE
Make testcontainer based tests runnable with Podman/Colima container runtimes on MacOs

### DIFF
--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -636,6 +636,48 @@ func (c *clusterClient) loadEndpointAddresses(zone, namespace, name string) ([]s
 	return result, nil
 }
 
+// loadEndpointAddressesWithPorts returns endpoint addresses including their ports.
+func (c *clusterClient) loadEndpointAddressesWithPorts(zone, namespace, name string) ([]string, error) {
+	var result, resultByZone []string
+	if c.enableEndpointSlices {
+		url := fmt.Sprintf(EndpointSlicesNamespaceFmt, namespace) +
+			toLabelSelectorQuery(map[string]string{endpointSliceServiceNameLabel: name})
+
+		var endpointSlices endpointSliceList
+		if err := c.getJSON(url, &endpointSlices); err != nil {
+			return nil, fmt.Errorf("requesting endpointslices for %s/%s failed: %w", namespace, name, err)
+		}
+
+		ready := collectReadyEndpoints(&endpointSlices)
+		if len(ready) != 1 {
+			return nil, fmt.Errorf("unexpected number of endpoint slices for %s/%s: %d", namespace, name, len(ready))
+		}
+
+		for _, eps := range ready {
+			if zone != "" {
+				resultByZone = eps.addressesByZone(zone)
+			}
+			result = eps.addressesWithPorts()
+
+			break
+		}
+	} else {
+		url := fmt.Sprintf(EndpointsNamespaceFmt, namespace) + "/" + name
+
+		var ep endpoint
+		if err := c.getJSON(url, &ep); err != nil {
+			return nil, fmt.Errorf("requesting endpoints for %s/%s failed: %w", namespace, name, err)
+		}
+		result = ep.addressesWithPorts()
+	}
+	if len(resultByZone) >= minEndpointsByZone {
+		result = resultByZone
+	}
+	sort.Strings(result)
+
+	return result, nil
+}
+
 func (c *clusterClient) logMissingRouteGroupsOnce() {
 	if c.loggedMissingRouteGroups {
 		return

--- a/dataclients/kubernetes/clusterstate.go
+++ b/dataclients/kubernetes/clusterstate.go
@@ -138,6 +138,33 @@ func (state *clusterState) getEndpointAddresses(zone, namespace, name string) []
 	return addresses
 }
 
+// getEndpointAddressesWithPorts returns all addresses including their ports from endpoints/endpointslices.
+// Each address is formatted as "ip:port" using the port from the endpoint subset.
+func (state *clusterState) getEndpointAddressesWithPorts(zone, namespace, name string) []string {
+	rID := newResourceID(namespace, name)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	var addresses []string
+	if state.enableEndpointSlices {
+		if eps, ok := state.endpointSlices[rID]; ok {
+			addresses = eps.addressesWithPorts()
+		} else {
+			return nil
+		}
+	} else {
+		if ep, ok := state.endpoints[rID]; ok {
+			addresses = ep.addressesWithPorts()
+		} else {
+			return nil
+		}
+	}
+	sort.Strings(addresses)
+
+	return addresses
+}
+
 // GetEndpointsByTarget returns the skipper endpoints for kubernetes endpoints.
 func (state *clusterState) GetEndpointsByTarget(namespace, name, protocol, scheme string, target *definitions.BackendPort) []string {
 	epID := endpointID{

--- a/dataclients/kubernetes/endpoints.go
+++ b/dataclients/kubernetes/endpoints.go
@@ -87,6 +87,20 @@ func (ep *endpoint) addresses() []string {
 	return result
 }
 
+// addressesWithPorts returns all addresses with their associated ports.
+// Each address is combined with its port from the subset.
+func (ep *endpoint) addressesWithPorts() []string {
+	result := make([]string, 0)
+	for _, s := range ep.Subsets {
+		for _, a := range s.Addresses {
+			for _, p := range s.Ports {
+				result = append(result, net.JoinHostPort(a.IP, strconv.Itoa(p.Port)))
+			}
+		}
+	}
+	return result
+}
+
 type subset struct {
 	Addresses []*address `json:"addresses"`
 	Ports     []*port    `json:"ports"`

--- a/dataclients/kubernetes/endpointslices.go
+++ b/dataclients/kubernetes/endpointslices.go
@@ -96,6 +96,11 @@ func (eps *skipperEndpointSlice) addresses() []string {
 	return result
 }
 
+// addressesWithPorts returns all addresses as-is since endpointslices have addresses that already include ports.
+func (eps *skipperEndpointSlice) addressesWithPorts() []string {
+	return eps.addresses()
+}
+
 type endpointSliceList struct {
 	Meta  *definitions.Metadata
 	Items []*endpointSlice `json:"items"`

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -627,6 +627,23 @@ func (c *Client) LoadEndpointAddresses(zone, namespace, name string) ([]string, 
 	return c.ClusterClient.loadEndpointAddresses(zone, namespace, name)
 }
 
+// GetEndpointAddressesWithPorts returns the list of all addresses including ports for the given service.
+// Addresses are formatted as "ip:port".
+func (c *Client) GetEndpointAddressesWithPorts(zone, ns, name string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state == nil {
+		return nil
+	}
+	return c.state.getEndpointAddressesWithPorts(zone, ns, name)
+}
+
+// LoadEndpointAddressesWithPorts returns the list of all addresses including ports for the given service.
+// Addresses are formatted as "ip:port".
+func (c *Client) LoadEndpointAddressesWithPorts(zone, namespace, name string) ([]string, error) {
+	return c.ClusterClient.loadEndpointAddressesWithPorts(zone, namespace, name)
+}
+
 func compareStringList(a, b []string) []string {
 	c := make([]string, 0)
 	for i := len(a) - 1; i >= 0; i-- {

--- a/net/redistest/redistest.go
+++ b/net/redistest/redistest.go
@@ -77,11 +77,15 @@ func newTestRedisWithOptions(t testing.TB, opts options) (address string, done f
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	ip, err := container.ContainerIP(ctx)
+	host, err := container.Host(ctx)
 	if err != nil {
-		t.Fatalf("Failed to get redis container ip: %v", err)
+		t.Fatalf("Failed to get redis container host: %v", err)
 	}
-	address = net.JoinHostPort(ip, "6379")
+	mappedPort, err := container.MappedPort(ctx, "6379/tcp")
+	if err != nil {
+		t.Fatalf("Failed to get redis container port: %v", err)
+	}
+	address = net.JoinHostPort(host, mappedPort.Port())
 
 	t.Logf("Started redis server at %s in %v", address, time.Since(start))
 

--- a/net/valkeytest/valkeytest.go
+++ b/net/valkeytest/valkeytest.go
@@ -73,11 +73,15 @@ func newTestValkeyWithOptions(t testing.TB, opts options) (address string, done 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	ip, err := container.ContainerIP(ctx)
+	host, err := container.Host(ctx)
 	if err != nil {
-		t.Fatalf("Failed to get valkey container ip: %v", err)
+		t.Fatalf("Failed to get valkey container host: %v", err)
 	}
-	address = net.JoinHostPort(ip, "6379")
+	mappedPort, err := container.MappedPort(ctx, "6379/tcp")
+	if err != nil {
+		t.Fatalf("Failed to get valkey container port: %v", err)
+	}
+	address = net.JoinHostPort(host, mappedPort.Port())
 
 	t.Logf("Started valkey server at %s in %v", address, time.Since(start))
 

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,13 @@ Build and test all packages:
 > On Mac the tests may fail because of low max open file limit. Please make sure you have correct limits setup
 by following [these instructions](https://gist.github.com/tombigel/d503800a282fcadbee14b537735d202c).
 
+> When using Podman or Colima container runtimes, tests using [testcontainers](https://golang.testcontainers.org/) 
+> fail because the [moby-ryuk](https://github.com/testcontainers/moby-ryuk) module does not support these runtimes.
+> See [moby-ryuk/issue](https://github.com/testcontainers/moby-ryuk/issues/23).
+>
+> To work around this, disable ryuk by setting the environment variable `TESTCONTAINERS_RYUK_DISABLED="true"` when 
+> running tests with Podman or Colima.
+
 ##### Working from IntelliJ / GoLand
 
 To run or debug skipper from _IntelliJ IDEA_ or _GoLand_, you need to create this configuration:

--- a/redis_test.go
+++ b/redis_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	stdlibhttptest "net/http/httptest"
 	"os"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -552,13 +553,21 @@ func createFilterRegistry(specs ...filters.Spec) filters.Registry {
 
 func createRedisEndpointsSpec(t *testing.T, addrs ...string) string {
 	t.Helper()
-	var addresses []map[string]any
+	var subsets []any
 	for _, addr := range addrs {
 		host, port, err := net.SplitHostPort(addr)
 		require.NoError(t, err)
-		require.Equal(t, "6379", port)
 
-		addresses = append(addresses, map[string]any{"ip": host})
+		portNumber, err := strconv.Atoi(port)
+		require.NoError(t, err)
+
+		subsets = append(subsets, map[string]any{
+			"addresses": []map[string]any{{"ip": host}},
+			"ports": []map[string]any{{
+				"port":     portNumber,
+				"protocol": "TCP",
+			}},
+		})
 	}
 
 	ep := map[string]any{
@@ -568,15 +577,7 @@ func createRedisEndpointsSpec(t *testing.T, addrs ...string) string {
 			"name":      "redis",
 			"namespace": "skipper",
 		},
-		"subsets": []any{
-			map[string]any{
-				"addresses": addresses,
-				"ports": []map[string]any{{
-					"port":     6379,
-					"protocol": "TCP",
-				}},
-			},
-		},
+		"subsets": subsets,
 	}
 
 	// JSON is a valid YAML

--- a/routesrv/redishandler.go
+++ b/routesrv/redishandler.go
@@ -42,16 +42,25 @@ func (rh *RedisHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func getRedisAddresses(opts *skipper.Options, kdc *kubernetes.Client, m metrics.Metrics) func() ([]byte, error) {
 	return func() ([]byte, error) {
-		a := kdc.GetEndpointAddresses("", opts.KubernetesRedisServiceNamespace, opts.KubernetesRedisServiceName)
+		a := kdc.GetEndpointAddressesWithPorts("", opts.KubernetesRedisServiceNamespace, opts.KubernetesRedisServiceName)
 		log.Debugf("Redis updater called and found %d redis endpoints: %v", len(a), a)
 		m.UpdateGauge("redis_endpoints", float64(len(a)))
 
 		result := RedisEndpoints{
 			Endpoints: make([]RedisEndpoint, len(a)),
 		}
-		port := strconv.Itoa(opts.KubernetesRedisServicePort)
-		for i := range a {
-			result.Endpoints[i].Address = net.JoinHostPort(a[i], port)
+		// If no addresses with ports, fall back to old method
+		if len(a) == 0 {
+			a = kdc.GetEndpointAddresses("", opts.KubernetesRedisServiceNamespace, opts.KubernetesRedisServiceName)
+			log.Debugf("Falling back to GetEndpointAddresses, found %d endpoints", len(a))
+			port := strconv.Itoa(opts.KubernetesRedisServicePort)
+			for i := range a {
+				result.Endpoints[i].Address = net.JoinHostPort(a[i], port)
+			}
+		} else {
+			for i := range a {
+				result.Endpoints[i].Address = a[i]
+			}
 		}
 
 		data, err := json.Marshal(result)

--- a/routesrv/valkeyhandler.go
+++ b/routesrv/valkeyhandler.go
@@ -42,16 +42,25 @@ func (vh *ValkeyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func getValkeyAddresses(opts *skipper.Options, kdc *kubernetes.Client, m metrics.Metrics) func() ([]byte, error) {
 	return func() ([]byte, error) {
-		a := kdc.GetEndpointAddresses("", opts.KubernetesValkeyServiceNamespace, opts.KubernetesValkeyServiceName)
+		a := kdc.GetEndpointAddressesWithPorts("", opts.KubernetesValkeyServiceNamespace, opts.KubernetesValkeyServiceName)
 		log.Debugf("Valkey updater called and found %d valkey endpoints: %v", len(a), a)
 		m.UpdateGauge("valkey_endpoints", float64(len(a)))
 
 		result := ValkeyEndpoints{
 			Endpoints: make([]ValkeyEndpoint, len(a)),
 		}
-		port := strconv.Itoa(opts.KubernetesValkeyServicePort)
-		for i := range a {
-			result.Endpoints[i].Address = net.JoinHostPort(a[i], port)
+		// If no addresses with ports, fall back to old method
+		if len(a) == 0 {
+			a = kdc.GetEndpointAddresses("", opts.KubernetesValkeyServiceNamespace, opts.KubernetesValkeyServiceName)
+			log.Debugf("Falling back to GetEndpointAddresses, found %d endpoints", len(a))
+			port := strconv.Itoa(opts.KubernetesValkeyServicePort)
+			for i := range a {
+				result.Endpoints[i].Address = net.JoinHostPort(a[i], port)
+			}
+		} else {
+			for i := range a {
+				result.Endpoints[i].Address = a[i]
+			}
 		}
 
 		data, err := json.Marshal(result)

--- a/skipper.go
+++ b/skipper.go
@@ -1601,17 +1601,25 @@ func getKubernetesAddrUpdater(kdc *kubernetes.Client, loaded bool, ns, name stri
 		// has polled the data once or kdc.GetEndpointAddresses should be blocking
 		// call to kubernetes API
 		return func() ([]string, error) {
-			a := kdc.GetEndpointAddresses("", ns, name)
-			log.Debugf("GetEndpointAddresses found %d redis/valkey endpoints", len(a))
-
-			return joinPort(a, port), nil
+			a := kdc.GetEndpointAddressesWithPorts("", ns, name)
+			log.Debugf("GetEndpointAddressesWithPorts found %d redis/valkey endpoints", len(a))
+			// If no addresses with ports, fall back to old method
+			if len(a) == 0 {
+				a = kdc.GetEndpointAddresses("", ns, name)
+				a = joinPort(a, port)
+			}
+			return a, nil
 		}
 	} else {
 		return func() ([]string, error) {
-			a, err := kdc.LoadEndpointAddresses("", ns, name)
-			log.Debugf("LoadEndpointAddresses found %d redis/valkey endpoints, err: %v", len(a), err)
-
-			return joinPort(a, port), err
+			a, err := kdc.LoadEndpointAddressesWithPorts("", ns, name)
+			log.Debugf("LoadEndpointAddressesWithPorts found %d redis/valkey endpoints, err: %v", len(a), err)
+			if err != nil || len(a) == 0 {
+				// Fall back to old method
+				a, err = kdc.LoadEndpointAddresses("", ns, name)
+				a = joinPort(a, port)
+			}
+			return a, err
 		}
 	}
 }

--- a/valkey_test.go
+++ b/valkey_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	stdlibhttptest "net/http/httptest"
 	"os"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -553,13 +554,21 @@ spec:
 
 func createValkeyEndpointsSpec(t *testing.T, addrs ...string) string {
 	t.Helper()
-	var addresses []map[string]any
+	var subsets []any
 	for _, addr := range addrs {
 		host, port, err := net.SplitHostPort(addr)
 		require.NoError(t, err)
-		require.Equal(t, "6379", port)
 
-		addresses = append(addresses, map[string]any{"ip": host})
+		portNumber, err := strconv.Atoi(port)
+		require.NoError(t, err)
+
+		subsets = append(subsets, map[string]any{
+			"addresses": []map[string]any{{"ip": host}},
+			"ports": []map[string]any{{
+				"port":     portNumber,
+				"protocol": "TCP",
+			}},
+		})
 	}
 
 	ep := map[string]any{
@@ -569,15 +578,7 @@ func createValkeyEndpointsSpec(t *testing.T, addrs ...string) string {
 			"name":      "valkey",
 			"namespace": "skipper",
 		},
-		"subsets": []any{
-			map[string]any{
-				"addresses": addresses,
-				"ports": []map[string]any{{
-					"port":     6379,
-					"protocol": "TCP",
-				}},
-			},
-		},
+		"subsets": subsets,
 	}
 
 	// JSON is a valid YAML


### PR DESCRIPTION
Updates readme.md instructing disable ryuk when running tests with Podman/Colima container runtimes and updates the test helpers from container IPs to host plus mapped ports so Podman/Colima on macOS can reach containers. Linux developers are not affected because Docker on Linux already supports this access pattern and tests continue to work the same way.

