### PR TITLE
fix: unbounded read of consuming the http.Body in the validation webhook

### DIFF
--- a/dataclients/kubernetes/admission/admission.go
+++ b/dataclients/kubernetes/admission/admission.go
@@ -13,6 +13,7 @@ import (
 const (
 	metricNamespace = "routegroup_admission"
 	metricSubsystem = "admitter"
+	maxBodySize     = 3145728
 )
 
 var (
@@ -71,9 +72,9 @@ func Handler(admitter admitter) http.HandlerFunc {
 			return
 		}
 
-		defer r.Body.Close()
-
-		body, err := io.ReadAll(r.Body)
+		rc := http.MaxBytesReader(w, r.Body, maxBodySize)
+		defer rc.Close()
+		body, err := io.ReadAll(rc)
 		if err != nil {
 			log.Errorf("Failed to read request: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/dataclients/kubernetes/admission/admission_test.go
+++ b/dataclients/kubernetes/admission/admission_test.go
@@ -315,3 +315,37 @@ func TestMalformedRequests(t *testing.T) {
 		})
 	}
 }
+
+func TestBodySizeLimit(t *testing.T) {
+	routeGroupHandler := Handler(&RouteGroupAdmitter{RouteGroupValidator: &definitions.RouteGroupValidator{}})
+	ingressHandler := Handler(&IngressAdmitter{IngressValidator: &definitions.IngressV1Validator{}})
+
+	size := maxBodySize + 1
+	buf := bytes.Buffer{}
+	buf.WriteString("{")
+	for range size - 1 {
+		buf.WriteString(" ")
+	}
+	buf.WriteString("}")
+
+	makeRequest := func() *http.Request {
+		method := "POST"
+
+		req := httptest.NewRequest(method, "http://example.com/foo", strings.NewReader(buf.String()))
+		req.Header.Set("Content-Type", "application/json")
+		return req
+	}
+
+	t.Run("route group", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		routeGroupHandler(w, makeRequest())
+		assert.Equal(t, 500, w.Code)
+	})
+
+	t.Run("ingress", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ingressHandler(w, makeRequest())
+		assert.Equal(t, 500, w.Code)
+	})
+
+}


### PR DESCRIPTION
fix: unbounded read of consuming the http.Body in the validation webhook

Reported by @alcls01111