### PR TITLE
test(opa): add regression tests for GHSA-8qqm-fp2q-v734

### DIFF
--- a/filters/openpolicyagent/ghsa-8qqm-fp2q-v734_test.go
+++ b/filters/openpolicyagent/ghsa-8qqm-fp2q-v734_test.go
@@ -273,3 +273,107 @@ allow if {
 		})
 	}
 }
+
+// TestAdvisoryDenyOnPresencePolicyNotBypassed reproduces the PoC from
+// GHSA-8qqm-fp2q-v734 / CVE-2026-65838: a deny-on-presence Rego policy must
+// not fail open when the request body exceeds maxBodyBytes.
+func TestAdvisoryDenyOnPresencePolicyNotBypassed(t *testing.T) {
+	const maxBody = 32
+	smallPayload := `{"action":"delete"}`
+	largePayload := `{"action":"delete","pad":"` + strings.Repeat("X", 64) + `"}`
+
+	bundleName := "test-bundle-deny-on-presence"
+	opaControlPlane := opasdktest.MustNewServer(
+		opasdktest.MockBundle("/bundles/"+bundleName, map[string]string{
+			"main.rego": `
+package envoy.authz
+
+import rego.v1
+
+default allow := true
+
+allow := false if {
+    input.parsed_body.action == "delete"
+}
+`,
+		}),
+	)
+	defer opaControlPlane.Stop()
+
+	config := fmt.Appendf(nil, `{
+		"services": {"test": {"url": %q}},
+		"bundles": {"test": {"resource": "/bundles/{{ .bundlename }}"}},
+		"labels": {"environment": "test"},
+		"plugins": {"envoy_ext_authz_grpc": {"path": "envoy/authz/allow", "dry-run": false}}
+	}`, opaControlPlane.URL())
+
+	opaRegistry, err := openpolicyagent.NewOpenPolicyAgentRegistry(
+		openpolicyagent.WithPreloadingEnabled(true),
+		openpolicyagent.WithEnableDataPreProcessingOptimization(true),
+		openpolicyagent.WithInstanceStartupTimeout(5*time.Second),
+		openpolicyagent.WithMaxRequestBodyBytes(maxBody),
+		openpolicyagent.WithOpenPolicyAgentInstanceConfig(openpolicyagent.WithConfigTemplate(config)),
+	)
+	if err != nil {
+		t.Fatalf("opaRegistry: %v", err)
+	}
+	defer opaRegistry.Close()
+
+	fr := make(filters.Registry)
+	fr.Register(opaauthorizerequest.NewOpaAuthorizeRequestWithBodySpec(opaRegistry))
+
+	r := eskip.MustParse(fmt.Sprintf(`r1: * -> opaAuthorizeRequestWithBody("%s") -> "%s";`, bundleName, "http://127.0.0.1:0"))
+	dc := testdataclient.New(r)
+	defer dc.Close()
+
+	rt := routing.New(routing.Options{
+		FilterRegistry:  fr,
+		DataClients:     []routing.DataClient{dc},
+		PreProcessors:   []routing.PreProcessor{opaRegistry.NewPreProcessor()},
+		PostProcessors:  []routing.PostProcessor{opaRegistry},
+		PollTimeout:     time.Second,
+		SignalFirstLoad: true,
+	})
+	defer rt.Close()
+	<-rt.FirstLoad()
+
+	pr := proxy.WithParams(proxy.Params{Routing: rt})
+	defer pr.Close()
+	ts := httptest.NewServer(pr)
+	defer ts.Close()
+
+	for _, tt := range []struct {
+		name       string
+		payload    string
+		wantStatus int
+	}{
+		{
+			name:       "small body with forbidden action denied",
+			payload:    smallPayload,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "oversized body with forbidden action still denied",
+			payload:    largePayload,
+			wantStatus: http.StatusForbidden,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", ts.URL, strings.NewReader(tt.payload))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			rsp, err := ts.Client().Do(req)
+			if err != nil {
+				t.Fatalf("do: %v", err)
+			}
+			defer rsp.Body.Close()
+
+			if rsp.StatusCode != tt.wantStatus {
+				t.Fatalf("[%s] status = %d, want %d", tt.name, rsp.StatusCode, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/filters/openpolicyagent/openpolicyagent_test.go
+++ b/filters/openpolicyagent/openpolicyagent_test.go
@@ -1127,7 +1127,8 @@ func TestBodyExtraction(t *testing.T) {
 		maxBodySize    int64
 		readBodyBuffer int64
 
-		bodyInPolicy string
+		bodyInPolicy  string
+		wantTruncated bool
 	}{
 		{
 			msg:            "Read body ",
@@ -1157,6 +1158,16 @@ func TestBodyExtraction(t *testing.T) {
 			maxBodySize:    5,
 			readBodyBuffer: 5,
 			bodyInPolicy:   `{ "we`,
+			wantTruncated:  true,
+		},
+		{
+			msg:            "Read body when Content-Length exceeds maxBodyBytes (GHSA-8qqm-fp2q-v734)",
+			body:           `{ "welcome": "world" }`,
+			contentLength:  1024,
+			maxBodySize:    5,
+			readBodyBuffer: 5,
+			bodyInPolicy:   `{ "we`,
+			wantTruncated:  true,
 		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
@@ -1179,7 +1190,7 @@ func TestBodyExtraction(t *testing.T) {
 				Body:          io.NopCloser(bytes.NewReader([]byte(ti.body))),
 			}
 
-			body, peekBody, _, finalizer, err := inst.ExtractHttpBodyOptionally(&req)
+			body, peekBody, truncated, finalizer, err := inst.ExtractHttpBodyOptionally(&req)
 			defer finalizer()
 			assert.NoError(t, err)
 			defer body.Close()
@@ -1189,6 +1200,7 @@ func TestBodyExtraction(t *testing.T) {
 			assert.Equal(t, ti.body, string(fullBody), "Full body must be readable")
 
 			assert.Equal(t, ti.bodyInPolicy, string(peekBody), "Body has been read up till maximum")
+			assert.Equal(t, ti.wantTruncated, truncated, "truncated_body flag")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds regression coverage for GHSA-8qqm-fp2q-v734 / CVE-2026-65838, where requests with a declared Content-Length larger than -open-policy-agent-max-request-body-size could bypass OPA deny-on-presence Rego policies.

- Unit test: ExtractHttpBodyOptionally asserts truncated_body when Content-Length exceeds the cap.
- Integration test: reproduces the advisory PoC policy and verifies small and oversized payloads are denied.

The runtime fix is already on master (#4126 and the Jul 20 truncated_body merge). These tests guard against regressions.

## Test plan

- [ ] go test ./filters/openpolicyagent/... -run 'TestBodyExtraction|TestAdvisoryDenyOnPresencePolicyNotBypassed|TestTruncatedBodyChunkedBypass|TestPolicyMaxBodySizeTruncated'