### PR TITLE
routing: measure data client LoadAll/LoadUpdate duration

### DIFF
--- a/routing/datasource.go
+++ b/routing/datasource.go
@@ -59,6 +59,16 @@ func (d *incomingData) log(l logging.Logger, suppress bool) {
 	}
 }
 
+// dataClientName returns a name for the data client suitable for use in metric
+// keys, using NamedDataClient.Name() when available.
+func dataClientName(c DataClient) string {
+	name := "unknown"
+	if nc, ok := c.(NamedDataClient); ok {
+		name = nc.Name()
+	}
+	return name
+}
+
 // continuously receives route definitions from a data client on the output channel.
 // The function does not return unless quit is closed. When started, it request for the
 // whole current set of routes, and continues polling for the subsequent updates. When a
@@ -67,6 +77,7 @@ func (d *incomingData) log(l logging.Logger, suppress bool) {
 // nondeterministic way, but this may change in the future.
 func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <-chan struct{}) {
 	initial := true
+	clientName := dataClientName(c)
 	var ticker *time.Ticker
 	if o.PollTimeout != 0 {
 		ticker = time.NewTicker(o.PollTimeout)
@@ -74,6 +85,8 @@ func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <
 		ticker = time.NewTicker(time.Millisecond)
 	}
 	defer ticker.Stop()
+	now := time.Now()
+
 	for {
 		var (
 			routes     []*eskip.Route
@@ -83,8 +96,10 @@ func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <
 
 		if initial {
 			routes, err = c.LoadAll()
+			o.Metrics.MeasureSince("routes.load_all."+clientName, now)
 		} else {
 			routes, deletedIDs, err = c.LoadUpdate()
+			o.Metrics.MeasureSince("routes.load_update."+clientName, now)
 		}
 
 		switch {
@@ -93,6 +108,7 @@ func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <
 		case err != nil:
 			o.Log.Error("error while receiving update;", err)
 			initial = true
+			now = time.Now()
 			continue
 		case initial || len(routes) > 0 || len(deletedIDs) > 0:
 			var incoming *incomingData
@@ -111,7 +127,8 @@ func receiveFromClient(c DataClient, o Options, out chan<- *incomingData, quit <
 		}
 
 		select {
-		case <-ticker.C:
+		case t := <-ticker.C:
+			now = t
 		case <-quit:
 			return
 		}

--- a/routing/datasource_test.go
+++ b/routing/datasource_test.go
@@ -774,3 +774,57 @@ func (s slowCreateSpec) CreateFilter(args []interface{}) (filters.Filter, error)
 
 func (s slowCreateFilter) Request(ctx filters.FilterContext) {}
 func (s slowCreateFilter) Response(filters.FilterContext)    {}
+
+func TestDataClientLoadMetrics(t *testing.T) {
+	m := &metricstest.MockMetrics{Now: time.Now()}
+
+	dc, err := testdataclient.NewDoc(`r0: * -> <shunt>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := routing.New(routing.Options{
+		DataClients:     []routing.DataClient{dc},
+		Metrics:         m,
+		SignalFirstLoad: true,
+	})
+	defer func() {
+		r.Close()
+		dc.Close()
+	}()
+
+	<-r.FirstLoad()
+
+	// LoadAll ran during the first load.
+	waitForMeasure(t, m, "routes.load_all.unknown")
+
+	// Trigger an update to exercise the LoadUpdate path.
+	if err := dc.UpdateDoc(`r1: * -> <shunt>`, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForMeasure(t, m, "routes.load_update.unknown")
+}
+
+func waitForMeasure(t *testing.T, m *metricstest.MockMetrics, key string) {
+	t.Helper()
+	timeout := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		found := false
+		m.WithMeasures(func(measures map[string][]time.Duration) {
+			_, found = measures[key]
+		})
+		if found {
+			return
+		}
+
+		select {
+		case <-timeout:
+			t.Fatalf("timed out waiting for measure %q", key)
+		case <-ticker.C:
+		}
+	}
+}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -268,6 +268,10 @@ func New(o Options) *Routing {
 		o.Log = &logging.DefaultLog{}
 	}
 
+	if o.Metrics == nil {
+		o.Metrics = metrics.Void
+	}
+
 	uniqueClients := make(map[DataClient]struct{}, len(o.DataClients))
 	for i, c := range o.DataClients {
 		if _, ok := uniqueClients[c]; ok {


### PR DESCRIPTION
Fixes #4086

Adds per-data-client timing of LoadAll and LoadUpdate in receiveFromClient
using the existing Metrics.MeasureSince. Keyed by client name and operation:
- `routes.<client>.load_all`
- `routes.<client>.load_update`

The client name comes from NamedDataClient.Name() where available, falling
back to the concrete type otherwise.

As agreed with @fvigneault in #4086, this encodes the name and
operation in the metric key (rather than a new Prometheus histogram with
explicit labels) and drops the result/error dimension.
