### PR TITLE
test(opa): deny requests with truncated bodies

### DIFF
--- a/filters/openpolicyagent/ghsa-8qqm-fp2q-v734_test.go
+++ b/filters/openpolicyagent/ghsa-8qqm-fp2q-v734_test.go
@@ -293,6 +293,10 @@ import rego.v1
 default allow := true
 
 allow := false if {
+    input.truncated_body
+}
+
+allow := false if {
     input.parsed_body.action == "delete"
 }
 `,


### PR DESCRIPTION
TestAdvisoryDenyOnPresencePolicyNotBypassed update the test Rego policy to deny truncated request bodies. Oversized JSON cannot be fully parsed, so the policy must handle input.truncated_body explicitly