### PR TITLE
fix: eliminate race in TestCacheFilter_ColdMissCoalescing

### DIFF
--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -365,8 +365,11 @@ func (mc *missCounting) Get(ctx context.Context, key string) (*Entry, error) {
 func TestCacheFilter_ColdMissCoalescing(t *testing.T) {
 	// Hold the upstream fetch until all N goroutines have performed their
 	// storage.Get and received a miss. At that point every goroutine is either
-	// already inside DoChan's wait list or in the tiny, scheduler-opaque gap
-	// between the nil check and the DoChan call — guaranteeing exactly 1 fetch.
+	// already inside DoChan's wait list or in the scheduler-opaque gap between
+	// the nil check and the DoChan call. Any goroutine that resumes after the
+	// singleflight completes will hit the double-check inside fetchFn (line 382
+	// of filter.go) and return without a second upstream call, keeping fetchCount
+	// at 1.
 	const N = 50
 	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
 

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -348,43 +347,44 @@ func TestCacheFilter_SWR_HardExpiry_Miss(t *testing.T) {
 	})
 }
 
-// missCounting wraps a Storage and counts non-vary Get calls that return a miss.
+// missCounting wraps a Storage and signals wg on each non-vary Get that returns a miss.
 type missCounting struct {
 	Storage
-	missCount atomic.Int64
+	wg sync.WaitGroup
 }
 
 func (mc *missCounting) Get(ctx context.Context, key string) (*Entry, error) {
 	e, err := mc.Storage.Get(ctx, key)
 	if e == nil && err == nil && !strings.HasPrefix(key, "vary:") {
-		mc.missCount.Add(1)
+		mc.wg.Done()
 	}
 	return e, err
 }
 
 func TestCacheFilter_ColdMissCoalescing(t *testing.T) {
 	// Hold the upstream fetch until all N goroutines have performed their
-	// storage.Get and received a miss. At that point every goroutine is either
+	// storage.Get and observed a miss. At that point every goroutine is either
 	// already inside DoChan's wait list or in the scheduler-opaque gap between
-	// the nil check and the DoChan call. Any goroutine that resumes after the
-	// singleflight completes will hit the double-check inside fetchFn (line 382
-	// of filter.go) and return without a second upstream call, keeping fetchCount
-	// at 1.
+	// the nil check and the DoChan call — so exactly 1 fetch fires.
+	//
+	// mc.wg is the barrier: each goroutine calls wg.Done() inside storage.Get
+	// on a miss, and the fetch stub calls wg.Wait() before returning, keeping
+	// the singleflight open until all N goroutines have committed to joining it.
 	const N = 50
 	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
 
-	// Wrap storage to count how many goroutines have confirmed a cache miss.
 	mc := &missCounting{Storage: f.storage}
+	mc.wg.Add(N)
 	f.storage = mc
 
 	var fetchCount int64
+	fetchStarted := make(chan struct{})
 	releaseAll := make(chan struct{})
 
 	f.fetch = func(req *http.Request) (*http.Response, error) {
 		atomic.AddInt64(&fetchCount, 1)
-		for mc.missCount.Load() < N {
-			runtime.Gosched()
-		}
+		close(fetchStarted)
+		mc.wg.Wait() // block until every goroutine has confirmed a cache miss
 		<-releaseAll
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -408,10 +408,7 @@ func TestCacheFilter_ColdMissCoalescing(t *testing.T) {
 		}()
 	}
 
-	// Wait until the fetch is running and all N goroutines have missed the cache.
-	for mc.missCount.Load() < N || atomic.LoadInt64(&fetchCount) == 0 {
-		runtime.Gosched()
-	}
+	<-fetchStarted // fetch is running; all N misses will be counted before it returns
 	close(releaseAll)
 	wg.Wait()
 

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -347,28 +348,40 @@ func TestCacheFilter_SWR_HardExpiry_Miss(t *testing.T) {
 	})
 }
 
+// missCounting wraps a Storage and counts non-vary Get calls that return a miss.
+type missCounting struct {
+	Storage
+	missCount atomic.Int64
+}
+
+func (mc *missCounting) Get(ctx context.Context, key string) (*Entry, error) {
+	e, err := mc.Storage.Get(ctx, key)
+	if e == nil && err == nil && !strings.HasPrefix(key, "vary:") {
+		mc.missCount.Add(1)
+	}
+	return e, err
+}
+
 func TestCacheFilter_ColdMissCoalescing(t *testing.T) {
-	// Hold the upstream fetch until all N goroutines have checked in, proving
-	// that exactly 1 fetch fires for the whole cohort.
+	// Hold the upstream fetch until all N goroutines have performed their
+	// storage.Get and received a miss. At that point every goroutine is either
+	// already inside DoChan's wait list or in the tiny, scheduler-opaque gap
+	// between the nil check and the DoChan call — guaranteeing exactly 1 fetch.
 	const N = 50
 	f := newTestFilter(t, time.Minute, 15*time.Second, time.Minute)
 
-	var fetchStarted sync.Once
-	fetchStartedCh := make(chan struct{})
-	releaseAll := make(chan struct{})
-	var fetchCount int64
+	// Wrap storage to count how many goroutines have confirmed a cache miss.
+	mc := &missCounting{Storage: f.storage}
+	f.storage = mc
 
-	// The leader waits for all N goroutines to signal (wgIn.Done) before the
-	// fetch returns. Each goroutine signals just before calling f.Request so
-	// it is either already in DoChan's wait list or about to enter it while
-	// the leader is still blocked on <-releaseAll.
-	var wgIn sync.WaitGroup
-	wgIn.Add(N)
+	var fetchCount int64
+	releaseAll := make(chan struct{})
 
 	f.fetch = func(req *http.Request) (*http.Response, error) {
 		atomic.AddInt64(&fetchCount, 1)
-		fetchStarted.Do(func() { close(fetchStartedCh) })
-		wgIn.Wait()
+		for mc.missCount.Load() < N {
+			runtime.Gosched()
+		}
 		<-releaseAll
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -387,13 +400,15 @@ func TestCacheFilter_ColdMissCoalescing(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			ctx := newCtx("GET", url, "")
-			wgIn.Done()
 			f.Request(ctx)
 			results[i] = ctx
 		}()
 	}
 
-	<-fetchStartedCh
+	// Wait until the fetch is running and all N goroutines have missed the cache.
+	for mc.missCount.Load() < N || atomic.LoadInt64(&fetchCount) == 0 {
+		runtime.Gosched()
+	}
 	close(releaseAll)
 	wg.Wait()
 


### PR DESCRIPTION
## Problem

`TestCacheFilter_ColdMissCoalescing` was intermittently failing under `-race` with:

```
--- FAIL: TestCacheFilter_ColdMissCoalescing (0.00s)
    filter_test.go:401: expected 1 upstream fetch, got 2
```

The test asserts that 50 concurrent cold-miss requests coalesce into exactly one upstream fetch via `singleflight.DoChan`.

The previous synchronization used a `sync.WaitGroup` (`wgIn`) where each goroutine called `wgIn.Done()` **before** calling `f.Request()`. The fetch stub blocked on `wgIn.Wait()`, intending to hold the singleflight open until all goroutines had joined it.

This had a [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to-time-of-use) gap: a goroutine could call `wgIn.Done()`, get preempted, and resume while the fetch stub had already unblocked from `wgIn.Wait()` but had not yet called `storage.Set()`. At that point the goroutine would call `storage.Get()` → `nil` and enter `DoChan()`. If the leader's `fetchFn` had returned in the interim, `DoChan()` would start a new singleflight round and fire a second upstream fetch. Under the race detector's overhead this window was wide enough to trigger reliably.

## Fix

Replaced `wgIn` with a `missCounting` storage wrapper that embeds a `sync.WaitGroup`. Each goroutine calls `wg.Done()` inside `storage.Get()` at the exact moment it observes a cache miss - the last possible point before `coalesce()` → `DoChan()`. The fetch stub calls `wg.Wait()`, which durably blocks `fetchFn` until all N goroutines have confirmed a miss and are either inside `DoChan`'s waitlist or in the scheduler-opaque gap immediately before it. Only then does `fetchFn` call `storage.Set()` and return, closing the singleflight round.

The main goroutine's spin loop was replaced with a `fetchStarted` channel closed by the fetch stub on entry, eliminating all busy-waits.

### Before

<img width="6795" height="4395" alt="Goroutine Missed Window-2026-05-26-141411" src="https://github.com/user-attachments/assets/0fb1da49-0707-49b3-a49e-c83fc5e42299" />

### After

<img width="5770" height="2840" alt="Goroutine Missed Window-2026-05-26-141426" src="https://github.com/user-attachments/assets/73b8ffe0-6563-4841-a18d-f2c46f46fe0f" />

No production code was changed.