### PR TITLE
Feature: mtls support in httpclient - net.Client 

### DIFF
--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -45,7 +45,7 @@ type clientTraceTimeT int
 
 const clientTraceTime clientTraceTimeT = 1
 
-type certReloader struct {
+type CertReloader struct {
 	cert        atomic.Pointer[tls.Certificate]
 	sp          *secrets.SecretPaths
 	certFile    string
@@ -57,7 +57,12 @@ type certReloader struct {
 	log         logging.Logger
 }
 
-func newCertReloader(certFile, keyFile string, interval time.Duration, log logging.Logger) (*certReloader, error) {
+// NewCertReloader reads cert and key from provided files and starts
+// an update loop that every interval reads the files. If cert or
+// key changed and are valid it will swap the data, such that
+// GetClientCertificate returns the new rotated *tls.Certificate.
+// You have to use Close() in order to not leak a goroutine.
+func NewCertReloader(certFile, keyFile string, interval time.Duration, log logging.Logger) (*CertReloader, error) {
 	sp := secrets.NewSecretPaths(interval)
 	if err := sp.Add(certFile); err != nil {
 		sp.Close()
@@ -82,7 +87,7 @@ func newCertReloader(certFile, keyFile string, interval time.Duration, log loggi
 		sp.Close()
 		return nil, fmt.Errorf("initial key pair: %w", err)
 	}
-	cr := &certReloader{
+	cr := &CertReloader{
 		sp:          sp,
 		certFile:    certFile,
 		keyFile:     keyFile,
@@ -96,7 +101,7 @@ func newCertReloader(certFile, keyFile string, interval time.Duration, log loggi
 	return cr, nil
 }
 
-func (cr *certReloader) refreshLoop(interval time.Duration) {
+func (cr *CertReloader) refreshLoop(interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -109,7 +114,7 @@ func (cr *certReloader) refreshLoop(interval time.Duration) {
 	}
 }
 
-func (cr *certReloader) reload() {
+func (cr *CertReloader) reload() {
 	certPEM, certOK := cr.sp.GetSecret(cr.certFile)
 	keyPEM, keyOK := cr.sp.GetSecret(cr.keyFile)
 	if !certOK || !keyOK {
@@ -125,14 +130,18 @@ func (cr *certReloader) reload() {
 	}
 	cr.lastCertPEM = certPEM
 	cr.lastKeyPEM = keyPEM
+	cr.log.Info("certReloader: updated cert")
 	cr.cert.Store(&cert)
 }
 
-func (cr *certReloader) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+// GetClientCertificate returns the tls.Certificate and can be used as
+// tls.Config.GetClientCertificate to get rotated client certs.
+func (cr *CertReloader) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 	return cr.cert.Load(), nil
 }
 
-func (cr *certReloader) Close() {
+// Close stops all background goroutines.
+func (cr *CertReloader) Close() {
 	cr.once.Do(func() {
 		close(cr.quit)
 		cr.sp.Close()
@@ -147,7 +156,7 @@ type Client struct {
 	client http.Client
 	tr     *Transport
 	sr     secrets.SecretsReader
-	cr     *certReloader
+	cr     *CertReloader
 }
 
 // NewClient creates a wrapped http.Client and uses Transport to
@@ -177,7 +186,7 @@ func NewClient(o Options) *Client {
 		sr = secrets.NewStaticDelegateSecret(sp, o.BearerTokenFile)
 	}
 
-	var cr *certReloader
+	var cr *CertReloader
 	if o.CertFile != "" && o.KeyFile != "" && o.Transport == nil {
 		if o.CertRefreshInterval == 0 {
 			if o.BearerTokenRefreshInterval != 0 {
@@ -187,7 +196,7 @@ func NewClient(o Options) *Client {
 			}
 		}
 		var err error
-		cr, err = newCertReloader(o.CertFile, o.KeyFile, o.CertRefreshInterval, o.Log)
+		cr, err = NewCertReloader(o.CertFile, o.KeyFile, o.CertRefreshInterval, o.Log)
 		if err != nil {
 			o.Log.Errorf("Failed to initialize cert reloader: %v", err)
 		} else {

--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -1,8 +1,10 @@
 package net
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -42,6 +45,100 @@ type clientTraceTimeT int
 
 const clientTraceTime clientTraceTimeT = 1
 
+type certReloader struct {
+	cert        atomic.Pointer[tls.Certificate]
+	sp          *secrets.SecretPaths
+	certFile    string
+	keyFile     string
+	lastCertPEM []byte
+	lastKeyPEM  []byte
+	quit        chan struct{}
+	once        sync.Once
+	log         logging.Logger
+}
+
+func newCertReloader(certFile, keyFile string, interval time.Duration, log logging.Logger) (*certReloader, error) {
+	sp := secrets.NewSecretPaths(interval)
+	if err := sp.Add(certFile); err != nil {
+		sp.Close()
+		return nil, fmt.Errorf("cert file: %w", err)
+	}
+	if err := sp.Add(keyFile); err != nil {
+		sp.Close()
+		return nil, fmt.Errorf("key file: %w", err)
+	}
+	certPEM, ok := sp.GetSecret(certFile)
+	if !ok {
+		sp.Close()
+		return nil, fmt.Errorf("cert file not found: %s", certFile)
+	}
+	keyPEM, ok := sp.GetSecret(keyFile)
+	if !ok {
+		sp.Close()
+		return nil, fmt.Errorf("key file not found: %s", keyFile)
+	}
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		sp.Close()
+		return nil, fmt.Errorf("initial key pair: %w", err)
+	}
+	cr := &certReloader{
+		sp:          sp,
+		certFile:    certFile,
+		keyFile:     keyFile,
+		lastCertPEM: certPEM,
+		lastKeyPEM:  keyPEM,
+		quit:        make(chan struct{}),
+		log:         log,
+	}
+	cr.cert.Store(&cert)
+	go cr.refreshLoop(interval)
+	return cr, nil
+}
+
+func (cr *certReloader) refreshLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			cr.reload()
+		case <-cr.quit:
+			return
+		}
+	}
+}
+
+func (cr *certReloader) reload() {
+	certPEM, certOK := cr.sp.GetSecret(cr.certFile)
+	keyPEM, keyOK := cr.sp.GetSecret(cr.keyFile)
+	if !certOK || !keyOK {
+		return
+	}
+	if bytes.Equal(certPEM, cr.lastCertPEM) && bytes.Equal(keyPEM, cr.lastKeyPEM) {
+		return
+	}
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		cr.log.Errorf("certReloader: Failed to parse key pair: %v", err)
+		return
+	}
+	cr.lastCertPEM = certPEM
+	cr.lastKeyPEM = keyPEM
+	cr.cert.Store(&cert)
+}
+
+func (cr *certReloader) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return cr.cert.Load(), nil
+}
+
+func (cr *certReloader) Close() {
+	cr.once.Do(func() {
+		close(cr.quit)
+		cr.sp.Close()
+	})
+}
+
 // Client adds additional features like Bearer token injection, and
 // opentracing to the wrapped http.Client with the same interface as
 // http.Client from the stdlib.
@@ -50,6 +147,7 @@ type Client struct {
 	client http.Client
 	tr     *Transport
 	sr     secrets.SecretsReader
+	cr     *certReloader
 }
 
 // NewClient creates a wrapped http.Client and uses Transport to
@@ -74,9 +172,30 @@ func NewClient(o Options) *Client {
 		}
 		sp := secrets.NewSecretPaths(o.BearerTokenRefreshInterval)
 		if err := sp.Add(o.BearerTokenFile); err != nil {
-			o.Log.Errorf("failed to read secret: %v", err)
+			o.Log.Errorf("Failed to read secret: %v", err)
 		}
 		sr = secrets.NewStaticDelegateSecret(sp, o.BearerTokenFile)
+	}
+
+	var cr *certReloader
+	if o.CertFile != "" && o.KeyFile != "" && o.Transport == nil {
+		if o.CertRefreshInterval == 0 {
+			if o.BearerTokenRefreshInterval != 0 {
+				o.CertRefreshInterval = o.BearerTokenRefreshInterval
+			} else {
+				o.CertRefreshInterval = defaultRefreshInterval
+			}
+		}
+		var err error
+		cr, err = newCertReloader(o.CertFile, o.KeyFile, o.CertRefreshInterval, o.Log)
+		if err != nil {
+			o.Log.Errorf("Failed to initialize cert reloader: %v", err)
+		} else {
+			tr.tr.TLSClientConfig = &tls.Config{
+				RootCAs:              o.RootCAs,
+				GetClientCertificate: cr.GetClientCertificate,
+			}
+		}
 	}
 
 	c := &Client{
@@ -88,6 +207,7 @@ func NewClient(o Options) *Client {
 		},
 		tr: tr,
 		sr: sr,
+		cr: cr,
 	}
 
 	return c
@@ -98,6 +218,9 @@ func (c *Client) Close() {
 		c.tr.Close()
 		if c.sr != nil {
 			c.sr.Close()
+		}
+		if c.cr != nil {
+			c.cr.Close()
 		}
 	})
 }
@@ -228,6 +351,18 @@ type Options struct {
 	BearerTokenRefreshInterval time.Duration
 	// SecretsReader is used to read and refresh bearer tokens
 	SecretsReader secrets.SecretsReader
+
+	// CertFile is the path to a PEM-encoded client certificate for mTLS.
+	// Must be set together with KeyFile. Ignored when Transport is non-nil.
+	CertFile string
+	// KeyFile is the path to a PEM-encoded private key for mTLS.
+	// Must be set together with CertFile. Ignored when Transport is non-nil.
+	KeyFile string
+	// CertRefreshInterval is how often CertFile/KeyFile are re-read.
+	// Defaults to BearerTokenRefreshInterval, or 5 minutes if both are zero.
+	CertRefreshInterval time.Duration
+	// RootCAs to pass as part of the TLSClientConfig to the underlying http.Transport
+	RootCAs *x509.CertPool
 
 	// Log is used for error logging
 	Log logging.Logger

--- a/net/httpclient_example_test.go
+++ b/net/httpclient_example_test.go
@@ -1,11 +1,20 @@
 package net_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"log"
+	"math/big"
 	stdlibnet "net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"time"
 
 	"github.com/lightstep/lightstep-tracer-go"
@@ -398,4 +407,288 @@ func ExampleClient_withAfterResponseHook() {
 	// Output:
 	// response code: 255
 	// span status.code: 200
+}
+
+func ExampleClient_withMtlsCertRotation() {
+	now := time.Now()
+	caPEM, caKeyPEM, caCert, caKey := generateCert(certOptions{
+		cn:        "Test Master Root CA and server cert",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(24 * time.Hour),
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+	})
+
+	opts := certOptions{
+		cn:        "localhost",
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+		notBefore: now.Add(-2 * time.Hour),
+		notAfter:  now.Add(1 * time.Hour),
+		extKeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		signerCert: caCert,
+		signerKey:  caKey,
+	}
+	clientCertPEM, clientKeyPEM, _, _ := generateCert(opts)
+
+	// Setup trust pools
+	serverClientCAs := x509.NewCertPool()
+	serverClientCAs.AppendCertsFromPEM(caPEM) // Server only trusts master CA
+
+	clientRootCAs := x509.NewCertPool()
+	clientRootCAs.AppendCertsFromPEM(caPEM)
+
+	// Setup Test Server
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	serverCert, err := tls.X509KeyPair(caPEM, caKeyPEM)
+	if err != nil {
+		log.Fatalf("failed to prepare server cert: %v", err)
+	}
+
+	srv.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    serverClientCAs,
+		Certificates: []tls.Certificate{serverCert},
+
+		// Explicitly enforce client SAN validation at the TLS layer
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if len(verifiedChains) > 0 && len(verifiedChains[0]) > 0 {
+				clientCert := verifiedChains[0][0]
+				// Reject the client if it has not the expected IP SAN
+				allowedIP := stdlibnet.ParseIP("127.0.0.1")
+				fail := true
+				for _, ipadrr := range clientCert.IPAddresses {
+					if ipadrr.Equal(allowedIP) {
+						fail = false
+						break
+					}
+				}
+				if fail {
+					return fmt.Errorf("mTLS authentication failed: client certificate SAN extension should contain expected IP 127.0.0.1")
+				}
+			}
+			return nil
+		},
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	certFile, keyFile, cleanUp := writeTempCertFiles(clientCertPEM, clientKeyPEM)
+	defer cleanUp()
+
+	//
+	// the Client will create a CertReloader and TLSClientConfig
+	//
+	cli := net.NewClient(net.Options{
+		CertFile:            certFile,
+		KeyFile:             keyFile,
+		CertRefreshInterval: 10 * time.Millisecond,
+		RootCAs:             clientRootCAs,
+	})
+	defer cli.Close() // do not leak goroutines
+
+	rsp, err := cli.Get(srv.URL)
+	if err != nil {
+		log.Fatalf("mTLS request failed unexpectedly: %v", err)
+	}
+	rsp.Body.Close()
+
+	fmt.Printf("response code: %d\n", rsp.StatusCode)
+
+	// renew expired cert
+	certPEM1, keyPEM1, _, _ := generateCert(certOptions{
+		cn:        "localhost",
+		notBefore: now.Add(-2 * time.Hour),
+		notAfter:  now.Add(-1 * time.Hour), // expired
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+		extKeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		signerCert: caCert,
+		signerKey:  caKey,
+	})
+	certFile1, keyFile1, cleanUp1 := writeTempCertFiles(certPEM1, keyPEM1)
+	defer cleanUp1()
+	os.Rename(certFile1, certFile)
+	os.Rename(keyFile1, keyFile)
+	cli.CloseIdleConnections()
+
+	time.Sleep(50 * time.Millisecond)
+
+	rsp, err = cli.Get(srv.URL)
+	if err == nil {
+		log.Fatal("mTLS request should be rejected")
+	} else {
+		fmt.Printf("Failed as expected\n")
+	}
+
+	// renew cert not matching SAN IP
+	certPEM2, keyPEM2, _, _ := generateCert(certOptions{
+		cn:        "localhost",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(1 * time.Hour),
+		dns:       "localhost",
+		ip:        "10.0.0.1", // unknown IP
+		extKeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		signerCert: caCert,
+		signerKey:  caKey,
+	})
+	certFile2, keyFile2, cleanUp2 := writeTempCertFiles(certPEM2, keyPEM2)
+	defer cleanUp2()
+	os.Rename(certFile2, certFile)
+	os.Rename(keyFile2, keyFile)
+	cli.CloseIdleConnections()
+
+	time.Sleep(50 * time.Millisecond)
+
+	rsp, err = cli.Get(srv.URL)
+	if err == nil {
+		log.Fatal("mTLS request should be rejected")
+	} else {
+		fmt.Printf("Failed as expected\n")
+	}
+
+	// renew cert good cert
+	certPEM3, keyPEM3, _, _ := generateCert(certOptions{
+		cn:        "localhost",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(1 * time.Hour),
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+		extKeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		signerCert: caCert,
+		signerKey:  caKey,
+	})
+	certFile3, keyFile3, cleanUp3 := writeTempCertFiles(certPEM3, keyPEM3)
+	defer cleanUp3()
+	os.Rename(certFile3, certFile)
+	os.Rename(keyFile3, keyFile)
+	cli.CloseIdleConnections()
+
+	time.Sleep(50 * time.Millisecond)
+
+	rsp, err = cli.Get(srv.URL)
+	if err != nil {
+		log.Fatalf("mTLS request failed unexpectedly: %v", err)
+	}
+	rsp.Body.Close()
+
+	fmt.Printf("response code: %d\n", rsp.StatusCode)
+
+	// Output:
+	// response code: 200
+	// Failed as expected
+	// Failed as expected
+	// response code: 200
+
+}
+
+type certOptions struct {
+	cn           string
+	dns          string
+	ip           string
+	notBefore    time.Time
+	notAfter     time.Time
+	extKeyUsages []x509.ExtKeyUsage
+	signerCert   *x509.Certificate // If nil, certificate will be self-signed
+	signerKey    *ecdsa.PrivateKey
+}
+
+func generateCert(opts certOptions) (certPEM, keyPEM []byte, parsedCert *x509.Certificate, privateKey *ecdsa.PrivateKey) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		log.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: opts.cn},
+		NotBefore:    opts.notBefore,
+		NotAfter:     opts.notAfter,
+
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           opts.extKeyUsages,
+		BasicConstraintsValid: true,
+	}
+
+	// SAN DNS
+	if opts.dns != "" {
+		template.DNSNames = []string{opts.dns}
+	}
+	// SAN IP
+	if opts.ip != "" {
+		if ip := stdlibnet.ParseIP(opts.ip); ip != nil {
+			template.IPAddresses = []stdlibnet.IP{ip}
+		}
+	}
+
+	signingTemplate := template
+	signingKey := privateKey
+
+	// If a separate signer CA is provided, use it instead of self-signing
+	if opts.signerCert != nil && opts.signerKey != nil {
+		signingTemplate = opts.signerCert
+		signingKey = opts.signerKey
+	} else {
+		// If self-signed, act as a CA so it can be added to RootCAs pools
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, signingTemplate, &privateKey.PublicKey, signingKey)
+	if err != nil {
+		log.Fatalf("failed to create certificate: %v", err)
+	}
+
+	parsedCert, err = x509.ParseCertificate(certDER)
+	if err != nil {
+		log.Fatalf("failed to parse generated certificate: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		log.Fatalf("failed to marshal key: %v", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return
+}
+
+func writeTempCertFiles(cert, key []byte) (string, string, func()) {
+	cFile, err := os.CreateTemp("", "client-cert-*.crt")
+	if err != nil {
+		log.Fatalf("failed to create temp cert file: %v", err)
+	}
+	kFile, err := os.CreateTemp("", "client-key-*.key")
+	if err != nil {
+		log.Fatalf("failed to create temp key file: %v", err)
+	}
+
+	if err := os.WriteFile(cFile.Name(), cert, 0644); err != nil {
+		log.Fatalf("failed to write temp cert: %v", err)
+	}
+	if err := os.WriteFile(kFile.Name(), key, 0600); err != nil {
+		log.Fatalf("failed to write temp key: %v", err)
+	}
+
+	return cFile.Name(), kFile.Name(), func() {
+		_ = os.Remove(cFile.Name())
+		_ = os.Remove(kFile.Name())
+	}
 }

--- a/net/httpclient_test.go
+++ b/net/httpclient_test.go
@@ -2,8 +2,17 @@ package net
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
@@ -11,12 +20,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/AlexanderYastrebov/noleak"
 	"github.com/google/go-cmp/cmp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/zalando/skipper/logging"
 	"github.com/zalando/skipper/secrets"
 	"github.com/zalando/skipper/tracing/tracers/basic"
 	"github.com/zalando/skipper/tracing/tracingtest"
@@ -501,5 +512,220 @@ func verifyTagHasNonZeroValue(t *testing.T, span *tracingtest.MockSpan, name str
 	t.Helper()
 	if got := span.Tag(name); got != nil && got != "" {
 		t.Errorf("unexpected %q tag value: %q", name, got)
+	}
+}
+
+func generateTestCert(t *testing.T, cn, dns, ip string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+
+		// SAN
+		IPAddresses: []net.IP{net.ParseIP(ip)},
+		DNSNames:    []string{dns},
+
+		// KeyUsage and ExtKeyUsage configurations
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		// FIX: Include BOTH ServerAuth and ClientAuth roles
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return
+}
+
+func writeTempCertFiles(t *testing.T, certPEM, keyPEM []byte) (certFile, keyFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "tls.crt")
+	keyFile = filepath.Join(dir, "tls.key")
+	if err := os.WriteFile(certFile, certPEM, 0600); err != nil {
+		t.Fatalf("failed to write cert file: %v", err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	return
+}
+
+func TestCertReloader(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+	certFile, keyFile := writeTempCertFiles(t, certPEM, keyPEM)
+
+	for _, tt := range []struct {
+		name     string
+		certFile string
+		keyFile  string
+		wantErr  bool
+	}{
+		{
+			name:     "valid cert and key loads successfully",
+			certFile: certFile,
+			keyFile:  keyFile,
+		},
+		{
+			name:     "missing cert file returns error",
+			certFile: "/nonexistent/cert.pem",
+			keyFile:  keyFile,
+			wantErr:  true,
+		},
+		{
+			name:     "missing key file returns error",
+			certFile: certFile,
+			keyFile:  "/nonexistent/key.pem",
+			wantErr:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cr, err := newCertReloader(tt.certFile, tt.keyFile, 50*time.Millisecond, &logging.DefaultLog{})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			defer cr.Close()
+			if cr.cert.Load() == nil {
+				t.Fatal("cert not loaded after construction")
+			}
+		})
+	}
+}
+
+func TestCertReloaderRotation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		certPEM1, keyPEM1 := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+		certFile, keyFile := writeTempCertFiles(t, certPEM1, keyPEM1)
+
+		cr, err := newCertReloader(certFile, keyFile, 20*time.Millisecond, &logging.DefaultLog{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer cr.Close()
+
+		initial := cr.cert.Load()
+
+		certPEM2, keyPEM2 := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+		if err := os.WriteFile(certFile, certPEM2, 0600); err != nil {
+			t.Fatalf("failed to update cert file: %v", err)
+		}
+		if err := os.WriteFile(keyFile, keyPEM2, 0600); err != nil {
+			t.Fatalf("failed to update key file: %v", err)
+		}
+
+		time.Sleep(200 * time.Millisecond)
+
+		updated := cr.cert.Load()
+		if initial == updated {
+			t.Fatal("cert pointer did not change after file rotation")
+		}
+	})
+}
+
+func TestClientMTLSNoLeak(t *testing.T) {
+	noleak.Check(t)
+
+	certPEM, keyPEM := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+	certFile, keyFile := writeTempCertFiles(t, certPEM, keyPEM)
+
+	cli := NewClient(Options{
+		CertFile:            certFile,
+		KeyFile:             keyFile,
+		CertRefreshInterval: 50 * time.Millisecond,
+	})
+	cli.Close()
+}
+
+func TestClientMTLS(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		cn      string
+		dns     string
+		ip      string
+		wantErr bool
+	}{
+		{
+			name:    "SAN ok success",
+			cn:      "localhost",
+			dns:     "localhost",
+			ip:      "127.0.0.1",
+			wantErr: false,
+		},
+		{
+			name:    "SAN ok no success",
+			cn:      "localhost2",
+			dns:     "localhost2",
+			ip:      "127.0.0.2",
+			wantErr: true,
+		},
+	} {
+
+		t.Run(tt.name, func(t *testing.T) {
+			certPEM, keyPEM := generateTestCert(t, tt.cn, tt.dns, tt.ip)
+			clientCert, err := tls.X509KeyPair(certPEM, keyPEM)
+			if err != nil {
+				t.Fatalf("failed to parse client cert: %v", err)
+			}
+			certFile, keyFile := writeTempCertFiles(t, certPEM, keyPEM)
+
+			rootCAs, err := x509.SystemCertPool()
+			if err != nil {
+				t.Fatalf("Failed to get system cert pool: %v", err)
+			}
+			rootCAs.AppendCertsFromPEM(certPEM)
+
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			srv.TLS = &tls.Config{
+				ClientAuth:   tls.RequireAndVerifyClientCert, // RequireAnyClientCert
+				ClientCAs:    rootCAs,
+				Certificates: []tls.Certificate{clientCert},
+			}
+			srv.StartTLS()
+			defer srv.Close()
+
+			cli := NewClient(Options{
+				CertFile:            certFile,
+				KeyFile:             keyFile,
+				CertRefreshInterval: 50 * time.Millisecond,
+				RootCAs:             rootCAs,
+			})
+			defer cli.Close()
+
+			rsp, err := cli.Get(srv.URL)
+			if err != nil {
+				if tt.wantErr {
+					t.Logf("mTLS successful denied: %v", err)
+					return
+				}
+				t.Fatalf("mTLS request failed: %v", err)
+			}
+			rsp.Body.Close()
+			if rsp.StatusCode != http.StatusOK {
+				t.Errorf("unexpected status: %d", rsp.StatusCode)
+			}
+		})
 	}
 }

--- a/net/httpclient_test.go
+++ b/net/httpclient_test.go
@@ -515,59 +515,16 @@ func verifyTagHasNonZeroValue(t *testing.T, span *tracingtest.MockSpan, name str
 	}
 }
 
-func generateTestCert(t *testing.T, cn, dns, ip string) (certPEM, keyPEM []byte) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("failed to generate key: %v", err)
-	}
-	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: cn},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-
-		// SAN
-		IPAddresses: []net.IP{net.ParseIP(ip)},
-		DNSNames:    []string{dns},
-
-		// KeyUsage and ExtKeyUsage configurations
-		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		// FIX: Include BOTH ServerAuth and ClientAuth roles
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageServerAuth,
-			x509.ExtKeyUsageClientAuth,
-		},
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
-	if err != nil {
-		t.Fatalf("failed to create certificate: %v", err)
-	}
-	keyDER, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		t.Fatalf("failed to marshal key: %v", err)
-	}
-	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-	return
-}
-
-func writeTempCertFiles(t *testing.T, certPEM, keyPEM []byte) (certFile, keyFile string) {
-	t.Helper()
-	dir := t.TempDir()
-	certFile = filepath.Join(dir, "tls.crt")
-	keyFile = filepath.Join(dir, "tls.key")
-	if err := os.WriteFile(certFile, certPEM, 0600); err != nil {
-		t.Fatalf("failed to write cert file: %v", err)
-	}
-	if err := os.WriteFile(keyFile, keyPEM, 0600); err != nil {
-		t.Fatalf("failed to write key file: %v", err)
-	}
-	return
-}
-
+// 3. Dynamic Operational Security - cert loading
 func TestCertReloader(t *testing.T) {
-	certPEM, keyPEM := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+	now := time.Now()
+	certPEM, keyPEM, _, _ := generateCert(t, certOptions{
+		cn:        "localhost",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(24 * time.Hour),
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+	})
 	certFile, keyFile := writeTempCertFiles(t, certPEM, keyPEM)
 
 	for _, tt := range []struct {
@@ -595,7 +552,7 @@ func TestCertReloader(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			cr, err := newCertReloader(tt.certFile, tt.keyFile, 50*time.Millisecond, &logging.DefaultLog{})
+			cr, err := NewCertReloader(tt.certFile, tt.keyFile, 50*time.Millisecond, &logging.DefaultLog{})
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -613,12 +570,20 @@ func TestCertReloader(t *testing.T) {
 	}
 }
 
+// 3. Dynamic Operational Security - rotation
 func TestCertReloaderRotation(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		certPEM1, keyPEM1 := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+		now := time.Now()
+		certPEM1, keyPEM1, _, _ := generateCert(t, certOptions{
+			cn:        "localhost",
+			notBefore: now.Add(-1 * time.Hour),
+			notAfter:  now.Add(24 * time.Hour),
+			dns:       "localhost",
+			ip:        "127.0.0.1",
+		})
 		certFile, keyFile := writeTempCertFiles(t, certPEM1, keyPEM1)
 
-		cr, err := newCertReloader(certFile, keyFile, 20*time.Millisecond, &logging.DefaultLog{})
+		cr, err := NewCertReloader(certFile, keyFile, 20*time.Millisecond, &logging.DefaultLog{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -626,7 +591,13 @@ func TestCertReloaderRotation(t *testing.T) {
 
 		initial := cr.cert.Load()
 
-		certPEM2, keyPEM2 := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+		certPEM2, keyPEM2, _, _ := generateCert(t, certOptions{
+			cn:        "localhost",
+			notBefore: now.Add(-1 * time.Hour),
+			notAfter:  now.Add(24 * time.Hour),
+			dns:       "localhost",
+			ip:        "127.0.0.1",
+		})
 		if err := os.WriteFile(certFile, certPEM2, 0600); err != nil {
 			t.Fatalf("failed to update cert file: %v", err)
 		}
@@ -645,8 +616,14 @@ func TestCertReloaderRotation(t *testing.T) {
 
 func TestClientMTLSNoLeak(t *testing.T) {
 	noleak.Check(t)
-
-	certPEM, keyPEM := generateTestCert(t, "localhost", "localhost", "127.0.0.1")
+	now := time.Now()
+	certPEM, keyPEM, _, _ := generateCert(t, certOptions{
+		cn:        "localhost",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(24 * time.Hour),
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+	})
 	certFile, keyFile := writeTempCertFiles(t, certPEM, keyPEM)
 
 	cli := NewClient(Options{
@@ -682,7 +659,14 @@ func TestClientMTLS(t *testing.T) {
 	} {
 
 		t.Run(tt.name, func(t *testing.T) {
-			certPEM, keyPEM := generateTestCert(t, tt.cn, tt.dns, tt.ip)
+			now := time.Now()
+			certPEM, keyPEM, _, _ := generateCert(t, certOptions{
+				cn:        tt.cn,
+				notBefore: now.Add(-1 * time.Hour),
+				notAfter:  now.Add(24 * time.Hour),
+				dns:       tt.dns,
+				ip:        tt.ip,
+			})
 			clientCert, err := tls.X509KeyPair(certPEM, keyPEM)
 			if err != nil {
 				t.Fatalf("failed to parse client cert: %v", err)
@@ -728,4 +712,360 @@ func TestClientMTLS(t *testing.T) {
 			}
 		})
 	}
+}
+
+type certOptions struct {
+	cn           string
+	dns          string
+	ip           string
+	notBefore    time.Time
+	notAfter     time.Time
+	extKeyUsages []x509.ExtKeyUsage
+	signerCert   *x509.Certificate // If nil, certificate will be self-signed
+	signerKey    *ecdsa.PrivateKey
+}
+
+// generateCert handles creating customized test certificates based on options
+func generateCert(t *testing.T, opts certOptions) (certPEM, keyPEM []byte, parsedCert *x509.Certificate, privateKey *ecdsa.PrivateKey) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: opts.cn},
+		NotBefore:    opts.notBefore,
+		NotAfter:     opts.notAfter,
+
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           opts.extKeyUsages,
+		BasicConstraintsValid: true,
+	}
+
+	// SAN DNS
+	if opts.dns != "" {
+		template.DNSNames = []string{opts.dns}
+	}
+	// SAN IP
+	if opts.ip != "" {
+		if ip := net.ParseIP(opts.ip); ip != nil {
+			template.IPAddresses = []net.IP{ip}
+		}
+	}
+
+	signingTemplate := template
+	signingKey := privateKey
+
+	// If a separate signer CA is provided, use it instead of self-signing
+	if opts.signerCert != nil && opts.signerKey != nil {
+		signingTemplate = opts.signerCert
+		signingKey = opts.signerKey
+	} else {
+		// If self-signed, act as a CA so it can be added to RootCAs pools
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, signingTemplate, &privateKey.PublicKey, signingKey)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	parsedCert, err = x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("failed to parse generated certificate: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return
+}
+
+// 1. Trust & Authority Boundaries (Adversarial Tests)
+// 2. Certificate Lifecycle & Cryptographic Constraints
+// 4. Protocol Hardening
+func TestClientMTLS_SecurityAndHardening(t *testing.T) {
+	now := time.Now()
+	caPEM, caKeyPEM, caCert, caKey := generateCert(t, certOptions{
+		cn:        "Test Master Root CA",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(24 * time.Hour),
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+	})
+
+	for _, tt := range []struct {
+		name              string
+		modifyOptions     func(opts *certOptions)
+		serverMinTLS      uint16
+		bypassClientCerts bool
+		wantErr           bool
+	}{
+		{
+			name: "Untrusted Rogue Client CA must be denied",
+			modifyOptions: func(opts *certOptions) {
+				// Break relationship to Master CA: make it self-signed by a random rogue CA
+				opts.signerCert = nil
+				opts.signerKey = nil
+			},
+			wantErr: true,
+		},
+		{
+			name:              "Anonymous Client (Missing Cert) must be denied",
+			bypassClientCerts: true,
+			wantErr:           true,
+		},
+		{
+			name: "Expired Client Certificate must be denied",
+			modifyOptions: func(opts *certOptions) {
+				opts.notBefore = now.Add(-5 * time.Hour)
+				opts.notAfter = now.Add(-1 * time.Hour) // expired
+			},
+			wantErr: true,
+		},
+		{
+			name: "Future Client Certificate must be denied",
+			modifyOptions: func(opts *certOptions) {
+				opts.notBefore = now.Add(1 * time.Hour) // valid in the future
+				opts.notAfter = now.Add(5 * time.Hour)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Incompatible Key Usage (Missing ClientAuth) must be denied",
+			modifyOptions: func(opts *certOptions) {
+				// ServerAuth only, missing ClientAuth role
+				opts.extKeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing SAN (DNS/IP)",
+			modifyOptions: func(opts *certOptions) {
+				opts.ip = ""
+				opts.dns = ""
+			},
+			serverMinTLS: tls.VersionTLS13, // Force server to demand modern TLS 1.3
+			wantErr:      true,
+		},
+		{
+			name:         "Protocol Hardening - Secure negotiation on TLS 1.3 works",
+			serverMinTLS: tls.VersionTLS13, // Force server to demand modern TLS 1.3
+			wantErr:      false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Default valid options signed by our trusted Master CA
+			opts := certOptions{
+				cn:        "localhost",
+				dns:       "localhost",
+				ip:        "127.0.0.1",
+				notBefore: now.Add(-1 * time.Hour),
+				notAfter:  now.Add(1 * time.Hour),
+				extKeyUsages: []x509.ExtKeyUsage{
+					x509.ExtKeyUsageServerAuth,
+					x509.ExtKeyUsageClientAuth,
+				},
+				signerCert: caCert,
+				signerKey:  caKey,
+			}
+
+			if tt.modifyOptions != nil {
+				tt.modifyOptions(&opts)
+			}
+
+			clientCertPEM, clientKeyPEM, _, _ := generateCert(t, opts)
+
+			// Setup trust pools
+			serverClientCAs := x509.NewCertPool()
+			serverClientCAs.AppendCertsFromPEM(caPEM) // Server only trusts master CA
+
+			clientRootCAs := x509.NewCertPool()
+			clientRootCAs.AppendCertsFromPEM(caPEM)
+
+			// Setup Test Server
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			serverCert, err := tls.X509KeyPair(caPEM, caKeyPEM)
+			if err != nil {
+				t.Fatalf("failed to prepare server cert: %v", err)
+			}
+
+			srv.TLS = &tls.Config{
+				MinVersion:   tt.serverMinTLS,
+				ClientAuth:   tls.RequireAndVerifyClientCert,
+				ClientCAs:    serverClientCAs,
+				Certificates: []tls.Certificate{serverCert},
+
+				// Explicitly enforce client SAN validation at the TLS layer
+				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+					if len(verifiedChains) > 0 && len(verifiedChains[0]) > 0 {
+						clientCert := verifiedChains[0][0]
+						// Reject the client if it has neither an IP SAN nor a DNS SAN
+						if len(clientCert.IPAddresses) == 0 && len(clientCert.DNSNames) == 0 {
+							return fmt.Errorf("mTLS authentication failed: client certificate missing SAN extensions")
+						}
+					}
+					return nil
+				},
+			}
+			srv.StartTLS()
+			defer srv.Close()
+
+			var certFile, keyFile string
+			if !tt.bypassClientCerts {
+				certFile, keyFile = writeTempCertFiles(t, clientCertPEM, clientKeyPEM)
+			} else {
+				certFile, keyFile = "missing_cert.crt", "missing_key.key"
+			}
+
+			cli := NewClient(Options{
+				CertFile:            certFile,
+				KeyFile:             keyFile,
+				CertRefreshInterval: 10 * time.Millisecond,
+				RootCAs:             clientRootCAs,
+			})
+			defer cli.Close()
+
+			rsp, err := cli.Get(srv.URL)
+			if err != nil {
+				if tt.wantErr {
+					t.Logf("Handshake rejected successfully as expected: %v", err)
+					return
+				}
+				t.Fatalf("mTLS request failed unexpectedly: %v", err)
+			}
+			defer rsp.Body.Close()
+
+			if tt.wantErr {
+				t.Errorf("Expected failure, but request connected successfully with status %d", rsp.StatusCode)
+			}
+		})
+	}
+}
+
+// 3. Case 3: Live Rotation Fallback Test
+//
+// This dynamic test creates a valid client connection, breaks the
+// underlying certificate file on disk, allows the background polling
+// engine to execute, and validates that your client does not crash or
+// lose its current in-memory certificates.
+func TestClientMTLS_RotationFallback(t *testing.T) {
+	now := time.Now()
+	caPEM, _, caCert, caKey := generateCert(t, certOptions{
+		cn:        "Master Root CA",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(24 * time.Hour),
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+	})
+
+	opts := certOptions{
+		cn:        "localhost",
+		dns:       "localhost",
+		ip:        "127.0.0.1",
+		notBefore: now.Add(-1 * time.Hour),
+		notAfter:  now.Add(1 * time.Hour),
+		extKeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		signerCert: caCert,
+		signerKey:  caKey,
+	}
+	certPEM, keyPEM, _, _ := generateCert(t, opts)
+
+	serverClientCAs := x509.NewCertPool()
+	serverClientCAs.AppendCertsFromPEM(caPEM)
+	clientRootCAs := x509.NewCertPool()
+	clientRootCAs.AppendCertsFromPEM(caPEM)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	bytesCaKey, err := x509.MarshalECPrivateKey(caKey)
+	if err != nil {
+		t.Fatalf("Failed to marshal private CA key: %v", err)
+	}
+
+	serverCert, _ := tls.X509KeyPair(caPEM, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: bytesCaKey}))
+	srv.TLS = &tls.Config{
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    serverClientCAs,
+		Certificates: []tls.Certificate{serverCert},
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	certFile, keyFile := writeTempCertFiles(t, certPEM, keyPEM)
+
+	cli := NewClient(Options{
+		CertFile:            certFile,
+		KeyFile:             keyFile,
+		CertRefreshInterval: 20 * time.Millisecond,
+		RootCAs:             clientRootCAs,
+	})
+	defer cli.Close()
+
+	// Assert baseline connection works perfectly
+	rsp, err := cli.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Initial baseline request failed: %v", err)
+	}
+	rsp.Body.Close()
+
+	// Corrupt the file system: overwrite key file with garbage data
+	err = os.WriteFile(keyFile, []byte("NOT A VALID PEM BLOCK --- CORRUPTED"), 0600)
+	if err != nil {
+		t.Fatalf("failed to corrupt key file: %v", err)
+	}
+
+	// Wait out the refresher interval (allow background ticker to execute 2.5 cycles)
+	time.Sleep(50 * time.Millisecond)
+
+	// Fire a follow-up request. It must still succeed via the working in-memory fallback cache!
+	rspFallback, err := cli.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Resilience failure! Client dropped its working certificate when disk write failed: %v", err)
+	}
+	defer rspFallback.Body.Close()
+
+	if rspFallback.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected fallback status code: %d", rspFallback.StatusCode)
+	}
+}
+
+func writeTempCertFiles(t *testing.T, cert, key []byte) (string, string) {
+	t.Helper()
+	cFile, err := os.CreateTemp("", "client-cert-*.crt")
+	if err != nil {
+		t.Fatalf("failed to create temp cert file: %v", err)
+	}
+	kFile, err := os.CreateTemp("", "client-key-*.key")
+	if err != nil {
+		t.Fatalf("failed to create temp key file: %v", err)
+	}
+
+	if err := os.WriteFile(cFile.Name(), cert, 0644); err != nil {
+		t.Fatalf("failed to write temp cert: %v", err)
+	}
+	if err := os.WriteFile(kFile.Name(), key, 0600); err != nil {
+		t.Fatalf("failed to write temp key: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Remove(cFile.Name())
+		_ = os.Remove(kFile.Name())
+	})
+	return cFile.Name(), kFile.Name()
 }


### PR DESCRIPTION
Example skipper/net.Client with mTLS and cert rotation
```
rootCAs, _ := x509.SystemCertPool()
caCertPEM, _ := os.ReadFile("path/to/your/custom-ca.crt")
rootCAs.AppendCertsFromPEM(caCertPEM)

net.NewClient(net.Options{
	CertFile:            certFile,
	KeyFile:             keyFile,
	CertRefreshInterval: time.Minute,
	RootCAs:             rootCAs,
})
```