### PR TITLE
feat: add opt-in support for Prometheus native histograms

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,47 +33,47 @@ type Config struct {
 	Flags      *flag.FlagSet
 
 	// generic:
-	Address                          string         `yaml:"address"`
-	InsecureAddress                  string         `yaml:"insecure-address"`
-	EnableTCPQueue                   bool           `yaml:"enable-tcp-queue"`
-	ExpectedBytesPerRequest          int            `yaml:"expected-bytes-per-request"`
-	MaxTCPListenerConcurrency        int            `yaml:"max-tcp-listener-concurrency"`
-	MaxTCPListenerQueue              int            `yaml:"max-tcp-listener-queue"`
-	EnableCopyStreamPoolExperimental bool           `yaml:"enable-copy-stream-pool"`
-	IgnoreTrailingSlash              bool           `yaml:"ignore-trailing-slash"`
-	Insecure                         bool           `yaml:"insecure"`
-	ProxyPreserveHost                bool           `yaml:"proxy-preserve-host"`
-	DevMode                          bool           `yaml:"dev-mode"`
-	SupportListener                  string         `yaml:"support-listener"`
-	DebugListener                    string         `yaml:"debug-listener"`
-	CertPathTLS                      string         `yaml:"tls-cert"`
-	KeyPathTLS                       string         `yaml:"tls-key"`
-	StatusChecks                     *listFlag      `yaml:"status-checks"`
-	PrintVersion                     bool           `yaml:"version"`
-	MaxLoopbacks                     int            `yaml:"max-loopbacks"`
-	DefaultHTTPStatus                int            `yaml:"default-http-status"`
-	PluginDir                        string         `yaml:"plugindir"`
-	LoadBalancerHealthCheckInterval  time.Duration  `yaml:"lb-healthcheck-interval"`
-	ReverseSourcePredicate           bool           `yaml:"reverse-source-predicate"`
-	RemoveHopHeaders                 bool           `yaml:"remove-hop-headers"`
-	RfcPatchPath                     bool           `yaml:"rfc-patch-path"`
-	MaxAuditBody                     int            `yaml:"max-audit-body"`
-	MaxMatcherBufferSize             uint64         `yaml:"max-matcher-buffer-size"`
-	EnableBreakers                   bool           `yaml:"enable-breakers"`
-	Breakers                         breakerFlags   `yaml:"breaker"`
-	EnableRatelimiters               bool           `yaml:"enable-ratelimits"`
-	Ratelimits                       ratelimitFlags `yaml:"ratelimits"`
-	EnableRouteFIFOMetrics           bool           `yaml:"enable-route-fifo-metrics"`
-	EnableRouteLIFOMetrics           bool           `yaml:"enable-route-lifo-metrics"`
-	MetricsFlavour                   *listFlag      `yaml:"metrics-flavour"`
-	DisableMetricsCompression        bool           `yaml:"disable-metrics-compression"`
-	EnableNativeHistograms           bool           `yaml:"enable-native-histograms"`
-	NativeHistogramBucketFactor      float64        `yaml:"native-histogram-bucket-factor"`
-	FilterPlugins                    *pluginFlag    `yaml:"filter-plugin"`
-	PredicatePlugins                 *pluginFlag    `yaml:"predicate-plugin"`
-	DataclientPlugins                *pluginFlag    `yaml:"dataclient-plugin"`
-	MultiPlugins                     *pluginFlag    `yaml:"multi-plugin"`
-	CompressEncodings                *listFlag      `yaml:"compress-encodings"`
+	Address                               string         `yaml:"address"`
+	InsecureAddress                       string         `yaml:"insecure-address"`
+	EnableTCPQueue                        bool           `yaml:"enable-tcp-queue"`
+	ExpectedBytesPerRequest               int            `yaml:"expected-bytes-per-request"`
+	MaxTCPListenerConcurrency             int            `yaml:"max-tcp-listener-concurrency"`
+	MaxTCPListenerQueue                   int            `yaml:"max-tcp-listener-queue"`
+	EnableCopyStreamPoolExperimental      bool           `yaml:"enable-copy-stream-pool"`
+	IgnoreTrailingSlash                   bool           `yaml:"ignore-trailing-slash"`
+	Insecure                              bool           `yaml:"insecure"`
+	ProxyPreserveHost                     bool           `yaml:"proxy-preserve-host"`
+	DevMode                               bool           `yaml:"dev-mode"`
+	SupportListener                       string         `yaml:"support-listener"`
+	DebugListener                         string         `yaml:"debug-listener"`
+	CertPathTLS                           string         `yaml:"tls-cert"`
+	KeyPathTLS                            string         `yaml:"tls-key"`
+	StatusChecks                          *listFlag      `yaml:"status-checks"`
+	PrintVersion                          bool           `yaml:"version"`
+	MaxLoopbacks                          int            `yaml:"max-loopbacks"`
+	DefaultHTTPStatus                     int            `yaml:"default-http-status"`
+	PluginDir                             string         `yaml:"plugindir"`
+	LoadBalancerHealthCheckInterval       time.Duration  `yaml:"lb-healthcheck-interval"`
+	ReverseSourcePredicate                bool           `yaml:"reverse-source-predicate"`
+	RemoveHopHeaders                      bool           `yaml:"remove-hop-headers"`
+	RfcPatchPath                          bool           `yaml:"rfc-patch-path"`
+	MaxAuditBody                          int            `yaml:"max-audit-body"`
+	MaxMatcherBufferSize                  uint64         `yaml:"max-matcher-buffer-size"`
+	EnableBreakers                        bool           `yaml:"enable-breakers"`
+	Breakers                              breakerFlags   `yaml:"breaker"`
+	EnableRatelimiters                    bool           `yaml:"enable-ratelimits"`
+	Ratelimits                            ratelimitFlags `yaml:"ratelimits"`
+	EnableRouteFIFOMetrics                bool           `yaml:"enable-route-fifo-metrics"`
+	EnableRouteLIFOMetrics                bool           `yaml:"enable-route-lifo-metrics"`
+	MetricsFlavour                        *listFlag      `yaml:"metrics-flavour"`
+	DisableMetricsCompression             bool           `yaml:"disable-metrics-compression"`
+	EnablePrometheusNativeHistograms      bool           `yaml:"enable-prometheus-native-histograms"`
+	PrometheusNativeHistogramBucketFactor float64        `yaml:"prometheus-native-histogram-bucket-factor"`
+	FilterPlugins                         *pluginFlag    `yaml:"filter-plugin"`
+	PredicatePlugins                      *pluginFlag    `yaml:"predicate-plugin"`
+	DataclientPlugins                     *pluginFlag    `yaml:"dataclient-plugin"`
+	MultiPlugins                          *pluginFlag    `yaml:"multi-plugin"`
+	CompressEncodings                     *listFlag      `yaml:"compress-encodings"`
 
 	// logging, metrics, profiling, tracing:
 	EnablePrometheusMetrics             bool      `yaml:"enable-prometheus-metrics"`
@@ -450,8 +450,8 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableRouteLIFOMetrics, "enable-route-lifo-metrics", false, "enable metrics for the individual route LIFO queues")
 	flag.Var(cfg.MetricsFlavour, "metrics-flavour", "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale', 'prometheus' and 'otel', you can select multiple or all of them by using one option with ',' separated values")
 	flag.BoolVar(&cfg.DisableMetricsCompression, "disable-metrics-compression", false, "disable metrics compression on /metrics handler endpoint.")
-	flag.BoolVar(&cfg.EnableNativeHistograms, "enable-native-histograms", false, "enables prometheus native histograms in addition to the classic bucketed histograms")
-	flag.Float64Var(&cfg.NativeHistogramBucketFactor, "native-histogram-bucket-factor", 0, "resolution of prometheus native histograms, must be greater than 1, defaults to 1.1 when native histograms are enabled")
+	flag.BoolVar(&cfg.EnablePrometheusNativeHistograms, "enable-prometheus-native-histograms", false, "enables prometheus native histograms in addition to the classic bucketed histograms")
+	flag.Float64Var(&cfg.PrometheusNativeHistogramBucketFactor, "prometheus-native-histogram-bucket-factor", 0, "resolution of prometheus native histograms, must be greater than 1, defaults to 1.1 when native histograms are enabled")
 	flag.Var(cfg.FilterPlugins, "filter-plugin", "set a custom filter plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.PredicatePlugins, "predicate-plugin", "set a custom predicate plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.DataclientPlugins, "dataclient-plugin", "set a custom dataclient plugins to load, a comma separated list of name and arguments")
@@ -925,44 +925,44 @@ func (c *Config) ToOptions() skipper.Options {
 
 	options := skipper.Options{
 		// generic:
-		Address:                          c.Address,
-		InsecureAddress:                  c.InsecureAddress,
-		StatusChecks:                     c.StatusChecks.values,
-		EnableTCPQueue:                   c.EnableTCPQueue,
-		ExpectedBytesPerRequest:          c.ExpectedBytesPerRequest,
-		MaxTCPListenerConcurrency:        c.MaxTCPListenerConcurrency,
-		MaxTCPListenerQueue:              c.MaxTCPListenerQueue,
-		EnableCopyStreamPoolExperimental: c.EnableCopyStreamPoolExperimental,
-		IgnoreTrailingSlash:              c.IgnoreTrailingSlash,
-		DevMode:                          c.DevMode,
-		SupportListener:                  c.SupportListener,
-		DebugListener:                    c.DebugListener,
-		CertPathTLS:                      c.CertPathTLS,
-		KeyPathTLS:                       c.KeyPathTLS,
-		TLSClientAuth:                    c.TLSClientAuth,
-		TLSMinVersion:                    c.getMinTLSVersion(),
-		CipherSuites:                     c.filterCipherSuites(),
-		MaxLoopbacks:                     c.MaxLoopbacks,
-		DefaultHTTPStatus:                c.DefaultHTTPStatus,
-		ReverseSourcePredicate:           c.ReverseSourcePredicate,
-		MaxAuditBody:                     c.MaxAuditBody,
-		MaxMatcherBufferSize:             c.MaxMatcherBufferSize,
-		EnableBreakers:                   c.EnableBreakers,
-		BreakerSettings:                  c.Breakers,
-		EnableRatelimiters:               c.EnableRatelimiters,
-		RatelimitSettings:                c.Ratelimits,
-		EnableRouteFIFOMetrics:           c.EnableRouteFIFOMetrics,
-		EnableRouteLIFOMetrics:           c.EnableRouteLIFOMetrics,
-		MetricsFlavours:                  c.MetricsFlavour.values,
-		DisableMetricsCompression:        c.DisableMetricsCompression,
-		EnableNativeHistograms:           c.EnableNativeHistograms,
-		NativeHistogramBucketFactor:      c.NativeHistogramBucketFactor,
-		FilterPlugins:                    c.FilterPlugins.values,
-		PredicatePlugins:                 c.PredicatePlugins.values,
-		DataClientPlugins:                c.DataclientPlugins.values,
-		Plugins:                          c.MultiPlugins.values,
-		PluginDirs:                       []string{skipper.DefaultPluginDir},
-		CompressEncodings:                c.CompressEncodings.values,
+		Address:                               c.Address,
+		InsecureAddress:                       c.InsecureAddress,
+		StatusChecks:                          c.StatusChecks.values,
+		EnableTCPQueue:                        c.EnableTCPQueue,
+		ExpectedBytesPerRequest:               c.ExpectedBytesPerRequest,
+		MaxTCPListenerConcurrency:             c.MaxTCPListenerConcurrency,
+		MaxTCPListenerQueue:                   c.MaxTCPListenerQueue,
+		EnableCopyStreamPoolExperimental:      c.EnableCopyStreamPoolExperimental,
+		IgnoreTrailingSlash:                   c.IgnoreTrailingSlash,
+		DevMode:                               c.DevMode,
+		SupportListener:                       c.SupportListener,
+		DebugListener:                         c.DebugListener,
+		CertPathTLS:                           c.CertPathTLS,
+		KeyPathTLS:                            c.KeyPathTLS,
+		TLSClientAuth:                         c.TLSClientAuth,
+		TLSMinVersion:                         c.getMinTLSVersion(),
+		CipherSuites:                          c.filterCipherSuites(),
+		MaxLoopbacks:                          c.MaxLoopbacks,
+		DefaultHTTPStatus:                     c.DefaultHTTPStatus,
+		ReverseSourcePredicate:                c.ReverseSourcePredicate,
+		MaxAuditBody:                          c.MaxAuditBody,
+		MaxMatcherBufferSize:                  c.MaxMatcherBufferSize,
+		EnableBreakers:                        c.EnableBreakers,
+		BreakerSettings:                       c.Breakers,
+		EnableRatelimiters:                    c.EnableRatelimiters,
+		RatelimitSettings:                     c.Ratelimits,
+		EnableRouteFIFOMetrics:                c.EnableRouteFIFOMetrics,
+		EnableRouteLIFOMetrics:                c.EnableRouteLIFOMetrics,
+		MetricsFlavours:                       c.MetricsFlavour.values,
+		DisableMetricsCompression:             c.DisableMetricsCompression,
+		EnablePrometheusNativeHistograms:      c.EnablePrometheusNativeHistograms,
+		PrometheusNativeHistogramBucketFactor: c.PrometheusNativeHistogramBucketFactor,
+		FilterPlugins:                         c.FilterPlugins.values,
+		PredicatePlugins:                      c.PredicatePlugins.values,
+		DataClientPlugins:                     c.DataclientPlugins.values,
+		Plugins:                               c.MultiPlugins.values,
+		PluginDirs:                            []string{skipper.DefaultPluginDir},
+		CompressEncodings:                     c.CompressEncodings.values,
 
 		// logging, metrics, profiling, tracing:
 		EnablePrometheusMetrics:             c.EnablePrometheusMetrics,

--- a/config/config.go
+++ b/config/config.go
@@ -451,7 +451,7 @@ func NewConfig() *Config {
 	flag.Var(cfg.MetricsFlavour, "metrics-flavour", "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale', 'prometheus' and 'otel', you can select multiple or all of them by using one option with ',' separated values")
 	flag.BoolVar(&cfg.DisableMetricsCompression, "disable-metrics-compression", false, "disable metrics compression on /metrics handler endpoint.")
 	flag.BoolVar(&cfg.EnablePrometheusNativeHistograms, "enable-prometheus-native-histograms", false, "enables prometheus native histograms in addition to the classic bucketed histograms")
-	flag.Float64Var(&cfg.PrometheusNativeHistogramBucketFactor, "prometheus-native-histogram-bucket-factor", 0, "resolution of prometheus native histograms, must be greater than 1, defaults to 1.1 when native histograms are enabled")
+	flag.Float64Var(&cfg.PrometheusNativeHistogramBucketFactor, "prometheus-native-histogram-bucket-factor", metrics.DefaultNativeHistogramFactor, "resolution of prometheus native histograms, must be greater than 1, defaults to 1.1 when native histograms are enabled")
 	flag.Var(cfg.FilterPlugins, "filter-plugin", "set a custom filter plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.PredicatePlugins, "predicate-plugin", "set a custom predicate plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.DataclientPlugins, "dataclient-plugin", "set a custom dataclient plugins to load, a comma separated list of name and arguments")

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,8 @@ type Config struct {
 	EnableRouteLIFOMetrics           bool           `yaml:"enable-route-lifo-metrics"`
 	MetricsFlavour                   *listFlag      `yaml:"metrics-flavour"`
 	DisableMetricsCompression        bool           `yaml:"disable-metrics-compression"`
+	EnableNativeHistograms           bool           `yaml:"enable-native-histograms"`
+	NativeHistogramBucketFactor      float64        `yaml:"native-histogram-bucket-factor"`
 	FilterPlugins                    *pluginFlag    `yaml:"filter-plugin"`
 	PredicatePlugins                 *pluginFlag    `yaml:"predicate-plugin"`
 	DataclientPlugins                *pluginFlag    `yaml:"dataclient-plugin"`
@@ -448,6 +450,8 @@ func NewConfig() *Config {
 	flag.BoolVar(&cfg.EnableRouteLIFOMetrics, "enable-route-lifo-metrics", false, "enable metrics for the individual route LIFO queues")
 	flag.Var(cfg.MetricsFlavour, "metrics-flavour", "Metrics flavour is used to change the exposed metrics format. Supported metric formats: 'codahale', 'prometheus' and 'otel', you can select multiple or all of them by using one option with ',' separated values")
 	flag.BoolVar(&cfg.DisableMetricsCompression, "disable-metrics-compression", false, "disable metrics compression on /metrics handler endpoint.")
+	flag.BoolVar(&cfg.EnableNativeHistograms, "enable-native-histograms", false, "enables prometheus native histograms in addition to the classic bucketed histograms")
+	flag.Float64Var(&cfg.NativeHistogramBucketFactor, "native-histogram-bucket-factor", 0, "resolution of prometheus native histograms, must be greater than 1, defaults to 1.1 when native histograms are enabled")
 	flag.Var(cfg.FilterPlugins, "filter-plugin", "set a custom filter plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.PredicatePlugins, "predicate-plugin", "set a custom predicate plugins to load, a comma separated list of name and arguments")
 	flag.Var(cfg.DataclientPlugins, "dataclient-plugin", "set a custom dataclient plugins to load, a comma separated list of name and arguments")
@@ -951,6 +955,8 @@ func (c *Config) ToOptions() skipper.Options {
 		EnableRouteLIFOMetrics:           c.EnableRouteLIFOMetrics,
 		MetricsFlavours:                  c.MetricsFlavour.values,
 		DisableMetricsCompression:        c.DisableMetricsCompression,
+		EnableNativeHistograms:           c.EnableNativeHistograms,
+		NativeHistogramBucketFactor:      c.NativeHistogramBucketFactor,
 		FilterPlugins:                    c.FilterPlugins.values,
 		PredicatePlugins:                 c.PredicatePlugins.values,
 		DataClientPlugins:                c.DataclientPlugins.values,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,6 +82,7 @@ func defaultConfig(with func(*Config)) *Config {
 		MaxAuditBody:                            1024,
 		MaxMatcherBufferSize:                    2097152,
 		MetricsFlavour:                          commaListFlag("codahale", "prometheus", "otel"),
+		PrometheusNativeHistogramBucketFactor:   metrics.DefaultNativeHistogramFactor,
 		FilterPlugins:                           newPluginFlag(),
 		PredicatePlugins:                        newPluginFlag(),
 		DataclientPlugins:                       newPluginFlag(),

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -290,11 +290,11 @@ Skipper can additionally expose [Prometheus native
 histograms](https://prometheus.io/docs/specs/native_histograms/) for
 all histogram metrics:
 
-    -enable-native-histograms
+    -enable-prometheus-native-histograms
 
 Classic bucketed histograms are kept, so this is backwards compatible
 with existing dashboards and alerts. The resolution of native
-histograms can be tuned with `-native-histogram-bucket-factor`, which
+histograms can be tuned with `-prometheus-native-histogram-bucket-factor`, which
 must be greater than 1 and defaults to 1.1. Note that native
 histograms are only transmitted via the protobuf exposition format,
 so the scraping Prometheus needs `--enable-feature=native-histograms`.

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -284,21 +284,6 @@ option to enable it:
 It will return [Prometheus](https://prometheus.io/) metrics on the
 common metrics endpoint :9911/metrics.
 
-### Prometheus native histograms
-
-Skipper can additionally expose [Prometheus native
-histograms](https://prometheus.io/docs/specs/native_histograms/) for
-all histogram metrics:
-
-    -enable-prometheus-native-histograms
-
-Classic bucketed histograms are kept, so this is backwards compatible
-with existing dashboards and alerts. The resolution of native
-histograms can be tuned with `-prometheus-native-histogram-bucket-factor`, which
-must be greater than 1 and defaults to 1.1. Note that native
-histograms are only transmitted via the protobuf exposition format,
-so the scraping Prometheus needs `--enable-feature=native-histograms`.
-
 To monitor skipper we recommend the following queries:
 
 - P99 Proxy latency: `histogram_quantile(0.99, sum(rate(skipper_proxy_total_duration_seconds_bucket{}[1m])) by (le))`
@@ -316,6 +301,21 @@ To monitor skipper we recommend the following queries:
 - If you use Kubernetes limits or Linux cgroup CFS quotas (depends on label selector): `sum(rate(container_cpu_cfs_throttled_periods_total{container_name="skipper-ingress"}[1m]))`
 
 You may add static metrics labels like `version` using Prometheus [relabeling feature](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config).
+
+### Prometheus native histograms
+
+Skipper can additionally expose [Prometheus native
+histograms](https://prometheus.io/docs/specs/native_histograms/) for
+all histogram metrics:
+
+    -enable-prometheus-native-histograms
+
+Classic bucketed histograms are kept, so this is backwards compatible
+with existing dashboards and alerts. The resolution of native
+histograms can be tuned with `-prometheus-native-histogram-bucket-factor`, which
+must be greater than 1 and defaults to 1.1. Note that native
+histograms are only transmitted via the protobuf exposition format,
+so the scraping Prometheus needs `--enable-feature=native-histograms`.
 
 ### OpenTelemetry (OTel)
 

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -284,6 +284,21 @@ option to enable it:
 It will return [Prometheus](https://prometheus.io/) metrics on the
 common metrics endpoint :9911/metrics.
 
+### Prometheus native histograms
+
+Skipper can additionally expose [Prometheus native
+histograms](https://prometheus.io/docs/specs/native_histograms/) for
+all histogram metrics:
+
+    -enable-native-histograms
+
+Classic bucketed histograms are kept, so this is backwards compatible
+with existing dashboards and alerts. The resolution of native
+histograms can be tuned with `-native-histogram-bucket-factor`, which
+must be greater than 1 and defaults to 1.1. Note that native
+histograms are only transmitted via the protobuf exposition format,
+so the scraping Prometheus needs `--enable-feature=native-histograms`.
+
 To monitor skipper we recommend the following queries:
 
 - P99 Proxy latency: `histogram_quantile(0.99, sum(rate(skipper_proxy_total_duration_seconds_bucket{}[1m])) by (le))`

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -209,6 +209,14 @@ type Options struct {
 
 	// DisableCompression defaults to enable compression on the metrics endpoint, can be disabled if set to true
 	DisableCompression bool
+
+	// EnableNativeHistograms enables Prometheus native (sparse) histograms
+	// in addition to classic bucketed histograms.
+	EnableNativeHistograms bool
+
+	// NativeHistogramBucketFactor controls the resolution of native
+	// histograms. Must be > 1. Defaults to 1.1 when native histograms are enabled.
+	NativeHistogramBucketFactor float64
 }
 
 var (

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -210,13 +210,13 @@ type Options struct {
 	// DisableCompression defaults to enable compression on the metrics endpoint, can be disabled if set to true
 	DisableCompression bool
 
-	// EnableNativeHistograms enables Prometheus native (sparse) histograms
+	// EnablePrometheusNativeHistograms enables Prometheus native (sparse) histograms
 	// in addition to classic bucketed histograms.
-	EnableNativeHistograms bool
+	EnablePrometheusNativeHistograms bool
 
-	// NativeHistogramBucketFactor controls the resolution of native
+	// PrometheusNativeHistogramBucketFactor controls the resolution of native
 	// histograms. Must be > 1. Defaults to 1.1 when native histograms are enabled.
-	NativeHistogramBucketFactor float64
+	PrometheusNativeHistogramBucketFactor float64
 }
 
 var (

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -82,6 +82,9 @@ type Prometheus struct {
 // NewPrometheus returns a new Prometheus metric backend.
 func NewPrometheus(opts Options) *Prometheus {
 	opts = applyCompatibilityDefaults(opts)
+	if opts.EnableNativeHistograms && opts.NativeHistogramBucketFactor <= 1 {
+		opts.NativeHistogramBucketFactor = 1.1
+	}
 
 	p := &Prometheus{
 		registry: opts.PrometheusRegistry,
@@ -108,13 +111,13 @@ func NewPrometheus(opts Options) *Prometheus {
 	}
 	p.namespace = namespace
 
-	p.routeLookupM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.routeLookupM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promRouteSubsystem,
 		Name:      "lookup_duration_seconds",
 		Help:      "Duration in seconds of a route lookup.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 
 	p.routeErrorsM = register(p, prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
@@ -123,101 +126,101 @@ func NewPrometheus(opts Options) *Prometheus {
 		Help:      "The total of route lookup errors.",
 	}, []string{}))
 
-	p.responseM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.responseM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promResponseSubsystem,
 		Name:      "duration_seconds",
 		Help:      "Duration in seconds of a response.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"code", "method", "route"}))
+	}), []string{"code", "method", "route"}))
 
-	p.responseSizeM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.responseSizeM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promResponseSubsystem,
 		Name:      "size_bytes",
 		Help:      "Size of response in bytes.",
 		Buckets:   responseSizeBuckets,
-	}, []string{"host"}))
+	}), []string{"host"}))
 
-	p.filterCreateM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.filterCreateM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promFilterSubsystem,
 		Name:      "create_duration_seconds",
 		Help:      "Duration in seconds of filter creation.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"filter"}))
+	}), []string{"filter"}))
 
-	p.filterRequestM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.filterRequestM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promFilterSubsystem,
 		Name:      "request_duration_seconds",
 		Help:      "Duration in seconds of a filter request.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"filter"}))
+	}), []string{"filter"}))
 
-	p.filterAllRequestM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.filterAllRequestM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promFilterSubsystem,
 		Name:      "all_request_duration_seconds",
 		Help:      "Duration in seconds of a filter request by all filters.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"route"}))
+	}), []string{"route"}))
 
-	p.filterAllCombinedRequestM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.filterAllCombinedRequestM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promFilterSubsystem,
 		Name:      "all_combined_request_duration_seconds",
 		Help:      "Duration in seconds of a filter request combined by all filters.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 
-	p.backendRequestHeadersM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.backendRequestHeadersM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promBackendSubsystem,
 		Name:      "request_header_bytes",
 		Help:      "Size of a backend request header.",
 		Buckets:   requestSizeBuckets,
-	}, []string{"host"}))
+	}), []string{"host"}))
 
-	p.backendM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.backendM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promBackendSubsystem,
 		Name:      "duration_seconds",
 		Help:      "Duration in seconds of a proxy backend.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"route", "host"}))
+	}), []string{"route", "host"}))
 
-	p.backendCombinedM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.backendCombinedM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promBackendSubsystem,
 		Name:      "combined_duration_seconds",
 		Help:      "Duration in seconds of a proxy backend combined.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 
-	p.filterResponseM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.filterResponseM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promFilterSubsystem,
 		Name:      "response_duration_seconds",
 		Help:      "Duration in seconds of a filter request.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"filter"}))
+	}), []string{"filter"}))
 
-	p.filterAllResponseM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.filterAllResponseM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promFilterSubsystem,
 		Name:      "all_response_duration_seconds",
 		Help:      "Duration in seconds of a filter response by all filters.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"route"}))
+	}), []string{"route"}))
 
-	p.filterAllCombinedResponseM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.filterAllCombinedResponseM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promFilterSubsystem,
 		Name:      "all_combined_response_duration_seconds",
 		Help:      "Duration in seconds of a filter response combined by all filters.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 
 	metrics := []string{}
 	if opts.EnableServeStatusCodeMetric {
@@ -226,13 +229,13 @@ func NewPrometheus(opts Options) *Prometheus {
 	if opts.EnableServeMethodMetric {
 		metrics = append(metrics, "method")
 	}
-	p.serveRouteM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.serveRouteM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promServeSubsystem,
 		Name:      "route_duration_seconds",
 		Help:      "Duration in seconds of serving a route.",
 		Buckets:   opts.HistogramBuckets,
-	}, append(metrics, "route")))
+	}), append(metrics, "route")))
 	p.serveRouteCounterM = register(p, prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: promServeSubsystem,
@@ -240,13 +243,13 @@ func NewPrometheus(opts Options) *Prometheus {
 		Help:      "Total number of requests of serving a route.",
 	}, []string{"code", "method", "route"}))
 
-	p.serveHostM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.serveHostM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promServeSubsystem,
 		Name:      "host_duration_seconds",
 		Help:      "Duration in seconds of serving a host.",
 		Buckets:   opts.HistogramBuckets,
-	}, append(metrics, "host")))
+	}), append(metrics, "host")))
 	p.serveHostCounterM = register(p, prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: promServeSubsystem,
@@ -254,37 +257,37 @@ func NewPrometheus(opts Options) *Prometheus {
 		Help:      "Total number of requests of serving a host.",
 	}, []string{"code", "method", "host"}))
 
-	p.proxyTotalM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.proxyTotalM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promProxySubsystem,
 		Name:      "total_duration_seconds",
 		Help:      "Total duration in seconds of skipper latency.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 
-	p.proxyRequestM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.proxyRequestM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promProxySubsystem,
 		Name:      "request_duration_seconds",
 		Help:      "Duration in seconds of skipper latency for request.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 
-	p.proxyResponseM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.proxyResponseM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promProxySubsystem,
 		Name:      "response_duration_seconds",
 		Help:      "Duration in seconds of skipper latency for response.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 
-	p.backend5xxM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.backend5xxM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promBackendSubsystem,
 		Name:      "5xx_duration_seconds",
 		Help:      "Duration in seconds of backend 5xx.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{}))
+	}), []string{}))
 	p.backendErrorsM = register(p, prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: promBackendSubsystem,
@@ -311,13 +314,13 @@ func NewPrometheus(opts Options) *Prometheus {
 		Name:      "gauges",
 		Help:      "Gauges number of custom metrics.",
 	}, []string{"key"}))
-	p.customHistogramM = register(p, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	p.customHistogramM = register(p, prometheus.NewHistogramVec(p.histogramOpts(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: promCustomSubsystem,
 		Name:      "duration_seconds",
 		Help:      "Duration in seconds of custom metrics.",
 		Buckets:   opts.HistogramBuckets,
-	}, []string{"key"}))
+	}), []string{"key"}))
 
 	p.invalidRouteM = register(p, prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -338,6 +341,22 @@ func NewPrometheus(opts Options) *Prometheus {
 // sinceS returns the seconds passed since the start time until now.
 func (p *Prometheus) sinceS(start time.Time) float64 {
 	return time.Since(start).Seconds()
+}
+
+// histogramOpts enables native histograms on the given options when
+// configured, keeping the classic buckets for backward compatibility.
+func (p *Prometheus) histogramOpts(o prometheus.HistogramOpts) prometheus.HistogramOpts {
+	if p.opts.EnableNativeHistograms {
+		// with a native histogram bucket factor set, empty buckets would
+		// disable the classic histogram instead of using the defaults
+		if len(o.Buckets) == 0 {
+			o.Buckets = prometheus.DefBuckets
+		}
+		o.NativeHistogramBucketFactor = p.opts.NativeHistogramBucketFactor
+		o.NativeHistogramMaxBucketNumber = 100
+		o.NativeHistogramMinResetDuration = time.Hour
+	}
+	return o
 }
 
 func register[T prometheus.Collector](p *Prometheus, cs T) T {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -41,6 +41,11 @@ var DefaultRequestSizeBuckets = []float64{4 * KiB, 8 * KiB, 16 * KiB, 64 * KiB}
 // DefaultResponseSizeBuckets are chosen to cover 2^(10*n) sizes up to 1 GiB and halves of those.
 var DefaultResponseSizeBuckets = []float64{1, 512, 1 * KiB, 512 * KiB, 1 * MiB, 512 * MiB, 1 * GiB}
 
+// DefaultNativeHistogramFactor is the default bucket factor for Prometheus
+// native histograms, based on the OTEL recommendation, see
+// https://www.kubernetes.dev/resources/keps/5808/
+const DefaultNativeHistogramFactor = 1.1
+
 // Prometheus implements the prometheus metrics backend.
 type Prometheus struct {
 	// Metrics.
@@ -83,7 +88,7 @@ type Prometheus struct {
 func NewPrometheus(opts Options) *Prometheus {
 	opts = applyCompatibilityDefaults(opts)
 	if opts.EnablePrometheusNativeHistograms && opts.PrometheusNativeHistogramBucketFactor <= 1 {
-		opts.PrometheusNativeHistogramBucketFactor = 1.1
+		opts.PrometheusNativeHistogramBucketFactor = DefaultNativeHistogramFactor
 	}
 
 	p := &Prometheus{
@@ -353,6 +358,10 @@ func (p *Prometheus) histogramOpts(o prometheus.HistogramOpts) prometheus.Histog
 			o.Buckets = prometheus.DefBuckets
 		}
 		o.NativeHistogramBucketFactor = p.opts.PrometheusNativeHistogramBucketFactor
+		// A limit of 160 buckets and a reset duration of 1h bound the memory
+		// of native histograms, as recommended by the Prometheus docs
+		// https://prometheus.io/docs/specs/native_histograms/ and by OTEL,
+		// see https://www.kubernetes.dev/resources/keps/5808/
 		o.NativeHistogramMaxBucketNumber = 160
 		o.NativeHistogramMinResetDuration = time.Hour
 	}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -82,8 +82,8 @@ type Prometheus struct {
 // NewPrometheus returns a new Prometheus metric backend.
 func NewPrometheus(opts Options) *Prometheus {
 	opts = applyCompatibilityDefaults(opts)
-	if opts.EnableNativeHistograms && opts.NativeHistogramBucketFactor <= 1 {
-		opts.NativeHistogramBucketFactor = 1.1
+	if opts.EnablePrometheusNativeHistograms && opts.PrometheusNativeHistogramBucketFactor <= 1 {
+		opts.PrometheusNativeHistogramBucketFactor = 1.1
 	}
 
 	p := &Prometheus{
@@ -346,13 +346,13 @@ func (p *Prometheus) sinceS(start time.Time) float64 {
 // histogramOpts enables native histograms on the given options when
 // configured, keeping the classic buckets for backward compatibility.
 func (p *Prometheus) histogramOpts(o prometheus.HistogramOpts) prometheus.HistogramOpts {
-	if p.opts.EnableNativeHistograms {
+	if p.opts.EnablePrometheusNativeHistograms {
 		// with a native histogram bucket factor set, empty buckets would
 		// disable the classic histogram instead of using the defaults
 		if len(o.Buckets) == 0 {
 			o.Buckets = prometheus.DefBuckets
 		}
-		o.NativeHistogramBucketFactor = p.opts.NativeHistogramBucketFactor
+		o.NativeHistogramBucketFactor = p.opts.PrometheusNativeHistogramBucketFactor
 		o.NativeHistogramMaxBucketNumber = 160
 		o.NativeHistogramMinResetDuration = time.Hour
 	}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -353,7 +353,7 @@ func (p *Prometheus) histogramOpts(o prometheus.HistogramOpts) prometheus.Histog
 			o.Buckets = prometheus.DefBuckets
 		}
 		o.NativeHistogramBucketFactor = p.opts.NativeHistogramBucketFactor
-		o.NativeHistogramMaxBucketNumber = 100
+		o.NativeHistogramMaxBucketNumber = 160
 		o.NativeHistogramMinResetDuration = time.Hour
 	}
 	return o

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/metrics"
@@ -1338,4 +1339,34 @@ func TestScopedPrometheusRegistererPrefix(t *testing.T) {
 	if !found {
 		t.Errorf("expected metric with name 'customprefix_mysubsystem_mycounter' to be registered")
 	}
+}
+
+func TestPrometheusMetricsNativeHistograms(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	pm := metrics.NewPrometheus(metrics.Options{
+		PrometheusRegistry:     reg,
+		EnableNativeHistograms: true,
+	})
+
+	pm.MeasureBackend5xx(time.Now().Add(-15 * time.Millisecond))
+
+	metricFamilies, err := reg.Gather()
+	require.NoError(t, err)
+
+	var histogram *dto.Histogram
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "skipper_backend_5xx_duration_seconds" {
+			require.Len(t, mf.Metric, 1)
+			histogram = mf.Metric[0].GetHistogram()
+			break
+		}
+	}
+	require.NotNil(t, histogram, "expected to find skipper_backend_5xx_duration_seconds histogram")
+
+	// classic buckets are kept for backward compatibility
+	assert.NotEmpty(t, histogram.GetBucket(), "expected classic histogram buckets")
+
+	// native histogram data is emitted in addition
+	assert.NotNil(t, histogram.Schema, "expected native histogram schema")
+	assert.NotEmpty(t, histogram.GetPositiveSpan(), "expected native histogram positive spans")
 }

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -1344,8 +1344,8 @@ func TestScopedPrometheusRegistererPrefix(t *testing.T) {
 func TestPrometheusMetricsNativeHistograms(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	pm := metrics.NewPrometheus(metrics.Options{
-		PrometheusRegistry:     reg,
-		EnableNativeHistograms: true,
+		PrometheusRegistry:               reg,
+		EnablePrometheusNativeHistograms: true,
 	})
 
 	pm.MeasureBackend5xx(time.Now().Add(-15 * time.Millisecond))

--- a/skipper.go
+++ b/skipper.go
@@ -890,6 +890,14 @@ type Options struct {
 	// DisableMetricsCompression if enabled it will disable compression on the metrics handler, defaults to false
 	DisableMetricsCompression bool
 
+	// EnableNativeHistograms enables Prometheus native histograms
+	// in addition to the classic bucketed histograms
+	EnableNativeHistograms bool
+
+	// NativeHistogramBucketFactor controls the resolution of Prometheus
+	// native histograms, defaults to 1.1 if not set
+	NativeHistogramBucketFactor float64
+
 	// LoadBalancerHealthCheckInterval is *deprecated* and not in use anymore
 	LoadBalancerHealthCheckInterval time.Duration
 
@@ -1808,6 +1816,8 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		PrometheusRegistry:                 o.PrometheusRegistry,
 		EnablePrometheusStartLabel:         o.EnablePrometheusStartLabel,
 		DisableCompression:                 o.DisableMetricsCompression,
+		EnableNativeHistograms:             o.EnableNativeHistograms,
+		NativeHistogramBucketFactor:        o.NativeHistogramBucketFactor,
 	}
 
 	mtr := o.MetricsBackend

--- a/skipper.go
+++ b/skipper.go
@@ -890,13 +890,13 @@ type Options struct {
 	// DisableMetricsCompression if enabled it will disable compression on the metrics handler, defaults to false
 	DisableMetricsCompression bool
 
-	// EnableNativeHistograms enables Prometheus native histograms
+	// EnablePrometheusNativeHistograms enables Prometheus native histograms
 	// in addition to the classic bucketed histograms
-	EnableNativeHistograms bool
+	EnablePrometheusNativeHistograms bool
 
-	// NativeHistogramBucketFactor controls the resolution of Prometheus
+	// PrometheusNativeHistogramBucketFactor controls the resolution of Prometheus
 	// native histograms, defaults to 1.1 if not set
-	NativeHistogramBucketFactor float64
+	PrometheusNativeHistogramBucketFactor float64
 
 	// LoadBalancerHealthCheckInterval is *deprecated* and not in use anymore
 	LoadBalancerHealthCheckInterval time.Duration
@@ -1785,39 +1785,39 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	}
 
 	mtrOpts := metrics.Options{
-		Format:                             metricsKind,
-		Prefix:                             o.MetricsPrefix,
-		EnableDebugGcMetrics:               o.EnableDebugGcMetrics,
-		EnableRuntimeMetrics:               o.EnableRuntimeMetrics,
-		EnableServeRouteMetrics:            o.EnableServeRouteMetrics,
-		EnableServeRouteCounter:            o.EnableServeRouteCounter,
-		EnableServeHostMetrics:             o.EnableServeHostMetrics,
-		EnableServeHostCounter:             o.EnableServeHostCounter,
-		EnableServeMethodMetric:            o.EnableServeMethodMetric,
-		EnableServeStatusCodeMetric:        o.EnableServeStatusCodeMetric,
-		EnableProxyRequestMetrics:          o.EnableProxyRequestMetrics,
-		EnableProxyResponseMetrics:         o.EnableProxyResponseMetrics,
-		EnableBackendHostMetrics:           o.EnableBackendHostMetrics,
-		EnableProfile:                      o.EnableProfile,
-		BlockProfileRate:                   o.BlockProfileRate,
-		MutexProfileFraction:               o.MutexProfileFraction,
-		MemProfileRate:                     o.MemProfileRate,
-		EnableAllFiltersMetrics:            o.EnableAllFiltersMetrics,
-		EnableCombinedResponseMetrics:      o.EnableCombinedResponseMetrics,
-		EnableRouteResponseMetrics:         o.EnableRouteResponseMetrics,
-		EnableRouteBackendErrorsCounters:   o.EnableRouteBackendErrorsCounters,
-		EnableRouteStreamingErrorsCounters: o.EnableRouteStreamingErrorsCounters,
-		EnableRouteBackendMetrics:          o.EnableRouteBackendMetrics,
-		UseExpDecaySample:                  o.MetricsUseExpDecaySample,
-		HistogramBuckets:                   o.HistogramMetricBuckets,
-		ResponseSizeBuckets:                o.ResponseSizeBuckets,
-		RequestSizeBuckets:                 o.RequestSizeBuckets,
-		DisableCompatibilityDefaults:       o.DisableMetricsCompatibilityDefaults,
-		PrometheusRegistry:                 o.PrometheusRegistry,
-		EnablePrometheusStartLabel:         o.EnablePrometheusStartLabel,
-		DisableCompression:                 o.DisableMetricsCompression,
-		EnableNativeHistograms:             o.EnableNativeHistograms,
-		NativeHistogramBucketFactor:        o.NativeHistogramBucketFactor,
+		Format:                                metricsKind,
+		Prefix:                                o.MetricsPrefix,
+		EnableDebugGcMetrics:                  o.EnableDebugGcMetrics,
+		EnableRuntimeMetrics:                  o.EnableRuntimeMetrics,
+		EnableServeRouteMetrics:               o.EnableServeRouteMetrics,
+		EnableServeRouteCounter:               o.EnableServeRouteCounter,
+		EnableServeHostMetrics:                o.EnableServeHostMetrics,
+		EnableServeHostCounter:                o.EnableServeHostCounter,
+		EnableServeMethodMetric:               o.EnableServeMethodMetric,
+		EnableServeStatusCodeMetric:           o.EnableServeStatusCodeMetric,
+		EnableProxyRequestMetrics:             o.EnableProxyRequestMetrics,
+		EnableProxyResponseMetrics:            o.EnableProxyResponseMetrics,
+		EnableBackendHostMetrics:              o.EnableBackendHostMetrics,
+		EnableProfile:                         o.EnableProfile,
+		BlockProfileRate:                      o.BlockProfileRate,
+		MutexProfileFraction:                  o.MutexProfileFraction,
+		MemProfileRate:                        o.MemProfileRate,
+		EnableAllFiltersMetrics:               o.EnableAllFiltersMetrics,
+		EnableCombinedResponseMetrics:         o.EnableCombinedResponseMetrics,
+		EnableRouteResponseMetrics:            o.EnableRouteResponseMetrics,
+		EnableRouteBackendErrorsCounters:      o.EnableRouteBackendErrorsCounters,
+		EnableRouteStreamingErrorsCounters:    o.EnableRouteStreamingErrorsCounters,
+		EnableRouteBackendMetrics:             o.EnableRouteBackendMetrics,
+		UseExpDecaySample:                     o.MetricsUseExpDecaySample,
+		HistogramBuckets:                      o.HistogramMetricBuckets,
+		ResponseSizeBuckets:                   o.ResponseSizeBuckets,
+		RequestSizeBuckets:                    o.RequestSizeBuckets,
+		DisableCompatibilityDefaults:          o.DisableMetricsCompatibilityDefaults,
+		PrometheusRegistry:                    o.PrometheusRegistry,
+		EnablePrometheusStartLabel:            o.EnablePrometheusStartLabel,
+		DisableCompression:                    o.DisableMetricsCompression,
+		EnablePrometheusNativeHistograms:      o.EnablePrometheusNativeHistograms,
+		PrometheusNativeHistogramBucketFactor: o.PrometheusNativeHistogramBucketFactor,
 	}
 
 	mtr := o.MetricsBackend


### PR DESCRIPTION
Adds opt-in support for Prometheus native histograms, as discussed in #3898.

- New options: -enable-prometheus-native-histograms and -prometheus-native-histogram-bucket-factor (default 1.1, exported as metrics.DefaultNativeHistogramFactor)
- Dual emission: classic bucketed histograms are kept, so this is fully backward compatible with existing dashboards/alerts; when the flag is off there is no behavior change
- When a native bucket factor is set and `Buckets` is empty, client_golang drops classic buckets instead of applying defaults — the helper falls back to `prometheus.DefBuckets` to preserve them
- `NativeHistogramMaxBucketNumber=160` and `NativeHistogramMinResetDuration=1h`, per the [Prometheus docs](https://prometheus.io/docs/specs/native_histograms/) and OTEL/KEP recommendation, are set to bound memory; happy to make these configurable if preferred
- Native histograms are only transmitted via the protobuf exposition format, so text `/metrics` output is unchanged; docs updated accordingly

Fixes #3898
