### PR TITLE
Fix pipeline flakiness

### DIFF
--- a/net/valkey_test.go
+++ b/net/valkey_test.go
@@ -446,8 +446,6 @@ func TestValkeyClient(t *testing.T) {
 					t.Fatalf("Failed to create ring client: %v", err)
 				}
 			}
-			startedUpdater := time.Now()
-
 			defer func() {
 				if !cli.closed {
 					t.Error("Failed to close valkey ring client")
@@ -474,47 +472,6 @@ func TestValkeyClient(t *testing.T) {
 			if tt.options.Tracer != nil {
 				span := cli.StartSpan("test")
 				span.Finish()
-			}
-
-			if tt.options.Metrics != nil {
-				updater.update()
-				updater.update()
-				time.Sleep(2*cli.options.UpdateInterval - time.Since(startedUpdater))
-
-				if mock, ok := cli.metrics.(*metricstest.MockMetrics); ok {
-					mock.WithGauges(func(m map[string]float64) {
-						key := tt.options.MetricsPrefix + "shards"
-						if v, ok := m[key]; !ok {
-							t.Fatalf("Failed to get metric %q", key)
-						} else {
-							for k, v := range m {
-								t.Logf("metric %s: %v", k, v)
-							}
-							i := int(v)
-							if i != 2 {
-								t.Fatalf("Failed to get 2 shards, got: %d", i)
-							}
-						}
-					})
-
-					for range 15 {
-						a, err := updater.update()
-						if err != nil {
-							t.Fatalf("Failed to update list: %v", err)
-						}
-						t.Logf("updated: %v", a)
-						time.Sleep(cli.options.UpdateInterval)
-
-						mock.WithGauges(func(m map[string]float64) {
-							key := tt.options.MetricsPrefix + "shards"
-							if _, ok := m[key]; ok {
-								for k, v := range m {
-									t.Logf("metric %s: %v", k, v)
-								}
-							}
-						})
-					}
-				}
 			}
 
 			if tt.options.AddrUpdater != nil {
@@ -546,6 +503,50 @@ func TestValkeyClient(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValkeyClientMetricsUpdater(t *testing.T) {
+	valkeyAddr, done := valkeytest.NewTestValkey(t)
+	defer done()
+	valkeyAddr2, done2 := valkeytest.NewTestValkey(t)
+	defer done2()
+
+	updater := &addressUpdater{addrs: []string{valkeyAddr, valkeyAddr2}}
+	cli, err := NewValkeyRingClient(&ValkeyOptions{
+		Addrs:          []string{valkeyAddr},
+		AddrUpdater:    updater.update,
+		UpdateInterval: 100 * time.Millisecond,
+		Metrics:        &metricstest.MockMetrics{},
+		MetricsPrefix:  "skipper.valkey.",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create valkey ring client: %v", err)
+	}
+	defer cli.Close()
+
+	// Shift n so the goroutine's next tick returns 2 shards.
+	updater.update()
+	updater.update()
+
+	mock := cli.metrics.(*metricstest.MockMetrics)
+	key := "skipper.valkey.shards"
+
+	deadline := time.Now().Add(10 * cli.options.UpdateInterval)
+	var gotShards int
+	for time.Now().Before(deadline) {
+		mock.WithGauges(func(m map[string]float64) {
+			if v, ok := m[key]; ok {
+				gotShards = int(v)
+			}
+		})
+		if gotShards == 2 {
+			break
+		}
+		time.Sleep(cli.options.UpdateInterval / 2)
+	}
+	if gotShards != 2 {
+		t.Fatalf("Failed to observe 2 shards within deadline, got: %d", gotShards)
 	}
 }
 

--- a/proxy/fifo_backendtimeout_with_teeloopback_test.go
+++ b/proxy/fifo_backendtimeout_with_teeloopback_test.go
@@ -88,7 +88,7 @@ func TestBackendTimeoutWithSlowBodyWriterShadow(t *testing.T) {
 
 	N := 500 //500000
 	resCH := make(chan int, N)
-	client, closeClient := createClient(p, 80*time.Millisecond, 120*time.Millisecond)
+	client, closeClient := createClient(p, 500*time.Millisecond, 120*time.Millisecond)
 	defer closeClient()
 	sendRequests(t, N, p, client, resCH)
 	logFifoMetrics(t, mockMetrics)


### PR DESCRIPTION
# Description

Fixes two pre-existing flaky CI failures unrelated to the cache filter changes.

**`net`: `TestValkeyClient/With_metrics_and_AddrUpdater`**

The test used `time.Sleep(2*UpdateInterval - elapsed)` before asserting the shard count. On a loaded CI runner, `RingAvailable()` (a real network ping) takes >100ms, collapsing the sleep below one ticker period - both tick 1 and tick 2 fire before the assertion, leaving the metric at 1 shard instead of 2.

Fix: extract into a standalone `TestValkeyClientMetricsUpdater` with its own `addressUpdater` instance (eliminates shared-`n` coupling across sub-tests) and replace the sleep with a polling loop with a 10-interval deadline.

**`proxy`: `TestBackendTimeoutWithSlowBodyWriterShadow`**

The 80ms client timeout used for the final health-check is too tight when 500 goroutines are running under `-race` (2–5× slower). `TestBackendTimeoutWithSlowBodyShadow`, the passing sibling, uses 800ms. Widened to 500ms.