### PR TITLE
tracing: use tags to reduce cost

### DIFF
--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -542,11 +542,13 @@ func (t *Transport) CloseIdleConnections() {
 // traces are added as logs into the created span.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var span opentracing.Span
+	var roundTripStart time.Time
 	if t.spanName != "" {
 		req, span = t.injectSpan(req)
 		defer span.Finish()
 		if t.clientTraceByTag {
-			ctx := context.WithValue(req.Context(), clientTraceTime, time.Now())
+			roundTripStart = time.Now()
+			ctx := context.WithValue(req.Context(), clientTraceTime, roundTripStart)
 			req = injectClientTraceByTag(ctx, req, span)
 		} else {
 			req = injectClientTraceByEvent(req, span)
@@ -564,7 +566,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.afterResponse(rsp, err)
 	}
 	if span != nil {
-		span.LogKV("http_do", "stop")
+		if t.clientTraceByTag {
+			span.SetTag("http_do", time.Since(roundTripStart).Microseconds())
+		} else {
+			span.LogKV("http_do", "stop")
+		}
 		if rsp != nil {
 			ext.HTTPStatusCode.Set(span, uint16(rsp.StatusCode))
 		}

--- a/net/httpclient_test.go
+++ b/net/httpclient_test.go
@@ -415,6 +415,75 @@ func TestTransport(t *testing.T) {
 	}
 }
 
+func TestTransportRoundTripHTTPDoByTag(t *testing.T) {
+	tracer := tracingtest.NewTracer()
+
+	s := startTestServer(func(*http.Request) {})
+	defer s.Close()
+
+	rt := NewTransport(Options{Tracer: tracer, OpentracingEventsByTag: true})
+	defer rt.Close()
+	rt = WithSpanName(rt, "myspan")
+
+	req := httptest.NewRequest("GET", "http://"+s.Listener.Addr().String()+"/", nil)
+	_, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("Transport.RoundTrip() error = %v", err)
+	}
+
+	span := tracer.FindSpan("myspan")
+	if span == nil {
+		t.Fatal("span not found")
+	}
+
+	if _, ok := span.Tags()["http_do"]; !ok {
+		t.Errorf("expected http_do to be recorded as a span tag, tags: %v", span.Tags())
+	}
+	if hasLogField(span, "http_do") {
+		t.Errorf("expected no http_do log event when clientTraceByTag is enabled, logs: %v", span.Logs())
+	}
+}
+
+func TestTransportRoundTripHTTPDoByEvent(t *testing.T) {
+	tracer := tracingtest.NewTracer()
+
+	s := startTestServer(func(*http.Request) {})
+	defer s.Close()
+
+	rt := NewTransport(Options{Tracer: tracer})
+	defer rt.Close()
+	rt = WithSpanName(rt, "myspan")
+
+	req := httptest.NewRequest("GET", "http://"+s.Listener.Addr().String()+"/", nil)
+	_, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("Transport.RoundTrip() error = %v", err)
+	}
+
+	span := tracer.FindSpan("myspan")
+	if span == nil {
+		t.Fatal("span not found")
+	}
+
+	if _, ok := span.Tags()["http_do"]; ok {
+		t.Errorf("expected no http_do span tag when clientTraceByTag is disabled, tags: %v", span.Tags())
+	}
+	if !hasLogField(span, "http_do") {
+		t.Errorf("expected http_do log events when clientTraceByTag is disabled, logs: %v", span.Logs())
+	}
+}
+
+func hasLogField(span *tracingtest.MockSpan, key string) bool {
+	for _, record := range span.Logs() {
+		for _, field := range record.Fields {
+			if field.Key == key {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type requestCheck func(*http.Request)
 
 func startTestServer(check requestCheck) *httptest.Server {

--- a/proxy/healthy_endpoints.go
+++ b/proxy/healthy_endpoints.go
@@ -59,10 +59,7 @@ func (h *healthyEndpoints) filterHealthyEndpoints(ctx *context, endpoints []rout
 	if len(filtered) < len(endpoints) {
 		if span != nil {
 			span.SetTag("phc.endpoints.dropped", true)
-			span.LogKV(
-				"event", "phc",
-				"dropped_endpoints", unhealthyEndpointsCount,
-			)
+			span.SetTag("phc.endpoints.dropped.count", unhealthyEndpointsCount)
 		}
 		metrics.IncCounter("passive-health-check.requests.passed")
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1159,7 +1159,7 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 		// - for `Canceled` it could be either the same `context canceled` or `unexpected EOF` (net.OpError)
 		// - for `DeadlineExceeded` it is net.Error(timeout=true, temporary=true) wrapping this `context deadline exceeded`
 		if cerr := req.Context().Err(); cerr != nil {
-			ctx.proxySpan.LogKV("event", "error", "message", ensureUTF8(cerr.Error()))
+			p.tracing.logError(ctx.proxySpan, BackendContextErrorTag, cerr.Error())
 			switch cerr {
 			case stdlibcontext.Canceled:
 				return nil, &proxyError{err: cerr, code: 499}
@@ -1169,7 +1169,7 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 		}
 
 		errMessage := err.Error()
-		ctx.proxySpan.LogKV("event", "error", "message", ensureUTF8(errMessage))
+		p.tracing.logError(ctx.proxySpan, BackendErrorTag, errMessage)
 
 		if perr, ok := err.(*proxyError); ok {
 			perr.err = fmt.Errorf("failed to do backend roundtrip to %s: %w", req.URL.Host, perr.err)
@@ -1432,7 +1432,7 @@ func (p *Proxy) do(ctx *context, parentSpan ot.Span) (err error) {
 
 		done, allow := p.checkBreaker(ctx)
 		if !allow {
-			tracing.LogKV("circuit_breaker", "open", ctx.request.Context())
+			p.tracing.logEvent(parentSpan, CircuitBreakerTag, "open")
 			p.makeErrorResponse(ctx, errCircuitBreakerOpen)
 			p.applyFiltersOnError(ctx, processedFilters)
 			return errCircuitBreakerOpen
@@ -1632,7 +1632,7 @@ func (p *Proxy) errorResponse(ctx *context, err error) {
 	}
 
 	if err == errRouteLookupFailed {
-		ctx.initialSpan.LogKV("event", "error", "message", errRouteLookup.Error())
+		p.tracing.logError(ctx.initialSpan, RouteLookupErrorTag, errRouteLookup.Error())
 	}
 
 	p.tracing.setTag(ctx.initialSpan, ErrorTag, true)

--- a/proxy/tracing.go
+++ b/proxy/tracing.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"time"
+
 	ot "github.com/opentracing/opentracing-go"
 
 	"github.com/zalando/skipper/net"
@@ -33,6 +35,14 @@ const (
 	StreamHeadersEvent = "stream_Headers"
 	StreamBodyEvent    = "streamBody.byte"
 	StreamBodyError    = "streamBody error"
+
+	BackendContextErrorTag = "backend.context.error"
+	BackendErrorTag        = "backend.error"
+	RouteLookupErrorTag    = "route_lookup.error"
+	CircuitBreakerTag      = "circuit_breaker"
+
+	FilterStartTagSuffix = ".start"
+	FilterEndTagSuffix   = ".end"
 
 	ClientTraceDNS            = net.ClientTraceDNS
 	ClientTraceConnect        = net.ClientTraceConnect
@@ -90,6 +100,17 @@ func (pt *proxyTracing) logEvent(span ot.Span, eventName, eventValue string) {
 		pt.setTag(span, eventName, eventValue)
 	} else {
 		pt.logKV(span, eventName, eventValue)
+	}
+}
+
+func (pt *proxyTracing) logError(span ot.Span, tag, message string) {
+	if span == nil {
+		return
+	}
+	if pt.clientTraceByTag {
+		pt.setTag(span, tag, message)
+	} else {
+		span.LogKV("event", "error", "message", ensureUTF8(message))
 	}
 }
 
@@ -156,12 +177,20 @@ func (ft *filterTracing) finish() {
 
 func (ft *filterTracing) logStart(filterName string) {
 	if ft != nil && ft.logEvents {
-		ft.span.LogKV(filterName, StartEvent)
+		if ft.clientTraceByTag {
+			ft.span.SetTag(filterName+FilterStartTagSuffix, time.Now().UnixMicro())
+		} else {
+			ft.span.LogKV(filterName, StartEvent)
+		}
 	}
 }
 
 func (ft *filterTracing) logEnd(filterName string) {
 	if ft != nil && ft.logEvents {
-		ft.span.LogKV(filterName, EndEvent)
+		if ft.clientTraceByTag {
+			ft.span.SetTag(filterName+FilterEndTagSuffix, time.Now().UnixMicro())
+		} else {
+			ft.span.LogKV(filterName, EndEvent)
+		}
 	}
 }

--- a/proxy/tracing_test.go
+++ b/proxy/tracing_test.go
@@ -701,6 +701,44 @@ func spanLogs(span *tracingtest.MockSpan) string {
 	return strings.Join(logs, ", ")
 }
 
+func TestLogFilterEventsByTag(t *testing.T) {
+	tracer := tracingtest.NewTracer()
+	tracing := newProxyTracing(&OpenTracingParams{
+		Tracer:           tracer,
+		LogFilterEvents:  true,
+		ClientTraceByTag: true,
+	})
+
+	ctx := &context{request: &http.Request{}}
+
+	ft := tracing.startFilterTracing("request_filters", ctx)
+	for _, f := range []string{"f1", "f2"} {
+		ft.logStart(f)
+		ft.logEnd(f)
+	}
+	ft.finish()
+
+	spans := tracer.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+
+	if len(span.Logs()) != 0 {
+		t.Errorf("expected no log events when clientTraceByTag is enabled, got: %d", len(span.Logs()))
+	}
+
+	tags := span.Tags()
+	for _, key := range []string{"f1" + FilterStartTagSuffix, "f1" + FilterEndTagSuffix, "f2" + FilterStartTagSuffix, "f2" + FilterEndTagSuffix} {
+		ts, ok := tags[key]
+		if !ok {
+			t.Errorf("expected tag %q to be set", key)
+			continue
+		}
+		if v, ok := ts.(int64); !ok || v <= 0 {
+			t.Errorf("expected tag %q to hold a positive timestamp, got: %v", key, ts)
+		}
+	}
+}
+
 func TestEnabledLogStreamEvents(t *testing.T) {
 	tracer := tracingtest.NewTracer()
 	tracing := newProxyTracing(&OpenTracingParams{
@@ -804,6 +842,58 @@ func TestLogEventWithEmptySpan(t *testing.T) {
 	// should not panic
 	tracing.logEvent(nil, "test", StartEvent)
 	tracing.logEvent(nil, "test", EndEvent)
+}
+
+func TestLogErrorByTag(t *testing.T) {
+	tracer := tracingtest.NewTracer()
+	tracing := newProxyTracing(&OpenTracingParams{
+		Tracer:           tracer,
+		ClientTraceByTag: true,
+	})
+	span := tracer.StartSpan("test")
+
+	tracing.logError(span, BackendErrorTag, "backend down")
+	span.Finish()
+
+	mockSpan := span.(*tracingtest.MockSpan)
+
+	if got := mockSpan.Tags()[BackendErrorTag]; got != "backend down" {
+		t.Errorf("expected error message as tag %q, got: %v", BackendErrorTag, got)
+	}
+	if len(mockSpan.Logs()) != 0 {
+		t.Errorf("expected no log events when clientTraceByTag is enabled, got: %d", len(mockSpan.Logs()))
+	}
+}
+
+func TestLogErrorByEvent(t *testing.T) {
+	tracer := tracingtest.NewTracer()
+	tracing := newProxyTracing(&OpenTracingParams{
+		Tracer: tracer,
+	})
+	span := tracer.StartSpan("test")
+
+	tracing.logError(span, BackendErrorTag, "backend down")
+	span.Finish()
+
+	mockSpan := span.(*tracingtest.MockSpan)
+
+	if _, ok := mockSpan.Tags()[BackendErrorTag]; ok {
+		t.Errorf("expected no error tag when clientTraceByTag is disabled")
+	}
+	if len(mockSpan.Logs()) != 1 {
+		t.Fatalf("expected one error log event, got: %d", len(mockSpan.Logs()))
+	}
+}
+
+func TestLogErrorWithEmptySpan(t *testing.T) {
+	tracer := tracingtest.NewTracer()
+	tracing := newProxyTracing(&OpenTracingParams{
+		Tracer:           tracer,
+		ClientTraceByTag: true,
+	})
+
+	// should not panic
+	tracing.logError(nil, BackendErrorTag, "backend down")
 }
 
 func TestSetTagWithEmptySpan(t *testing.T) {


### PR DESCRIPTION
This is a follow up on https://github.com/zalando/skipper/pull/3882 where we didn't use the flag in some hotspots and is causing producing huge amount of span events specially filters tracing