### PR TITLE
Add decompressRequest filter for handling compressed request body

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1104,6 +1104,28 @@ Example:
 * -> decompress() -> "https://www.example.org"
 ```
 
+### decompressRequest
+
+The filter, when executed on the request path, checks if the request entity is
+compressed by a supported algorithm (`gzip`, `deflate`, `br`, `zstd`). To decide, it
+checks the `Content-Encoding` header of the incoming request.
+
+When decompressing the request, it removes the `Content-Encoding` and the
+`Content-Length` headers, and the request body is wrapped with a streaming decoder so
+the backend receives the decompressed payload.
+
+If the encoding is not supported, the filter does not modify the request, but sets the
+`filter::decompress::not-possible` key in the state bag. If decompression initialization
+fails, it additionally sets the `filter::decompress::error` key with the error.
+
+The decompression happens in a streaming way, using only a small internal buffer.
+
+Example:
+
+```
+* -> decompressRequest() -> "https://www.example.org"
+```
+
 ### static
 
 Serves static content from the filesystem.

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -163,6 +163,7 @@ func Filters() []filters.Spec {
 		NewStatus(),
 		NewCompress(),
 		NewDecompress(),
+		NewDecompressRequest(),
 		NewHeaderToQuery(),
 		NewQueryToHeader(),
 		NewBackendTimeout(),

--- a/filters/builtin/decompressrequest.go
+++ b/filters/builtin/decompressrequest.go
@@ -1,0 +1,66 @@
+package builtin
+
+import (
+	"net/http"
+
+	"github.com/zalando/skipper/filters"
+)
+
+type decompressRequest struct{}
+
+// NewDecompressRequest creates a filter specification for the decompressRequest() filter.
+// The filter attempts to decompress the request body, if it was compressed
+// with any of deflate, gzip, br or zstd.
+//
+// If decompression is not possible, but the body is compressed, then it indicates it
+// with the "filter::decompress::not-possible" key in the state-bag. If the decompression
+// was attempted and failed to get initialized, it indicates it in addition with the
+// "filter::decompress::error" state-bag key, storing the error. Due to the streaming,
+// decompression may fail after all the filters were processed.
+//
+// The filter does not need any parameters.
+func NewDecompressRequest() filters.Spec {
+	return decompressRequest{}
+}
+
+func (d decompressRequest) Name() string { return filters.DecompressRequestName }
+
+func (d decompressRequest) CreateFilter([]interface{}) (filters.Filter, error) {
+	return d, nil
+}
+
+func (d decompressRequest) Response(filters.FilterContext) {}
+
+func (d decompressRequest) Request(ctx filters.FilterContext) {
+	req := ctx.Request()
+
+	encs := getEncodings(req.Header.Get("Content-Encoding"))
+	if len(encs) == 0 {
+		return
+	}
+
+	if !encodingsSupported(encs) {
+		ctx.StateBag()[DecompressionNotPossible] = true
+		return
+	}
+
+	req.Header.Del("Content-Encoding")
+	req.Header.Del("Content-Length")
+	req.ContentLength = -1
+
+	b, err := newDecodedBody(req.Body, encs)
+	if err != nil {
+		// we may have already sniffed from the request via the gzip.Reader
+		req.Body.Close()
+		req.Body = http.NoBody
+
+		sb := ctx.StateBag()
+		sb[DecompressionNotPossible] = true
+		sb[DecompressionError] = err
+
+		ctx.Logger().Errorf("Error while initializing request decompression: %v", err)
+		return
+	}
+
+	req.Body = b
+}

--- a/filters/builtin/decompressrequest_test.go
+++ b/filters/builtin/decompressrequest_test.go
@@ -1,0 +1,131 @@
+package builtin
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func gzipped(t *testing.T, payload string) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write([]byte(payload)); err != nil {
+		t.Fatalf("failed to write gzip data: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+	return &buf
+}
+
+func newDecompressRequestContext(t *testing.T, body io.Reader, encoding string) *filtertest.Context {
+	t.Helper()
+	req, err := http.NewRequest("POST", "http://example.com", body)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	if encoding != "" {
+		req.Header.Set("Content-Encoding", encoding)
+	}
+	return &filtertest.Context{
+		FRequest:  req,
+		FStateBag: make(map[string]interface{}),
+	}
+}
+
+func TestDecompressRequestGzip(t *testing.T) {
+	ctx := newDecompressRequestContext(t, gzipped(t, "test payload"), "gzip")
+
+	f, err := NewDecompressRequest().CreateFilter(nil)
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	f.Request(ctx)
+
+	if got := ctx.Request().Header.Get("Content-Encoding"); got != "" {
+		t.Errorf("expected Content-Encoding header to be removed, got: %q", got)
+	}
+	if ctx.Request().ContentLength != -1 {
+		t.Errorf("expected ContentLength to be -1, got: %d", ctx.Request().ContentLength)
+	}
+
+	got, err := io.ReadAll(ctx.Request().Body)
+	if err != nil {
+		t.Fatalf("failed to read decompressed body: %v", err)
+	}
+	if string(got) != "test payload" {
+		t.Errorf("expected decompressed body to be %q, got: %q", "test payload", string(got))
+	}
+
+	if _, ok := ctx.StateBag()[DecompressionNotPossible]; ok {
+		t.Error("did not expect DecompressionNotPossible to be set")
+	}
+}
+
+func TestDecompressRequestNoEncoding(t *testing.T) {
+	body := bytes.NewBufferString("plain")
+	ctx := newDecompressRequestContext(t, body, "")
+
+	f, err := NewDecompressRequest().CreateFilter(nil)
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	f.Request(ctx)
+
+	got, err := io.ReadAll(ctx.Request().Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if string(got) != "plain" {
+		t.Errorf("expected body unchanged, got: %q", string(got))
+	}
+	if _, ok := ctx.StateBag()[DecompressionNotPossible]; ok {
+		t.Error("did not expect DecompressionNotPossible to be set")
+	}
+}
+
+func TestDecompressRequestUnsupportedEncoding(t *testing.T) {
+	ctx := newDecompressRequestContext(t, bytes.NewBufferString("x"), "unsupported")
+
+	f, err := NewDecompressRequest().CreateFilter(nil)
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	f.Request(ctx)
+
+	if _, ok := ctx.StateBag()[DecompressionNotPossible]; !ok {
+		t.Error("expected DecompressionNotPossible to be set in state bag")
+	}
+	if got := ctx.Request().Header.Get("Content-Encoding"); got != "unsupported" {
+		t.Errorf("expected Content-Encoding to be preserved when unsupported, got: %q", got)
+	}
+}
+
+func TestDecompressRequestInvalidPayload(t *testing.T) {
+	// claim gzip but send non-gzip data; gzip.Reader.Reset will fail during init.
+	ctx := newDecompressRequestContext(t, bytes.NewBufferString("not gzip data"), "gzip")
+
+	f, err := NewDecompressRequest().CreateFilter(nil)
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	f.Request(ctx)
+
+	if _, ok := ctx.StateBag()[DecompressionNotPossible]; !ok {
+		t.Error("expected DecompressionNotPossible to be set on init error")
+	}
+	if _, ok := ctx.StateBag()[DecompressionError]; !ok {
+		t.Error("expected DecompressionError to be set on init error")
+	}
+}
+
+func TestDecompressRequestName(t *testing.T) {
+	if got := NewDecompressRequest().Name(); got != "decompressRequest" {
+		t.Errorf("unexpected filter name: %q", got)
+	}
+}

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -251,6 +251,7 @@ const (
 	StatusName                                 = "status"
 	CompressName                               = "compress"
 	DecompressName                             = "decompress"
+	DecompressRequestName                      = "decompressRequest"
 	SetQueryName                               = "setQuery"
 	DropQueryName                              = "dropQuery"
 	InlineContentName                          = "inlineContent"


### PR DESCRIPTION
## PR Description

### Add `decompressRequest` filter

Adds a new filter `decompressRequest()` that decompresses the request body on the request path, mirroring the existing `decompress()` filter that operates on response bodies.

#### Motivation

Skipper currently supports decompressing response bodies via the `decompress()` filter, but there is no equivalent for request bodies. Backends that don't natively understand compressed request payloads (e.g. clients sending `Content-Encoding: gzip` on `POST`/`PUT`) can't be transparently fronted by Skipper today. This filter closes that gap.

#### Changes

- New filter decompressrequest.go implementing `decompressRequest()`.
  - Reads the request's `Content-Encoding` header and streams the body through the appropriate decoder.
  - Supported encodings: `gzip`, `deflate`, `br`, `zstd` (reuses `newDecodedBody`, `getEncodings`, `encodingsSupported` from the existing `decompress` filter — no duplication of decoder logic or pools).
  - On success: removes `Content-Encoding` and `Content-Length` headers and sets `ContentLength = -1` so the request is sent to the backend as a streamed, decompressed body.
  - On unsupported encoding: leaves the request unmodified and sets `filter::decompress::not-possible` in the state bag.
  - On init failure: closes the body, replaces it with `http.NoBody`, sets both `filter::decompress::not-possible` and `filter::decompress::error` in the state bag, and logs the error. Same state-bag keys as `decompress()` for consistency.
- Registered the new spec in builtin.go and added the `DecompressRequestName` constant in filters.go.
- Tests in decompressrequest_test.go covering:
  - successful gzip decompression and header/`ContentLength` cleanup
  - request without `Content-Encoding` is passed through unchanged
  - unsupported encoding sets `DecompressionNotPossible` and preserves headers
  - invalid gzip payload sets both `DecompressionNotPossible` and `DecompressionError`
  - filter name
- Documentation entry added under filters.md.

#### Note

- The state-bag keys (`DecompressionNotPossible`, `DecompressionError`) are intentionally shared with `decompress()`; if you'd prefer request-specific keys to disambiguate, happy to split them.
