### PR TITLE
fix error type assertion

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1171,10 +1171,10 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 		errMessage := err.Error()
 		p.tracing.logError(ctx.proxySpan, BackendErrorTag, errMessage)
 
-		if perr, ok := err.(*proxyError); ok {
+		if perr, ok := errors.AsType[*proxyError](err); ok {
 			perr.err = fmt.Errorf("failed to do backend roundtrip to %s: %w", req.URL.Host, perr.err)
 			return nil, perr
-		} else if nerr, ok := err.(net.Error); ok {
+		} else if nerr, ok := errors.AsType[net.Error](err); ok {
 			var status int
 			if nerr.Timeout() {
 				status = http.StatusGatewayTimeout


### PR DESCRIPTION
[Failed race_proxy check logs](https://github.com/zalando/skipper/actions/runs/30820275300/job/91708155376?pr=4166):


```
vvolokitina@ZALANDO-83132 1-INFRA % gh run view 30820275300 \
  --repo zalando/skipper \
  --job 91708155376 \
  --log |
rg -n -C 6 'TestProxyMTLS_OutboundNoClientCert|certificate required|expected 503'
5596-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2696139Z time="2026-08-03T14:00:18Z" level=info msg="Added secret file: /tmp/proxy-mtls-cert-1834588605.crt"
5597-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2696338Z time="2026-08-03T14:00:18Z" level=info msg="Added secret file: /tmp/proxy-mtls-key-2522134525.key"
5598-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2696677Z 2026/08/03 14:00:18 http: TLS handshake error from 127.0.0.1:34892: tls: failed to verify certificate: x509: certificate signed by unknown authority
5599-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2697645Z time="2026-08-03T14:00:18Z" level=error msg="error while proxying after 4.31659ms, route  with backend network https://127.0.0.1:34819, status code 503: dialing failed false: net.Error during backend roundtrip to 127.0.0.1:34819: timeout=false temporary='false': remote error: tls: unknown certificate authority, remote host: 127.0.0.1, request: \"GET / HTTP/1.1\", host: 127.0.0.1:42519, user agent: \"Go-http-client/1.1\""
5600-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2697821Z time="2026-08-03T14:00:18Z" level=info msg="Stop secrets background refresher"
5601-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2698053Z 2026/08/03 14:00:18 http: TLS handshake error from 127.0.0.1:38150: tls: client didn't provide a certificate
5602:check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2699018Z time="2026-08-03T14:00:18Z" level=error msg="error while proxying after 4.746136ms, route  with backend network https://127.0.0.1:36683, status code 500: dialing failed false: unexpected error from Go stdlib net/http package during roundtrip: readLoopPeekFailLocked: remote error: tls: certificate required, remote host: 127.0.0.1, request: \"GET / HTTP/1.1\", host: 127.0.0.1:36061, user agent: \"Go-http-client/1.1\""
5603:check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2699162Z --- FAIL: TestProxyMTLS_OutboundNoClientCert (0.01s)
5604:check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2699435Z     proxy_mtls_test.go:316: expected 503 when no client cert presented, got 500
5605-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2699657Z time="2026-08-03T14:00:18Z" level=info msg="Added secret file: /tmp/proxy-mtls-cert-1160787288.crt"
5606-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2699859Z time="2026-08-03T14:00:18Z" level=info msg="Added secret file: /tmp/proxy-mtls-key-309552918.key"
5607-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2700338Z 2026/08/03 14:00:18 http: TLS handshake error from 127.0.0.1:55610: tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2026-08-03T14:00:18Z is after 2026-08-03T13:00:18Z
5608-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2701281Z time="2026-08-03T14:00:18Z" level=error msg="error while proxying after 4.236492ms, route  with backend network https://127.0.0.1:35831, status code 503: dialing failed false: net.Error during backend roundtrip to 127.0.0.1:35831: timeout=false temporary='false': remote error: tls: expired certificate, remote host: 127.0.0.1, request: \"GET / HTTP/1.1\", host: 127.0.0.1:34391, user agent: \"Go-http-client/1.1\""
5609-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2701495Z time="2026-08-03T14:00:18Z" level=info msg="Stop secrets background refresher"
5610-check-race_proxy   Run make check-race_proxy       2026-08-03T14:00:50.2701795Z time="2026-08-03T14:00:18Z" level=info msg="Added secret file: /tmp/proxy-mtls-cert-2636285699.crt"

```

The backend rejected the TLS connection `tls: client didn't provide a certificate`. Go then wrapped the network error `readLoopPeekFailLocked: remote error: tls: certificate required`. Because err.(net.Error) only checks the outer error, Skipper failed to recognize it as a backend network failure and returned 500 `expected 503 when no client cert presented, got 500`. Using errors.AsType[net.Error] traverses the wrapped error chain, finds the underlying network error, and consistently classifies it as a backend failure returning 503