### PR TITLE
auth: timeout OpenID config lookup

### DIFF
--- a/filters/auth/doc.go
+++ b/filters/auth/doc.go
@@ -218,8 +218,8 @@ Example response from the openid-configuration endpoint:
 
 Additionally, you can also pass CLI argument
 -oauth2-tokenintrospect-timeout=<OAuthTokenintrospectTimeout> to control the
-default timeout duration for OAuth validation request. The default
-tokenintrospect timeout is 2s.
+default timeout duration for OAuth validation and OpenID provider
+configuration requests. The default tokenintrospect timeout is 2s.
 
 All oauthTokenintrospection* filters will work on the tokenintrospect response.
 

--- a/filters/auth/jwt_validation.go
+++ b/filters/auth/jwt_validation.go
@@ -61,7 +61,7 @@ func (s *jwtValidationSpec) CreateFilter(args []interface{}) (filters.Filter, er
 
 	issuerURL := sargs[0]
 
-	cfg, err := getOpenIDConfig(issuerURL)
+	cfg, err := getOpenIDConfig(issuerURL, s.options)
 	if err != nil {
 		return nil, err
 	}

--- a/filters/auth/jwt_validation_test.go
+++ b/filters/auth/jwt_validation_test.go
@@ -313,3 +313,27 @@ func TestJWTValidationJwksError(t *testing.T) {
 	}*/
 
 }
+
+func TestJWTValidationOpenIDConfigTimeout(t *testing.T) {
+	issuerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != TokenIntrospectionConfigPath {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		<-r.Context().Done()
+	}))
+	defer issuerServer.Close()
+
+	spec := NewJwtValidationWithOptions(TokenintrospectionOptions{
+		Timeout: 50 * time.Millisecond,
+	})
+
+	start := time.Now()
+	_, err := spec.CreateFilter([]interface{}{issuerServer.URL})
+	if err == nil {
+		t.Fatal("expected OpenID config lookup to time out")
+	}
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("OpenID config lookup took too long: %v", elapsed)
+	}
+}

--- a/filters/auth/tokenintrospection.go
+++ b/filters/auth/tokenintrospection.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/net"
 )
 
 const (
@@ -33,6 +33,8 @@ const (
 
 	tokenintrospectionCacheKey   = "tokenintrospection"
 	TokenIntrospectionConfigPath = "/.well-known/openid-configuration"
+	openIDConfigSpanName         = "openid-config"
+	defaultOpenIDConfigTimeout   = 3 * time.Second
 )
 
 type TokenintrospectionOptions struct {
@@ -213,13 +215,23 @@ func newSecureOAuthTokenintrospectionFilter(typ roleCheckType, timeout time.Dura
 	}
 }
 
-func getOpenIDConfig(issuerURL string) (*openIDConfig, error) {
+func (o TokenintrospectionOptions) openIDConfigTimeout() time.Duration {
+	if o.Timeout > 0 {
+		return o.Timeout
+	}
+	return defaultOpenIDConfigTimeout
+}
+
+func getOpenIDConfig(issuerURL string, options TokenintrospectionOptions) (*openIDConfig, error) {
 	u, err := url.Parse(issuerURL + TokenIntrospectionConfigPath)
 	if err != nil {
 		return nil, err
 	}
 
-	rsp, err := http.Get(u.String())
+	cli := newOpenIDConfigClient(options)
+	defer cli.Close()
+
+	rsp, err := cli.Get(u.String())
 	if err != nil {
 		return nil, err
 	}
@@ -232,6 +244,27 @@ func getOpenIDConfig(issuerURL string) (*openIDConfig, error) {
 	var cfg openIDConfig
 	err = d.Decode(&cfg)
 	return &cfg, err
+}
+
+func newOpenIDConfigClient(o TokenintrospectionOptions) *net.Client {
+	if o.Tracer == nil {
+		o.Tracer = opentracing.NoopTracer{}
+	}
+	if o.MaxIdleConns <= 0 {
+		o.MaxIdleConns = defaultMaxIdleConns
+	}
+
+	timeout := o.openIDConfigTimeout()
+	return net.NewClient(net.Options{
+		Timeout:                 timeout,
+		ResponseHeaderTimeout:   timeout,
+		TLSHandshakeTimeout:     timeout,
+		MaxIdleConnsPerHost:     o.MaxIdleConns,
+		Tracer:                  o.Tracer,
+		OpentracingComponentTag: "skipper",
+		OpentracingSpanName:     openIDConfigSpanName,
+		OpentracingEventsByTag:  o.OpenTracingClientTraceByTag,
+	})
 }
 
 func (s *tokenIntrospectionSpec) Name() string {
@@ -284,7 +317,7 @@ func (s *tokenIntrospectionSpec) CreateFilter(args []interface{}) (filters.Filte
 		sargs = sargs[1:]
 	}
 
-	cfg, err := getOpenIDConfig(issuerURL)
+	cfg, err := getOpenIDConfig(issuerURL, s.options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add a timeout for OpenID provider configuration discovery, defaulting to 2s

Signed-off-by: Veronika Volokitina <v.volokitinaa@gmail.com>