### PR TITLE
Refactor: extract Valkey Del command and ratelimit ring client injection

### DIFF
--- a/net/valkey.go
+++ b/net/valkey.go
@@ -277,6 +277,11 @@ func (vr *valkeyRing) Expire(ctx context.Context, key string, expire time.Durati
 	return shard.Do(ctx, shard.B().Expire().Key(key).Seconds(int64(expire.Seconds())).Build())
 }
 
+func (vr *valkeyRing) Del(ctx context.Context, key string) valkey.ValkeyResult {
+	shard := vr.shardForKey(key)
+	return shard.Do(ctx, shard.B().Del().Key(key).Build())
+}
+
 func (vr *valkeyRing) Get(ctx context.Context, key string) valkey.ValkeyResult {
 	shard := vr.shardForKey(key)
 	return shard.Do(ctx, shard.B().Get().Key(key).Build())
@@ -517,6 +522,11 @@ func (vrc *ValkeyRingClient) Ping(ctx context.Context, shard string) error {
 
 func (vrc *ValkeyRingClient) Expire(ctx context.Context, key string, d time.Duration) (int64, error) {
 	res := vrc.ring.Expire(ctx, key, d)
+	return res.ToInt64()
+}
+
+func (vrc *ValkeyRingClient) Del(ctx context.Context, key string) (int64, error) {
+	res := vrc.ring.Del(ctx, key)
 	return res.ToInt64()
 }
 

--- a/net/valkey.go
+++ b/net/valkey.go
@@ -2,6 +2,7 @@ package net
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -32,6 +33,8 @@ const (
 	DefaultDialTimeout      = 25 * time.Millisecond
 	DefaultKeepAlive        = time.Second
 )
+
+var ErrValkeyNoResult = errors.New("failed to SetWithExpire, no result")
 
 // ValkeyOptions is used to configure the ValkeyRing
 //
@@ -543,7 +546,7 @@ func (vrc *ValkeyRingClient) Set(ctx context.Context, key, val string) (string, 
 func (vrc *ValkeyRingClient) SetWithExpire(ctx context.Context, key string, value string, expire time.Duration) error {
 	results := vrc.ring.SetWithExpire(ctx, key, value, expire)
 	if len(results) == 0 {
-		return fmt.Errorf("failed to SetWithExpire, no result")
+		return ErrValkeyNoResult
 	}
 	for _, res := range results {
 		if err := res.Error(); err != nil {

--- a/net/valkey.go
+++ b/net/valkey.go
@@ -532,15 +532,15 @@ func (vrc *ValkeyRingClient) Set(ctx context.Context, key, val string) (string, 
 
 func (vrc *ValkeyRingClient) SetWithExpire(ctx context.Context, key string, value string, expire time.Duration) error {
 	results := vrc.ring.SetWithExpire(ctx, key, value, expire)
+	if len(results) == 0 {
+		return fmt.Errorf("failed to SetWithExpire, no result")
+	}
 	for _, res := range results {
 		if err := res.Error(); err != nil {
 			return err
 		}
 	}
-	if len(results) == 0 {
-		return fmt.Errorf("failed to SetWithExpire, no result")
-	}
-	return results[len(results)-1].Error()
+	return nil
 }
 
 func (vrc *ValkeyRingClient) ZAdd(ctx context.Context, key, val string, score float64) (int64, error) {

--- a/ratelimit/redis.go
+++ b/ratelimit/redis.go
@@ -28,11 +28,11 @@ type clusterLimitRedis struct {
 }
 
 const (
-	redisMetricsPrefix                    = "swarm.redis."
-	redisAllowMetricsFormat               = redisMetricsPrefix + "query.allow.%s"
-	redisRetryAfterMetricsFormat          = redisMetricsPrefix + "query.retryafter.%s"
-	redisAllowMetricsFormatWithGroup      = redisMetricsPrefix + "query.allow.%s.%s"
-	redisRetryAfterMetricsFormatWithGroup = redisMetricsPrefix + "query.retryafter.%s.%s"
+	RedisMetricsPrefix                    = "swarm.redis."
+	redisAllowMetricsFormat               = RedisMetricsPrefix + "query.allow.%s"
+	redisRetryAfterMetricsFormat          = RedisMetricsPrefix + "query.retryafter.%s"
+	redisAllowMetricsFormatWithGroup      = RedisMetricsPrefix + "query.allow.%s.%s"
+	redisRetryAfterMetricsFormatWithGroup = RedisMetricsPrefix + "query.retryafter.%s.%s"
 
 	redisAllowSpanName       = "redis_allow"
 	redisOldestScoreSpanName = "redis_oldest_score"
@@ -111,7 +111,7 @@ func (c *clusterLimitRedis) commonTags() opentracing.Tags {
 //
 // Uses provided context for creating an OpenTracing span.
 func (c *clusterLimitRedis) Allow(ctx context.Context, clearText string) bool {
-	c.metrics.IncCounter(redisMetricsPrefix + "total")
+	c.metrics.IncCounter(RedisMetricsPrefix + "total")
 	now := time.Now()
 
 	var span opentracing.Span
@@ -139,9 +139,9 @@ func (c *clusterLimitRedis) Allow(ctx context.Context, clearText string) bool {
 	c.measureQuery(redisAllowMetricsFormat, redisAllowMetricsFormatWithGroup, &failed, now)
 
 	if allow {
-		c.metrics.IncCounter(redisMetricsPrefix + "allows")
+		c.metrics.IncCounter(RedisMetricsPrefix + "allows")
 	} else {
-		c.metrics.IncCounter(redisMetricsPrefix + "forbids")
+		c.metrics.IncCounter(RedisMetricsPrefix + "forbids")
 	}
 	return allow
 }

--- a/ratelimit/redis_test.go
+++ b/ratelimit/redis_test.go
@@ -231,9 +231,9 @@ func Test_clusterLimitRedis_AllowCanceledContext(t *testing.T) {
 			assert.Empty(t, span.Logs())
 
 			m.WithCounters(func(counters map[string]int64) {
-				assert.Equal(t, int64(1), counters[redisMetricsPrefix+"total"])
-				assert.NotContains(t, counters, redisMetricsPrefix+"allows")
-				assert.NotContains(t, counters, redisMetricsPrefix+"forbids")
+				assert.Equal(t, int64(1), counters[RedisMetricsPrefix+"total"])
+				assert.NotContains(t, counters, RedisMetricsPrefix+"allows")
+				assert.NotContains(t, counters, RedisMetricsPrefix+"forbids")
 			})
 			m.WithMeasures(func(measures map[string][]time.Duration) {
 				assert.Empty(t, measures)

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -84,17 +84,38 @@ func NewSwimSwarmRegistry(swarm Swarmer, settings ...Settings) *Registry {
 // the optional provided default settings.
 func NewRedisSwarmRegistry(ro *net.RedisOptions, settings ...Settings) *Registry {
 	if ro != nil && ro.MetricsPrefix == "" {
-		ro.MetricsPrefix = redisMetricsPrefix
+		ro.MetricsPrefix = RedisMetricsPrefix
 	}
 
+	return NewRatelimitRegistryRedis(net.NewRedisRingClient(ro), settings...)
+}
+
+// NewValkeySwarmRegistry initializes a registry with Valkey shards
+// and the optional provided default settings.
+func NewValkeySwarmRegistry(vo *net.ValkeyOptions, settings ...Settings) (*Registry, error) {
+	if vo != nil && vo.MetricsPrefix == "" {
+		vo.MetricsPrefix = ValkeyMetricsPrefix
+	}
+
+	ring, err := net.NewValkeyRingClient(vo)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRatelimitRegistryValkey(ring, settings...), nil
+}
+
+// NewRatelimitRegistryRedis creates a registry for the given redis ring client.
+func NewRatelimitRegistryRedis(ring *net.RedisRingClient, settings ...Settings) *Registry {
 	r := &Registry{
 		once:      sync.Once{},
 		global:    getSwarmRegistryDefaultSettings(),
 		lookup:    make(map[Settings]*Ratelimit),
-		redisRing: net.NewRedisRingClient(ro),
+		redisRing: ring,
 	}
-	if ro != nil {
-		r.redisRing.StartMetricsCollection()
+
+	if ring != nil {
+		ring.StartMetricsCollection()
 	}
 
 	if len(settings) > 0 {
@@ -104,18 +125,8 @@ func NewRedisSwarmRegistry(ro *net.RedisOptions, settings ...Settings) *Registry
 	return r
 }
 
-// NewValkeySwarmRegistry initializes a registry with Valkey shards
-// and the optional provided default settings.
-func NewValkeySwarmRegistry(vo *net.ValkeyOptions, settings ...Settings) (*Registry, error) {
-	if vo != nil && vo.MetricsPrefix == "" {
-		vo.MetricsPrefix = valkeyMetricsPrefix
-	}
-
-	ring, err := net.NewValkeyRingClient(vo)
-	if err != nil {
-		return nil, err
-	}
-
+// NewRatelimitRegistryValkey creates a registry for the given valkey ring client.
+func NewRatelimitRegistryValkey(ring *net.ValkeyRingClient, settings ...Settings) *Registry {
 	r := &Registry{
 		once:       sync.Once{},
 		global:     getSwarmRegistryDefaultSettings(),
@@ -127,7 +138,7 @@ func NewValkeySwarmRegistry(vo *net.ValkeyOptions, settings ...Settings) (*Regis
 		r.global = settings[0]
 	}
 
-	return r, nil
+	return r
 }
 
 // Close teardown Registry and dependent resources

--- a/ratelimit/registry.go
+++ b/ratelimit/registry.go
@@ -27,6 +27,7 @@ type Registry struct {
 	swarm      Swarmer
 	redisRing  *net.RedisRingClient
 	valkeyRing *net.ValkeyRingClient
+	ownRing    bool // true only when this registry created the ring
 }
 
 // NewRegistry initializes a registry with the provided default settings.
@@ -87,7 +88,9 @@ func NewRedisSwarmRegistry(ro *net.RedisOptions, settings ...Settings) *Registry
 		ro.MetricsPrefix = RedisMetricsPrefix
 	}
 
-	return NewRatelimitRegistryRedis(net.NewRedisRingClient(ro), settings...)
+	r := NewRatelimitRegistryRedis(net.NewRedisRingClient(ro), settings...)
+	r.ownRing = true
+	return r
 }
 
 // NewValkeySwarmRegistry initializes a registry with Valkey shards
@@ -102,7 +105,9 @@ func NewValkeySwarmRegistry(vo *net.ValkeyOptions, settings ...Settings) (*Regis
 		return nil, err
 	}
 
-	return NewRatelimitRegistryValkey(ring, settings...), nil
+	r := NewRatelimitRegistryValkey(ring, settings...)
+	r.ownRing = true
+	return r, nil
 }
 
 // NewRatelimitRegistryRedis creates a registry for the given redis ring client.
@@ -112,6 +117,7 @@ func NewRatelimitRegistryRedis(ring *net.RedisRingClient, settings ...Settings) 
 		global:    getSwarmRegistryDefaultSettings(),
 		lookup:    make(map[Settings]*Ratelimit),
 		redisRing: ring,
+		ownRing:   false,
 	}
 
 	if ring != nil {
@@ -132,6 +138,7 @@ func NewRatelimitRegistryValkey(ring *net.ValkeyRingClient, settings ...Settings
 		global:     getSwarmRegistryDefaultSettings(),
 		lookup:     make(map[Settings]*Ratelimit),
 		valkeyRing: ring,
+		ownRing:    false,
 	}
 
 	if len(settings) > 0 {
@@ -144,11 +151,13 @@ func NewRatelimitRegistryValkey(ring *net.ValkeyRingClient, settings ...Settings
 // Close teardown Registry and dependent resources
 func (r *Registry) Close() {
 	r.once.Do(func() {
-		if r.redisRing != nil {
-			r.redisRing.Close()
-		}
-		if r.valkeyRing != nil {
-			r.valkeyRing.Close()
+		if r.ownRing {
+			if r.redisRing != nil {
+				r.redisRing.Close()
+			}
+			if r.valkeyRing != nil {
+				r.valkeyRing.Close()
+			}
 		}
 		for _, rl := range r.lookup {
 			rl.Close()

--- a/ratelimit/valkey.go
+++ b/ratelimit/valkey.go
@@ -28,11 +28,11 @@ type clusterLimitValkey struct {
 }
 
 const (
-	valkeyMetricsPrefix                    = "swarm.valkey."
-	valkeyAllowMetricsFormat               = valkeyMetricsPrefix + "query.allow.%s"
-	valkeyRetryAfterMetricsFormat          = valkeyMetricsPrefix + "query.retryafter.%s"
-	valkeyAllowMetricsFormatWithGroup      = valkeyMetricsPrefix + "query.allow.%s.%s"
-	valkeyRetryAfterMetricsFormatWithGroup = valkeyMetricsPrefix + "query.retryafter.%s.%s"
+	ValkeyMetricsPrefix                    = "swarm.valkey."
+	valkeyAllowMetricsFormat               = ValkeyMetricsPrefix + "query.allow.%s"
+	valkeyRetryAfterMetricsFormat          = ValkeyMetricsPrefix + "query.retryafter.%s"
+	valkeyAllowMetricsFormatWithGroup      = ValkeyMetricsPrefix + "query.allow.%s.%s"
+	valkeyRetryAfterMetricsFormatWithGroup = ValkeyMetricsPrefix + "query.retryafter.%s.%s"
 
 	valkeyAllowSpanName       = "valkey_allow"
 	valkeyOldestScoreSpanName = "valkey_oldest_score"
@@ -111,7 +111,7 @@ func (c *clusterLimitValkey) commonTags() opentracing.Tags {
 //
 // Uses provided context for creating an OpenTracing span.
 func (c *clusterLimitValkey) Allow(ctx context.Context, clearText string) bool {
-	c.metrics.IncCounter(valkeyMetricsPrefix + "total")
+	c.metrics.IncCounter(ValkeyMetricsPrefix + "total")
 	now := time.Now()
 
 	var span opentracing.Span
@@ -139,9 +139,9 @@ func (c *clusterLimitValkey) Allow(ctx context.Context, clearText string) bool {
 	c.measureQuery(valkeyAllowMetricsFormat, valkeyAllowMetricsFormatWithGroup, &failed, now)
 
 	if allow {
-		c.metrics.IncCounter(valkeyMetricsPrefix + "allows")
+		c.metrics.IncCounter(ValkeyMetricsPrefix + "allows")
 	} else {
-		c.metrics.IncCounter(valkeyMetricsPrefix + "forbids") // TODO(sszuecs) forbids or better deny?
+		c.metrics.IncCounter(ValkeyMetricsPrefix + "forbids") // TODO(sszuecs) forbids or better deny?
 	}
 	return allow
 }

--- a/ratelimit/valkey_test.go
+++ b/ratelimit/valkey_test.go
@@ -240,9 +240,9 @@ func Test_clusterLimitValkey_AllowCanceledContext(t *testing.T) {
 			assert.Empty(t, span.Logs())
 
 			m.WithCounters(func(counters map[string]int64) {
-				assert.Equal(t, int64(1), counters[valkeyMetricsPrefix+"total"])
-				assert.NotContains(t, counters, valkeyMetricsPrefix+"allows")
-				assert.NotContains(t, counters, valkeyMetricsPrefix+"forbids")
+				assert.Equal(t, int64(1), counters[ValkeyMetricsPrefix+"total"])
+				assert.NotContains(t, counters, ValkeyMetricsPrefix+"allows")
+				assert.NotContains(t, counters, ValkeyMetricsPrefix+"forbids")
 			})
 			m.WithMeasures(func(measures map[string][]time.Duration) {
 				assert.Empty(t, measures)

--- a/skipper.go
+++ b/skipper.go
@@ -2280,21 +2280,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		}
 	}
 
-	if !slices.Contains(o.DisabledFilters, cache.Name) && valkeyRing != nil {
-		o.CustomFilters = append(o.CustomFilters, cache.NewCacheFilter(
-			o.cacheBudget(),
-			o.Address,
-			skpnet.Options{
-				IdleConnTimeout:         o.CloseIdleConnsPeriod,
-				MaxIdleConnsPerHost:     o.IdleConnectionsPerHost,
-				Tracer:                  tracer,
-				OpentracingComponentTag: "skipper",
-				OpentracingSpanName:     "cache_revalidation",
-				OpentracingEventsByTag:  o.OpenTracingClientTraceByTag,
-			},
-		))
-	}
-
 	if o.TLSMinVersion == 0 {
 		o.TLSMinVersion = tls.VersionTLS12
 	}

--- a/skipper.go
+++ b/skipper.go
@@ -2215,11 +2215,41 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		}
 	}
 
-	var ratelimitRegistry *ratelimit.Registry
-	var failClosedRatelimitPostProcessor *ratelimitfilters.FailClosedPostProcessor
+	var valkeyRing *skpnet.ValkeyRingClient
+	if valkeyOptions != nil {
+		if valkeyOptions.MetricsPrefix == "" {
+			valkeyOptions.MetricsPrefix = ratelimit.ValkeyMetricsPrefix
+		}
+		valkeyRing, err = skpnet.NewValkeyRingClient(valkeyOptions)
+		if err != nil {
+			return err
+		}
+		defer valkeyRing.Close()
+	}
+
+	var (
+		ratelimitRegistry                *ratelimit.Registry
+		failClosedRatelimitPostProcessor *ratelimitfilters.FailClosedPostProcessor
+	)
 	if o.EnableRatelimiters || len(o.RatelimitSettings) > 0 {
 		log.Infof("enabled ratelimiters %v: %v", o.EnableRatelimiters, o.RatelimitSettings)
-		ratelimitRegistry = ratelimit.NewSwarmRegistry(swarmer, redisOptions, valkeyOptions, o.RatelimitSettings...)
+
+		switch {
+		case valkeyRing != nil:
+			ratelimitRegistry = ratelimit.NewRatelimitRegistryValkey(valkeyRing, o.RatelimitSettings...)
+
+		case redisOptions != nil:
+			if redisOptions.MetricsPrefix == "" {
+				redisOptions.MetricsPrefix = ratelimit.RedisMetricsPrefix
+			}
+			redisRing := skpnet.NewRedisRingClient(redisOptions)
+			ratelimitRegistry = ratelimit.NewRatelimitRegistryRedis(redisRing, o.RatelimitSettings...)
+			defer redisRing.Close()
+
+		default:
+			// swim based Swarmer (deprecated)
+			ratelimitRegistry = ratelimit.NewSwarmRegistry(swarmer, redisOptions, valkeyOptions, o.RatelimitSettings...)
+		}
 		defer ratelimitRegistry.Close()
 
 		if hook := o.SwarmRegistry; hook != nil {
@@ -2248,6 +2278,21 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		if redisOptions != nil || valkeyOptions != nil {
 			o.CustomFilters = append(o.CustomFilters, ratelimitfilters.NewClusterLeakyBucketRatelimit(ratelimitRegistry))
 		}
+	}
+
+	if !slices.Contains(o.DisabledFilters, cache.Name) && valkeyRing != nil {
+		o.CustomFilters = append(o.CustomFilters, cache.NewCacheFilter(
+			o.cacheBudget(),
+			o.Address,
+			skpnet.Options{
+				IdleConnTimeout:         o.CloseIdleConnsPeriod,
+				MaxIdleConnsPerHost:     o.IdleConnectionsPerHost,
+				Tracer:                  tracer,
+				OpentracingComponentTag: "skipper",
+				OpentracingSpanName:     "cache_revalidation",
+				OpentracingEventsByTag:  o.OpenTracingClientTraceByTag,
+			},
+		))
 	}
 
 	if o.TLSMinVersion == 0 {


### PR DESCRIPTION
## Related Issue

Prerequisite PR for #4033, [extracted](https://github.com/zalando/skipper/pull/4033#discussion_r3597828649) to reduce the size of the cache filter PR.

## Summary

- **`net/valkey.go`**: adds `Del` method to `valkeyRing` and `ValkeyRingClient`; fixes `SetWithExpire` empty-result guard ordering (guard-before-loop for clarity)
- **`ratelimit/redis.go` / `ratelimit/valkey.go`**: exports `RedisMetricsPrefix` and `ValkeyMetricsPrefix` constants so callers outside the package can reference them
- **`ratelimit/registry.go`**: introduces `NewRatelimitRegistryRedis` and `NewRatelimitRegistryValkey` - injectable constructors that accept a pre-created ring client, enabling ring reuse across subsystems
- **`skipper.go`**: creates the shared `valkeyRing` once and passes it to both the ratelimit registry and (in #4033) the cache filter, replacing the old `NewSwarmRegistry` call
