### PR TITLE
Fix east-west host classification

### DIFF
--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -508,12 +508,10 @@ func splitHosts(hosts []string, domains []string) ([]string, []string) {
 	externalHosts := []string{}
 
 	for _, host := range hosts {
-		for _, d := range domains {
-			if strings.HasSuffix(host, d) {
-				internalHosts = append(internalHosts, host)
-			} else {
-				externalHosts = append(externalHosts, host)
-			}
+		if isEastWestHost(host, domains) {
+			internalHosts = append(internalHosts, host)
+		} else {
+			externalHosts = append(externalHosts, host)
 		}
 	}
 

--- a/dataclients/kubernetes/routegroup_internal_test.go
+++ b/dataclients/kubernetes/routegroup_internal_test.go
@@ -1,0 +1,78 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitHosts(t *testing.T) {
+	tests := []struct {
+		name                  string
+		hosts                 []string
+		domains               []string
+		expectedInternalHosts []string
+		expectedExternalHosts []string
+	}{
+		{
+			name: "single internal domain",
+			hosts: []string{
+				"api.example.org",
+				"batch.skipper.cluster.local",
+			},
+			domains: []string{
+				"skipper.cluster.local",
+			},
+			expectedInternalHosts: []string{
+				"batch.skipper.cluster.local",
+			},
+			expectedExternalHosts: []string{
+				"api.example.org",
+			},
+		},
+		{
+			name: "multiple internal domains",
+			hosts: []string{
+				"api.example.org",
+				"batch.skipper.cluster.local",
+				"single-get.internal.cluster.local",
+			},
+			domains: []string{
+				"skipper.cluster.local",
+				"internal.cluster.local",
+			},
+			expectedInternalHosts: []string{
+				"batch.skipper.cluster.local",
+				"single-get.internal.cluster.local",
+			},
+			expectedExternalHosts: []string{
+				"api.example.org",
+			},
+		},
+		{
+			name: "no internal domains",
+			hosts: []string{
+				"api.example.org",
+				"batch.example.org",
+			},
+			domains:               nil,
+			expectedInternalHosts: []string{},
+			expectedExternalHosts: []string{
+				"api.example.org",
+				"batch.example.org",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			internalHosts, externalHosts := splitHosts(test.hosts, test.domains)
+
+			if !reflect.DeepEqual(internalHosts, test.expectedInternalHosts) {
+				t.Fatalf("unexpected internal hosts: got %v, want %v", internalHosts, test.expectedInternalHosts)
+			}
+			if !reflect.DeepEqual(externalHosts, test.expectedExternalHosts) {
+				t.Fatalf("unexpected external hosts: got %v, want %v", externalHosts, test.expectedExternalHosts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix RouteGroup east-west host classification when multiple east-west range domains are configured.

Previously, `splitHosts` classified each host once per configured domain. Due to which a host matching one east-west domain could still be added to `externalHosts` when it did not match another domain.

Example:

```go
hosts := []string{"batch.skipper.cluster.local"}
domains := []string{"ingress.cluster.local", "skipper.cluster.local"}
```

Host gets mapped to both externalHosts and internalHosts.

Note: I was going through the code and found this behaviour. If this is expected code behaviour we can close this PR.

Suggested label: bugfix

fixes https://github.com/zalando/skipper/issues/4129