### PR TITLE
Fix ForwardBackend filters initialization in routegroup

### DIFF
--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -298,6 +298,7 @@ func applyBackend(ctx *routeGroupContext, backend *definitions.SkipperBackend, r
 	case eskip.ForwardBackend:
 		r.Backend = ctx.forwardBackendURL
 		r.BackendType = eskip.NetworkBackend
+		r.Filters = []*eskip.Filter{}
 	}
 
 	if ctx.backendNameTracingTag {

--- a/dataclients/kubernetes/testdata/routegroups/backends/forward-with-filters.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/backends/forward-with-filters.eskip
@@ -1,0 +1,8 @@
+kube_rg____example_org__catchall__0_0:
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
+	-> <shunt>;
+
+kube_rg__default__myapp__all__0_0:
+	Host("^(example[.]org[.]?(:[0-9]+)?)$")
+	&& PathSubtree("/")
+	-> "http://forward.example";

--- a/dataclients/kubernetes/testdata/routegroups/backends/forward-with-filters.kube
+++ b/dataclients/kubernetes/testdata/routegroups/backends/forward-with-filters.kube
@@ -1,0 +1,1 @@
+forward-backend-url: http://forward.example

--- a/dataclients/kubernetes/testdata/routegroups/backends/forward-with-filters.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/backends/forward-with-filters.yaml
@@ -1,0 +1,16 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+spec:
+  hosts:
+    - example.org
+  backends:
+    - name: fwd
+      type: forward
+  routes:
+    - pathSubtree: /
+      filters:
+        - status(200)
+      backends:
+        - backendName: fwd

--- a/routesrv/routesrv_test.go
+++ b/routesrv/routesrv_test.go
@@ -651,6 +651,37 @@ func TestRoutesWithForwardBackend(t *testing.T) {
 	wantHTTPCode(t, w, http.StatusOK)
 }
 
+func TestRoutesWithForwardBackendFiltersDropped(t *testing.T) {
+	defer tl.Reset()
+	ks, _ := newKubeServer(t, loadKubeYAML(t, "testdata/forward-backend-with-filter.yaml"))
+	ks.Start()
+	defer ks.Close()
+	rs := newRouteServerWithOptions(t, skipper.Options{
+		SourcePollTimeout: pollInterval,
+		Kubernetes:        true,
+		KubernetesURL:     ks.URL,
+		ForwardBackendURL: "http://forward.example",
+	})
+
+	rs.StartUpdates()
+	defer rs.StopUpdates()
+
+	if err := tl.WaitFor(routesrv.LogRoutesInitialized, waitTimeout); err != nil {
+		t.Fatalf("routes not initialized: %v", err)
+	}
+	w := getRoutes(rs)
+
+	want := parseEskipFixture(t, "testdata/forward-backend-with-filter.eskip")
+	got, err := eskip.Parse(w.Body.String())
+	if err != nil {
+		t.Fatalf("served routes are not valid eskip: %s", w.Body)
+	}
+	if !eskip.EqLists(got, want) {
+		t.Errorf("expected to receive route without filters: %s", cmp.Diff(got, want))
+	}
+	wantHTTPCode(t, w, http.StatusOK)
+}
+
 func TestESkipBytesHandlerWithCorrectEtag(t *testing.T) {
 	defer tl.Reset()
 	ks, _ := newKubeServer(t, loadKubeYAML(t, "testdata/lb-target-multi.yaml"))

--- a/routesrv/testdata/forward-backend-with-filter.eskip
+++ b/routesrv/testdata/forward-backend-with-filter.eskip
@@ -1,0 +1,1 @@
+kube_rg__default__my_test__all__0_0: PathSubtree("/") -> "http://forward.example";

--- a/routesrv/testdata/forward-backend-with-filter.yaml
+++ b/routesrv/testdata/forward-backend-with-filter.yaml
@@ -1,0 +1,14 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: my-test
+spec:
+  backends:
+    - name: fwd
+      type: forward
+  routes:
+    - pathSubtree: /
+      filters:
+        - status(200)
+      backends:
+        - backendName: fwd


### PR DESCRIPTION
Align filter cleanup behavior between ingress and routegroup processing in kubernetes dataclient.
Filters are cleaned up during the processing of ingress and left as is during the processing of routegroups.

IIUC the logic, default filters will not be cleared anyway, because they are added later in polling.go. 
This is the risk we should accept.