### PR TITLE
feat: add weightedRoundRobin load balancer algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ skptesting/lorem.html
 .vscode/*
 *.test
 
+skptesting/okserver
+skptesting/lb-algorithms.eskip

--- a/config/config.go
+++ b/config/config.go
@@ -582,7 +582,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.KubernetesValkeyServiceName, "kubernetes-valkey-service-name", "", "Sets name for valkey to be used to lookup endpoints")
 	flag.IntVar(&cfg.KubernetesValkeyServicePort, "kubernetes-valkey-service-port", 6379, "Sets the port for valkey to be used to lookup endpoints")
 	flag.StringVar(&cfg.KubernetesBackendTrafficAlgorithmString, "kubernetes-backend-traffic-algorithm", kubernetes.TrafficPredicateAlgorithm.String(), "sets the algorithm to be used for traffic splitting between backends: traffic-predicate or traffic-segment-predicate")
-	flag.StringVar(&cfg.KubernetesDefaultLoadBalancerAlgorithm, "kubernetes-default-lb-algorithm", kubernetes.DefaultLoadBalancerAlgorithm, "sets the default algorithm to be used for load balancing between backend endpoints, available options: roundRobin, consistentHash, random, powerOfRandomNChoices")
+	flag.StringVar(&cfg.KubernetesDefaultLoadBalancerAlgorithm, "kubernetes-default-lb-algorithm", kubernetes.DefaultLoadBalancerAlgorithm, "sets the default algorithm to be used for load balancing between backend endpoints, available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin")
 	flag.BoolVar(&cfg.KubernetesForceService, "kubernetes-force-service", false, "overrides default Skipper functionality and routes traffic using Kubernetes Services instead of Endpoints")
 	flag.StringVar(&cfg.KubernetesStatusFromService, "kubernetes-status-from-service", "", "when set to <namespace>/<name>, updates Ingress status.loadBalancer.ingress from the referenced service")
 

--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -67,11 +67,13 @@ spec:
                         `random` - backend is chosen at random.
                         `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to prevent popular keys from overloading a single backend endpoint.
                         `powerOfRandomNChoices` - backend is chosen by selecting N random endpoints and picking the one with least outstanding requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
+                        `weightedRoundRobin` - backend is chosen by smooth weighted round robin with dynamic weights based on the ratio of successful round trips per endpoint, weights are updated by the passive health check when enabled.
                       enum:
                       - roundRobin
                       - random
                       - consistentHash
                       - powerOfRandomNChoices
+                      - weightedRoundRobin
                       type: string
                     endpoints:
                       description: Endpoints is required for type `lb`

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -257,7 +257,7 @@ type Options struct {
 	BackendTrafficAlgorithm BackendTrafficAlgorithm
 
 	// DefaultLoadBalancerAlgorithm sets the default algorithm to be used for load balancing between backend endpoints,
-	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices
+	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin
 	DefaultLoadBalancerAlgorithm string
 
 	// ForwardBackendURL allows to use <forward> backend via kubernetes, for example routegroup backend `type: forward`.

--- a/docs/kubernetes/migrate.md
+++ b/docs/kubernetes/migrate.md
@@ -629,6 +629,7 @@ Available algorithms:
 - `random`
 - `consistentHash`
 - `powerOfRandomNChoices`
+- `weightedRoundRobin`
 
 Your JIT based runtime applications have to ramp up slowly to traffic.
 You can use the [fadeIn](../reference/filters.md#fadein) filter to

--- a/docs/kubernetes/routegroup-crd.md
+++ b/docs/kubernetes/routegroup-crd.md
@@ -72,7 +72,7 @@ fields are the name and the type, while the rest of the fields may be required b
   name: <string>
   type: <string>            one of "service|shunt|loopback|dynamic|lb|network|forward"
   address: <string>         optional, required for type=network
-  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash|powerOfRandomNChoices
+  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash|powerOfRandomNChoices|weightedRoundRobin
   endpoints: <stringarray>  optional, required for type=lb
   serviceName: <string>     optional, required for type=service
   servicePort: <number>     optional, required for type=service

--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -297,6 +297,7 @@ Current implemented algorithms:
 - `random`: backend is chosen at random
 - `consistentHash`: backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to prevent popular keys from overloading a single backend endpoint.
 - `powerOfRandomNChoices`: backend is chosen by powerOfRandomNChoices algorithm with selecting N random endpoints and picking the one with least outstanding requests from them. (http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf)
+- `weightedRoundRobin`: backend is chosen by [smooth weighted round robin](https://github.com/nginx/nginx/commit/52327e0627f49dbda1e8db695e63a4b0af4448b1) with dynamic weights based on the ratio of successful round trips per endpoint. Weights are updated by the [passive health check](../operation/operation.md) stats loop, so they only change when the passive health check is enabled; with equal weights it behaves like `roundRobin`.
 - __TODO__: https://github.com/zalando/skipper/issues/557
 
 Route example with 2 backends and the `roundRobin` algorithm:
@@ -317,6 +318,11 @@ r0: * -> <consistentHash, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 Route example with 2 backends and the `powerOfRandomNChoices` algorithm:
 ```
 r0: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+```
+
+Route example with 2 backends and the `weightedRoundRobin` algorithm:
+```
+r0: * -> <weightedRoundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 ```
 
 Proxy with `roundRobin` loadbalancer and two backends:

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -272,6 +272,7 @@ func (p *powerOfRandomNChoices) getScore(e routing.LBEndpoint) int64 {
 
 type weightedRoundRobin struct {
 	mu             sync.Mutex
+	rnd            *rand.Rand
 	currentWeights map[string]float64
 }
 
@@ -280,6 +281,7 @@ type weightedRoundRobin struct {
 // registry within the last stats reset period.
 func newWeightedRoundRobin(endpoints []string) routing.LBAlgorithm {
 	return &weightedRoundRobin{
+		rnd:            rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0)), // #nosec
 		currentWeights: make(map[string]float64, len(endpoints)),
 	}
 }
@@ -289,8 +291,11 @@ func newWeightedRoundRobin(endpoints []string) routing.LBAlgorithm {
 // Each endpoint accumulates its weight per round and the endpoint with the
 // highest accumulated weight is selected and reduced by the total weight of
 // the round. With equal weights it behaves like the roundrobin algorithm.
+// Iteration starts at a random offset so that ties are not biased towards
+// the first endpoint of the list.
 func (w *weightedRoundRobin) Apply(ctx *routing.LBContext) routing.LBEndpoint {
-	if len(ctx.LBEndpoints) == 1 {
+	ne := len(ctx.LBEndpoints)
+	if ne == 1 {
 		return ctx.LBEndpoints[0]
 	}
 
@@ -300,7 +305,9 @@ func (w *weightedRoundRobin) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 	total := 0.0
 	best := 0
 	bestWeight := math.Inf(-1)
-	for i := range ctx.LBEndpoints {
+	offset := w.rnd.IntN(ne) // #nosec
+	for k := 0; k < ne; k++ {
+		i := (offset + k) % ne
 		e := &ctx.LBEndpoints[i]
 		weight := e.Metrics.Weight()
 		total += weight

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -278,9 +278,9 @@ type weightedRoundRobin struct {
 // newWeightedRoundRobin creates a smooth weighted roundrobin algorithm
 // with weights based on the failed round trips observed by the endpoint
 // registry within the last stats reset period.
-func newWeightedRoundRobin([]string) routing.LBAlgorithm {
+func newWeightedRoundRobin(endpoints []string) routing.LBAlgorithm {
 	return &weightedRoundRobin{
-		currentWeights: make(map[string]float64),
+		currentWeights: make(map[string]float64, len(endpoints)),
 	}
 }
 
@@ -313,19 +313,6 @@ func (w *weightedRoundRobin) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 		}
 	}
 	w.currentWeights[ctx.LBEndpoints[best].Host] -= total
-
-	// forget endpoints that are no longer part of the route
-	if len(w.currentWeights) > 2*len(ctx.Route.LBEndpoints) {
-		known := make(map[string]struct{}, len(ctx.Route.LBEndpoints))
-		for i := range ctx.Route.LBEndpoints {
-			known[ctx.Route.LBEndpoints[i].Host] = struct{}{}
-		}
-		for host := range w.currentWeights {
-			if _, ok := known[host]; !ok {
-				delete(w.currentWeights, host)
-			}
-		}
-	}
 
 	return ctx.LBEndpoints[best]
 }

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -3,6 +3,7 @@ package loadbalancer
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/rand/v2"
 	"sort"
 	"sync"
@@ -34,6 +35,10 @@ const (
 
 	// PowerOfRandomNChoices selects N random endpoints and picks the one with least outstanding requests from them.
 	PowerOfRandomNChoices
+
+	// WeightedRoundRobin distributes requests proportionally to the dynamic
+	// endpoint weights derived from observed failed round trips.
+	WeightedRoundRobin
 )
 
 const powerOfRandomNChoicesDefaultN = 2
@@ -48,6 +53,7 @@ var (
 		Random:                newRandom,
 		ConsistentHash:        newConsistentHash,
 		PowerOfRandomNChoices: newPowerOfRandomNChoices,
+		WeightedRoundRobin:    newWeightedRoundRobin,
 	}
 	defaultAlgorithm = newRoundRobin
 )
@@ -264,6 +270,66 @@ func (p *powerOfRandomNChoices) getScore(e routing.LBEndpoint) int64 {
 	return -int64(e.Metrics.InflightRequests())
 }
 
+type weightedRoundRobin struct {
+	mu             sync.Mutex
+	currentWeights map[string]float64
+}
+
+// newWeightedRoundRobin creates a smooth weighted roundrobin algorithm
+// with weights based on the failed round trips observed by the endpoint
+// registry within the last stats reset period.
+func newWeightedRoundRobin([]string) routing.LBAlgorithm {
+	return &weightedRoundRobin{
+		currentWeights: make(map[string]float64),
+	}
+}
+
+// Apply implements routing.LBAlgorithm with a smooth weighted roundrobin
+// algorithm, see https://github.com/nginx/nginx/commit/52327e0627f49dbda1e8db695e63a4b0af4448b1.
+// Each endpoint accumulates its weight per round and the endpoint with the
+// highest accumulated weight is selected and reduced by the total weight of
+// the round. With equal weights it behaves like the roundrobin algorithm.
+func (w *weightedRoundRobin) Apply(ctx *routing.LBContext) routing.LBEndpoint {
+	if len(ctx.LBEndpoints) == 1 {
+		return ctx.LBEndpoints[0]
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	total := 0.0
+	best := 0
+	bestWeight := math.Inf(-1)
+	for i := range ctx.LBEndpoints {
+		e := &ctx.LBEndpoints[i]
+		weight := e.Metrics.Weight()
+		total += weight
+
+		cw := w.currentWeights[e.Host] + weight
+		w.currentWeights[e.Host] = cw
+		if cw > bestWeight {
+			bestWeight = cw
+			best = i
+		}
+	}
+	w.currentWeights[ctx.LBEndpoints[best].Host] -= total
+
+	// forget endpoints that are no longer part of the route
+	if len(w.currentWeights) > 2*len(ctx.Route.LBEndpoints) {
+		known := make(map[string]struct{}, len(ctx.Route.LBEndpoints))
+		for i := range ctx.Route.LBEndpoints {
+			known[ctx.Route.LBEndpoints[i].Host] = struct{}{}
+		}
+		for host := range w.currentWeights {
+			if _, ok := known[host]; !ok {
+				delete(w.currentWeights, host)
+			}
+		}
+	}
+
+	return ctx.LBEndpoints[best]
+}
+
 type (
 	algorithmProvider   struct{}
 	initializeAlgorithm func(endpoints []string) routing.LBAlgorithm
@@ -290,6 +356,8 @@ func AlgorithmFromString(a string) (Algorithm, error) {
 		return ConsistentHash, nil
 	case "powerOfRandomNChoices":
 		return PowerOfRandomNChoices, nil
+	case "weightedRoundRobin":
+		return WeightedRoundRobin, nil
 	default:
 		return None, errors.New("unsupported algorithm")
 	}
@@ -306,6 +374,8 @@ func (a Algorithm) String() string {
 		return "consistentHash"
 	case PowerOfRandomNChoices:
 		return "powerOfRandomNChoices"
+	case WeightedRoundRobin:
+		return "weightedRoundRobin"
 	default:
 		return ""
 	}

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zalando/skipper/eskip"
@@ -649,34 +650,102 @@ func TestWeightedRoundRobinEqualWeights(t *testing.T) {
 }
 
 func BenchmarkWeightedRoundRobinAlgorithm(b *testing.B) {
-	const N = 10
-	eps := make([]string, N)
-	for i := range N {
-		eps[i] = fmt.Sprintf("10.0.0.%d:8080", i)
-	}
+	for _, n := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("%d_endpoints", n), func(b *testing.B) {
+			eps := make([]string, n)
+			for i := range n {
+				eps[i] = fmt.Sprintf("10.0.%d.%d:8080", i/256, i%256)
+			}
 
-	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+			endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+			defer endpointRegistry.Close()
+
+			alg := newWeightedRoundRobin(eps)
+
+			lbeps := make([]routing.LBEndpoint, len(eps))
+			for i := range len(eps) {
+				lbeps[i] = routing.LBEndpoint{
+					Scheme:  "http",
+					Host:    eps[i],
+					Metrics: endpointRegistry.GetMetrics(eps[i]),
+				}
+			}
+
+			lbc := &routing.LBContext{
+				Route:       &routing.Route{},
+				LBEndpoints: lbeps,
+			}
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				alg.Apply(lbc)
+			}
+		})
+	}
+}
+
+func TestWeightedRoundRobinFailingBackend(t *testing.T) {
+	eps := []string{"http://127.0.0.1:1231/foo", "http://127.0.0.1:1232/foo", "http://127.0.0.1:1233/foo"}
+
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{
+		PassiveHealthCheckEnabled:     true,
+		StatsResetPeriod:              100 * time.Millisecond,
+		MinRequests:                   10,
+		MinHealthCheckDropProbability: 0.05,
+		MaxHealthCheckDropProbability: 0.95,
+	})
 	defer endpointRegistry.Close()
 
-	alg := newWeightedRoundRobin(eps)
+	p := NewAlgorithmProvider()
+	r := &routing.Route{
+		Route: eskip.Route{
+			BackendType: eskip.LBBackend,
+			LBAlgorithm: "weightedRoundRobin",
+			LBEndpoints: eskip.NewLBEndpoints(eps),
+		},
+	}
+	rt := p.Do([]*routing.Route{r})
+	endpointRegistry.Do([]*routing.Route{r})
 
-	lbeps := make([]routing.LBEndpoint, len(eps))
-	for i := range len(eps) {
-		lbeps[i] = routing.LBEndpoint{
-			Scheme:  "http",
-			Host:    eps[i],
-			Metrics: endpointRegistry.GetMetrics(eps[i]),
+	// simulate a failing backend: 80% of the round trips to the first
+	// endpoint fail, the other endpoints only see successful round trips
+	failing := rt[0].LBEndpoints[0].Metrics
+	for i := 0; i < 100; i++ {
+		failing.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: i%5 != 0})
+	}
+	for i := 1; i < 3; i++ {
+		for j := 0; j < 100; j++ {
+			rt[0].LBEndpoints[i].Metrics.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: false})
 		}
 	}
 
-	lbc := &routing.LBContext{
-		Route:       &routing.Route{},
-		LBEndpoints: lbeps,
+	// wait until the registry stats update assigns the reduced weight
+	for i := 0; i < 100 && failing.Weight() == 1.0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if failing.Weight() == 1.0 {
+		t.Fatal("failing endpoint weight was not updated")
 	}
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		alg.Apply(lbc)
+	req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
+	lbctx := &routing.LBContext{
+		Request:     req,
+		Route:       rt[0],
+		LBEndpoints: rt[0].LBEndpoints,
 	}
+
+	const rounds = 1000
+	h := make(map[string]int)
+	for i := 0; i < rounds; i++ {
+		h[rt[0].LBAlgorithm.Apply(lbctx).Host]++
+	}
+
+	failingCount := h[rt[0].LBEndpoints[0].Host]
+	for i := 1; i < 3; i++ {
+		healthyCount := h[rt[0].LBEndpoints[i].Host]
+		assert.Greater(t, healthyCount, 2*failingCount,
+			"healthy endpoint %d should receive more than twice the traffic of the failing endpoint", i)
+	}
+	assert.Greater(t, failingCount, 0, "failing endpoint must keep receiving some traffic to detect recovery")
 }

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -647,3 +647,36 @@ func TestWeightedRoundRobinEqualWeights(t *testing.T) {
 		assert.Equal(t, rounds/N, count, "host %s", host)
 	}
 }
+
+func BenchmarkWeightedRoundRobinAlgorithm(b *testing.B) {
+	const N = 10
+	eps := make([]string, N)
+	for i := range N {
+		eps[i] = fmt.Sprintf("10.0.0.%d:8080", i)
+	}
+
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
+
+	alg := newWeightedRoundRobin(eps)
+
+	lbeps := make([]routing.LBEndpoint, len(eps))
+	for i := range len(eps) {
+		lbeps[i] = routing.LBEndpoint{
+			Scheme:  "http",
+			Host:    eps[i],
+			Metrics: endpointRegistry.GetMetrics(eps[i]),
+		}
+	}
+
+	lbc := &routing.LBContext{
+		Route:       &routing.Route{},
+		LBEndpoints: lbeps,
+	}
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		alg.Apply(lbc)
+	}
+}

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -260,6 +260,11 @@ func TestApply(t *testing.T) {
 			expected:      N,
 			algorithm:     newPowerOfRandomNChoices(eps),
 			algorithmName: "powerOfRandomNChoices",
+		}, {
+			name:          "weightedRoundRobin algorithm",
+			expected:      N,
+			algorithm:     newWeightedRoundRobin(eps),
+			algorithmName: "weightedRoundRobin",
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
@@ -549,5 +554,96 @@ func BenchmarkRandomAlgorithm(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		alg.Apply(lbc)
+	}
+}
+
+type fixedWeightMetrics struct {
+	routing.Metrics
+	weight float64
+}
+
+func (m fixedWeightMetrics) Weight() float64 { return m.weight }
+
+func TestWeightedRoundRobinDistribution(t *testing.T) {
+	eps := []string{"http://127.0.0.1:1231/foo", "http://127.0.0.1:1232/foo", "http://127.0.0.1:1233/foo"}
+	weights := []float64{0.2, 0.8, 1.0}
+
+	p := NewAlgorithmProvider()
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
+	r := &routing.Route{
+		Route: eskip.Route{
+			BackendType: eskip.LBBackend,
+			LBAlgorithm: "weightedRoundRobin",
+			LBEndpoints: eskip.NewLBEndpoints(eps),
+		},
+	}
+	rt := p.Do([]*routing.Route{r})
+	endpointRegistry.Do([]*routing.Route{r})
+	for i := range rt[0].LBEndpoints {
+		rt[0].LBEndpoints[i].Metrics = fixedWeightMetrics{Metrics: rt[0].LBEndpoints[i].Metrics, weight: weights[i]}
+	}
+
+	req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
+	lbctx := &routing.LBContext{
+		Request:     req,
+		Route:       rt[0],
+		LBEndpoints: rt[0].LBEndpoints,
+	}
+
+	const rounds = 1000
+	h := make(map[string]int)
+	for i := 0; i < rounds; i++ {
+		h[rt[0].LBAlgorithm.Apply(lbctx).Host]++
+	}
+
+	// smooth weighted roundrobin distributes proportionally to the weights
+	total := 0.0
+	for _, w := range weights {
+		total += w
+	}
+	for i, w := range weights {
+		expected := rounds * w / total
+		assert.InDelta(t, expected, h[rt[0].LBEndpoints[i].Host], 1.0, "endpoint %d", i)
+	}
+}
+
+func TestWeightedRoundRobinEqualWeights(t *testing.T) {
+	const N = 5
+	eps := make([]string, 0, N)
+	for i := 0; i < N; i++ {
+		eps = append(eps, fmt.Sprintf("http://127.0.0.1:123%d/foo", i))
+	}
+
+	p := NewAlgorithmProvider()
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
+	r := &routing.Route{
+		Route: eskip.Route{
+			BackendType: eskip.LBBackend,
+			LBAlgorithm: "weightedRoundRobin",
+			LBEndpoints: eskip.NewLBEndpoints(eps),
+		},
+	}
+	rt := p.Do([]*routing.Route{r})
+	endpointRegistry.Do([]*routing.Route{r})
+
+	req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
+	lbctx := &routing.LBContext{
+		Request:     req,
+		Route:       rt[0],
+		LBEndpoints: rt[0].LBEndpoints,
+	}
+
+	// with the default weight of 1.0 every endpoint receives an equal share
+	const rounds = 1000
+	h := make(map[string]int)
+	for i := 0; i < rounds; i++ {
+		h[rt[0].LBAlgorithm.Apply(lbctx).Host]++
+	}
+
+	assert.Len(t, h, N)
+	for host, count := range h {
+		assert.Equal(t, rounds/N, count, "host %s", host)
 	}
 }

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -708,20 +709,40 @@ func TestWeightedRoundRobinFailingBackend(t *testing.T) {
 	rt := p.Do([]*routing.Route{r})
 	endpointRegistry.Do([]*routing.Route{r})
 
-	// simulate a failing backend: 80% of the round trips to the first
-	// endpoint fail, the other endpoints only see successful round trips
 	failing := rt[0].LBEndpoints[0].Metrics
-	for i := 0; i < 100; i++ {
-		failing.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: i%5 != 0})
-	}
-	for i := 1; i < 3; i++ {
-		for j := 0; j < 100; j++ {
-			rt[0].LBEndpoints[i].Metrics.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: false})
+
+	// Continuously feed the registry so that every stats reset period is
+	// populated: the first endpoint sees 80% failed round trips, the other
+	// endpoints only successful ones. This keeps the reduced weight stable
+	// regardless of when the background stats goroutine fires, avoiding a
+	// dependency on a single stats window.
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			for i := 0; i < 10; i++ {
+				failing.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: i%5 != 0})
+				for j := 1; j < 3; j++ {
+					rt[0].LBEndpoints[j].Metrics.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: false})
+				}
+			}
+			time.Sleep(time.Millisecond)
 		}
-	}
+	}()
+	defer func() {
+		close(done)
+		wg.Wait()
+	}()
 
 	// wait until the registry stats update assigns the reduced weight
-	for i := 0; i < 100 && failing.Weight() == 1.0; i++ {
+	for i := 0; i < 200 && failing.Weight() == 1.0; i++ {
 		time.Sleep(10 * time.Millisecond)
 	}
 	if failing.Weight() == 1.0 {

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zalando/skipper/eskip"
 	"github.com/zalando/skipper/net"
 	"github.com/zalando/skipper/routing"
@@ -566,207 +565,117 @@ type fixedWeightMetrics struct {
 
 func (m fixedWeightMetrics) Weight() float64 { return m.weight }
 
-func TestWeightedRoundRobinDistribution(t *testing.T) {
-	eps := []string{"http://127.0.0.1:1231/foo", "http://127.0.0.1:1232/foo", "http://127.0.0.1:1233/foo"}
-	weights := []float64{0.2, 0.8, 1.0}
-
-	p := NewAlgorithmProvider()
-	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
-	defer endpointRegistry.Close()
-	r := &routing.Route{
+func setupWeightedRoundRobinRoute(t *testing.T, registry *routing.EndpointRegistry, endpointAddresses []string) *routing.Route {
+	t.Helper()
+	provider := NewAlgorithmProvider()
+	route := &routing.Route{
 		Route: eskip.Route{
 			BackendType: eskip.LBBackend,
 			LBAlgorithm: "weightedRoundRobin",
-			LBEndpoints: eskip.NewLBEndpoints(eps),
+			LBEndpoints: eskip.NewLBEndpoints(endpointAddresses),
 		},
 	}
-	rt := p.Do([]*routing.Route{r})
-	endpointRegistry.Do([]*routing.Route{r})
-	for i := range rt[0].LBEndpoints {
-		rt[0].LBEndpoints[i].Metrics = fixedWeightMetrics{Metrics: rt[0].LBEndpoints[i].Metrics, weight: weights[i]}
+	processedRoutes := provider.Do([]*routing.Route{route})
+	registry.Do([]*routing.Route{route})
+	require.Len(t, processedRoutes, 1)
+	return processedRoutes[0]
+}
+
+func applyAndCountSelections(t *testing.T, route *routing.Route, rounds int) map[string]int {
+	t.Helper()
+	request, err := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
+	require.NoError(t, err)
+	lbContext := &routing.LBContext{
+		Request:     request,
+		Route:       route,
+		LBEndpoints: route.LBEndpoints,
 	}
 
-	req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
-	lbctx := &routing.LBContext{
-		Request:     req,
-		Route:       rt[0],
-		LBEndpoints: rt[0].LBEndpoints,
+	selectionCounts := make(map[string]int)
+	for i := 0; i < rounds; i++ {
+		selectionCounts[route.LBAlgorithm.Apply(lbContext).Host]++
+	}
+	return selectionCounts
+}
+
+func TestWeightedRoundRobinDistribution(t *testing.T) {
+	endpointAddresses := []string{"http://127.0.0.1:1231/foo", "http://127.0.0.1:1232/foo", "http://127.0.0.1:1233/foo"}
+	endpointWeights := []float64{0.2, 0.8, 1.0}
+
+	registry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer registry.Close()
+	route := setupWeightedRoundRobinRoute(t, registry, endpointAddresses)
+	for i := range route.LBEndpoints {
+		route.LBEndpoints[i].Metrics = fixedWeightMetrics{Metrics: route.LBEndpoints[i].Metrics, weight: endpointWeights[i]}
 	}
 
 	const rounds = 1000
-	h := make(map[string]int)
-	for i := 0; i < rounds; i++ {
-		h[rt[0].LBAlgorithm.Apply(lbctx).Host]++
-	}
+	selectionCounts := applyAndCountSelections(t, route, rounds)
 
 	// smooth weighted roundrobin distributes proportionally to the weights
-	total := 0.0
-	for _, w := range weights {
-		total += w
+	totalWeight := 0.0
+	for _, weight := range endpointWeights {
+		totalWeight += weight
 	}
-	for i, w := range weights {
-		expected := rounds * w / total
-		assert.InDelta(t, expected, h[rt[0].LBEndpoints[i].Host], 1.0, "endpoint %d", i)
+	for i, weight := range endpointWeights {
+		expectedSelections := rounds * weight / totalWeight
+		assert.InDelta(t, expectedSelections, selectionCounts[route.LBEndpoints[i].Host], 1.0, "endpoint %d", i)
 	}
 }
 
 func TestWeightedRoundRobinEqualWeights(t *testing.T) {
-	const N = 5
-	eps := make([]string, 0, N)
-	for i := 0; i < N; i++ {
-		eps = append(eps, fmt.Sprintf("http://127.0.0.1:123%d/foo", i))
+	const numberOfEndpoints = 5
+	endpointAddresses := make([]string, 0, numberOfEndpoints)
+	for i := 0; i < numberOfEndpoints; i++ {
+		endpointAddresses = append(endpointAddresses, fmt.Sprintf("http://127.0.0.1:123%d/foo", i))
 	}
 
-	p := NewAlgorithmProvider()
-	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
-	defer endpointRegistry.Close()
-	r := &routing.Route{
-		Route: eskip.Route{
-			BackendType: eskip.LBBackend,
-			LBAlgorithm: "weightedRoundRobin",
-			LBEndpoints: eskip.NewLBEndpoints(eps),
-		},
-	}
-	rt := p.Do([]*routing.Route{r})
-	endpointRegistry.Do([]*routing.Route{r})
-
-	req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
-	lbctx := &routing.LBContext{
-		Request:     req,
-		Route:       rt[0],
-		LBEndpoints: rt[0].LBEndpoints,
-	}
+	registry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer registry.Close()
+	route := setupWeightedRoundRobinRoute(t, registry, endpointAddresses)
 
 	// with the default weight of 1.0 every endpoint receives an equal share
 	const rounds = 1000
-	h := make(map[string]int)
-	for i := 0; i < rounds; i++ {
-		h[rt[0].LBAlgorithm.Apply(lbctx).Host]++
-	}
+	selectionCounts := applyAndCountSelections(t, route, rounds)
 
-	assert.Len(t, h, N)
-	for host, count := range h {
-		assert.Equal(t, rounds/N, count, "host %s", host)
+	assert.Len(t, selectionCounts, numberOfEndpoints)
+	for host, count := range selectionCounts {
+		assert.Equal(t, rounds/numberOfEndpoints, count, "host %s", host)
 	}
 }
 
 func BenchmarkWeightedRoundRobinAlgorithm(b *testing.B) {
-	for _, n := range []int{10, 100, 1000, 10000} {
-		b.Run(fmt.Sprintf("%d_endpoints", n), func(b *testing.B) {
-			eps := make([]string, n)
-			for i := range n {
-				eps[i] = fmt.Sprintf("10.0.%d.%d:8080", i/256, i%256)
+	for _, numberOfEndpoints := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("%d_endpoints", numberOfEndpoints), func(b *testing.B) {
+			endpointAddresses := make([]string, numberOfEndpoints)
+			for i := range numberOfEndpoints {
+				endpointAddresses[i] = fmt.Sprintf("10.0.%d.%d:8080", i/256, i%256)
 			}
 
-			endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
-			defer endpointRegistry.Close()
+			registry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+			defer registry.Close()
 
-			alg := newWeightedRoundRobin(eps)
+			algorithm := newWeightedRoundRobin(endpointAddresses)
 
-			lbeps := make([]routing.LBEndpoint, len(eps))
-			for i := range len(eps) {
-				lbeps[i] = routing.LBEndpoint{
+			endpoints := make([]routing.LBEndpoint, len(endpointAddresses))
+			for i := range len(endpointAddresses) {
+				endpoints[i] = routing.LBEndpoint{
 					Scheme:  "http",
-					Host:    eps[i],
-					Metrics: endpointRegistry.GetMetrics(eps[i]),
+					Host:    endpointAddresses[i],
+					Metrics: registry.GetMetrics(endpointAddresses[i]),
 				}
 			}
 
-			lbc := &routing.LBContext{
+			lbContext := &routing.LBContext{
 				Route:       &routing.Route{},
-				LBEndpoints: lbeps,
+				LBEndpoints: endpoints,
 			}
 
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				alg.Apply(lbc)
+				algorithm.Apply(lbContext)
 			}
 		})
 	}
-}
-
-func TestWeightedRoundRobinFailingBackend(t *testing.T) {
-	eps := []string{"http://127.0.0.1:1231/foo", "http://127.0.0.1:1232/foo", "http://127.0.0.1:1233/foo"}
-
-	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{
-		PassiveHealthCheckEnabled:     true,
-		StatsResetPeriod:              100 * time.Millisecond,
-		MinRequests:                   10,
-		MinHealthCheckDropProbability: 0.05,
-		MaxHealthCheckDropProbability: 0.95,
-	})
-	defer endpointRegistry.Close()
-
-	p := NewAlgorithmProvider()
-	r := &routing.Route{
-		Route: eskip.Route{
-			BackendType: eskip.LBBackend,
-			LBAlgorithm: "weightedRoundRobin",
-			LBEndpoints: eskip.NewLBEndpoints(eps),
-		},
-	}
-	rt := p.Do([]*routing.Route{r})
-	endpointRegistry.Do([]*routing.Route{r})
-
-	failing := rt[0].LBEndpoints[0].Metrics
-
-	// Continuously feed the registry so that every stats reset period is
-	// populated: the first endpoint sees 80% failed round trips, the other
-	// endpoints only successful ones. This keeps the reduced weight stable
-	// regardless of when the background stats goroutine fires, avoiding a
-	// dependency on a single stats window.
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for {
-			select {
-			case <-done:
-				return
-			default:
-			}
-			for i := 0; i < 10; i++ {
-				failing.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: i%5 != 0})
-				for j := 1; j < 3; j++ {
-					rt[0].LBEndpoints[j].Metrics.IncRequests(routing.IncRequestsOptions{FailedRoundTrip: false})
-				}
-			}
-			time.Sleep(time.Millisecond)
-		}
-	}()
-	defer func() {
-		close(done)
-		wg.Wait()
-	}()
-
-	// wait until the registry stats update assigns the reduced weight
-	for i := 0; i < 200 && failing.Weight() == 1.0; i++ {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if failing.Weight() == 1.0 {
-		t.Fatal("failing endpoint weight was not updated")
-	}
-
-	req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
-	lbctx := &routing.LBContext{
-		Request:     req,
-		Route:       rt[0],
-		LBEndpoints: rt[0].LBEndpoints,
-	}
-
-	const rounds = 1000
-	h := make(map[string]int)
-	for i := 0; i < rounds; i++ {
-		h[rt[0].LBAlgorithm.Apply(lbctx).Host]++
-	}
-
-	failingCount := h[rt[0].LBEndpoints[0].Host]
-	for i := 1; i < 3; i++ {
-		healthyCount := h[rt[0].LBEndpoints[i].Host]
-		assert.Greater(t, healthyCount, 2*failingCount,
-			"healthy endpoint %d should receive more than twice the traffic of the failing endpoint", i)
-	}
-	assert.Greater(t, failingCount, 0, "failing endpoint must keep receiving some traffic to detect recovery")
 }

--- a/loadbalancer/doc.go
+++ b/loadbalancer/doc.go
@@ -25,6 +25,16 @@ powerOfRandomNChoices Algorithm
 	and picks the one with least outstanding requests from them.
 	Currently, N is 2.
 
+weightedRoundRobin Algorithm
+
+	The weightedRoundRobin algorithm distributes requests across the
+	backend endpoints proportionally to their dynamic weights using
+	smooth weighted round robin. The weight of an endpoint is the
+	ratio of its successful round trips within the last stats reset
+	period of the endpoint registry and requires the passive health
+	check to be enabled to be updated. With equal weights it behaves
+	like the roundRobin algorithm.
+
 The load balancing algorithms also provide fade-in behavior for LB endpoints of routes where the
 fade-in duration was configured. This feature can be used to gradually add traffic to new instances of
 applications that require a certain amount of warm-up time.
@@ -35,6 +45,7 @@ Eskip example:
 	r2: * -> <consistentHash, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 	r3: * -> <random, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 	r4: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+	r5: * -> <weightedRoundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 
 Package loadbalancer also implements health checking of pool members for
 a group of routes, if backend calls are reported to the loadbalancer.

--- a/packaging/helm/skipper-aws/crds/routegroups.yaml
+++ b/packaging/helm/skipper-aws/crds/routegroups.yaml
@@ -58,6 +58,7 @@ spec:
                       - random
                       - consistentHash
                       - powerOfRandomNChoices
+                      - weightedRoundRobin
                       type: string
                     endpoints:
                       description: Endpoints is required for Type lb

--- a/proxy/healthy_endpoints_test.go
+++ b/proxy/healthy_endpoints_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -343,4 +344,57 @@ func TestPHCMaxUnhealthyEndpointsRatioParam(t *testing.T) {
 		)
 		assert.InDelta(t, 0.0, float64(counters["passive-health-check.requests.passed"]), 0.3*float64(nRequests)) // allow 30% error
 	})
+}
+
+func TestWeightedRoundRobinWithFailingBackend(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	// two healthy backends and one that always exceeds the backend
+	// timeout, so that its round trips fail and the endpoint registry
+	// reduces its weight
+	var healthyBackendRequests [2]atomic.Int64
+	var failingBackendRequests atomic.Int64
+
+	backendURLs := []string{}
+	for i := range healthyBackendRequests {
+		counter := &healthyBackendRequests[i]
+		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			counter.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		backendURLs = append(backendURLs, backend.URL)
+		t.Cleanup(backend.Close)
+	}
+	failingBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failingBackendRequests.Add(1)
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	backendURLs = append(backendURLs, failingBackend.URL)
+	t.Cleanup(failingBackend.Close)
+
+	// the endpoint registry updates the weights from the failed round
+	// trips, while the passive health check filtering stays disabled so
+	// that the observed traffic distribution is the effect of the
+	// weightedRoundRobin algorithm alone
+	proxyParams := Params{
+		EndpointRegistry: defaultEndpointRegistry(),
+		Metrics:          &metricstest.MockMetrics{},
+	}
+	routeDoc := fmt.Sprintf(`* -> backendTimeout("20ms") -> <weightedRoundRobin, "%s">`,
+		strings.Join(backendURLs, `", "`))
+	proxyServer := setupProxyWithCustomProxyParams(t, routeDoc, proxyParams)
+
+	fireVegeta(t, proxyServer, 3000, 1*time.Second, 5*time.Second)
+
+	failingCount := failingBackendRequests.Load()
+	assert.Greater(t, failingCount, int64(0),
+		"failing backend must keep receiving some traffic to detect recovery")
+	for i := range healthyBackendRequests {
+		healthyCount := healthyBackendRequests[i].Load()
+		assert.Greater(t, healthyCount, 2*failingCount,
+			"healthy backend %d should receive more than twice the traffic of the failing backend", i)
+	}
 }

--- a/routing/endpointregistry.go
+++ b/routing/endpointregistry.go
@@ -27,6 +27,7 @@ type Metrics interface {
 
 	IncRequests(o IncRequestsOptions)
 	HealthCheckDropProbability() float64
+	Weight() float64
 }
 
 type IncRequestsOptions struct {
@@ -42,6 +43,7 @@ type entry struct {
 	totalFailedRoundTrips      [2]atomic.Int64
 	curSlot                    atomic.Int64
 	healthCheckDropProbability atomic.Value // float64
+	weight                     atomic.Value // float64
 }
 
 var _ Metrics = &entry{}
@@ -86,9 +88,19 @@ func (e *entry) HealthCheckDropProbability() float64 {
 	return e.healthCheckDropProbability.Load().(float64)
 }
 
+// Weight returns the dynamic weight of the endpoint based on the ratio of
+// successful round trips in the last stats reset period. It is 1.0 for
+// endpoints without failures and never goes below the complement of the
+// maximum health check drop probability, so that failing endpoints keep
+// receiving a small share of requests to detect recovery.
+func (e *entry) Weight() float64 {
+	return e.weight.Load().(float64)
+}
+
 func newEntry() *entry {
 	result := &entry{}
 	result.healthCheckDropProbability.Store(0.0)
+	result.weight.Store(1.0)
 	result.SetDetected(time.Time{})
 	result.SetLastSeen(time.Time{})
 	return result
@@ -168,16 +180,19 @@ func (r *EndpointRegistry) updateStats() {
 			e.totalRequests[nextSlot].Store(0)
 
 			newDropProbability := 0.0
+			newWeight := 1.0
 			failed := e.totalFailedRoundTrips[curSlot].Load()
 			requests := e.totalRequests[curSlot].Load()
 			if requests > r.minRequests {
 				failedRoundTripsRatio := float64(failed) / float64(requests)
+				newWeight = max(1.0-failedRoundTripsRatio, 1.0-r.maxHealthCheckDropProbability)
 				if failedRoundTripsRatio > r.minHealthCheckDropProbability {
 					log.Infof("Passive health check: marking %q as unhealthy due to failed round trips ratio: %0.2f", key, failedRoundTripsRatio)
 					newDropProbability = min(failedRoundTripsRatio, r.maxHealthCheckDropProbability)
 				}
 			}
 			e.healthCheckDropProbability.Store(newDropProbability)
+			e.weight.Store(newWeight)
 			e.curSlot.Store(nextSlot)
 
 			return true

--- a/routing/endpointregistry_internal_test.go
+++ b/routing/endpointregistry_internal_test.go
@@ -47,6 +47,9 @@ func TestStats(t *testing.T) {
 	if p := mtr.HealthCheckDropProbability(); p > 0.0 {
 		t.Fatalf("Failed to get 0 drop probability at start got: %0.2f", p)
 	}
+	if w := mtr.Weight(); w != 1.0 {
+		t.Fatalf("Failed to get 1.0 weight at start got: %0.2f", w)
+	}
 
 	// populate values
 	go reg.updateStats()
@@ -55,6 +58,11 @@ func TestStats(t *testing.T) {
 	mtr = reg.GetMetrics(ep)
 	if p := mtr.HealthCheckDropProbability(); p < 0.5 || p > 0.9 {
 		t.Fatalf("Failed to get drop probability: %0.2f", p)
+	}
+	// 9 of 11 requests failed, weight is the success ratio,
+	// bounded below by 1 - maxHealthCheckDropProbability
+	if w := mtr.Weight(); w < 0.1 || w > 0.5 {
+		t.Fatalf("Failed to get weight: %0.2f", w)
 	}
 
 	// clear slots
@@ -66,5 +74,8 @@ func TestStats(t *testing.T) {
 	mtr = reg.GetMetrics(ep)
 	if p := mtr.HealthCheckDropProbability(); p > 0.0 {
 		t.Fatalf("Failed to reset drop probability got: %0.2f", p)
+	}
+	if w := mtr.Weight(); w != 1.0 {
+		t.Fatalf("Failed to reset weight got: %0.2f", w)
 	}
 }

--- a/skipper.go
+++ b/skipper.go
@@ -352,7 +352,7 @@ type Options struct {
 	KubernetesBackendTrafficAlgorithm kubernetes.BackendTrafficAlgorithm
 
 	// KubernetesDefaultLoadBalancerAlgorithm sets the default algorithm to be used for load balancing between backend endpoints,
-	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices
+	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin
 	KubernetesDefaultLoadBalancerAlgorithm string
 
 	// File containing static route definitions. Multiple may be given comma separated.

--- a/skptesting/benchmark-lb-algorithms.sh
+++ b/skptesting/benchmark-lb-algorithms.sh
@@ -1,0 +1,147 @@
+#! /bin/bash
+
+# Benchmarks load balancer algorithms end to end against a large number
+# of backend processes, to measure the algorithm overhead and lock
+# contention under sustained load.
+#
+# The backends are okserver processes (see okserver.c), each responding
+# with a fixed 200 on its own port. One skipper instance load balances a
+# single route across all of them, and the load generator drives it for
+# the configured duration, once per algorithm.
+#
+# usage: benchmark-lb-algorithms.sh [backends] [duration] [connections] [algorithms] [skipper-binary]
+#
+# example: benchmark-lb-algorithms.sh 1000 2m 128 "roundRobin weightedRoundRobin"
+#
+# The load is generated with wrk (https://github.com/wg/wrk), or hey
+# (https://github.com/rakyll/hey) when wrk is not available.
+#
+# environment:
+#   PROXYPORT          proxy listen port, default 9090
+#   BASEPORT           first backend port, default 10000
+#   PORTS_PER_PROCESS  backend ports served by one okserver process,
+#                      default 1; raise it on systems where the process
+#                      limit does not allow one process per backend
+
+set -o pipefail
+
+cwd="$(cd "$(dirname "$0")" && pwd)"
+cd "$cwd" || exit 1
+
+backends=${1:-1000}
+duration=${2:-1m}
+connections=${3:-128}
+algorithms=${4:-"roundRobin random powerOfRandomNChoices weightedRoundRobin"}
+bin=${5:-"$cwd"/../bin/skipper}
+
+baseport=${BASEPORT:-10000}
+proxyport=${PROXYPORT:-9090}
+
+log() {
+	echo "$@" >&2
+}
+
+if [ ! -x "$bin" ]; then
+	log "skipper binary not found at $bin, run 'make skipper' first or pass the binary as the 5th argument"
+	exit 1
+fi
+
+loadgen=
+if command -v wrk > /dev/null; then
+	loadgen=wrk
+elif command -v hey > /dev/null; then
+	loadgen=hey
+else
+	log "ERR: neither 'wrk' (https://github.com/wg/wrk) nor 'hey' (https://github.com/rakyll/hey) found in \$PATH"
+	exit 2
+fi
+
+ulimit -n 65536 2> /dev/null
+
+if [ ! -x okserver ] || [ okserver.c -nt okserver ]; then
+	log [building okserver]
+	cc -O2 -o okserver okserver.c -lpthread || exit 1
+fi
+
+backendpids=
+skipperpid=
+
+cleanup() {
+	[ -n "$skipperpid" ] && kill -9 "$skipperpid" 2> /dev/null
+	[ -n "$backendpids" ] && kill -9 $backendpids 2> /dev/null
+	rm -f "$cwd"/lb-algorithms.eskip
+}
+
+trap 'cleanup; exit 0' SIGINT
+
+portsperprocess=${PORTS_PER_PROCESS:-1}
+
+log; log "[starting $backends backends]"
+for ((i = 0; i < backends; i += portsperprocess)); do
+	n=$portsperprocess
+	[ $((i + n)) -gt "$backends" ] && n=$((backends - i))
+	./okserver $((baseport + i)) $n &
+	backendpids="$backendpids $!"
+	disown
+done
+
+# wait for the last backend to accept connections
+for ((i = 0; i < 50; i++)); do
+	curl -s -o /dev/null http://127.0.0.1:$((baseport + backends - 1))/ && break
+	sleep 0.1
+done
+log "[backends started]"
+
+endpoints() {
+	for ((i = 0; i < backends; i++)); do
+		printf '"http://127.0.0.1:%d"' $((baseport + i))
+		[ $i -lt $((backends - 1)) ] && printf ', '
+	done
+}
+
+eps=$(endpoints)
+
+run_load() {
+	if [ "$loadgen" = wrk ]; then
+		wrk -c "$connections" -d "$1" --latency http://127.0.0.1:$proxyport/
+	else
+		hey -z "$1" -c "$connections" http://127.0.0.1:$proxyport/ |
+			grep -E 'Requests/sec|Average|Slowest|Fastest|50%|90%|99%|responses'
+	fi
+}
+
+for algorithm in $algorithms; do
+	echo "lb: * -> <$algorithm, $eps>;" > "$cwd"/lb-algorithms.eskip
+
+	"$bin" -access-log-disabled -address ":$proxyport" \
+		-routes-file "$cwd"/lb-algorithms.eskip -insecure \
+		-support-listener :0 \
+		-passive-health-check "period=5s,min-requests=10,max-drop-probability=0.9" \
+		-idle-conns-num "$connections" -close-idle-conns-period=60s 2> \
+		>(grep -Ev 'INFO|write: broken pipe|connection reset by peer') &
+	skipperpid=$!
+	disown
+
+	for ((i = 0; i < 50; i++)); do
+		curl -s -o /dev/null http://127.0.0.1:$proxyport/ && break
+		sleep 0.1
+	done
+	if ! curl -s -o /dev/null http://127.0.0.1:$proxyport/; then
+		log "ERR: skipper did not start listening on :$proxyport"
+		cleanup
+		exit 1
+	fi
+
+	log; log "[warmup $algorithm]"
+	run_load 5s > /dev/null 2>&1
+	log "[benchmarking $algorithm, $backends backends, $connections connections, $duration]"
+	run_load "$duration"
+	log "[benchmarking $algorithm done]"
+
+	kill -9 "$skipperpid" 2> /dev/null
+	skipperpid=
+	sleep 0.5
+done
+
+cleanup
+log; log [all done]

--- a/skptesting/okserver.c
+++ b/skptesting/okserver.c
@@ -1,0 +1,140 @@
+/*
+okserver is a minimal HTTP server that responds to every request with
+a fixed 200 response. It is used by the load balancer benchmarks to
+run a large number of backend processes with a small footprint.
+
+Build:
+
+	cc -O2 -o okserver okserver.c -lpthread
+
+Usage:
+
+	okserver <port> [count]
+
+When count is given, the server listens on all ports from port to
+port+count-1 in a single process. This allows simulating many endpoints
+on systems where the process limit does not allow one process per
+endpoint.
+*/
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static const char response[] =
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: text/plain\r\n"
+    "Content-Length: 3\r\n"
+    "\r\n"
+    "OK\n";
+
+static void *serve(void *arg) {
+	int conn = (int)(long)arg;
+	char buf[4096];
+
+	for (;;) {
+		/* read one request, assume no body and that the header
+		   arrives in one segment, which holds for benchmark
+		   clients on loopback */
+		ssize_t n = read(conn, buf, sizeof(buf));
+		if (n <= 0)
+			break;
+
+		if (write(conn, response, sizeof(response)-1) < 0)
+			break;
+	}
+
+	close(conn);
+	return NULL;
+}
+
+static void *accept_loop(void *arg) {
+	int listener = (int)(long)arg;
+	int one = 1;
+
+	for (;;) {
+		int conn = accept(listener, NULL, NULL);
+		if (conn < 0)
+			continue;
+
+		setsockopt(conn, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+		pthread_t t;
+		if (pthread_create(&t, NULL, serve, (void *)(long)conn) == 0)
+			pthread_detach(t);
+		else
+			close(conn);
+	}
+
+	return NULL;
+}
+
+static int listen_on(int port) {
+	int listener = socket(AF_INET, SOCK_STREAM, 0);
+	if (listener < 0) {
+		perror("socket");
+		return -1;
+	}
+
+	int one = 1;
+	setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+	struct sockaddr_in addr;
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_port = htons((unsigned short)port);
+
+	if (bind(listener, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		perror("bind");
+		return -1;
+	}
+
+	if (listen(listener, 1024) < 0) {
+		perror("listen");
+		return -1;
+	}
+
+	return listener;
+}
+
+int main(int argc, char **argv) {
+	if (argc != 2 && argc != 3) {
+		fprintf(stderr, "usage: %s <port> [count]\n", argv[0]);
+		return 1;
+	}
+
+	signal(SIGPIPE, SIG_IGN);
+
+	int port = atoi(argv[1]);
+	int count = argc == 3 ? atoi(argv[2]) : 1;
+	if (count < 1)
+		count = 1;
+
+	for (int i = 0; i < count; i++) {
+		int listener = listen_on(port + i);
+		if (listener < 0)
+			return 1;
+
+		if (i == count-1) {
+			/* run the last accept loop on the main thread */
+			accept_loop((void *)(long)listener);
+			return 0;
+		}
+
+		pthread_t t;
+		if (pthread_create(&t, NULL, accept_loop, (void *)(long)listener) != 0) {
+			perror("pthread_create");
+			return 1;
+		}
+		pthread_detach(t);
+	}
+
+	return 0;
+}

--- a/skptesting/readme.md
+++ b/skptesting/readme.md
@@ -48,6 +48,19 @@ skptesting/benchmark-compress.sh 12 128 3
 Benchmarks skipper as an HTTP compression proxy with a static file server behind it, running for 12s, over 128
 connections and with a preliminary warmup time of 3s.
 
+## Benchmark Load Balancer Algorithms
+
+```
+skptesting/benchmark-lb-algorithms.sh 1000 2m 128 "roundRobin weightedRoundRobin"
+```
+
+Benchmarks the load balancer algorithms end to end against a large number of local backend processes to
+measure the algorithm overhead and lock contention under sustained load, here 1000 backends, for 2 minutes,
+over 128 connections. The backends are instances of a minimal C HTTP server (okserver.c) that is compiled
+automatically. See the script header for the environment variables that control the ports and the number of
+backend ports served per one process, for systems with a low process limit. Requires a C compiler, and wrk
+or hey (https://github.com/rakyll/hey) as the load generator.
+
 ## Set CPU Frequency Scaling
 
 Set the system CPU scaling governor to best performance:


### PR DESCRIPTION
Adds a `weightedRoundRobin` load balancer algorithm, as discussed in #557 with @szuecs and @MustafaSaber.

## How it works

- The endpoint registry now tracks a dynamic per-endpoint weight: the ratio of successful round trips within the last stats reset period, computed in the same loop that derives the passive health check drop probability. `Weight()` is added to the `routing.Metrics` interface (allowed under the weak-compatibility policy for the `routing` package).
- The new algorithm uses [smooth weighted round robin](https://github.com/nginx/nginx/commit/52327e0627f49dbda1e8db695e63a4b0af4448b1) over these weights, keyed by host so it works with the passive-health-check-filtered endpoint subset. With equal weights it behaves exactly like `roundRobin`.
- No eskip or Kubernetes plumbing was needed — the weight travels through the existing `LBEndpoint.Metrics` channel, per @MustafaSaber's suggestion.

## Design decisions to note

- **Weights require passive health check to be enabled**: the weight is updated by the PHC stats loop, so without `-passive-health-check` the algorithm behaves like `roundRobin` (documented in backends.md and the package docs). Happy to add a startup warning for this combination if preferred.
- **Weight floor**: weights are bounded below by `1 - maxHealthCheckDropProbability`, so failing endpoints keep receiving a small share of traffic to detect recovery — mirroring the PHC clamping semantics.
- The RouteGroup CRD enum (both `routegroups_crd.yaml` and the helm chart copy) is updated so the algorithm is accepted in RouteGroups.

## Testing

- Deterministic distribution test (smooth WRR is exactly proportional): weights 0.2/0.8/1.0 over 1000 rounds yield exact proportional shares.
- Equal-weights test asserting identical behavior to `roundRobin` (exact `rounds/N` per endpoint).
- Weight computation asserted in the endpoint registry stats test (success ratio, floor, and reset back to 1.0).
- Benchmark: ~447ns/op at 10 endpoints (vs ~5ns for `random`) — the mutex + map cost of smooth WRR, negligible against a proxied request.

Ref #557
