### PR TITLE
refactor: remove unused code

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	stdlibcontext "context"
 	"crypto/tls"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -703,13 +702,6 @@ func (p *Proxy) mapRequest(ctx *context, requestContext stdlibcontext.Context) (
 		rr.Header["User-Agent"] = []string{""}
 	}
 	rr.Host = host
-
-	// If there is basic auth configured in the URL we add them as headers
-	if u.User != nil {
-		up := u.User.String()
-		upBase64 := base64.StdEncoding.EncodeToString([]byte(up))
-		rr.Header.Add("Authorization", fmt.Sprintf("Basic %s", upBase64))
-	}
 
 	ctxspan := ot.SpanFromContext(r.Context())
 	if ctxspan != nil {


### PR DESCRIPTION
u.User can never be set, because it is based on Request.URL and on server side User is never defined:

```
% go doc http.Request.URL
package http // import "net/http"

type Request struct {
    // URL specifies either the URI being requested (for server requests) or the URL to
    // access (for client requests).
    //
    // For server requests, the URL is parsed from the URI supplied on the Request-Line
    // as stored in RequestURI. For most requests, fields other than Path and RawQuery
    // will be empty. (See RFC 7230, Section 5.3)

```

ref: https://github.com/zalando/skipper/commit/14f6097703f00eea3fcfcd41d961b777ed7aa055#diff-1d74870266949f1927a500e5f0002617239d3e3cd9bcceee6be014738e5e0f2bR238