### PR TITLE
fix: apply workaround for readTimeout

### DIFF
--- a/filters/builtin/timeout_test.go
+++ b/filters/builtin/timeout_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/filtertest"
+	"github.com/zalando/skipper/io/iotest"
 	"github.com/zalando/skipper/net"
 	"github.com/zalando/skipper/proxy/proxytest"
 )
@@ -179,20 +180,22 @@ func TestTimeoutsFilterReadTimeout(t *testing.T) {
 		args     string
 		workTime time.Duration
 		want     int
+		wantRsp  string
 		wantErr  bool
 	}{
 		{
 			name:     "ReadTimeout bigger than reading time should return 200",
 			args:     "1s",
-			workTime: 10 * time.Millisecond,
+			workTime: 0,
 			want:     http.StatusOK,
+			wantRsp:  "OK",
 			wantErr:  false,
 		}, {
 			name:     "ReadTimeout smaller than reading time should timeout",
 			args:     "15ms",
-			workTime: 5 * time.Millisecond,
+			workTime: 6 * time.Millisecond,
 			want:     499,
-			wantErr:  false,
+			wantErr:  true,
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -210,7 +213,7 @@ func TestTimeoutsFilterReadTimeout(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					if err := ctx.Err(); err != nil {
-						t.Fatalf("backend handler observes error form context: %v", err)
+						t.Fatalf("backend handler observes error from context: %v", err)
 					}
 				default:
 				}
@@ -224,7 +227,7 @@ func TestTimeoutsFilterReadTimeout(t *testing.T) {
 			filter := NewReadTimeout().(*timeout)
 
 			fr.Register(filter)
-			r := &eskip.Route{Filters: []*eskip.Filter{{Name: filter.Name(), Args: []interface{}{tt.args}}}, Backend: backend.URL}
+			r := &eskip.Route{Filters: []*eskip.Filter{{Name: filter.Name(), Args: []any{tt.args}}}, Backend: backend.URL}
 
 			proxy := proxytest.New(fr, r)
 			defer proxy.Close()
@@ -233,21 +236,15 @@ func TestTimeoutsFilterReadTimeout(t *testing.T) {
 				t.Fatalf("Failed to parse url %s: %v", proxy.URL, err)
 			}
 
-			client := net.NewClient(net.Options{})
-			defer client.Close()
-
 			var req *http.Request
 			dat := bytes.NewBufferString("abcdefghijklmn")
-			req, err = http.NewRequest("POST", reqURL.String(), &slowReader{
-				data: dat,
-				d:    tt.workTime,
-			})
+			req, err = http.NewRequest("POST", reqURL.String(), iotest.NewSlowReader(dat, tt.workTime))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			rsp, err := client.Do(req)
-
+			req.ContentLength = int64(dat.Len())
+			rsp, err := proxy.Client().Do(req)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -257,10 +254,14 @@ func TestTimeoutsFilterReadTimeout(t *testing.T) {
 			if rsp.StatusCode != tt.want {
 				t.Fatalf("Failed to get %d, got %d", tt.want, rsp.StatusCode)
 			}
-			_, err = io.Copy(io.Discard, rsp.Body)
+			buf, err := io.ReadAll(rsp.Body)
 			if err != nil {
 				t.Fatalf("Failed to read response body: %v", err)
-
+			}
+			if !tt.wantErr {
+				if string(buf) != tt.wantRsp {
+					t.Fatalf("Failed to get response, got: %q", string(buf))
+				}
 			}
 		})
 	}
@@ -299,7 +300,7 @@ func TestTimeoutsFilterWriteTimeout(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 
 				now := time.Now()
-				for i := 0; i < 5; i++ {
+				for range 5 {
 					n, err := w.Write([]byte(strings.Repeat("a", 8192)))
 					if err != nil {
 						t.Logf("Failed to write: %v", err)
@@ -367,16 +368,4 @@ func TestTimeoutsFilterWriteTimeout(t *testing.T) {
 		})
 	}
 
-}
-
-type slowReader struct {
-	data *bytes.Buffer
-	d    time.Duration
-}
-
-func (sr *slowReader) Read(b []byte) (int, error) {
-	r := io.LimitReader(sr.data, 2)
-	n, err := r.Read(b)
-	time.Sleep(sr.d)
-	return n, err
 }

--- a/io/iotest/reader.go
+++ b/io/iotest/reader.go
@@ -50,3 +50,10 @@ func (sr *SlowReader) Read(p []byte) (n int, err error) {
 
 	return n, nil
 }
+
+func (sr *SlowReader) Close() error {
+	if rc, ok := sr.r.(io.ReadCloser); ok {
+		return rc.Close()
+	}
+	return nil
+}

--- a/proxy/clienttimeout_test.go
+++ b/proxy/clienttimeout_test.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -101,6 +103,81 @@ func TestClientCancellation(t *testing.T) {
 		if count != N {
 			t.Errorf("expected '%s' %d times, got %d", m, N, tp.log.Count(m))
 		}
+	}
+}
+
+func TestReadTimeoutSocketClosed(t *testing.T) {
+	backend := startTestServer([]byte("backend reply"), 0, func(*http.Request) {})
+	defer backend.Close()
+
+	doc := fmt.Sprintf(`
+		r1: Path("/timeout") -> readTimeout("10ms") -> status(201) -> "%s";
+		r2: Path("/ok") -> status(200) -> inlineContent("OK") -> <shunt>
+	`, backend.URL)
+
+	tp, err := newTestProxy(doc, FlagsNone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tp.close()
+
+	ps := httptest.NewServer(tp.proxy)
+	defer ps.Close()
+
+	addr := ps.Listener.Addr().String()
+
+	readResp := func(conn net.Conn) *http.Response {
+		t.Helper()
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			t.Fatalf("Failed to read response: %v", err)
+		}
+
+		_, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read response body: %v", err)
+		}
+		resp.Body.Close()
+
+		return resp
+	}
+
+	// Verify both routes return their configured status codes (normal client).
+	for _, tc := range []struct {
+		path string
+		want int
+	}{
+		{"/timeout", http.StatusCreated},
+		{"/ok", http.StatusOK},
+	} {
+		resp, err := ps.Client().Get("http://" + addr + tc.path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", tc.path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != tc.want {
+			t.Errorf("GET %s: got %d, want %d", tc.path, resp.StatusCode, tc.want)
+		}
+	}
+
+	postConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial post conn: %v", err)
+	}
+	defer postConn.Close()
+
+	// Write only the headers + partial body, then stall. Do not close the
+	// connection — the proxy must wait for more bytes until the deadline fires.
+	if _, err := postConn.Write([]byte("POST /timeout HTTP/1.1\r\nHost: " + addr + "\r\nContent-Length: 2000\r\n\r\ntruncated")); err != nil {
+		t.Fatalf("Failed to write POST stall: %v", err)
+	}
+	postResp := readResp(postConn)
+	if postResp.StatusCode != 499 {
+		t.Errorf("POST /timeout with stalled body: got %d, want 499", postResp.StatusCode)
+	}
+	// Because of https://github.com/zalando/skipper/issues/4060 and https://github.com/golang/go/issues/70834 we want to have a closed connection
+	if !postResp.Close {
+		t.Fatalf("Failed to get close connection header")
 	}
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -2035,7 +2035,10 @@ func (p *Proxy) makeErrorResponse(ctx *context, perr *proxyError) {
 	case perr.code != 0:
 		code = perr.code
 		if perr.code == 499 {
+			// https://github.com/zalando/skipper/issues/4060
+			// readTimeout() hit and because of
 			// https://github.com/golang/go/issues/70834
+			// we need to close the underlying connection
 			ctx.response.Header.Set("Connection", "close")
 		}
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1444,9 +1444,11 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 
 		backendStart := time.Now()
 		if d, ok := ctx.StateBag()[filters.ReadTimeout].(time.Duration); ok {
-			e := ctx.ResponseController().SetReadDeadline(backendStart.Add(d))
-			if e != nil {
-				ctx.Logger().Errorf("Failed to set read deadline: %v", e)
+			if ctx.Request().ContentLength > 0 {
+				e := ctx.ResponseController().SetReadDeadline(backendStart.Add(d))
+				if e != nil {
+					ctx.Logger().Errorf("Failed to set read deadline: %v", e)
+				}
 			}
 		}
 
@@ -2032,6 +2034,10 @@ func (p *Proxy) makeErrorResponse(ctx *context, perr *proxyError) {
 		code = http.StatusBadGateway
 	case perr.code != 0:
 		code = perr.code
+		if perr.code == 499 {
+			// https://github.com/golang/go/issues/70834
+			ctx.response.Header.Set("Connection", "close")
+		}
 	}
 
 	text := http.StatusText(code) + "\n"


### PR DESCRIPTION
fix: apply workaround for readTimeout

ref: https://github.com/zalando/skipper/issues/4060
Go issue: https://github.com/golang/go/issues/70834
ref changeset Go: https://go-review.googlesource.com/c/go/+/637715