### PR TITLE
introduce timeout for decicion log task

### DIFF
--- a/filters/openpolicyagent/evaluation.go
+++ b/filters/openpolicyagent/evaluation.go
@@ -118,7 +118,7 @@ func FormOpenPolicyAgentMetaDataObject(decisionId string) (*pbstruct.Struct, err
 
 func (opa *OpenPolicyAgentInstance) logDecision(ctx context.Context, input interface{}, result *envoyauth.EvalResult, err error) error {
 	if opa.decisionLogChan != nil {
-		task := decisionLogTask{input: input, result: result, err: err}
+		task := decisionLogTask{input: input, result: result, err: err, ctx: ctx}
 		select {
 		case opa.decisionLogChan <- task:
 		default:

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/builtin"
+	nethttptest "github.com/zalando/skipper/net/httptest"
 	"github.com/zalando/skipper/proxy/proxytest"
 	"github.com/zalando/skipper/tracing/tracingtest"
 
@@ -923,20 +924,13 @@ func TestAuthorizeRequestFilterWithS3DecisionLogPlugin_SlowS3BlocksClientRespons
 	proxy := proxytest.New(fr, r...)
 	defer proxy.Close()
 
-	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/allow", nil)
-	require.NoError(t, err)
+	va := nethttptest.NewVegetaAttacker(proxy.URL+"/allow", 10, time.Second, 2*s3Delay)
+	va.Attack(io.Discard, 3*time.Second, t.Name())
 
-	start := time.Now()
-	rsp, err := proxy.Client().Do(req)
-	elapsed := time.Since(start)
-
-	require.NoError(t, err)
-	defer rsp.Body.Close()
-	assert.Equal(t, http.StatusOK, rsp.StatusCode)
-
-	assert.Less(t, elapsed, s3Delay,
-		"client round-trip (%v) should not be delayed by the S3 upload (%v); "+
-			"logDecision must not run on the request goroutine", elapsed, s3Delay)
+	assert.Equal(t, 1.0, va.Success(), "all requests should succeed")
+	assert.Less(t, va.Metrics().Latencies.Mean, s3Delay,
+		"mean client latency (%v) should not be delayed by the S3 upload (%v); "+
+			"logDecision must not run on the request goroutine", va.Metrics().Latencies.Mean, s3Delay)
 }
 
 // TestFullDecisionLogBufferBlocksClientResponse is the regression test for the buffer full scenario when

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	opasdktest "github.com/open-policy-agent/opa/v1/sdk/test"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/eskip"
@@ -1245,6 +1247,246 @@ func TestAuthorizeRequestInputContract(t *testing.T) {
 			assert.Equal(t, ti.expectedBody, string(body), "HTTP Body does not match")
 		})
 	}
+}
+
+// TestDecisionLogDroppedOnBundleReload reproduces the bug where a bundle reload causes
+// sustained "Decision log dropped: async buffer full" with no recovery.
+//
+// Root cause: when eopa_dl.Reconfigure() tears down the Benthos stream during a bundle
+// reload, runDecisionLogger may be blocked inside stream.Consume() on the stopped stream.
+// Because context.Background() has no deadline, the blocked tChan send never returns —
+// runDecisionLogger is permanently stuck and decisionLogChan fills up, causing every
+// subsequent logDecision to hit the non-blocking default branch and drop the event.
+// A pod restart is the only recovery path until the context is given a deadline.
+//
+// The test structure:
+//  1. Start OPA with async decision logging and a tiny eopa_dl HTTP buffer (max_bytes=1200).
+//     The slow log sink introduces backpressure so the Benthos buffer fills after the first event.
+//  2. Send a handful of requests and wait until the log sink is reached, confirming the
+//     Benthos stream is live and consuming decisions.
+//  3. Push a new discovery bundle revision, which triggers eopa_dl.Reconfigure() and
+//     tears down the running Benthos stream while runDecisionLogger may be inside Consume().
+//  4. Unblock the sink so the in-flight batch can complete. On a buggy build, the next
+//     Consume() call on the stopped stream blocks forever on context.Background().
+//  5. Flood with requests. If the drainer is stuck the channel fills and drops begin.
+//  6. Poll until a request produces no new drop — the channel has drained.
+//     On a buggy build this never happens; on a fixed build recovery occurs once the
+//     context deadline fires and runDecisionLogger can loop to the next task.
+func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive test, skipped in short mode")
+	}
+
+	hook := &dropCaptureHook{}
+	logrus.AddHook(hook)
+	t.Cleanup(func() {
+		logrus.StandardLogger().Hooks = make(logrus.LevelHooks)
+	})
+
+	// sinkReached is written once when the log sink receives its first batch,
+	// confirming the Benthos stream has flushed at least one event.
+	// sinkRelease is closed to let the in-flight request complete so the old stream
+	// can finish, giving the new stream a chance to replace it.
+	sinkReached := make(chan struct{}, 1)
+	sinkRelease := make(chan struct{})
+
+	// slowSink holds the first request until sinkRelease, keeping the eopa_dl
+	// memory buffer occupied so backpressure is applied to subsequent Consume calls.
+	const sinkDelay = 200 * time.Millisecond
+	logSink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case sinkReached <- struct{}{}:
+		default:
+		}
+		select {
+		case <-sinkRelease:
+		case <-r.Context().Done():
+			return
+		}
+		time.Sleep(sinkDelay)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer logSink.Close()
+
+	clientServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer clientServer.Close()
+
+	// eopa_dl config: max_bytes=1200 fits exactly one event (~874 bytes).
+	// Once event 1 is in the buffer and the sink stalls, a second Consume call blocks.
+	eopaDLConfig := fmt.Sprintf(`{
+		"buffer": { "type": "memory", "max_bytes": 1200 },
+		"output": {
+			"type": "http",
+			"url": %q,
+			"timeout": "60s",
+			"batching": { "at_period": "1ms", "at_bytes": 1 }
+		}
+	}`, logSink.URL+"/logs")
+
+	// discoveryData builds a discovery bundle payload. Bumping the revision causes the
+	// discovery plugin to re-evaluate and push a fresh eopa_dl config, triggering
+	// eopa_dl.Reconfigure() → Stop() + Start() on the Benthos stream.
+	discoveryData := func(version int) string {
+		return fmt.Sprintf(`{
+		  "discovery": {
+			"revision": "v%d",
+			"bundles": {
+			  "bundles/test": {
+				"persist": false,
+				"resource": "bundles/test",
+				"service": "test",
+				"polling": { "min_delay_seconds": 1, "max_delay_seconds": 1 }
+			  }
+			},
+			"plugins": { "eopa_dl": %s }
+		  }
+		}`, version, eopaDLConfig)
+	}
+
+	opaControlPlane := opasdktest.MustNewServer(
+		opasdktest.MockBundle("/bundles/test", map[string]string{
+			"main.rego": `
+				package envoy.authz
+				default allow = true
+			`,
+		}),
+		opasdktest.MockBundle("/bundles/discovery", map[string]string{
+			"data.json": discoveryData(1),
+		}),
+	)
+	defer opaControlPlane.Stop()
+
+	// buffer_size_limit_events=5: the async channel holds at most 5 pending tasks.
+	// At ~50 rps the channel fills within ~100 ms once the drainer is stuck.
+	config := []byte(fmt.Sprintf(`{
+		"services": { "test": { "url": %q } },
+		"discovery": {
+			"name": "discovery",
+			"resource": "/bundles/discovery",
+			"service": "test"
+		},
+		"labels": { "environment": "test" },
+		"decision_logs": {
+			"plugin": "eopa_dl",
+			"reporting": {
+				"buffer_type": "event",
+				"buffer_size_limit_events": 5
+			}
+		},
+		"plugins": {
+			"envoy_ext_authz_grpc": { "path": "envoy/authz/allow", "dry-run": false },
+			"eopa_dl": %s
+		}
+	}`, opaControlPlane.URL(), eopaDLConfig))
+
+	fr := make(filters.Registry)
+	opaFactory, err := openpolicyagent.NewOpenPolicyAgentRegistry(
+		openpolicyagent.WithTracer(tracingtest.NewTracer()),
+		openpolicyagent.WithAsyncDecisionLogging(true),
+		openpolicyagent.WithOpenPolicyAgentInstanceConfig(
+			openpolicyagent.WithConfigTemplate(config),
+		),
+	)
+	require.NoError(t, err)
+
+	ftSpec := NewOpaAuthorizeRequestSpec(opaFactory)
+	fr.Register(ftSpec)
+
+	r := eskip.MustParse(fmt.Sprintf(`* -> opaAuthorizeRequest("test") -> %q`, clientServer.URL))
+	proxy := proxytest.New(fr, r...)
+	defer proxy.Close()
+
+	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	require.NoError(t, err)
+
+	// Warm up: send a handful of requests to get decisions into the Benthos stream.
+	for i := 0; i < 5; i++ {
+		rsp, doErr := proxy.Client().Do(req)
+		require.NoError(t, doErr)
+		rsp.Body.Close()
+	}
+
+	// Wait until the log sink has received at least one batch — the stream is live.
+	select {
+	case <-sinkReached:
+	case <-time.After(10 * time.Second):
+		t.Fatal("log sink never received a request — decisions are not reaching eopa_dl")
+	}
+
+	// Push a new discovery revision. The discovery plugin detects the change,
+	// re-pushes the eopa_dl config, and calls eopa_dl.Reconfigure() → Stop() + Start().
+	// During Stop(), the inproc input is torn down. runDecisionLogger, which is in (or
+	// about to call) stream.Consume on the old stream, will block forever if the context
+	// has no deadline.
+	opaControlPlane.WithTestBundle("/bundles/discovery", map[string]string{
+		"data.json": discoveryData(2),
+	})
+
+	// Unblock the sink so the in-flight batch can finish.
+	// On a buggy build, the next Consume() call on the now-stopped stream deadlocks.
+	close(sinkRelease)
+
+	// Give the discovery poller time to pick up v2 and call Reconfigure.
+	time.Sleep(2500 * time.Millisecond)
+
+	// Flood with requests. If the drainer is stuck, the channel fills and all are dropped.
+	for i := 0; i < 20; i++ {
+		rsp, doErr := proxy.Client().Do(req)
+		require.NoError(t, doErr)
+		rsp.Body.Close()
+	}
+
+	dropsWhileStalled := hook.countContaining("Decision log dropped: async buffer full")
+	assert.Greater(t, dropsWhileStalled, 0,
+		"expected at least some decision log drops immediately after bundle reload "+
+			"(channel full while drainer is blocked) — check async logging is enabled and Reconfigure was triggered")
+
+	// Wait for self-recovery: once runDecisionLogger unblocks (via context timeout),
+	// the channel drains and subsequent requests are no longer dropped.
+	// On a buggy build this never becomes true; on a fixed build it settles quickly.
+	require.Eventually(t, func() bool {
+		before := hook.countContaining("Decision log dropped: async buffer full")
+		rsp, doErr := proxy.Client().Do(req)
+		if doErr != nil {
+			return false
+		}
+		rsp.Body.Close()
+		time.Sleep(200 * time.Millisecond)
+		after := hook.countContaining("Decision log dropped: async buffer full")
+		return after == before
+	}, 60*time.Second, 500*time.Millisecond,
+		"decision log drops did not stop after Reconfigure completed — runDecisionLogger did not recover; "+
+			"fix: pass a context with a deadline into doLogDecision instead of context.Background()")
+}
+
+// dropCaptureHook captures all logrus entries so tests can count specific log lines.
+type dropCaptureHook struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+func (h *dropCaptureHook) countContaining(sub string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, e := range h.entries {
+		if strings.Contains(e, sub) {
+			n++
+		}
+	}
+	return n
+}
+
+func (h *dropCaptureHook) Levels() []logrus.Level { return logrus.AllLevels }
+
+func (h *dropCaptureHook) Fire(entry *logrus.Entry) error {
+	line, _ := entry.String()
+	h.mu.Lock()
+	h.entries = append(h.entries, line)
+	h.mu.Unlock()
+	return nil
 }
 
 func isHeadersPresent(t *testing.T, expectedHeaders http.Header, headers http.Header) bool {

--- a/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
+++ b/filters/openpolicyagent/opaauthorizerequest/opaauthorizerequest_test.go
@@ -1243,29 +1243,11 @@ func TestAuthorizeRequestInputContract(t *testing.T) {
 	}
 }
 
-// TestDecisionLogDroppedOnBundleReload reproduces the bug where a bundle reload causes
-// sustained "Decision log dropped: async buffer full" with no recovery.
-//
-// Root cause: when eopa_dl.Reconfigure() tears down the Benthos stream during a bundle
-// reload, runDecisionLogger may be blocked inside stream.Consume() on the stopped stream.
-// Because context.Background() has no deadline, the blocked tChan send never returns —
-// runDecisionLogger is permanently stuck and decisionLogChan fills up, causing every
-// subsequent logDecision to hit the non-blocking default branch and drop the event.
-// A pod restart is the only recovery path until the context is given a deadline.
-//
-// The test structure:
-//  1. Start OPA with async decision logging and a tiny eopa_dl HTTP buffer (max_bytes=1200).
-//     The slow log sink introduces backpressure so the Benthos buffer fills after the first event.
-//  2. Send a handful of requests and wait until the log sink is reached, confirming the
-//     Benthos stream is live and consuming decisions.
-//  3. Push a new discovery bundle revision, which triggers eopa_dl.Reconfigure() and
-//     tears down the running Benthos stream while runDecisionLogger may be inside Consume().
-//  4. Unblock the sink so the in-flight batch can complete. On a buggy build, the next
-//     Consume() call on the stopped stream blocks forever on context.Background().
-//  5. Flood with requests. If the drainer is stuck the channel fills and drops begin.
-//  6. Poll until a request produces no new drop — the channel has drained.
-//     On a buggy build this never happens; on a fixed build recovery occurs once the
-//     context deadline fires and runDecisionLogger can loop to the next task.
+// TestDecisionLogDroppedOnBundleReload verifies that runDecisionLogger recovers after a
+// bundle reload. During eopa_dl.Reconfigure(), Stop() tears down the Benthos stream while
+// runDecisionLogger may be inside stream.Consume(). Without a context deadline the blocked
+// send never returns, decisionLogChan fills up, and all decisions are dropped permanently.
+// The fix passes a timeout context so the goroutine can unblock and resume draining.
 func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing-sensitive test, skipped in short mode")
@@ -1277,15 +1259,12 @@ func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 		logrus.StandardLogger().Hooks = make(logrus.LevelHooks)
 	})
 
-	// sinkReached is written once when the log sink receives its first batch,
-	// confirming the Benthos stream has flushed at least one event.
-	// sinkRelease is closed to let the in-flight request complete so the old stream
-	// can finish, giving the new stream a chance to replace it.
+	// sinkReached signals once the stream has delivered its first batch.
+	// sinkRelease unblocks the sink so the in-flight batch can complete.
 	sinkReached := make(chan struct{}, 1)
 	sinkRelease := make(chan struct{})
 
-	// slowSink holds the first request until sinkRelease, keeping the eopa_dl
-	// memory buffer occupied so backpressure is applied to subsequent Consume calls.
+	// Slow sink keeps the eopa_dl buffer full, applying backpressure to Consume.
 	const sinkDelay = 200 * time.Millisecond
 	logSink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
@@ -1307,8 +1286,7 @@ func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 	}))
 	defer clientServer.Close()
 
-	// eopa_dl config: max_bytes=1200 fits exactly one event (~874 bytes).
-	// Once event 1 is in the buffer and the sink stalls, a second Consume call blocks.
+	// max_bytes=1200 fits one event; a second event triggers backpressure and blocks Consume.
 	eopaDLConfig := fmt.Sprintf(`{
 		"buffer": { "type": "memory", "max_bytes": 1200 },
 		"output": {
@@ -1319,9 +1297,7 @@ func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 		}
 	}`, logSink.URL+"/logs")
 
-	// discoveryData builds a discovery bundle payload. Bumping the revision causes the
-	// discovery plugin to re-evaluate and push a fresh eopa_dl config, triggering
-	// eopa_dl.Reconfigure() → Stop() + Start() on the Benthos stream.
+	// Bumping the revision triggers eopa_dl.Reconfigure() → Stop() + Start().
 	discoveryData := func(version int) string {
 		return fmt.Sprintf(`{
 		  "discovery": {
@@ -1352,8 +1328,7 @@ func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 	)
 	defer opaControlPlane.Stop()
 
-	// buffer_size_limit_events=5: the async channel holds at most 5 pending tasks.
-	// At ~50 rps the channel fills within ~100 ms once the drainer is stuck.
+	// buffer_size_limit_events=5 so the channel fills quickly once the drainer is stuck.
 	config := []byte(fmt.Sprintf(`{
 		"services": { "test": { "url": %q } },
 		"discovery": {
@@ -1395,37 +1370,32 @@ func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
 	require.NoError(t, err)
 
-	// Warm up: send a handful of requests to get decisions into the Benthos stream.
+	// Warm up the pipeline.
 	for i := 0; i < 5; i++ {
 		rsp, doErr := proxy.Client().Do(req)
 		require.NoError(t, doErr)
 		rsp.Body.Close()
 	}
 
-	// Wait until the log sink has received at least one batch — the stream is live.
+	// Confirm the stream is live before triggering the reload.
 	select {
 	case <-sinkReached:
 	case <-time.After(10 * time.Second):
 		t.Fatal("log sink never received a request — decisions are not reaching eopa_dl")
 	}
 
-	// Push a new discovery revision. The discovery plugin detects the change,
-	// re-pushes the eopa_dl config, and calls eopa_dl.Reconfigure() → Stop() + Start().
-	// During Stop(), the inproc input is torn down. runDecisionLogger, which is in (or
-	// about to call) stream.Consume on the old stream, will block forever if the context
-	// has no deadline.
+	// Push revision v2 to trigger eopa_dl.Reconfigure() → Stop() + Start().
 	opaControlPlane.WithTestBundle("/bundles/discovery", map[string]string{
 		"data.json": discoveryData(2),
 	})
 
-	// Unblock the sink so the in-flight batch can finish.
-	// On a buggy build, the next Consume() call on the now-stopped stream deadlocks.
+	// Unblock the sink; on a buggy build the next Consume() on the stopped stream deadlocks.
 	close(sinkRelease)
 
-	// Give the discovery poller time to pick up v2 and call Reconfigure.
+	// Wait for the discovery poller to pick up v2 and call Reconfigure.
 	time.Sleep(2500 * time.Millisecond)
 
-	// Flood with requests. If the drainer is stuck, the channel fills and all are dropped.
+	// Fill the channel; if the drainer is stuck all events are dropped.
 	for i := 0; i < 20; i++ {
 		rsp, doErr := proxy.Client().Do(req)
 		require.NoError(t, doErr)
@@ -1437,9 +1407,7 @@ func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 		"expected at least some decision log drops immediately after bundle reload "+
 			"(channel full while drainer is blocked) — check async logging is enabled and Reconfigure was triggered")
 
-	// Wait for self-recovery: once runDecisionLogger unblocks (via context timeout),
-	// the channel drains and subsequent requests are no longer dropped.
-	// On a buggy build this never becomes true; on a fixed build it settles quickly.
+	// Once the context timeout fires, runDecisionLogger unblocks and the channel drains.
 	require.Eventually(t, func() bool {
 		before := hook.countContaining("Decision log dropped: async buffer full")
 		rsp, doErr := proxy.Client().Do(req)
@@ -1455,7 +1423,7 @@ func TestDecisionLogDroppedOnBundleReload(t *testing.T) {
 			"fix: pass a context with a deadline into doLogDecision instead of context.Background()")
 }
 
-// dropCaptureHook captures all logrus entries so tests can count specific log lines.
+// dropCaptureHook counts logrus entries containing a given substring.
 type dropCaptureHook struct {
 	mu      sync.Mutex
 	entries []string

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -803,7 +803,7 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 		bufSize := decisionLogBufferSize(opaConfig.DecisionLogs)
 		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
 		opa.decisionsProcessed = make(chan struct{})
-		if t := decisionLogS3OutputTimeout(opaConfig.DecisionLogs); t > 0 {
+		if t := decisionLogMaxOutputTimeout(opaConfig.DecisionLogs); t > 0 {
 			opa.decisionLogTaskTimeout = t
 		} else {
 			opa.decisionLogTaskTimeout = registry.decisionLogTaskTimeout
@@ -835,15 +835,21 @@ func allPluginsReady(allPluginsStatus map[string]*plugins.Status, pluginNames ..
 	return true
 }
 
-// decisionLogS3OutputTimeout parses the eopa_dl decision_logs config and returns
-// the timeout from the first S3 output entry, or 0 if not present or unparseable.
-func decisionLogS3OutputTimeout(rawConfig json.RawMessage) time.Duration {
+type decisionLogPluginConfig struct {
+	Output json.RawMessage `json:"output"`
+}
+
+type decisionLogOutputEntry struct {
+	Timeout string `json:"timeout"`
+}
+
+// decisionLogMaxOutputTimeout parses the eopa_dl decision_logs config and returns
+// the highest timeout defined across all output entries, or 0 if none are present or parseable.
+func decisionLogMaxOutputTimeout(rawConfig json.RawMessage) time.Duration {
 	if rawConfig == nil {
 		return 0
 	}
-	var cfg struct {
-		Output json.RawMessage `json:"output"`
-	}
+	var cfg decisionLogPluginConfig
 	if err := json.Unmarshal(rawConfig, &cfg); err != nil || cfg.Output == nil {
 		return 0
 	}
@@ -853,23 +859,17 @@ func decisionLogS3OutputTimeout(rawConfig json.RawMessage) time.Duration {
 		// Not an array — try as a single object.
 		outputs = []json.RawMessage{cfg.Output}
 	}
-	type outputEntry struct {
-		Type    string `json:"type"`
-		Timeout string `json:"timeout"`
-	}
+	var max time.Duration
 	for _, raw := range outputs {
-		var entry outputEntry
-		if err := json.Unmarshal(raw, &entry); err != nil {
+		var entry decisionLogOutputEntry
+		if err := json.Unmarshal(raw, &entry); err != nil || entry.Timeout == "" {
 			continue
 		}
-		if entry.Type == "s3" && entry.Timeout != "" {
-			d, err := time.ParseDuration(entry.Timeout)
-			if err == nil {
-				return d
-			}
+		if d, err := time.ParseDuration(entry.Timeout); err == nil && d > max {
+			max = d
 		}
 	}
-	return 0
+	return max
 }
 
 func decisionLogBufferSize(rawConfig json.RawMessage) int {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -64,6 +64,13 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
+	// decisionLogTaskTimeout bounds the time runDecisionLogger spends on a single
+	// doLogDecision call. Without a deadline, a Benthos stream.Consume() call on a
+	// stream that was stopped during eopa_dl.Reconfigure() blocks forever because
+	// the inproc reader is gone and context.Background() provides no escape hatch.
+	// 30 s is long enough for healthy Benthos stream delivery while ensuring recovery
+	// after a bundle reload within the OPA startup timeout window.
+	decisionLogTaskTimeout = 30 * time.Second
 
 	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
@@ -1039,7 +1046,10 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 func (opa *OpenPolicyAgentInstance) runDecisionLogger() {
 	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		if err := opa.doLogDecision(context.Background(), task.input, task.result, task.err); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), decisionLogTaskTimeout)
+		err := opa.doLogDecision(ctx, task.input, task.result, task.err)
+		cancel()
+		if err != nil {
 			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
 		}
 	}

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -865,7 +865,8 @@ func decisionLogMaxOutputTimeout(rawConfig json.RawMessage) time.Duration {
 		if err := json.Unmarshal(raw, &entry); err != nil || entry.Timeout == "" {
 			continue
 		}
-		if d, err := time.ParseDuration(entry.Timeout); err == nil && d > max {
+
+		if d, _ := time.ParseDuration(entry.Timeout); d > max {
 			max = d
 		}
 	}

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -64,11 +64,10 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
-	decisionLogTaskTimeoutMin       = 5 * time.Second
-
-	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
-	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
-	DefaultRequestBodyBufferSize = 8 * 1024 // 8 KB
+	defaultDecisionLogTaskTimeout   = 60 * time.Second
+	DefaultMaxRequestBodySize       = 1 << 20 // 1 MB
+	DefaultMaxMemoryBodyParsing     = 100 * DefaultMaxRequestBodySize
+	DefaultRequestBodyBufferSize    = 8 * 1024 // 8 KB
 
 	spanNameEval = "open-policy-agent"
 )
@@ -624,6 +623,7 @@ type decisionLogTask struct {
 	input  interface{}
 	result *envoyauth.EvalResult
 	err    error
+	ctx    context.Context
 }
 
 type OpenPolicyAgentInstance struct {
@@ -651,8 +651,9 @@ type OpenPolicyAgentInstance struct {
 
 	idGenerator flowid.Generator
 
-	decisionLogChan    chan decisionLogTask
-	decisionsProcessed chan struct{}
+	decisionLogChan          chan decisionLogTask
+	decisionsProcessed       chan struct{}
+	decisionLogCancelOnClose context.CancelFunc
 }
 
 func envVariablesMap() map[string]string {
@@ -793,7 +794,9 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 		bufSize := decisionLogBufferSize(opaConfig.DecisionLogs)
 		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
 		opa.decisionsProcessed = make(chan struct{})
-		go opa.runDecisionLogger(decisionLogTaskTimeout(bufSize, registry.instanceStartupTimeout))
+		closingCtx, cancel := context.WithCancel(context.Background())
+		opa.decisionLogCancelOnClose = cancel
+		go opa.runDecisionLogger(closingCtx)
 	}
 
 	manager.RegisterCompilerTrigger(opa.compilerUpdated)
@@ -1024,6 +1027,7 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 		opa.Logger().Info("Closing OPA instance...")
 		opa.closing = true
 		if opa.decisionLogChan != nil {
+			opa.decisionLogCancelOnClose()
 			close(opa.decisionLogChan)
 			select {
 			case <-opa.decisionsProcessed:
@@ -1034,36 +1038,23 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 	})
 }
 
-// decisionLogTaskTimeout returns the per-task timeout for runDecisionLogger.
-// It is bufSize/200 seconds (time to fill the buffer with 200rps),
-// clamped to [decisionLogTaskTimeoutMin, instanceStartupTimeout].
-func decisionLogTaskTimeout(bufSize int, instanceStartupTimeout time.Duration) time.Duration {
-	t := time.Duration(bufSize/200) * time.Second
-	if t < decisionLogTaskTimeoutMin {
-		t = decisionLogTaskTimeoutMin
-	}
-	if t > instanceStartupTimeout {
-		t = instanceStartupTimeout
-	}
-	return t
-}
-
 // runDecisionLogger drains decisionLogChan in the background so that logDecision
 // is never called on the request goroutine. The goroutine exits when the channel
 // is closed (during Close) and signals completion via decisionsProcessed.
-func (opa *OpenPolicyAgentInstance) runDecisionLogger(timeout time.Duration) {
+// closingCtx is cancelled by Close() to unblock any doLogDecision call that is stuck
+// (e.g. a Benthos stream.Consume() call on a stream stopped during eopa_dl.Reconfigure()).
+// A per-task timeout additionally bounds stuck calls during normal operation.
+func (opa *OpenPolicyAgentInstance) runDecisionLogger(closingCtx context.Context) {
 	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		// A context with timeout bounds the time runDecisionLogger spends on a single
-		// doLogDecision call. Without this, a Benthos stream.Consume() call on a
-		// stream that was stopped during eopa_dl.Reconfigure() blocks forever because
-		// the inproc reader is gone and context.Background() provides no escape hatch.
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		err := opa.doLogDecision(ctx, task.input, task.result, task.err)
-		cancel()
-		if err != nil {
+		ctx, cancel := context.WithTimeout(closingCtx, defaultDecisionLogTaskTimeout)
+		if span := opentracing.SpanFromContext(task.ctx); span != nil {
+			ctx = opentracing.ContextWithSpan(ctx, span)
+		}
+		if err := opa.doLogDecision(ctx, task.input, task.result, task.err); err != nil {
 			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
 		}
+		cancel()
 	}
 }
 

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -64,13 +64,7 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
-	// decisionLogTaskTimeout bounds the time runDecisionLogger spends on a single
-	// doLogDecision call. Without a deadline, a Benthos stream.Consume() call on a
-	// stream that was stopped during eopa_dl.Reconfigure() blocks forever because
-	// the inproc reader is gone and context.Background() provides no escape hatch.
-	// 5 s is long enough for a healthy stream under normal backpressure and short
-	// enough to recover within the NOT_READY window observed during a bundle reload.
-	decisionLogTaskTimeout = 5 * time.Second
+	decisionLogTaskTimeoutMin       = 5 * time.Second
 
 	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize
@@ -799,7 +793,7 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 		bufSize := decisionLogBufferSize(opaConfig.DecisionLogs)
 		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
 		opa.decisionsProcessed = make(chan struct{})
-		go opa.runDecisionLogger()
+		go opa.runDecisionLogger(decisionLogTaskTimeout(bufSize, registry.instanceStartupTimeout))
 	}
 
 	manager.RegisterCompilerTrigger(opa.compilerUpdated)
@@ -1040,13 +1034,31 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 	})
 }
 
+// decisionLogTaskTimeout returns the per-task timeout for runDecisionLogger.
+// It is bufSize/200 seconds (time to fill the buffer with 200rps),
+// clamped to [decisionLogTaskTimeoutMin, instanceStartupTimeout].
+func decisionLogTaskTimeout(bufSize int, instanceStartupTimeout time.Duration) time.Duration {
+	t := time.Duration(bufSize/200) * time.Second
+	if t < decisionLogTaskTimeoutMin {
+		t = decisionLogTaskTimeoutMin
+	}
+	if t > instanceStartupTimeout {
+		t = instanceStartupTimeout
+	}
+	return t
+}
+
 // runDecisionLogger drains decisionLogChan in the background so that logDecision
 // is never called on the request goroutine. The goroutine exits when the channel
 // is closed (during Close) and signals completion via decisionsProcessed.
-func (opa *OpenPolicyAgentInstance) runDecisionLogger() {
+func (opa *OpenPolicyAgentInstance) runDecisionLogger(timeout time.Duration) {
 	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		ctx, cancel := context.WithTimeout(context.Background(), decisionLogTaskTimeout)
+		// A context with timeout bounds the time runDecisionLogger spends on a single
+		// doLogDecision call. Without this, a Benthos stream.Consume() call on a
+		// stream that was stopped during eopa_dl.Reconfigure() blocks forever because
+		// the inproc reader is gone and context.Background() provides no escape hatch.
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		err := opa.doLogDecision(ctx, task.input, task.result, task.err)
 		cancel()
 		if err != nil {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -64,7 +64,7 @@ const (
 	defaultShutdownGracePeriod      = 30 * time.Second
 	DefaultOpaStartupTimeout        = 30 * time.Second
 	DefaultBackgroundTaskBufferSize = 100
-	defaultDecisionLogTaskTimeout   = 60 * time.Second
+	DefaultDecisionLogTaskTimeout   = 5 * time.Second
 	DefaultMaxRequestBodySize       = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing     = 100 * DefaultMaxRequestBodySize
 	DefaultRequestBodyBufferSize    = 8 * 1024 // 8 KB
@@ -131,7 +131,8 @@ type OpenPolicyAgentRegistry struct {
 	// New fields for pre-loading support
 	preloadingEnabled bool
 
-	asyncDecisionLogging bool
+	asyncDecisionLogging        bool
+	decisionLogTaskTimeout      time.Duration
 
 	// Background task system
 	backgroundTaskChan       chan *BackgroundTask
@@ -239,6 +240,13 @@ func WithControlLoopMaxJitter(maxJitter time.Duration) func(*OpenPolicyAgentRegi
 	}
 }
 
+func WithDecisionLogTaskTimeout(timeout time.Duration) func(*OpenPolicyAgentRegistry) error {
+	return func(cfg *OpenPolicyAgentRegistry) error {
+		cfg.decisionLogTaskTimeout = timeout
+		return nil
+	}
+}
+
 func WithPrometheusRegisterer(registerer prometheus.Registerer) func(*OpenPolicyAgentRegistry) error {
 	return func(cfg *OpenPolicyAgentRegistry) error {
 		cfg.prometheusRegisterer = registerer
@@ -302,6 +310,7 @@ func NewOpenPolicyAgentRegistry(opts ...func(*OpenPolicyAgentRegistry) error) (*
 		bodyReadBufferSize:       DefaultRequestBodyBufferSize,
 		controlLoopInterval:      DefaultControlLoopInterval,
 		controlLoopMaxJitter:     DefaultControlLoopMaxJitter,
+		decisionLogTaskTimeout:   DefaultDecisionLogTaskTimeout,
 		backgroundTaskBufferSize: DefaultBackgroundTaskBufferSize,
 	}
 
@@ -653,7 +662,7 @@ type OpenPolicyAgentInstance struct {
 
 	decisionLogChan          chan decisionLogTask
 	decisionsProcessed       chan struct{}
-	decisionLogCancelOnClose context.CancelFunc
+	decisionLogTaskTimeout   time.Duration
 }
 
 func envVariablesMap() map[string]string {
@@ -794,9 +803,12 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 		bufSize := decisionLogBufferSize(opaConfig.DecisionLogs)
 		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
 		opa.decisionsProcessed = make(chan struct{})
-		var closingCtx context.Context
-		closingCtx, opa.decisionLogCancelOnClose = context.WithCancel(context.Background())
-		go opa.runDecisionLogger(closingCtx)
+		if t := decisionLogS3OutputTimeout(opaConfig.DecisionLogs); t > 0 {
+			opa.decisionLogTaskTimeout = t
+		} else {
+			opa.decisionLogTaskTimeout = registry.decisionLogTaskTimeout
+		}
+		go opa.runDecisionLogger()
 	}
 
 	manager.RegisterCompilerTrigger(opa.compilerUpdated)
@@ -821,6 +833,43 @@ func allPluginsReady(allPluginsStatus map[string]*plugins.Status, pluginNames ..
 		}
 	}
 	return true
+}
+
+// decisionLogS3OutputTimeout parses the eopa_dl decision_logs config and returns
+// the timeout from the first S3 output entry, or 0 if not present or unparseable.
+func decisionLogS3OutputTimeout(rawConfig json.RawMessage) time.Duration {
+	if rawConfig == nil {
+		return 0
+	}
+	var cfg struct {
+		Output json.RawMessage `json:"output"`
+	}
+	if err := json.Unmarshal(rawConfig, &cfg); err != nil || cfg.Output == nil {
+		return 0
+	}
+	// Output may be a single object or an array.
+	var outputs []json.RawMessage
+	if err := json.Unmarshal(cfg.Output, &outputs); err != nil {
+		// Not an array — try as a single object.
+		outputs = []json.RawMessage{cfg.Output}
+	}
+	type outputEntry struct {
+		Type    string `json:"type"`
+		Timeout string `json:"timeout"`
+	}
+	for _, raw := range outputs {
+		var entry outputEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			continue
+		}
+		if entry.Type == "s3" && entry.Timeout != "" {
+			d, err := time.ParseDuration(entry.Timeout)
+			if err == nil {
+				return d
+			}
+		}
+	}
+	return 0
 }
 
 func decisionLogBufferSize(rawConfig json.RawMessage) int {
@@ -1027,7 +1076,6 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 		opa.Logger().Info("Closing OPA instance...")
 		opa.closing = true
 		if opa.decisionLogChan != nil {
-			opa.decisionLogCancelOnClose()
 			close(opa.decisionLogChan)
 			select {
 			case <-opa.decisionsProcessed:
@@ -1041,18 +1089,17 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 // runDecisionLogger drains decisionLogChan in the background so that logDecision
 // is never called on the request goroutine. The goroutine exits when the channel
 // is closed (during Close) and signals completion via decisionsProcessed.
-// closingCtx is cancelled by Close() to unblock any doLogDecision call that is stuck
-// (e.g. a Benthos stream.Consume() call on a stream stopped during eopa_dl.Reconfigure()).
-// A per-task timeout additionally bounds stuck calls during normal operation.
-func (opa *OpenPolicyAgentInstance) runDecisionLogger(closingCtx context.Context) {
+// A per-task timeout bounds stuck calls (e.g. a Benthos stream.Consume() call on a
+// stream stopped during eopa_dl.Reconfigure()).
+func (opa *OpenPolicyAgentInstance) runDecisionLogger() {
 	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		opa.processDecisionLogTask(closingCtx, task)
+		opa.processDecisionLogTask(task)
 	}
 }
 
-func (opa *OpenPolicyAgentInstance) processDecisionLogTask(closingCtx context.Context, task decisionLogTask) {
-	ctx, cancel := context.WithTimeout(closingCtx, defaultDecisionLogTaskTimeout)
+func (opa *OpenPolicyAgentInstance) processDecisionLogTask(task decisionLogTask) {
+	ctx, cancel := context.WithTimeout(context.Background(), opa.decisionLogTaskTimeout)
 	defer cancel()
 	if span := opentracing.SpanFromContext(task.ctx); span != nil {
 		ctx = opentracing.ContextWithSpan(ctx, span)

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -131,8 +131,8 @@ type OpenPolicyAgentRegistry struct {
 	// New fields for pre-loading support
 	preloadingEnabled bool
 
-	asyncDecisionLogging        bool
-	decisionLogTaskTimeout      time.Duration
+	asyncDecisionLogging   bool
+	decisionLogTaskTimeout time.Duration
 
 	// Background task system
 	backgroundTaskChan       chan *BackgroundTask
@@ -660,9 +660,9 @@ type OpenPolicyAgentInstance struct {
 
 	idGenerator flowid.Generator
 
-	decisionLogChan          chan decisionLogTask
-	decisionsProcessed       chan struct{}
-	decisionLogTaskTimeout   time.Duration
+	decisionLogChan        chan decisionLogTask
+	decisionsProcessed     chan struct{}
+	decisionLogTaskTimeout time.Duration
 }
 
 func envVariablesMap() map[string]string {

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -794,8 +794,8 @@ func (registry *OpenPolicyAgentRegistry) new(store storage.Store, bundleName str
 		bufSize := decisionLogBufferSize(opaConfig.DecisionLogs)
 		opa.decisionLogChan = make(chan decisionLogTask, bufSize)
 		opa.decisionsProcessed = make(chan struct{})
-		closingCtx, cancel := context.WithCancel(context.Background())
-		opa.decisionLogCancelOnClose = cancel
+		var closingCtx context.Context
+		closingCtx, opa.decisionLogCancelOnClose = context.WithCancel(context.Background())
 		go opa.runDecisionLogger(closingCtx)
 	}
 
@@ -1047,14 +1047,18 @@ func (opa *OpenPolicyAgentInstance) Close(ctx context.Context) {
 func (opa *OpenPolicyAgentInstance) runDecisionLogger(closingCtx context.Context) {
 	defer close(opa.decisionsProcessed)
 	for task := range opa.decisionLogChan {
-		ctx, cancel := context.WithTimeout(closingCtx, defaultDecisionLogTaskTimeout)
-		if span := opentracing.SpanFromContext(task.ctx); span != nil {
-			ctx = opentracing.ContextWithSpan(ctx, span)
-		}
-		if err := opa.doLogDecision(ctx, task.input, task.result, task.err); err != nil {
-			opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
-		}
-		cancel()
+		opa.processDecisionLogTask(closingCtx, task)
+	}
+}
+
+func (opa *OpenPolicyAgentInstance) processDecisionLogTask(closingCtx context.Context, task decisionLogTask) {
+	ctx, cancel := context.WithTimeout(closingCtx, defaultDecisionLogTaskTimeout)
+	defer cancel()
+	if span := opentracing.SpanFromContext(task.ctx); span != nil {
+		ctx = opentracing.ContextWithSpan(ctx, span)
+	}
+	if err := opa.doLogDecision(ctx, task.input, task.result, task.err); err != nil {
+		opa.Logger().WithFields(map[string]interface{}{"err": err}).Error("Unable to log decision to control plane.")
 	}
 }
 

--- a/filters/openpolicyagent/openpolicyagent.go
+++ b/filters/openpolicyagent/openpolicyagent.go
@@ -68,9 +68,9 @@ const (
 	// doLogDecision call. Without a deadline, a Benthos stream.Consume() call on a
 	// stream that was stopped during eopa_dl.Reconfigure() blocks forever because
 	// the inproc reader is gone and context.Background() provides no escape hatch.
-	// 30 s is long enough for healthy Benthos stream delivery while ensuring recovery
-	// after a bundle reload within the OPA startup timeout window.
-	decisionLogTaskTimeout = 30 * time.Second
+	// 5 s is long enough for a healthy stream under normal backpressure and short
+	// enough to recover within the NOT_READY window observed during a bundle reload.
+	decisionLogTaskTimeout = 5 * time.Second
 
 	DefaultMaxRequestBodySize    = 1 << 20 // 1 MB
 	DefaultMaxMemoryBodyParsing  = 100 * DefaultMaxRequestBodySize

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -1472,6 +1472,63 @@ func TestPrintTracing(t *testing.T) {
 	}
 }
 
+func TestDecisionLogS3OutputTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		config   string
+		expected time.Duration
+	}{
+		{
+			name:     "s3 output with timeout",
+			config:   `{"output": [{"type": "s3", "bucket": "b", "region": "eu-west-1", "timeout": "2s"}]}`,
+			expected: 2 * time.Second,
+		},
+		{
+			name:     "s3 output as single object",
+			config:   `{"output": {"type": "s3", "bucket": "b", "region": "eu-west-1", "timeout": "10s"}}`,
+			expected: 10 * time.Second,
+		},
+		{
+			name:     "s3 output without timeout",
+			config:   `{"output": [{"type": "s3", "bucket": "b", "region": "eu-west-1"}]}`,
+			expected: 0,
+		},
+		{
+			name:     "non-s3 output with timeout",
+			config:   `{"output": [{"type": "http", "url": "http://example.com", "timeout": "5s"}]}`,
+			expected: 0,
+		},
+		{
+			name:     "s3 and console outputs",
+			config:   `{"output": [{"type": "s3", "bucket": "b", "region": "eu-west-1", "timeout": "3s"}, {"type": "console"}]}`,
+			expected: 3 * time.Second,
+		},
+		{
+			name:     "nil config",
+			config:   "",
+			expected: 0,
+		},
+		{
+			name:     "invalid json",
+			config:   `{invalid}`,
+			expected: 0,
+		},
+		{
+			name:     "invalid timeout value",
+			config:   `{"output": [{"type": "s3", "bucket": "b", "region": "eu-west-1", "timeout": "notaduration"}]}`,
+			expected: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw json.RawMessage
+			if tc.config != "" {
+				raw = json.RawMessage(tc.config)
+			}
+			assert.Equal(t, tc.expected, decisionLogS3OutputTimeout(raw))
+		})
+	}
+}
+
 // TestAsyncDecisionLogDroppedCounter verifies the decision_log.dropped counter
 func TestAsyncDecisionLogDroppedCounter(t *testing.T) {
 	mockMetrics := &metricstest.MockMetrics{}

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -1472,7 +1472,7 @@ func TestPrintTracing(t *testing.T) {
 	}
 }
 
-func TestDecisionLogS3OutputTimeout(t *testing.T) {
+func TestDecisionLogMaxOutputTimeout(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		config   string
@@ -1494,14 +1494,19 @@ func TestDecisionLogS3OutputTimeout(t *testing.T) {
 			expected: 0,
 		},
 		{
-			name:     "non-s3 output with timeout",
+			name:     "http output with timeout",
 			config:   `{"output": [{"type": "http", "url": "http://example.com", "timeout": "5s"}]}`,
-			expected: 0,
+			expected: 5 * time.Second,
 		},
 		{
 			name:     "s3 and console outputs",
 			config:   `{"output": [{"type": "s3", "bucket": "b", "region": "eu-west-1", "timeout": "3s"}, {"type": "console"}]}`,
 			expected: 3 * time.Second,
+		},
+		{
+			name:     "multiple outputs with different timeouts returns highest",
+			config:   `{"output": [{"type": "s3", "bucket": "b", "region": "eu-west-1", "timeout": "3s"}, {"type": "http", "url": "http://example.com", "timeout": "7s"}]}`,
+			expected: 7 * time.Second,
 		},
 		{
 			name:     "nil config",
@@ -1524,7 +1529,7 @@ func TestDecisionLogS3OutputTimeout(t *testing.T) {
 			if tc.config != "" {
 				raw = json.RawMessage(tc.config)
 			}
-			assert.Equal(t, tc.expected, decisionLogS3OutputTimeout(raw))
+			assert.Equal(t, tc.expected, decisionLogMaxOutputTimeout(raw))
 		})
 	}
 }


### PR DESCRIPTION
## Problem

When asyncDecisionLogging is enabled and a new policy bundle is deployed, eopa_dl.Reconfigure() calls Stop() on the running Benthos stream followed by Start() on a new one. If `runDecisionLogger` is inside stream.Consume() on the old stream at that moment, the Benthos producer closure tries to write the decision event to an internal channel whose reader (inproc input) has been destroyed by Stop().
  
Because `doLogDecision` was called with context.Background() (without deadline) the blocked send never returns. `runDecisionLogger` is permanently stuck on that one call and stops draining `decisionLogChan`.

With the goroutine stuck, once the channel fills to capacity (buffer_size_limit_events), every subsequent `logDecision` call hits the non-blocking default branch and drops the event, logging "Decision log dropped: async buffer full." The warning continues indefinitely with no self-recovery. The only fix prior to this change was a pod restart.
 
## Fix
Set timeout for the context passed for decision logging. The value for the timeout is decided using the configured timeout for the eopa_dl output type