### PR TITLE
fix: host metrics should be measured and stored correctly in case of HostAny() predicate

### DIFF
--- a/metrics/metricstest/metricsmock.go
+++ b/metrics/metricstest/metricsmock.go
@@ -5,6 +5,7 @@ package metricstest
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -187,7 +188,14 @@ func (m *MockMetrics) MeasureProxy(requestDuration, responseDuration time.Durati
 }
 
 func (m *MockMetrics) MeasureServe(routeID, host, method string, code int, start time.Time) {
-	// implement me
+	d := time.Since(start)
+	m.WithMeasures(func(measures map[string][]time.Duration) {
+		measures[routeID] = append(measures[routeID], d)
+		measures[host] = append(measures[host], d)
+		measures[method] = append(measures[method], d)
+		measures[strconv.Itoa(code)] = append(measures[strconv.Itoa(code)], d)
+	})
+
 }
 
 func (m *MockMetrics) IncRoutingFailures() {

--- a/predicates/host/any.go
+++ b/predicates/host/any.go
@@ -3,6 +3,7 @@ package host
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/zalando/skipper/predicates"
 	"github.com/zalando/skipper/routing"
@@ -10,7 +11,7 @@ import (
 
 type anySpec struct{}
 
-type anyPredicate struct {
+type AnyPredicate struct {
 	hosts []string
 }
 
@@ -29,7 +30,7 @@ func (*anySpec) Create(args []interface{}) (routing.Predicate, error) {
 	if len(args) == 0 {
 		return nil, predicates.ErrInvalidPredicateParameters
 	}
-	p := &anyPredicate{}
+	p := &AnyPredicate{}
 	for _, arg := range args {
 		if host, ok := arg.(string); ok {
 			p.hosts = append(p.hosts, host)
@@ -40,11 +41,6 @@ func (*anySpec) Create(args []interface{}) (routing.Predicate, error) {
 	return p, nil
 }
 
-func (ap *anyPredicate) Match(r *http.Request) bool {
-	for _, host := range ap.hosts {
-		if host == r.Host {
-			return true
-		}
-	}
-	return false
+func (ap *AnyPredicate) Match(r *http.Request) bool {
+	return slices.Contains(ap.hosts, r.Host)
 }

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/metrics"
+	hostPred "github.com/zalando/skipper/predicates/host"
 	"github.com/zalando/skipper/routing"
 	"github.com/zalando/skipper/tracing"
 
@@ -253,7 +254,16 @@ func (c *context) Serve(r *http.Response) {
 }
 
 func (c *context) metricsHost() string {
-	if c.route == nil || len(c.route.HostRegexps) == 0 {
+	if c.route == nil {
+		return unknownHost
+	}
+
+	if len(c.route.HostRegexps) == 0 {
+		for _, p := range c.route.Predicates {
+			if _, ok := p.(*hostPred.AnyPredicate); ok {
+				return c.request.Host
+			}
+		}
 		return unknownHost
 	}
 

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -285,7 +285,7 @@ func TestMeasureProxyWatch(t *testing.T) {
 
 			// wait until metrics are recorded
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				m.WithMeasures(func(measures map[string][]time.Duration) { assert.Len(c, measures, 3) })
+				m.WithMeasures(func(measures map[string][]time.Duration) { assert.Len(c, measures, 7) })
 			}, 100*time.Millisecond, 1*time.Millisecond)
 
 			m.WithMeasures(func(measures map[string][]time.Duration) {

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -218,6 +218,7 @@ func TestMeasureHostMetrics(t *testing.T) {
 	get(reqFoo)
 	get(reqBar)
 
+	time.Sleep(100 * time.Millisecond) // We hope to get data populated
 	m.WithMeasures(func(measures map[string][]time.Duration) {
 		assert.Equal(t, 1, len(measures["foo"]))
 		assert.Equal(t, 1, len(measures["bar"]))

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -219,13 +219,13 @@ func TestMeasureHostMetrics(t *testing.T) {
 	get(reqBar)
 
 	m.WithMeasures(func(measures map[string][]time.Duration) {
-		assert.Equal(t, len(measures["foo"]), 1)
-		assert.Equal(t, len(measures["bar"]), 1)
-		assert.Equal(t, len(measures["GET"]), 2)
-		assert.Equal(t, len(measures["200"]), 2)
-		assert.Equal(t, len(measures["proxy.request.duration"]), 2)
-		assert.Equal(t, len(measures["proxy.response.duration"]), 2)
-		assert.Equal(t, len(measures["proxy.total.duration"]), 2)
+		assert.Equal(t, 1, len(measures["foo"]))
+		assert.Equal(t, 1, len(measures["bar"]))
+		assert.Equal(t, 2, len(measures["GET"]))
+		assert.Equal(t, 2, len(measures["200"]))
+		assert.Equal(t, 2, len(measures["proxy.request.duration"]))
+		assert.Equal(t, 2, len(measures["proxy.response.duration"]))
+		assert.Equal(t, 2, len(measures["proxy.total.duration"]))
 		assert.Equal(t, measures["foo"], measures["foo.skipper.test"])
 	})
 }

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/metrics/metricstest"
 	"github.com/zalando/skipper/net/dnstest"
+	"github.com/zalando/skipper/predicates/host"
 	"github.com/zalando/skipper/proxy"
 	"github.com/zalando/skipper/proxy/proxytest"
 	"github.com/zalando/skipper/routing"
@@ -159,6 +161,72 @@ func TestMeasureBackendRequestHeader(t *testing.T) {
 		barSize := values[fmt.Sprintf("backend.%s.request_header_bytes", barHost)][0]
 
 		assert.Equal(t, barSize-fooSize, float64(len(barHeader)-len(fooHeader)))
+	})
+}
+
+func TestMeasureHostMetrics(t *testing.T) {
+	dnstest.LoopbackNames(t, "foo.skipper.test", "bar.skipper.test")
+
+	m := &metricstest.MockMetrics{}
+	defer m.Close()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("OK"))
+	}))
+	defer backend.Close()
+
+	p := proxytest.Config{
+		Routes: eskip.MustParse(fmt.Sprintf(`
+			foo: HostAny("foo.skipper.test") -> "%s";
+			bar: Host("^bar[.]skipper[.]test") -> "%s";
+		`, backend.URL, backend.URL)),
+		RoutingOptions: routing.Options{
+			FilterRegistry: builtin.MakeRegistry(),
+			Predicates: []routing.PredicateSpec{
+				host.NewAny(),
+			},
+		},
+		ProxyParams: proxy.Params{Metrics: m},
+	}.Create()
+	defer p.Close()
+
+	client := p.Client()
+	get := func(req *http.Request) {
+		t.Helper()
+		rsp, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 200, rsp.StatusCode, "called %s with host %s", req.URL.String(), req.Host)
+		io.Copy(io.Discard, rsp.Body)
+		rsp.Body.Close()
+	}
+
+	fooHost := net.JoinHostPort("foo.skipper.test", p.Port)
+	barHost := net.JoinHostPort("bar.skipper.test", p.Port)
+
+	reqFoo, err := http.NewRequest("GET", "http://"+fooHost, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	reqFoo.Host = "foo.skipper.test" // HostAny() does not ignore port
+
+	reqBar, err := http.NewRequest("GET", "http://"+barHost, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	get(reqFoo)
+	get(reqBar)
+
+	m.WithMeasures(func(measures map[string][]time.Duration) {
+		assert.Equal(t, len(measures["foo"]), 1)
+		assert.Equal(t, len(measures["bar"]), 1)
+		assert.Equal(t, len(measures["GET"]), 2)
+		assert.Equal(t, len(measures["200"]), 2)
+		assert.Equal(t, len(measures["proxy.request.duration"]), 2)
+		assert.Equal(t, len(measures["proxy.response.duration"]), 2)
+		assert.Equal(t, len(measures["proxy.total.duration"]), 2)
+		assert.Equal(t, measures["foo"], measures["foo.skipper.test"])
 	})
 }
 


### PR DESCRIPTION
fix: host metrics should be measured and stored correctly in case of HostAny() predicate

Before this fix we measured a route like the following in the bucket `"_unknownhost_"`:

```
r: HostAny("www.example.com") -> <shunt>
```
