### PR TITLE
Fix bounded consistent hash with filtered endpoints

### DIFF
--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -188,6 +188,7 @@ func (ch *consistentHash) boundedLoadSearch(key string, balanceFactor float64, c
 	for i := 0; i < ch.Len(); i++ {
 		endpointIndex := ch.hashRing[ringIndex].index
 		if skipEndpoint(ctx, endpointIndex) {
+			ringIndex = (ringIndex + 1) % ch.Len()
 			continue
 		}
 		load := ctx.Route.LBEndpoints[endpointIndex].Metrics.InflightRequests()

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -701,3 +701,81 @@ func BenchmarkWeightedRoundRobinAlgorithm(b *testing.B) {
 		})
 	}
 }
+
+func TestConsistentHashBoundedLoadSearchSkipsFilteredEndpoints(t *testing.T) {
+	endpoints := []string{
+		"http://127.0.0.1:8080",
+		"http://127.0.0.2:8080",
+		"http://127.0.0.3:8080",
+	}
+	request, err := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
+	require.NoError(t, err)
+
+	route := NewAlgorithmProvider().Do([]*routing.Route{{
+		Route: eskip.Route{
+			BackendType: eskip.LBBackend,
+			LBAlgorithm: ConsistentHash.String(),
+			LBEndpoints: eskip.NewLBEndpoints(endpoints),
+		},
+	}})[0]
+
+	endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+	defer endpointRegistry.Close()
+	endpointRegistry.Do([]*routing.Route{route})
+
+	ch := route.LBAlgorithm.(*consistentHash)
+
+	var key string
+	var selectedIndex int
+	var skippedIndex int
+
+	for ringIndex, ringEntry := range ch.hashRing {
+		nextIndex := ch.hashRing[(ringIndex+1)%ch.Len()].index
+		if ringEntry.index == nextIndex {
+			continue
+		}
+
+		for vnode := 0; vnode < 100; vnode++ {
+			candidateKey := fmt.Sprintf("%s-%d", endpoints[ringEntry.index], vnode)
+			if hash(candidateKey) == ringEntry.hash {
+				key = candidateKey
+				selectedIndex = ringEntry.index
+				skippedIndex = nextIndex
+				break
+			}
+		}
+
+		if key != "" {
+			break
+		}
+	}
+
+	require.NotEmpty(t, key)
+
+	filteredEndpoints := make([]routing.LBEndpoint, 0, len(route.LBEndpoints)-1)
+
+	for i, endpoint := range route.LBEndpoints {
+		if i != skippedIndex {
+			filteredEndpoints = append(filteredEndpoints, endpoint)
+		}
+	}
+
+	addInflightRequests(endpointRegistry, route.LBEndpoints[selectedIndex], 20)
+
+	ctx := &routing.LBContext{
+		Request:     request,
+		Route:       route,
+		LBEndpoints: filteredEndpoints,
+		Params: map[string]interface{}{
+			ConsistentHashKey:           key,
+			ConsistentHashBalanceFactor: 1.25,
+		},
+	}
+
+	selected := ch.Apply(ctx)
+
+	if selected.Host == route.LBEndpoints[skippedIndex].Host {
+		t.Fatalf("selected filtered endpoint %q", selected.Host)
+	}
+
+}


### PR DESCRIPTION

Fix `boundedLoadSearch` so it advances to the next hash ring entry when the current endpoint has been filtered out. Filtered endpoints can happen before load balancing, for example through fade-in.

In bounded-load mode, the algorithm starts from the normal consistent-hash target. If that endpoint is overloaded, it walks forward in the hash ring looking for another endpoint below the load threshold.

Before this change, if the walk reached a filtered endpoint, the loop continued without advancing the ring index. This could repeatedly check the same filtered endpoint and eventually return it.

Example case:
```
Route endpoints: [A, B, C]
Candidate endpoints: [A, C]    // B was filtered out

Hash ring walk:  A -> B -> C

- A is selected by consistent hash but is overloaded.
- The algorithm moves to B.
- B is not in the candidate list, so it should be skipped.
- Previously the ring index was not advanced when skipping B.

With this change, the algorithm advances to C.
```

## Tests
```
go test ./loadbalancer -run TestConsistentHashBoundedLoadSearchSkipsFilteredEndpoints
go test ./loadbalancer
```

Suggested label: bug
Fixes: https://github.com/zalando/skipper/issues/4139