### PR TITLE
fix: wait for cipher refresher goroutine to exit on Close

### DIFF
--- a/secrets/encrypter.go
+++ b/secrets/encrypter.go
@@ -157,16 +157,14 @@ func (e *Encrypter) runCipherRefresher(refreshInterval time.Duration) error {
 	if err != nil {
 		return fmt.Errorf("failed to refresh ciphers: %w", err)
 	}
+	e.closedHook = make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(refreshInterval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-e.closer:
-				if e.closedHook != nil {
-					close(e.closedHook)
-				}
-
+				close(e.closedHook)
 				return
 			case <-ticker.C:
 				log.Debug("started refresh of ciphers")

--- a/secrets/encrypter_test.go
+++ b/secrets/encrypter_test.go
@@ -135,7 +135,6 @@ func TestCipherRefreshing(t *testing.T) {
 		enc := &Encrypter{
 			secretSource: SecSource,
 			closer:       make(chan struct{}),
-			closedHook:   make(chan struct{}),
 		}
 		enc.runCipherRefresher(d)
 		time.Sleep(sleepD)

--- a/secrets/registry.go
+++ b/secrets/registry.go
@@ -57,5 +57,8 @@ func (r *Registry) GetEncrypter(refreshInterval time.Duration, file string) (Enc
 func (r *Registry) Close() {
 	for _, v := range r.encrypterMap {
 		v.Close()
+		if v.closedHook != nil {
+			<-v.closedHook
+		}
 	}
 }


### PR DESCRIPTION
# Related Issue

Fixes a goroutine leak found while working on #4034.

## Problem

`Registry.Close()` called `v.Close()` on each encrypter but returned immediately, leaving the `runCipherRefresher` goroutine running until it observed the closed channel on its next select iteration. Under `noleak` this caused a test failure in the `secrets` package.

## Fix

Initialize `closedHook` inside `runCipherRefresher` (only when a goroutine is actually started) and drain it in `Registry.Close()` so shutdown blocks until the goroutine has exited. The `nil` guard on the drain ensures encrypters created without a refresh interval (no goroutine started) are unaffected.

No behavior change in production - `Close()` is only called at shutdown.