### PR TITLE
feat: add encodeBase64RequestHeader and encodeBase64ResponseHeader filters

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -356,6 +356,22 @@ decodeBase64RequestHeader("Authorization", 1) //
 
 Similar to [decodeBase64RequestHeader](#decodeBase64RequestHeader) on response headers.
 
+### encodeBase64RequestHeader
+
+Encodes the value of a chosen request header by encoding to base64. It
+supports partial value encoding by the optional second argument.
+
+Example:
+```
+encodeBase64RequestHeader("X-Foo")
+encodeBase64RequestHeader("X-Foo", 2)
+encodeBase64RequestHeader("Authorization", 1)
+```
+
+### encodeBase64ResponseHeader
+
+Similar to [encodeBase64RequestHeader](#encodeBase64RequestHeader) on response headers.
+
 ### encodeRequestHeader
 
 The filter has 2 arguments, the header name and the encoding.

--- a/filters/builtin/builtin.go
+++ b/filters/builtin/builtin.go
@@ -142,6 +142,8 @@ func Filters() []filters.Spec {
 		NewSetPath(),
 		NewModRequestHeader(),
 		NewModResponseHeader(),
+		NewEncodeRequestHeaderBase64(),
+		NewEncodeResponseHeaderBase64(),
 		NewEncodeRequestHeader(),
 		NewEncodeResponseHeader(),
 		NewDecodeRequestHeaderBase64(),

--- a/filters/builtin/header_base64.go
+++ b/filters/builtin/header_base64.go
@@ -1,0 +1,146 @@
+package builtin
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/zalando/skipper/filters"
+)
+
+type encodeBase64Type int
+
+const (
+	encodeRequestHeaderBase64 encodeBase64Type = iota
+	encodeResponseHeaderBase64
+)
+
+// encodeBase64 filter for encoding header values to base64
+type encodeBase64 struct {
+	typ        encodeBase64Type
+	headerName string
+	partIndex  *int // nil means encode entire value, otherwise encode the part at this index
+}
+
+// NewEncodeRequestHeaderBase64 returns a filter specification that encodes
+// a request header value (or a specific space-delimited part of it) to base64.
+// Instances expect one or two parameters:
+// - First parameter: header name (required)
+// - Second parameter: part index (optional, 0-based)
+// If the second parameter is not provided, the entire header value is encoded.
+// Name: "encodeBase64RequestHeader".
+func NewEncodeRequestHeaderBase64() filters.Spec {
+	return &encodeBase64{typ: encodeRequestHeaderBase64}
+}
+
+// NewEncodeResponseHeaderBase64 returns a filter specification that encodes
+// a response header value (or a specific space-delimited part of it) to base64.
+// Instances expect one or two parameters:
+// - First parameter: header name (required)
+// - Second parameter: part index (optional, 0-based)
+// If the second parameter is not provided, the entire header value is encoded.
+// Name: "encodeBase64ResponseHeader".
+func NewEncodeResponseHeaderBase64() filters.Spec {
+	return &encodeBase64{typ: encodeResponseHeaderBase64}
+}
+
+func (spec *encodeBase64) Name() string {
+	switch spec.typ {
+	case encodeRequestHeaderBase64:
+		return filters.EncodeBase64RequestHeaderName
+	case encodeResponseHeaderBase64:
+		return filters.EncodeBase64ResponseHeaderName
+	default:
+		panic("invalid encodeBase64 type")
+	}
+}
+
+//lint:ignore ST1016 "spec" makes sense here and we reuse the type for the filter
+func (spec *encodeBase64) CreateFilter(args []any) (filters.Filter, error) {
+	if len(args) < 1 || len(args) > 2 {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	headerName, ok := args[0].(string)
+	if !ok {
+		return nil, filters.ErrInvalidFilterParameters
+	}
+
+	var partIndex *int
+	if len(args) == 2 {
+		switch v := args[1].(type) {
+		case float64:
+			idx := int(v)
+			partIndex = &idx
+		default:
+			return nil, filters.ErrInvalidFilterParameters
+		}
+	}
+
+	return &encodeBase64{
+		typ:        spec.typ,
+		headerName: headerName,
+		partIndex:  partIndex,
+	}, nil
+}
+
+// encodeBase64Value encodes a value (or a specific part of it) to base64.
+// If partIndex is nil, it encodes the entire value.
+// If partIndex is provided, it splits the value by whitespace and encodes the part at that index.
+func encodeBase64Value(value string, partIndex *int) (string, error) {
+	if partIndex == nil {
+		// Encode the entire value
+		encoded := base64.StdEncoding.EncodeToString([]byte(value))
+		return encoded, nil
+	}
+
+	// Split by whitespace and encode the specified part
+	parts := strings.Fields(value)
+	if *partIndex < 0 || *partIndex >= len(parts) {
+		return "", fmt.Errorf("part index %d out of range (header has %d parts)", *partIndex, len(parts))
+	}
+
+	// Encode the part at the given index
+	parts[*partIndex] = base64.StdEncoding.EncodeToString([]byte(parts[*partIndex]))
+	return strings.Join(parts, " "), nil
+}
+
+func (f *encodeBase64) Request(ctx filters.FilterContext) {
+	if f.typ != encodeRequestHeaderBase64 {
+		return
+	}
+
+	header := ctx.Request().Header
+	headerValue := header.Get(f.headerName)
+	if headerValue == "" {
+		return
+	}
+
+	encoded, err := encodeBase64Value(headerValue, f.partIndex)
+	if err != nil {
+		ctx.Logger().Warnf("encodeBase64 filter error for header %s: %v", f.headerName, err)
+		return
+	}
+
+	header.Set(f.headerName, encoded)
+}
+
+func (f *encodeBase64) Response(ctx filters.FilterContext) {
+	if f.typ != encodeResponseHeaderBase64 {
+		return
+	}
+
+	header := ctx.Response().Header
+	headerValue := header.Get(f.headerName)
+	if headerValue == "" {
+		return
+	}
+
+	encoded, err := encodeBase64Value(headerValue, f.partIndex)
+	if err != nil {
+		ctx.Logger().Warnf("encodeBase64 filter error for header %s: %v", f.headerName, err)
+		return
+	}
+
+	header.Set(f.headerName, encoded)
+}

--- a/filters/builtin/header_base64_test.go
+++ b/filters/builtin/header_base64_test.go
@@ -1,0 +1,405 @@
+package builtin
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/zalando/skipper/filters"
+	"github.com/zalando/skipper/filters/filtertest"
+)
+
+func TestEncodeBase64CreateFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		newSpec func() filters.Spec
+		args    []interface{}
+		wantErr bool
+	}{
+		{
+			name:    "valid: request header, no index",
+			newSpec: NewEncodeRequestHeaderBase64,
+			args:    []interface{}{"X-Custom"},
+			wantErr: false,
+		},
+		{
+			name:    "valid: request header, with index",
+			newSpec: NewEncodeRequestHeaderBase64,
+			args:    []interface{}{"X-Custom", float64(1)},
+			wantErr: false,
+		},
+		{
+			name:    "valid: response header, no index",
+			newSpec: NewEncodeResponseHeaderBase64,
+			args:    []interface{}{"X-Custom"},
+			wantErr: false,
+		},
+		{
+			name:    "valid: response header, with index",
+			newSpec: NewEncodeResponseHeaderBase64,
+			args:    []interface{}{"X-Custom", float64(0)},
+			wantErr: false,
+		},
+		{
+			name:    "error: no arguments",
+			newSpec: NewEncodeRequestHeaderBase64,
+			args:    []interface{}{},
+			wantErr: true,
+		},
+		{
+			name:    "error: too many arguments",
+			newSpec: NewEncodeRequestHeaderBase64,
+			args:    []interface{}{"X-Custom", float64(1), "extra"},
+			wantErr: true,
+		},
+		{
+			name:    "error: first arg not string",
+			newSpec: NewEncodeRequestHeaderBase64,
+			args:    []interface{}{42},
+			wantErr: true,
+		},
+		{
+			name:    "error: second arg not number",
+			newSpec: NewEncodeRequestHeaderBase64,
+			args:    []interface{}{"X-Custom", "not-a-number"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := tt.newSpec()
+			f, err := spec.CreateFilter(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateFilter() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && f == nil {
+				t.Errorf("CreateFilter() returned nil filter")
+			}
+		})
+	}
+}
+
+func TestEncodeBase64RequestHeaderFullValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerName  string
+		headerValue string
+		expected    string
+	}{
+		{
+			name:        "encode full value",
+			headerName:  "X-Custom",
+			headerValue: "hello",
+			expected:    base64.StdEncoding.EncodeToString([]byte("hello")),
+		},
+		{
+			name:        "empty header",
+			headerName:  "X-Custom",
+			headerValue: "",
+			expected:    "",
+		},
+		{
+			name:        "special characters",
+			headerName:  "Authorization",
+			headerValue: "user:pass123!@#",
+			expected:    base64.StdEncoding.EncodeToString([]byte("user:pass123!@#")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := NewEncodeRequestHeaderBase64()
+			f, err := spec.CreateFilter([]interface{}{tt.headerName})
+			if err != nil {
+				t.Fatalf("CreateFilter failed: %v", err)
+			}
+
+			req, err := http.NewRequest("GET", "https://example.org/test", nil)
+			if err != nil {
+				t.Fatalf("NewRequest failed: %v", err)
+			}
+
+			if tt.headerValue != "" {
+				req.Header.Set(tt.headerName, tt.headerValue)
+			}
+
+			ctx := &filtertest.Context{FRequest: req}
+			f.Request(ctx)
+
+			result := req.Header.Get(tt.headerName)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEncodeBase64RequestHeaderWithIndex(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerName  string
+		headerValue string
+		partIndex   float64
+		expected    string
+	}{
+		{
+			name:        "encode second part (index 1)",
+			headerName:  "Authorization",
+			headerValue: "Bearer token123",
+			partIndex:   1,
+			expected:    "Bearer " + base64.StdEncoding.EncodeToString([]byte("token123")),
+		},
+		{
+			name:        "encode first part (index 0)",
+			headerName:  "X-Custom",
+			headerValue: "first second third",
+			partIndex:   0,
+			expected:    base64.StdEncoding.EncodeToString([]byte("first")) + " second third",
+		},
+		{
+			name:        "index out of range",
+			headerName:  "X-Custom",
+			headerValue: "a b c",
+			partIndex:   5,
+			expected:    "a b c", // Original value remains on error
+		},
+		{
+			name:        "negative index",
+			headerName:  "X-Custom",
+			headerValue: "a b c",
+			partIndex:   -1,
+			expected:    "a b c", // Original value remains on error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := NewEncodeRequestHeaderBase64()
+			f, err := spec.CreateFilter([]interface{}{tt.headerName, tt.partIndex})
+			if err != nil {
+				t.Fatalf("CreateFilter failed: %v", err)
+			}
+
+			req, err := http.NewRequest("GET", "https://example.org/test", nil)
+			if err != nil {
+				t.Fatalf("NewRequest failed: %v", err)
+			}
+
+			req.Header.Set(tt.headerName, tt.headerValue)
+
+			ctx := &filtertest.Context{FRequest: req}
+			f.Request(ctx)
+
+			result := req.Header.Get(tt.headerName)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEncodeBase64ResponseHeaderFullValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerName  string
+		headerValue string
+		expected    string
+	}{
+		{
+			name:        "encode full value",
+			headerName:  "X-Custom",
+			headerValue: "response-data",
+			expected:    base64.StdEncoding.EncodeToString([]byte("response-data")),
+		},
+		{
+			name:        "empty header",
+			headerName:  "X-Custom",
+			headerValue: "",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := NewEncodeResponseHeaderBase64()
+			f, err := spec.CreateFilter([]interface{}{tt.headerName})
+			if err != nil {
+				t.Fatalf("CreateFilter failed: %v", err)
+			}
+
+			resp := &http.Response{Header: make(http.Header)}
+			if tt.headerValue != "" {
+				resp.Header.Set(tt.headerName, tt.headerValue)
+			}
+
+			ctx := &filtertest.Context{FResponse: resp}
+			f.Response(ctx)
+
+			result := resp.Header.Get(tt.headerName)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEncodeBase64ResponseHeaderWithIndex(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerName  string
+		headerValue string
+		partIndex   float64
+		expected    string
+	}{
+		{
+			name:        "encode second part (index 1)",
+			headerName:  "X-Custom",
+			headerValue: "Header data",
+			partIndex:   1,
+			expected:    "Header " + base64.StdEncoding.EncodeToString([]byte("data")),
+		},
+		{
+			name:        "index out of range",
+			headerName:  "X-Custom",
+			headerValue: "single",
+			partIndex:   2,
+			expected:    "single", // Original value remains on error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := NewEncodeResponseHeaderBase64()
+			f, err := spec.CreateFilter([]interface{}{tt.headerName, tt.partIndex})
+			if err != nil {
+				t.Fatalf("CreateFilter failed: %v", err)
+			}
+
+			resp := &http.Response{Header: make(http.Header)}
+			resp.Header.Set(tt.headerName, tt.headerValue)
+
+			ctx := &filtertest.Context{FResponse: resp}
+			f.Response(ctx)
+
+			result := resp.Header.Get(tt.headerName)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEncodeBase64Value(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		partIndex *int
+		expected  string
+		wantErr   bool
+	}{
+		{
+			name:      "encode full value",
+			value:     "hello",
+			partIndex: nil,
+			expected:  base64.StdEncoding.EncodeToString([]byte("hello")),
+			wantErr:   false,
+		},
+		{
+			name:      "encode with index 0",
+			value:     "first second",
+			partIndex: func() *int { i := 0; return &i }(),
+			expected:  base64.StdEncoding.EncodeToString([]byte("first")) + " second",
+			wantErr:   false,
+		},
+		{
+			name:      "encode with index 1",
+			value:     "first second",
+			partIndex: func() *int { i := 1; return &i }(),
+			expected:  "first " + base64.StdEncoding.EncodeToString([]byte("second")),
+			wantErr:   false,
+		},
+		{
+			name:      "part index out of range",
+			value:     "single",
+			partIndex: func() *int { i := 5; return &i }(),
+			expected:  "",
+			wantErr:   true,
+		},
+		{
+			name:      "part index negative",
+			value:     "single",
+			partIndex: func() *int { i := -1; return &i }(),
+			expected:  "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := encodeBase64Value(tt.value, tt.partIndex)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("encodeBase64Value() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEncodeBase64FilterNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		newSpec  func() filters.Spec
+		expected string
+	}{
+		{
+			name:     "request header filter name",
+			newSpec:  NewEncodeRequestHeaderBase64,
+			expected: filters.EncodeBase64RequestHeaderName,
+		},
+		{
+			name:     "response header filter name",
+			newSpec:  NewEncodeResponseHeaderBase64,
+			expected: filters.EncodeBase64ResponseHeaderName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := tt.newSpec()
+			if spec.Name() != tt.expected {
+				t.Errorf("Name() = %q, want %q", spec.Name(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestEncodeBase64RealWorldScenario(t *testing.T) {
+	// Scenario: Encode the second part of an Authorization header to base64
+	spec := NewEncodeRequestHeaderBase64()
+	f, err := spec.CreateFilter([]interface{}{"Authorization", float64(1)})
+	if err != nil {
+		t.Fatalf("CreateFilter failed: %v", err)
+	}
+
+	authHeader := "Bearer my-secret-token"
+
+	req, err := http.NewRequest("GET", "https://example.org/api/v1/resource", nil)
+	if err != nil {
+		t.Fatalf("NewRequest failed: %v", err)
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	ctx := &filtertest.Context{FRequest: req}
+	f.Request(ctx)
+
+	result := req.Header.Get("Authorization")
+	expected := "Bearer " + base64.StdEncoding.EncodeToString([]byte("my-secret-token"))
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -237,6 +237,8 @@ const (
 	AppendContextResponseHeaderName            = "appendContextResponseHeader"
 	CopyRequestHeaderName                      = "copyRequestHeader"
 	CopyResponseHeaderName                     = "copyResponseHeader"
+	EncodeBase64RequestHeaderName              = "encodeBase64RequestHeader"
+	EncodeBase64ResponseHeaderName             = "encodeBase64ResponseHeader"
 	EncodeRequestHeaderName                    = "encodeRequestHeader"
 	EncodeResponseHeaderName                   = "encodeResponseHeader"
 	DecodeBase64RequestHeaderName              = "decodeBase64RequestHeader"


### PR DESCRIPTION
### Description

Add encodeBase64RequestHeader and encodeBase64ResponseHeader filters for base64-encoding header values, mirroring the decodeBase64RequestHeader/decodeBase64ResponseHeader filters from #4100.

Both filters take the same arguments:
- First argument: header name (required)
- Second argument: part index (optional, 0-based)

Without the part index, the entire header value is base64-encoded. With the part index, the value is split by whitespace and only that field is encoded.

### Usage

```
# Encode full request header value:
r: * -> encodeBase64RequestHeader("X-Custom-Header") -> "https://example.org";

# Encode only the second field (index 1):
r: * -> encodeBase64RequestHeader("Authorization", 1) -> "https://example.org";

# Same for response headers:
r: * -> encodeBase64ResponseHeader("X-Custom-Header") -> "https://example.org";
```

### Changes

- filters/filters.go: added EncodeBase64RequestHeaderName and EncodeBase64ResponseHeaderName constants
- filters/builtin/header_base64.go: filter implementation (Spec + Filter for req/resp pair)
- filters/builtin/builtin.go: registered NewEncodeRequestHeaderBase64() and NewEncodeResponseHeaderBase64()
- docs/reference/filters.md: documented both filters

### Testing

- 25 tests across 7 test functions covering:
  - CreateFilter validation (missing args, wrong types, too many args)
  - Request header full-value encoding, empty header, special characters
  - Request header with part index (index 0, 1, out-of-range, negative)
  - Response header full-value encoding and part encoding
  - Unit tests for the encodeBase64Value helper
  - Filter name verification for both variants

### Related Issues

Fixes #4099

### Checklist

- [x] Code follows the project style guidelines (gofmt)
- [x] Self-reviewed the code
- [x] Tests added / updated
- [x] All tests pass locally
- [x] No new warnings introduced
- [x] User documentation added in docs/reference/filters.md
- [x] DCO sign-off included