### PR TITLE
feature: enable h2c for server handler, proxy client and net client

### DIFF
--- a/.agents/skills/tests/SKILL.md
+++ b/.agents/skills/tests/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: test
+description: Create tests that fit skipper code
+license: MIT
+compatibility: opencode, claude
+metadata:
+  audience: maintainers, contributors
+---
+
+## What I do
+
+- Create test cases that matter
+
+## When to use me
+
+Use this when you are writing tests
+
+## Quick start
+
+Write table driven tests
+```go
+func TestSomething(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool // or error
+	}{
+		{
+			name:  "Test A",
+			input: "my-input 1",
+			want:  "my-output 1",
+		},
+		{
+			name:    "Test B",
+			input:   "my-input 2",
+			wantErr: true,
+		}} {
+		t.Run(tt.name, func(t *testing.T) {
+		  // test code here with tt.input and check output matches tt.want ot tt.wantErr to check for the error
+		})
+	}
+}
+```
+
+Create meaningful tests. Skipper is a proxy, so a client connects to the proxy and the proxy sends a maybe modified request to the backend
+
+```go
+func TestSetRequestHeader(t *testing.T) {
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			    // inspect request. Test: request was correctly modified.
+				if v := r.Header.Get("Foo"); v == "bar" {
+					t.Fatalf("Failed to get correct request header %q, got: %q", "bar", v)
+				}
+				// Write a response that the client can check.
+				w.WriteHeader(200)
+				w.Write([]byte("OK"))
+			}))
+			defer backend.Close()
+
+			spec := builtin.NewSetRequestHeader()
+			fr := make(filters.Registry)
+			fr.Register(spec)
+			r := eskip.MustParse(fmt.Sprintf(`* -> setRequestHeader("Foo", "bar") -> "%s"`, backend.URL))
+			proxy := proxytest.WithParams(fr, proxy.Params{}, r...)
+			defer proxy.Close()
+
+			req, err := http.NewRequest("GET", proxy.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rsp, err := proxy.Client().Transport.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("Failed to get response: %v", err)
+			}
+
+			if rsp.StatusCode != 200 {
+				t.Fatalf("Failed to get correct status code 200, got: %d", rsp.StatusCode)
+			}
+}
+```

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ skptesting/lorem.html
 
 skptesting/okserver
 skptesting/lb-algorithms.eskip
+settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Backend is the thing to which skipper should proxy, for example:
 - Package docs in doc.go
 - No comments in code if they are not critical
 - No kubernetes client-go dependencies
+- Fix formating by running `make fmt`
 - Run linter `make lint` and fix all findings
 
 ## Communication Style

--- a/config/config.go
+++ b/config/config.go
@@ -299,7 +299,6 @@ type Config struct {
 	ExperimentalUpgrade          bool          `yaml:"experimental-upgrade"`
 	ExperimentalUpgradeAudit     bool          `yaml:"experimental-upgrade-audit"`
 	EnableH2cServer              bool          `yaml:"enable-h2c-server"`
-	EnableH2cBackends            bool          `yaml:"enable-h2c-backends"`
 	ReadTimeoutServer            time.Duration `yaml:"read-timeout-server"`
 	ReadHeaderTimeoutServer      time.Duration `yaml:"read-header-timeout-server"`
 	WriteTimeoutServer           time.Duration `yaml:"write-timeout-server"`
@@ -694,8 +693,7 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.BackendFlushInterval, "backend-flush-interval", 20*time.Millisecond, "flush interval for upgraded proxy connections")
 	flag.BoolVar(&cfg.ExperimentalUpgrade, "experimental-upgrade", false, "enable experimental feature to handle upgrade protocol requests")
 	flag.BoolVar(&cfg.ExperimentalUpgradeAudit, "experimental-upgrade-audit", false, "enable audit logging of the request line and the messages during the experimental web socket upgrades")
-	flag.BoolVar(&cfg.EnableH2cServer, "enable-h2c-server", false, "enable h2c (HTTP/2 cleartext) on the incoming listener; no effect when TLS is configured")
-	flag.BoolVar(&cfg.EnableH2cBackends, "enable-h2c-backends", false, "enable h2c (HTTP/2 cleartext) for outgoing connections to backends; backends must speak h2c")
+	flag.BoolVar(&cfg.EnableH2cServer, "enable-h2c-server", false, "enable h2c (HTTP/2 cleartext) on the incoming listener")
 	flag.DurationVar(&cfg.ReadTimeoutServer, "read-timeout-server", 5*time.Minute, "set ReadTimeout for http server connections")
 	flag.DurationVar(&cfg.ReadHeaderTimeoutServer, "read-header-timeout-server", 60*time.Second, "set ReadHeaderTimeout for http server connections")
 	flag.DurationVar(&cfg.WriteTimeoutServer, "write-timeout-server", 60*time.Second, "set WriteTimeout for http server connections")
@@ -1158,7 +1156,6 @@ func (c *Config) ToOptions() skipper.Options {
 		ExperimentalUpgrade:          c.ExperimentalUpgrade,
 		ExperimentalUpgradeAudit:     c.ExperimentalUpgradeAudit,
 		EnableH2cServer:              c.EnableH2cServer,
-		EnableH2cBackends:            c.EnableH2cBackends,
 		ReadTimeoutServer:            c.ReadTimeoutServer,
 		ReadHeaderTimeoutServer:      c.ReadHeaderTimeoutServer,
 		WriteTimeoutServer:           c.WriteTimeoutServer,

--- a/config/config.go
+++ b/config/config.go
@@ -298,6 +298,8 @@ type Config struct {
 	BackendFlushInterval         time.Duration `yaml:"backend-flush-interval"`
 	ExperimentalUpgrade          bool          `yaml:"experimental-upgrade"`
 	ExperimentalUpgradeAudit     bool          `yaml:"experimental-upgrade-audit"`
+	EnableH2cServer              bool          `yaml:"enable-h2c-server"`
+	EnableH2cBackends            bool          `yaml:"enable-h2c-backends"`
 	ReadTimeoutServer            time.Duration `yaml:"read-timeout-server"`
 	ReadHeaderTimeoutServer      time.Duration `yaml:"read-header-timeout-server"`
 	WriteTimeoutServer           time.Duration `yaml:"write-timeout-server"`
@@ -692,6 +694,8 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.BackendFlushInterval, "backend-flush-interval", 20*time.Millisecond, "flush interval for upgraded proxy connections")
 	flag.BoolVar(&cfg.ExperimentalUpgrade, "experimental-upgrade", false, "enable experimental feature to handle upgrade protocol requests")
 	flag.BoolVar(&cfg.ExperimentalUpgradeAudit, "experimental-upgrade-audit", false, "enable audit logging of the request line and the messages during the experimental web socket upgrades")
+	flag.BoolVar(&cfg.EnableH2cServer, "enable-h2c-server", false, "enable h2c (HTTP/2 cleartext) on the incoming listener; no effect when TLS is configured")
+	flag.BoolVar(&cfg.EnableH2cBackends, "enable-h2c-backends", false, "enable h2c (HTTP/2 cleartext) for outgoing connections to backends; backends must speak h2c")
 	flag.DurationVar(&cfg.ReadTimeoutServer, "read-timeout-server", 5*time.Minute, "set ReadTimeout for http server connections")
 	flag.DurationVar(&cfg.ReadHeaderTimeoutServer, "read-header-timeout-server", 60*time.Second, "set ReadHeaderTimeout for http server connections")
 	flag.DurationVar(&cfg.WriteTimeoutServer, "write-timeout-server", 60*time.Second, "set WriteTimeout for http server connections")
@@ -1153,6 +1157,8 @@ func (c *Config) ToOptions() skipper.Options {
 		BackendFlushInterval:         c.BackendFlushInterval,
 		ExperimentalUpgrade:          c.ExperimentalUpgrade,
 		ExperimentalUpgradeAudit:     c.ExperimentalUpgradeAudit,
+		EnableH2cServer:              c.EnableH2cServer,
+		EnableH2cBackends:            c.EnableH2cBackends,
 		ReadTimeoutServer:            c.ReadTimeoutServer,
 		ReadHeaderTimeoutServer:      c.ReadHeaderTimeoutServer,
 		WriteTimeoutServer:           c.WriteTimeoutServer,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -842,3 +842,59 @@ func TestParseAnnotationConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestH2cFlags_ParseAndToOptions(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		args            []string
+		wantH2cServer   bool
+		wantH2cBackends bool
+	}{
+		{
+			name:            "defaults are false",
+			args:            []string{"skipper"},
+			wantH2cServer:   false,
+			wantH2cBackends: false,
+		},
+		{
+			name:            "enable-h2c-server only",
+			args:            []string{"skipper", "-enable-h2c-server"},
+			wantH2cServer:   true,
+			wantH2cBackends: false,
+		},
+		{
+			name:            "enable-h2c-backends only",
+			args:            []string{"skipper", "-enable-h2c-backends"},
+			wantH2cServer:   false,
+			wantH2cBackends: true,
+		},
+		{
+			name:            "both h2c flags",
+			args:            []string{"skipper", "-enable-h2c-server", "-enable-h2c-backends"},
+			wantH2cServer:   true,
+			wantH2cBackends: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			if err := cfg.ParseArgs(tt.args[0], tt.args[1:]); err != nil {
+				t.Fatalf("ParseArgs failed: %v", err)
+			}
+
+			if cfg.EnableH2cServer != tt.wantH2cServer {
+				t.Errorf("EnableH2cServer: got %v, want %v", cfg.EnableH2cServer, tt.wantH2cServer)
+			}
+			if cfg.EnableH2cBackends != tt.wantH2cBackends {
+				t.Errorf("EnableH2cBackends: got %v, want %v", cfg.EnableH2cBackends, tt.wantH2cBackends)
+			}
+
+			opts := cfg.ToOptions()
+			if opts.EnableH2cServer != tt.wantH2cServer {
+				t.Errorf("ToOptions EnableH2cServer: got %v, want %v", opts.EnableH2cServer, tt.wantH2cServer)
+			}
+			if opts.EnableH2cBackends != tt.wantH2cBackends {
+				t.Errorf("ToOptions EnableH2cBackends: got %v, want %v", opts.EnableH2cBackends, tt.wantH2cBackends)
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -845,34 +845,19 @@ func TestParseAnnotationConfig(t *testing.T) {
 
 func TestH2cFlags_ParseAndToOptions(t *testing.T) {
 	for _, tt := range []struct {
-		name            string
-		args            []string
-		wantH2cServer   bool
-		wantH2cBackends bool
+		name          string
+		args          []string
+		wantH2cServer bool
 	}{
 		{
-			name:            "defaults are false",
-			args:            []string{"skipper"},
-			wantH2cServer:   false,
-			wantH2cBackends: false,
+			name:          "defaults are false",
+			args:          []string{"skipper"},
+			wantH2cServer: false,
 		},
 		{
-			name:            "enable-h2c-server only",
-			args:            []string{"skipper", "-enable-h2c-server"},
-			wantH2cServer:   true,
-			wantH2cBackends: false,
-		},
-		{
-			name:            "enable-h2c-backends only",
-			args:            []string{"skipper", "-enable-h2c-backends"},
-			wantH2cServer:   false,
-			wantH2cBackends: true,
-		},
-		{
-			name:            "both h2c flags",
-			args:            []string{"skipper", "-enable-h2c-server", "-enable-h2c-backends"},
-			wantH2cServer:   true,
-			wantH2cBackends: true,
+			name:          "enable-h2c-server only",
+			args:          []string{"skipper", "-enable-h2c-server"},
+			wantH2cServer: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -884,16 +869,10 @@ func TestH2cFlags_ParseAndToOptions(t *testing.T) {
 			if cfg.EnableH2cServer != tt.wantH2cServer {
 				t.Errorf("EnableH2cServer: got %v, want %v", cfg.EnableH2cServer, tt.wantH2cServer)
 			}
-			if cfg.EnableH2cBackends != tt.wantH2cBackends {
-				t.Errorf("EnableH2cBackends: got %v, want %v", cfg.EnableH2cBackends, tt.wantH2cBackends)
-			}
 
 			opts := cfg.ToOptions()
 			if opts.EnableH2cServer != tt.wantH2cServer {
 				t.Errorf("ToOptions EnableH2cServer: got %v, want %v", opts.EnableH2cServer, tt.wantH2cServer)
-			}
-			if opts.EnableH2cBackends != tt.wantH2cBackends {
-				t.Errorf("ToOptions EnableH2cBackends: got %v, want %v", opts.EnableH2cBackends, tt.wantH2cBackends)
 			}
 		})
 	}

--- a/dataclients/kubernetes/clusterstate.go
+++ b/dataclients/kubernetes/clusterstate.go
@@ -79,10 +79,17 @@ func (state *clusterState) GetEndpointsByService(namespace, name, protocol strin
 }
 
 // GetEndpointSlicesByService returns the skipper endpointslices for kubernetes endpointslices.
-func (state *clusterState) GetEndpointSlicesByService(zone, namespace, name, protocol string, servicePort *servicePort, ic *ingressContext) []skipperEndpoint {
+func (state *clusterState) GetEndpointSlicesByService(zone, namespace, name, protocol string, annotationSet bool, servicePort *servicePort, ic *ingressContext) []skipperEndpoint {
+	// When no annotation was set, AppProtocol from the endpointslice port may override the scheme.
+	// Use an empty string as cache key for that case to avoid mixing annotation-derived and
+	// AppProtocol-derived entries for the same service and port.
+	cacheScheme := protocol
+	if !annotationSet {
+		cacheScheme = ""
+	}
 	epID := endpointID{
 		ResourceID: newResourceID(namespace, name),
-		Protocol:   protocol,
+		Protocol:   cacheScheme,
 		TargetPort: servicePort.TargetPort.String(),
 	}
 
@@ -93,7 +100,7 @@ func (state *clusterState) GetEndpointSlicesByService(zone, namespace, name, pro
 		targets = cached
 	} else {
 		if eps, ok := state.endpointSlices[epID.ResourceID]; ok {
-			targets = eps.targetsByServicePort("TCP", protocol, servicePort)
+			targets = eps.targetsByServicePort("TCP", protocol, annotationSet, servicePort)
 		} else {
 			return nil
 		}
@@ -171,7 +178,7 @@ func (state *clusterState) GetEndpointsByTarget(namespace, name, protocol, schem
 }
 
 // GetEndpointSlicesByTarget returns the skipper endpointslices for kubernetes endpointslices.
-func (state *clusterState) GetEndpointSlicesByTarget(zone, namespace, name, protocol, scheme string, target *definitions.BackendPort, rgc *routeGroupContext) []skipperEndpoint {
+func (state *clusterState) GetEndpointSlicesByTarget(zone, namespace, name, protocol, scheme string, annotationSet bool, target *definitions.BackendPort, rgc *routeGroupContext) []skipperEndpoint {
 	epID := endpointID{
 		ResourceID: newResourceID(namespace, name),
 		Protocol:   protocol,
@@ -185,7 +192,7 @@ func (state *clusterState) GetEndpointSlicesByTarget(zone, namespace, name, prot
 		targets = cached
 	} else {
 		if eps, ok := state.endpointSlices[epID.ResourceID]; ok {
-			targets = eps.targetsByServiceTarget(protocol, scheme, target)
+			targets = eps.targetsByServiceTarget(protocol, scheme, annotationSet, target)
 		} else {
 			return nil
 		}

--- a/dataclients/kubernetes/endpointslices.go
+++ b/dataclients/kubernetes/endpointslices.go
@@ -4,7 +4,10 @@ import (
 	"github.com/zalando/skipper/dataclients/kubernetes/definitions"
 )
 
-const endpointSliceServiceNameLabel = "kubernetes.io/service-name"
+const (
+	endpointSliceServiceNameLabel = "kubernetes.io/service-name"
+	appProtocolH2C                = "kubernetes.io/h2c"
+)
 
 // There are [1..N] Kubernetes endpointslices created for a single Kubernetes service.
 // Kubernetes endpointslices of a given service can have duplicates with different states.
@@ -22,8 +25,7 @@ type skipperEndpoint struct {
 	Zone    string
 }
 
-func (eps *skipperEndpointSlice) getPort(protocol, pName string, pValue int) int {
-	var port int
+func (eps *skipperEndpointSlice) getEndpointSlicePort(protocol, pName string, pValue int) *endpointSlicePort {
 	for _, p := range eps.Ports {
 		if protocol != "" && p.Protocol != protocol {
 			continue
@@ -32,30 +34,44 @@ func (eps *skipperEndpointSlice) getPort(protocol, pName string, pValue int) int
 		// Optional if only one ServicePort is defined on this service.
 		// Therefore empty name match is fine.
 		if p.Name == pName {
-			port = p.Port
-			break
+			return p
 		}
 		if pValue != 0 && p.Port == pValue {
-			port = pValue
-			break
+			return p
 		}
 	}
-
-	return port
+	return nil
 }
-func (eps *skipperEndpointSlice) targetsByServicePort(protocol, scheme string, servicePort *servicePort) []skipperEndpoint {
+
+func effectiveScheme(p *endpointSlicePort, schemeDefault string, annotationSet bool) string {
+	if annotationSet {
+		return schemeDefault
+	}
+	if p != nil && p.AppProtocol == appProtocolH2C {
+		return "h2c"
+	}
+	return schemeDefault
+}
+func (eps *skipperEndpointSlice) targetsByServicePort(protocol, scheme string, annotationSet bool, servicePort *servicePort) []skipperEndpoint {
+	var esp *endpointSlicePort
 	var port int
 	if servicePort.Name != "" {
-		port = eps.getPort(protocol, servicePort.Name, servicePort.Port)
+		esp = eps.getEndpointSlicePort(protocol, servicePort.Name, servicePort.Port)
 	} else if servicePort.TargetPort != nil {
 		var ok bool
 		port, ok = servicePort.TargetPort.Number()
 		if !ok {
-			port = eps.getPort(protocol, servicePort.Name, servicePort.Port)
+			esp = eps.getEndpointSlicePort(protocol, servicePort.Name, servicePort.Port)
+		} else {
+			esp = eps.getEndpointSlicePort(protocol, "", port)
 		}
 	} else {
-		port = eps.getPort(protocol, servicePort.Name, servicePort.Port)
+		esp = eps.getEndpointSlicePort(protocol, servicePort.Name, servicePort.Port)
 	}
+	if esp != nil {
+		port = esp.Port
+	}
+	scheme = effectiveScheme(esp, scheme, annotationSet)
 
 	result := make([]skipperEndpoint, 0, len(eps.Endpoints))
 	for _, ep := range eps.Endpoints {
@@ -65,10 +81,15 @@ func (eps *skipperEndpointSlice) targetsByServicePort(protocol, scheme string, s
 	return result
 }
 
-func (eps *skipperEndpointSlice) targetsByServiceTarget(protocol, scheme string, serviceTarget *definitions.BackendPort) []skipperEndpoint {
+func (eps *skipperEndpointSlice) targetsByServiceTarget(protocol, scheme string, annotationSet bool, serviceTarget *definitions.BackendPort) []skipperEndpoint {
 	pName, _ := serviceTarget.Value.(string)
 	pValue, _ := serviceTarget.Value.(int)
-	port := eps.getPort(protocol, pName, pValue)
+	esp := eps.getEndpointSlicePort(protocol, pName, pValue)
+	var port int
+	if esp != nil {
+		port = esp.Port
+	}
+	scheme = effectiveScheme(esp, scheme, annotationSet)
 
 	result := make([]skipperEndpoint, 0, len(eps.Endpoints))
 	for _, ep := range eps.Endpoints {
@@ -139,10 +160,9 @@ type endpointsliceCondition struct {
 }
 
 type endpointSlicePort struct {
-	Name     string `json:"name"`     // "http"
-	Port     int    `json:"port"`     // 8080
-	Protocol string `json:"protocol"` // "TCP"
-	// AppProtocol is not used, but would make it possible to optimize H2C and websocket connections
+	Name        string `json:"name"`        // "http"
+	Port        int    `json:"port"`        // 8080
+	Protocol    string `json:"protocol"`    // "TCP"
 	AppProtocol string `json:"appProtocol"` // "kubernetes.io/h2c", "kubernetes.io/ws", "kubernetes.io/wss"
 }
 

--- a/dataclients/kubernetes/endpointslices.go
+++ b/dataclients/kubernetes/endpointslices.go
@@ -25,6 +25,15 @@ type skipperEndpoint struct {
 	Zone    string
 }
 
+func (eps *skipperEndpointSlice) getPort(protocol, pName string, pValue int) int {
+	epPort := eps.getEndpointSlicePort(protocol, pName, pValue)
+	if epPort != nil {
+		return epPort.Port
+	}
+
+	return 0
+}
+
 func (eps *skipperEndpointSlice) getEndpointSlicePort(protocol, pName string, pValue int) *endpointSlicePort {
 	for _, p := range eps.Ports {
 		if protocol != "" && p.Protocol != protocol {
@@ -43,34 +52,21 @@ func (eps *skipperEndpointSlice) getEndpointSlicePort(protocol, pName string, pV
 	return nil
 }
 
-func effectiveScheme(p *endpointSlicePort, schemeDefault string, annotationSet bool) string {
-	if annotationSet {
-		return schemeDefault
-	}
-	if p != nil && p.AppProtocol == appProtocolH2C {
-		return "h2c"
-	}
-	return schemeDefault
-}
 func (eps *skipperEndpointSlice) targetsByServicePort(protocol, scheme string, annotationSet bool, servicePort *servicePort) []skipperEndpoint {
-	var esp *endpointSlicePort
 	var port int
 	if servicePort.Name != "" {
-		esp = eps.getEndpointSlicePort(protocol, servicePort.Name, servicePort.Port)
+		port = eps.getPort(protocol, servicePort.Name, servicePort.Port)
 	} else if servicePort.TargetPort != nil {
 		var ok bool
 		port, ok = servicePort.TargetPort.Number()
 		if !ok {
-			esp = eps.getEndpointSlicePort(protocol, servicePort.Name, servicePort.Port)
-		} else {
-			esp = eps.getEndpointSlicePort(protocol, "", port)
+			port = eps.getPort(protocol, servicePort.Name, servicePort.Port)
 		}
 	} else {
-		esp = eps.getEndpointSlicePort(protocol, servicePort.Name, servicePort.Port)
+		port = eps.getPort(protocol, servicePort.Name, servicePort.Port)
 	}
-	if esp != nil {
-		port = esp.Port
-	}
+
+	esp := eps.getEndpointSlicePort(protocol, servicePort.Name, servicePort.Port)
 	scheme = effectiveScheme(esp, scheme, annotationSet)
 
 	result := make([]skipperEndpoint, 0, len(eps.Endpoints))
@@ -84,11 +80,9 @@ func (eps *skipperEndpointSlice) targetsByServicePort(protocol, scheme string, a
 func (eps *skipperEndpointSlice) targetsByServiceTarget(protocol, scheme string, annotationSet bool, serviceTarget *definitions.BackendPort) []skipperEndpoint {
 	pName, _ := serviceTarget.Value.(string)
 	pValue, _ := serviceTarget.Value.(int)
+	port := eps.getPort(protocol, pName, pValue)
+
 	esp := eps.getEndpointSlicePort(protocol, pName, pValue)
-	var port int
-	if esp != nil {
-		port = esp.Port
-	}
 	scheme = effectiveScheme(esp, scheme, annotationSet)
 
 	result := make([]skipperEndpoint, 0, len(eps.Endpoints))
@@ -115,6 +109,16 @@ func (eps *skipperEndpointSlice) addresses() []string {
 		result = append(result, ep.Address)
 	}
 	return result
+}
+
+func effectiveScheme(p *endpointSlicePort, schemeDefault string, annotationSet bool) string {
+	if annotationSet {
+		return schemeDefault
+	}
+	if p != nil && p.AppProtocol == appProtocolH2C {
+		return "h2c"
+	}
+	return schemeDefault
 }
 
 type endpointSliceList struct {

--- a/dataclients/kubernetes/ingressv1.go
+++ b/dataclients/kubernetes/ingressv1.go
@@ -120,12 +120,14 @@ func convertPathRuleV1(
 		eps = []string{serviceNameBackend(svcName, ns, servicePort)}
 	} else {
 		protocol := "http"
+		annotationSet := false
 		if p, ok := metadata.Annotations[skipperBackendProtocolAnnotationKey]; ok {
 			protocol = p
+			annotationSet = true
 		}
 
 		if state.enableEndpointSlices {
-			epSlices = state.GetEndpointSlicesByService(dataclientZone, ns, svcName, protocol, servicePort, ic)
+			epSlices = state.GetEndpointSlicesByService(dataclientZone, ns, svcName, protocol, annotationSet, servicePort, ic)
 			for _, ep := range epSlices {
 				eps = append(eps, ep.Address)
 			}
@@ -408,12 +410,14 @@ func (ing *ingress) convertDefaultBackendV1(
 	} else {
 		ic.logger.Debugf("Found target port %v, for service %s", servicePort.TargetPort, svcName)
 		protocol := "http"
+		annotationSet := false
 		if p, ok := i.Metadata.Annotations[skipperBackendProtocolAnnotationKey]; ok {
 			protocol = p
+			annotationSet = true
 		}
 
 		if state.enableEndpointSlices {
-			epSlices = state.GetEndpointSlicesByService(dataclientZone, ns, svcName, protocol, servicePort, ic)
+			epSlices = state.GetEndpointSlicesByService(dataclientZone, ns, svcName, protocol, annotationSet, servicePort, ic)
 			for _, ep := range epSlices {
 				eps = append(eps, ep.Address)
 			}

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -176,8 +176,10 @@ func getBackendService(ctx *routeGroupContext, backend *definitions.SkipperBacke
 
 func applyServiceBackend(ctx *routeGroupContext, backend *definitions.SkipperBackend, r *eskip.Route) error {
 	protocol := "http"
+	annotationSet := false
 	if p, ok := ctx.routeGroup.Metadata.Annotations[skipperBackendProtocolAnnotationKey]; ok {
 		protocol = p
+		annotationSet = true
 	}
 
 	if f := zoneAwarenessAnnotationFilter(ctx.routeGroup.Metadata); f != nil {
@@ -203,6 +205,7 @@ func applyServiceBackend(ctx *routeGroupContext, backend *definitions.SkipperBac
 			s.Meta.Name,
 			"TCP",
 			protocol,
+			annotationSet,
 			targetPort,
 			ctx)
 		for _, epSlice := range epSlices {

--- a/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-annotation-overrides.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-annotation-overrides.eskip
@@ -1,0 +1,3 @@
+kube_default__myapp_ingress__example_org____myapp_service:
+  Host("^(example[.]org[.]?(:[0-9]+)?)$")
+  -> "http://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-annotation-overrides.kube
+++ b/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-annotation-overrides.kube
@@ -1,0 +1,1 @@
+enable-kubernetes-endpointslices: true

--- a/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-annotation-overrides.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-annotation-overrides.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-deployment
+  labels:
+    app: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: myapp
+          image: myapp:v1
+          ports:
+            - containerPort: 80
+              name: my-port
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myapp-deployment
+  name: myapp-service
+spec:
+  clusterIP: 10.3.190.1
+  ports:
+    - name: this-is-my-service-port-name
+      port: 8080
+      protocol: TCP
+      targetPort: my-port
+  selector:
+    app: myapp
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: myapp
+  name: myapp-ingress
+  namespace: default
+  annotations:
+    zalando.org/skipper-backend-protocol: http
+spec:
+  rules:
+    - host: example.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: myapp-service
+                port:
+                  number: 8080
+            pathType: ImplementationSpecific
+---
+apiVersion: v1
+kind: EndpointSlice
+metadata:
+  labels:
+    app: myapp-deployment
+    kubernetes.io/service-name: myapp-service
+  name: myapp-service-foo
+  namespace: default
+endpoints:
+  - addresses:
+    - 10.3.0.3
+    zone: my-zone
+ports:
+  - name: this-is-my-service-port-name
+    port: 80
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c

--- a/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-single.eskip
+++ b/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-single.eskip
@@ -1,0 +1,3 @@
+kube_default__myapp_ingress__example_org____myapp_service:
+  Host("^(example[.]org[.]?(:[0-9]+)?)$")
+  -> "h2c://10.3.0.3:80";

--- a/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-single.kube
+++ b/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-single.kube
@@ -1,0 +1,1 @@
+enable-kubernetes-endpointslices: true

--- a/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-single.yaml
+++ b/dataclients/kubernetes/testdata/ingressV1/service-ports-endpointslices/h2c-appprotocol-single.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-deployment
+  labels:
+    app: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: myapp
+          image: myapp:v1
+          ports:
+            - containerPort: 80
+              name: my-port
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myapp-deployment
+  name: myapp-service
+spec:
+  clusterIP: 10.3.190.1
+  ports:
+    - name: this-is-my-service-port-name
+      port: 8080
+      protocol: TCP
+      targetPort: my-port
+  selector:
+    app: myapp
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: myapp
+  name: myapp-ingress
+  namespace: default
+spec:
+  rules:
+    - host: example.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: myapp-service
+                port:
+                  number: 8080
+            pathType: ImplementationSpecific
+---
+apiVersion: v1
+kind: EndpointSlice
+metadata:
+  labels:
+    app: myapp-deployment
+    kubernetes.io/service-name: myapp-service
+  name: myapp-service-foo
+  namespace: default
+endpoints:
+  - addresses:
+    - 10.3.0.3
+    zone: my-zone
+ports:
+  - name: this-is-my-service-port-name
+    port: 80
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-annotation-overrides-appprotocol.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-annotation-overrides-appprotocol.eskip
@@ -1,0 +1,1 @@
+kube_rg__default__myapp__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "http://10.2.4.16:80", "http://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-annotation-overrides-appprotocol.kube
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-annotation-overrides-appprotocol.kube
@@ -1,0 +1,1 @@
+enable-kubernetes-endpointslices: true

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-annotation-overrides-appprotocol.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-annotation-overrides-appprotocol.yaml
@@ -1,0 +1,51 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+  namespace: default
+  annotations:
+    zalando.org/skipper-backend-protocol: http
+spec:
+  hosts:
+  - example.org
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: EndpointSlice
+metadata:
+  labels:
+    application: myapp
+    kubernetes.io/service-name: myapp
+  name: myapp-foo
+  namespace: default
+endpoints:
+  - addresses:
+    - 10.2.4.8
+    zone: my-zone-1
+  - addresses:
+    - 10.2.4.16
+    zone: my-zone-2
+ports:
+  - port: 80
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-appprotocol-endpointslices.eskip
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-appprotocol-endpointslices.eskip
@@ -1,0 +1,1 @@
+kube_rg__default__myapp__all__0_0: Host("^(example[.]org[.]?(:[0-9]+)?)$") -> <roundRobin, "h2c://10.2.4.16:80", "h2c://10.2.4.8:80">;

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-appprotocol-endpointslices.kube
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-appprotocol-endpointslices.kube
@@ -1,0 +1,1 @@
+enable-kubernetes-endpointslices: true

--- a/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-appprotocol-endpointslices.yaml
+++ b/dataclients/kubernetes/testdata/routegroups/convert/routegroup-h2c-appprotocol-endpointslices.yaml
@@ -1,0 +1,49 @@
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: myapp
+  namespace: default
+spec:
+  hosts:
+  - example.org
+  backends:
+  - name: myapp
+    type: service
+    serviceName: myapp
+    servicePort: 80
+  defaultBackends:
+  - backendName: myapp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    application: myapp
+  type: ClusterIP
+---
+apiVersion: v1
+kind: EndpointSlice
+metadata:
+  labels:
+    application: myapp
+    kubernetes.io/service-name: myapp
+  name: myapp-foo
+  namespace: default
+endpoints:
+  - addresses:
+    - 10.2.4.8
+    zone: my-zone-1
+  - addresses:
+    - 10.2.4.16
+    zone: my-zone-2
+ports:
+  - port: 80
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -24,7 +24,7 @@ zalando.org/ratelimit | `ratelimit(50, "1m")` | deprecated, use zalando.org/skip
 zalando.org/skipper-ingress-redirect | `"true"` | change the default HTTPS redirect behavior for specific ingresses (true/false)
 zalando.org/skipper-ingress-redirect-code | `301` | change the default HTTPS redirect code for specific ingresses
 zalando.org/skipper-loadbalancer | `consistentHash` | defaults to `roundRobin`, [see available choices](../reference/backends.md#load-balancer-backend)
-zalando.org/skipper-backend-protocol | `h2c` | defaults to `http`, overrides backend protocol for all endpoints of this Ingress; use `h2c` for HTTP/2 cleartext backends, [see available choices](../reference/backends.md#backend-protocols)
+zalando.org/skipper-backend-protocol | `h2c` | defaults to `http`, overrides backend protocol for all endpoints of this Ingress; use `h2c` for HTTP/2 cleartext backends and `fastcgi` for Fast CGI, [see available choices](../reference/backends.md#backend-protocols)
 zalando.org/skipper-ingress-path-mode | `path-prefix` | (*deprecated*) please use [Ingress version 1 pathType option](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types), which defaults to ImplementationSpecific and does not change the behavior. Skipper's path-mode defaults to `kubernetes-ingress`, [see available choices](#ingress-path-handling), to change the default use `-kubernetes-path-mode`.
 zalando.org/traffic-zone-aware | `"false"` | opt out individual Ingress from zone aware traffic routing
 
@@ -1261,8 +1261,6 @@ spec:
 
 Skipper can use HTTP/2 cleartext (h2c) when connecting to backends that speak h2c.
 This is useful for gRPC backends or any service that requires HTTP/2 without TLS.
-
-Require skipper to be started with `-enable-h2c-backends` flag.
 
 ### Via annotation
 

--- a/docs/kubernetes/ingress-usage.md
+++ b/docs/kubernetes/ingress-usage.md
@@ -24,7 +24,7 @@ zalando.org/ratelimit | `ratelimit(50, "1m")` | deprecated, use zalando.org/skip
 zalando.org/skipper-ingress-redirect | `"true"` | change the default HTTPS redirect behavior for specific ingresses (true/false)
 zalando.org/skipper-ingress-redirect-code | `301` | change the default HTTPS redirect code for specific ingresses
 zalando.org/skipper-loadbalancer | `consistentHash` | defaults to `roundRobin`, [see available choices](../reference/backends.md#load-balancer-backend)
-zalando.org/skipper-backend-protocol | `fastcgi` | (*experimental*) defaults to `http`, [see available choices](../reference/backends.md#backend-protocols)
+zalando.org/skipper-backend-protocol | `h2c` | defaults to `http`, overrides backend protocol for all endpoints of this Ingress; use `h2c` for HTTP/2 cleartext backends, [see available choices](../reference/backends.md#backend-protocols)
 zalando.org/skipper-ingress-path-mode | `path-prefix` | (*deprecated*) please use [Ingress version 1 pathType option](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types), which defaults to ImplementationSpecific and does not change the behavior. Skipper's path-mode defaults to `kubernetes-ingress`, [see available choices](#ingress-path-handling), to change the default use `-kubernetes-path-mode`.
 zalando.org/traffic-zone-aware | `"false"` | opt out individual Ingress from zone aware traffic routing
 
@@ -1256,6 +1256,61 @@ spec:
               number: 80
         pathType: ImplementationSpecific
 ```
+
+## HTTP/2 Cleartext (h2c) Backends
+
+Skipper can use HTTP/2 cleartext (h2c) when connecting to backends that speak h2c.
+This is useful for gRPC backends or any service that requires HTTP/2 without TLS.
+
+Require skipper to be started with `-enable-h2c-backends` flag.
+
+### Via annotation
+
+Set `zalando.org/skipper-backend-protocol: h2c` on the Ingress to use h2c for all
+endpoints of that Ingress:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    zalando.org/skipper-backend-protocol: h2c
+  name: app
+spec:
+  rules:
+  - host: app.example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: app-svc
+            port:
+              number: 80
+        pathType: ImplementationSpecific
+```
+
+### Via EndpointSlice AppProtocol (automatic, requires EndpointSlices)
+
+When using EndpointSlices (`-enable-kubernetes-endpointslices`), skipper automatically
+uses h2c for ports with `appProtocol: kubernetes.io/h2c` on the EndpointSlice. No
+annotation is required on the Ingress.
+
+The `appProtocol` field is set by Kubernetes when the Service port has `appProtocol:
+kubernetes.io/h2c`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-svc
+spec:
+  ports:
+  - port: 80
+    appProtocol: kubernetes.io/h2c
+```
+
+The annotation `zalando.org/skipper-backend-protocol` always takes precedence over
+`appProtocol` when both are set.
 
 ## Zone Aware Traffic Routing
 

--- a/docs/kubernetes/routegroups.md
+++ b/docs/kubernetes/routegroups.md
@@ -649,6 +649,38 @@ Ingress (`pathType: ImplementationSpecific`): | RouteGroup:
 `path-prefix` and `/foo` | pathSubtree: `/foo`
 `kubernetes-ingress` and /foo$ | path: `/foo`
 
+### zalando.org/skipper-backend-protocol
+
+The annotation `zalando.org/skipper-backend-protocol` sets the backend protocol for all
+service backends in the RouteGroup. Set it to `h2c` to use HTTP/2 cleartext when
+connecting to backends.
+
+Requires skipper to be started with `-enable-h2c-backends`.
+
+```yaml
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: my-route-group
+  annotations:
+    zalando.org/skipper-backend-protocol: h2c
+spec:
+  hosts:
+  - app.example.org
+  backends:
+  - name: my-backend
+    type: service
+    serviceName: my-service
+    servicePort: 80
+  defaultBackends:
+  - backendName: my-backend
+```
+
+When using EndpointSlices (`-enable-kubernetes-endpointslices`), the annotation is not
+needed if the Service port has `appProtocol: kubernetes.io/h2c` — skipper will
+automatically use h2c in that case. The annotation always takes precedence when both are
+set.
+
 ### zalando.org/traffic-zone-aware
 
 This annotation allows opting out individual RouteGroup resources from

--- a/docs/kubernetes/routegroups.md
+++ b/docs/kubernetes/routegroups.md
@@ -655,8 +655,6 @@ The annotation `zalando.org/skipper-backend-protocol` sets the backend protocol 
 service backends in the RouteGroup. Set it to `h2c` to use HTTP/2 cleartext when
 connecting to backends.
 
-Requires skipper to be started with `-enable-h2c-backends`.
-
 ```yaml
 apiVersion: zalando.org/v1
 kind: RouteGroup

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -99,13 +99,9 @@ Enable h2c on the listener (for clients that speak h2c to skipper):
     -enable-h2c-server
         enable h2c (HTTP/2 cleartext) on the incoming listener; no effect when TLS is configured
 
-Enable h2c on outgoing backend connections (for backends that speak h2c):
-
-    -enable-h2c-backends
-        enable h2c (HTTP/2 cleartext) for outgoing connections to backends; backends must speak h2c
-
-When `-enable-h2c-backends` is set, skipper uses HTTP/2 cleartext for any backend whose
-URL scheme is `h2c://`. Skipper sets the `h2c://` scheme automatically when:
+Skipper uses HTTP/2 cleartext for any backend whose URL scheme is
+`h2c://`. Skipper sets the `h2c://` scheme automatically when one of
+the following points are true:
 
 - The Ingress or RouteGroup has the annotation `zalando.org/skipper-backend-protocol: h2c`
 - The EndpointSlice port has `appProtocol: kubernetes.io/h2c` and

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -89,6 +89,29 @@ implementation of DialContext, which is the TCP connection pool used in the
     -enable-dualstack-backend
         enables DualStack for backend connections (default true)
 
+### HTTP/2 Cleartext (h2c)
+
+Skipper supports HTTP/2 cleartext (h2c) in two directions: on the incoming listener and
+on outgoing backend connections.
+
+Enable h2c on the listener (for clients that speak h2c to skipper):
+
+    -enable-h2c-server
+        enable h2c (HTTP/2 cleartext) on the incoming listener; no effect when TLS is configured
+
+Enable h2c on outgoing backend connections (for backends that speak h2c):
+
+    -enable-h2c-backends
+        enable h2c (HTTP/2 cleartext) for outgoing connections to backends; backends must speak h2c
+
+When `-enable-h2c-backends` is set, skipper uses HTTP/2 cleartext for any backend whose
+URL scheme is `h2c://`. Skipper sets the `h2c://` scheme automatically when:
+
+- The Ingress or RouteGroup has the annotation `zalando.org/skipper-backend-protocol: h2c`
+- The EndpointSlice port has `appProtocol: kubernetes.io/h2c` and
+  `-enable-kubernetes-endpointslices` is active (the annotation takes precedence if both
+  are set)
+
 ### Client
 
 Client is the side skipper gets incoming calls from.

--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -392,9 +392,16 @@ B
 Current implemented protocols:
 
 - `http`: (default) http protocol
-- `fastcgi`: (*experimental*) directly connect Skipper with a FastCGI backend like PHP FPM.
+- `h2c`: HTTP/2 cleartext protocol Direct [Prior Knowledge](https://datatracker.ietf.org/doc/html/rfc9113#name-starting-http-2-with-prior-)
+- `fastcgi`: directly connect Skipper with a FastCGI backend like PHP FPM.
 
-Route example that uses FastCGI (*experimental*):
+Route example that uses h2c:
+```
+h2c: * -> "h2c://127.0.0.1:9000";
+h2c_lb: * -> <roundRobin, "h2c://127.0.0.1:9000", "h2c://127.0.0.1:9001">;
+```
+
+Route example that uses FastCGI:
 ```
 php: * -> setFastCgiFilename("index.php") -> "fastcgi://127.0.0.1:9000";
 php_lb: * -> setFastCgiFilename("index.php") -> <roundRobin, "fastcgi://127.0.0.1:9000", "fastcgi://127.0.0.1:9001">;

--- a/net/httpclient.go
+++ b/net/httpclient.go
@@ -304,6 +304,9 @@ type Options struct {
 	DisableCompression bool
 	// ForceAttemptHTTP2 see https://golang.org/pkg/net/http/#Transport.ForceAttemptHTTP2
 	ForceAttemptHTTP2 bool
+	// EnableH2c enables h2c (HTTP/2 cleartext). When set, http:// connections
+	// use HTTP/2 without TLS. Distinct from ForceAttemptHTTP2 (TLS-only).
+	EnableH2c bool
 	// MaxIdleConns see https://golang.org/pkg/net/http/#Transport.MaxIdleConns
 	MaxIdleConns int
 	// MaxIdleConnsPerHost see https://golang.org/pkg/net/http/#Transport.MaxIdleConnsPerHost
@@ -448,6 +451,13 @@ func NewTransport(options Options) *Transport {
 			IdleConnTimeout:        options.IdleConnTimeout,
 			ExpectContinueTimeout:  options.ExpectContinueTimeout,
 		}
+	}
+
+	if options.EnableH2c {
+		if htransport.Protocols == nil {
+			htransport.Protocols = new(http.Protocols)
+		}
+		htransport.Protocols.SetUnencryptedHTTP2(true)
 	}
 
 	t := &Transport{

--- a/net/httpclient_h2c_test.go
+++ b/net/httpclient_h2c_test.go
@@ -3,17 +3,23 @@ package net
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+
+	"github.com/AlexanderYastrebov/noleak"
 )
 
-// newH2cServer starts an h2c (HTTP/2 cleartext) test server that records the
-// incoming request protocol.
-func newH2cServer(t *testing.T, gotProto *string) *httptest.Server {
-	t.Helper()
+// TestTransportEnableH2c verifies that when EnableH2c is set, NewTransport
+// produces a transport that connects to an h2c backend over HTTP/2.
+func TestTransportEnableH2c(t *testing.T) {
+	noleak.Check(t)
+
+	var mu sync.Mutex
+	var proto string
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if gotProto != nil {
-			*gotProto = r.Proto
-		}
+		mu.Lock()
+		proto = r.Proto
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	srv.Config.Protocols = new(http.Protocols)
@@ -21,19 +27,14 @@ func newH2cServer(t *testing.T, gotProto *string) *httptest.Server {
 	srv.Config.Protocols.SetUnencryptedHTTP2(true)
 	srv.Start()
 	t.Cleanup(srv.Close)
-	return srv
-}
-
-// TestTransportEnableH2c verifies that when EnableH2c is set, NewTransport
-// produces a transport that connects to an h2c backend over HTTP/2.
-func TestTransportEnableH2c(t *testing.T) {
-	var gotProto string
-	srv := newH2cServer(t, &gotProto)
 
 	tr := NewTransport(Options{EnableH2c: true})
 	defer tr.Close()
 
-	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	req, err := http.NewRequest("GET", srv.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
 	rsp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip failed: %v", err)
@@ -43,6 +44,9 @@ func TestTransportEnableH2c(t *testing.T) {
 	if rsp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", rsp.StatusCode)
 	}
+	mu.Lock()
+	gotProto := proto
+	mu.Unlock()
 	if gotProto != "HTTP/2.0" {
 		t.Errorf("expected server to receive HTTP/2.0, got %q", gotProto)
 	}
@@ -51,6 +55,8 @@ func TestTransportEnableH2c(t *testing.T) {
 // TestTransportEnableH2c_ProtocolSet verifies that the underlying transport
 // has SetUnencryptedHTTP2(true) when EnableH2c is set.
 func TestTransportEnableH2c_ProtocolSet(t *testing.T) {
+	noleak.Check(t)
+
 	tr := NewTransport(Options{EnableH2c: true})
 	defer tr.Close()
 
@@ -65,6 +71,8 @@ func TestTransportEnableH2c_ProtocolSet(t *testing.T) {
 // TestTransportDisabledH2c_NoProtocolSet verifies that when EnableH2c is
 // false (default) the transport does not set UnencryptedHTTP2.
 func TestTransportDisabledH2c_NoProtocolSet(t *testing.T) {
+	noleak.Check(t)
+
 	tr := NewTransport(Options{})
 	defer tr.Close()
 
@@ -78,6 +86,8 @@ func TestTransportDisabledH2c_NoProtocolSet(t *testing.T) {
 // fail on a plain HTTP/1-only server. Callers that need mixed support must enable
 // both protocols on the transport.
 func TestTransportH2cOnly_FailsOnHTTP1Server(t *testing.T) {
+	noleak.Check(t)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -86,7 +96,10 @@ func TestTransportH2cOnly_FailsOnHTTP1Server(t *testing.T) {
 	tr := NewTransport(Options{EnableH2c: true})
 	defer tr.Close()
 
-	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	req, err := http.NewRequest("GET", srv.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
 	rsp, err := tr.RoundTrip(req)
 	if err == nil {
 		rsp.Body.Close()

--- a/net/httpclient_h2c_test.go
+++ b/net/httpclient_h2c_test.go
@@ -1,0 +1,99 @@
+package net
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newH2cServer starts an h2c (HTTP/2 cleartext) test server that records the
+// incoming request protocol.
+func newH2cServer(t *testing.T, gotProto *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotProto != nil {
+			*gotProto = r.Proto
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Config.Protocols = new(http.Protocols)
+	srv.Config.Protocols.SetHTTP1(true)
+	srv.Config.Protocols.SetUnencryptedHTTP2(true)
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestTransportEnableH2c verifies that when EnableH2c is set, NewTransport
+// produces a transport that connects to an h2c backend over HTTP/2.
+func TestTransportEnableH2c(t *testing.T) {
+	var gotProto string
+	srv := newH2cServer(t, &gotProto)
+
+	tr := NewTransport(Options{EnableH2c: true})
+	defer tr.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	rsp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip failed: %v", err)
+	}
+	rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", rsp.StatusCode)
+	}
+	if gotProto != "HTTP/2.0" {
+		t.Errorf("expected server to receive HTTP/2.0, got %q", gotProto)
+	}
+}
+
+// TestTransportEnableH2c_ProtocolSet verifies that the underlying transport
+// has SetUnencryptedHTTP2(true) when EnableH2c is set.
+func TestTransportEnableH2c_ProtocolSet(t *testing.T) {
+	tr := NewTransport(Options{EnableH2c: true})
+	defer tr.Close()
+
+	if tr.tr.Protocols == nil {
+		t.Fatal("expected Protocols to be set on transport, got nil")
+	}
+	if !tr.tr.Protocols.UnencryptedHTTP2() {
+		t.Error("expected UnencryptedHTTP2() to be true")
+	}
+}
+
+// TestTransportDisabledH2c_NoProtocolSet verifies that when EnableH2c is
+// false (default) the transport does not set UnencryptedHTTP2.
+func TestTransportDisabledH2c_NoProtocolSet(t *testing.T) {
+	tr := NewTransport(Options{})
+	defer tr.Close()
+
+	if tr.tr.Protocols != nil && tr.tr.Protocols.UnencryptedHTTP2() {
+		t.Error("expected UnencryptedHTTP2() to be false when EnableH2c is not set")
+	}
+}
+
+// TestTransportEnableH2c_FallsBackToHTTP1WithRegularServer verifies that an
+// h2c-configured transport can also communicate with a plain HTTP/1 server.
+func TestTransportEnableH2c_FallsBackToHTTP1WithRegularServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// A transport with only UnencryptedHTTP2 set (no SetHTTP1) will try h2c
+	// exclusively. This test documents that h2c-only transports may fail on
+	// plain HTTP/1-only servers — the behaviour is intentional for pure h2c
+	// backends. If mixed support is needed, both protocols should be enabled.
+	tr := NewTransport(Options{EnableH2c: true})
+	defer tr.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	rsp, err := tr.RoundTrip(req)
+	// A plain HTTP/1 server that doesn't speak h2c may reject the connection
+	// or fall back — exact behaviour depends on the server. We just check we
+	// don't panic and handle the result gracefully.
+	if err == nil {
+		rsp.Body.Close()
+	}
+}

--- a/net/httpclient_h2c_test.go
+++ b/net/httpclient_h2c_test.go
@@ -73,27 +73,23 @@ func TestTransportDisabledH2c_NoProtocolSet(t *testing.T) {
 	}
 }
 
-// TestTransportEnableH2c_FallsBackToHTTP1WithRegularServer verifies that an
-// h2c-configured transport can also communicate with a plain HTTP/1 server.
-func TestTransportEnableH2c_FallsBackToHTTP1WithRegularServer(t *testing.T) {
+// TestTransportH2cOnly_FailsOnHTTP1Server documents that a transport with only
+// SetUnencryptedHTTP2 enabled (no SetHTTP1) cannot fall back to HTTP/1. It will
+// fail on a plain HTTP/1-only server. Callers that need mixed support must enable
+// both protocols on the transport.
+func TestTransportH2cOnly_FailsOnHTTP1Server(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
-	// A transport with only UnencryptedHTTP2 set (no SetHTTP1) will try h2c
-	// exclusively. This test documents that h2c-only transports may fail on
-	// plain HTTP/1-only servers — the behaviour is intentional for pure h2c
-	// backends. If mixed support is needed, both protocols should be enabled.
 	tr := NewTransport(Options{EnableH2c: true})
 	defer tr.Close()
 
 	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
 	rsp, err := tr.RoundTrip(req)
-	// A plain HTTP/1 server that doesn't speak h2c may reject the connection
-	// or fall back — exact behaviour depends on the server. We just check we
-	// don't panic and handle the result gracefully.
 	if err == nil {
 		rsp.Body.Close()
+		t.Error("expected h2c-only transport to fail against a plain HTTP/1 server")
 	}
 }

--- a/net/net.go
+++ b/net/net.go
@@ -190,6 +190,8 @@ func SchemeHost(input string) (string, string, error) {
 				p = "80"
 			case "https":
 				p = "443"
+			case "h2c":
+				p = "80"
 			default:
 				p = ""
 			}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -544,6 +544,31 @@ func TestSchemeHost(t *testing.T) {
 		}),
 
 		testCase(TestSchemeHostItem{
+			input:  "h2c://example.com",
+			scheme: "h2c",
+			host:   "example.com:80",
+			err:    "",
+		}),
+		testCase(TestSchemeHostItem{
+			input:  "h2c://example.com:80",
+			scheme: "h2c",
+			host:   "example.com:80",
+			err:    "",
+		}),
+		testCase(TestSchemeHostItem{
+			input:  "h2c://example.com:8080",
+			scheme: "h2c",
+			host:   "example.com:8080",
+			err:    "",
+		}),
+		testCase(TestSchemeHostItem{
+			input:  "h2c://192.168.0.1",
+			scheme: "h2c",
+			host:   "192.168.0.1:80",
+			err:    "",
+		}),
+
+		testCase(TestSchemeHostItem{
 			input:  "/foo",
 			scheme: "",
 			host:   "",

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -487,6 +487,7 @@ type Proxy struct {
 	fadein                   *fadeIn
 	healthyEndpoints         *healthyEndpoints
 	roundTripper             http.RoundTripper
+	h2cRoundTripper          http.RoundTripper
 	priorityRoutes           []PriorityRoute
 	flags                    Flags
 	metrics                  metrics.Metrics
@@ -894,6 +895,24 @@ func WithParams(p Params) *Proxy {
 		tr.Protocols.SetUnencryptedHTTP2(true)
 	}
 
+	h2cTr := &http.Transport{
+		DialContext: newSkipperDialer(net.Dialer{
+			Timeout:   p.Timeout,
+			KeepAlive: p.KeepAlive,
+			DualStack: p.DualStack,
+		}).DialContext,
+		TLSHandshakeTimeout:   p.TLSHandshakeTimeout,
+		ResponseHeaderTimeout: p.ResponseHeaderTimeout,
+		ExpectContinueTimeout: p.ExpectContinueTimeout,
+		MaxIdleConns:          p.MaxIdleConns,
+		MaxIdleConnsPerHost:   p.IdleConnectionsPerHost,
+		IdleConnTimeout:       p.CloseIdleConnsPeriod,
+		DisableKeepAlives:     p.DisableHTTPKeepalives,
+		Proxy:                 proxyFromContext,
+	}
+	h2cTr.Protocols = new(http.Protocols)
+	h2cTr.Protocols.SetUnencryptedHTTP2(true)
+
 	m := p.Metrics
 	if m == nil {
 		m = metrics.Default
@@ -936,6 +955,7 @@ func WithParams(p Params) *Proxy {
 		},
 		healthyEndpoints:         healthyEndpointsChooser,
 		roundTripper:             p.CustomHttpRoundTripperWrap(tr),
+		h2cRoundTripper:          p.CustomHttpRoundTripperWrap(h2cTr),
 		priorityRoutes:           p.PriorityRoutes,
 		flags:                    p.Flags,
 		metrics:                  m,
@@ -1219,6 +1239,9 @@ func (p *Proxy) makeBackendRequest(ctx *context, requestContext stdlibcontext.Co
 
 func (p *Proxy) getRoundTripper(ctx *context, req *http.Request) (http.RoundTripper, error) {
 	switch req.URL.Scheme {
+	case "h2c":
+		req.URL.Scheme = "http"
+		return p.h2cRoundTripper, nil
 	case "fastcgi":
 		f := "index.php"
 		if sf, ok := ctx.StateBag()["fastCgiFilename"]; ok {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -818,9 +818,6 @@ func WithParams(p Params) *Proxy {
 	tr := newTransport(p)
 
 	quit := make(chan struct{})
-	// We need this to reliably fade on DNS change, which is right
-	// now not fixed with IdleConnTimeout in the http.Transport.
-	// https://github.com/golang/go/issues/23427
 	if p.ClientTLS != nil {
 		tr.TLSClientConfig = p.ClientTLS
 	}
@@ -859,6 +856,9 @@ func WithParams(p Params) *Proxy {
 	h2cTr.Protocols = new(http.Protocols)
 	h2cTr.Protocols.SetUnencryptedHTTP2(true)
 
+	// We need this to reliably fade on DNS change, which is right
+	// now not fixed with IdleConnTimeout in the http.Transport.
+	// https://github.com/golang/go/issues/23427
 	if p.CloseIdleConnsPeriod > 0 {
 		go func() {
 			ticker := time.NewTicker(p.CloseIdleConnsPeriod)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -383,10 +383,6 @@ type Params struct {
 	// the provided files.
 	EnableMTLS bool
 
-	// EnableH2cBackends enables h2c (HTTP/2 cleartext) for outgoing connections
-	// to http:// backends. Backends must speak h2c.
-	EnableH2cBackends bool
-
 	// OpenTracing contains parameters related to OpenTracing instrumentation. For default values
 	// check OpenTracingParams
 	OpenTracing *OpenTracingParams
@@ -819,41 +815,12 @@ func WithParams(p Params) *Proxy {
 		}
 	}
 
-	tr := &http.Transport{
-		DialContext: newSkipperDialer(net.Dialer{
-			Timeout:   p.Timeout,
-			KeepAlive: p.KeepAlive,
-			DualStack: p.DualStack,
-		}).DialContext,
-		TLSHandshakeTimeout:   p.TLSHandshakeTimeout,
-		ResponseHeaderTimeout: p.ResponseHeaderTimeout,
-		ExpectContinueTimeout: p.ExpectContinueTimeout,
-		MaxIdleConns:          p.MaxIdleConns,
-		MaxIdleConnsPerHost:   p.IdleConnectionsPerHost,
-		IdleConnTimeout:       p.CloseIdleConnsPeriod,
-		DisableKeepAlives:     p.DisableHTTPKeepalives,
-		Proxy:                 proxyFromContext,
-	}
+	tr := newTransport(p)
 
 	quit := make(chan struct{})
 	// We need this to reliably fade on DNS change, which is right
 	// now not fixed with IdleConnTimeout in the http.Transport.
 	// https://github.com/golang/go/issues/23427
-	if p.CloseIdleConnsPeriod > 0 {
-		go func() {
-			ticker := time.NewTicker(p.CloseIdleConnsPeriod)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					tr.CloseIdleConnections()
-				case <-quit:
-					return
-				}
-			}
-		}()
-	}
-
 	if p.ClientTLS != nil {
 		tr.TLSClientConfig = p.ClientTLS
 	}
@@ -888,30 +855,25 @@ func WithParams(p Params) *Proxy {
 		}
 	}
 
-	if p.EnableH2cBackends {
-		if tr.Protocols == nil {
-			tr.Protocols = new(http.Protocols)
-		}
-		tr.Protocols.SetUnencryptedHTTP2(true)
-	}
-
-	h2cTr := &http.Transport{
-		DialContext: newSkipperDialer(net.Dialer{
-			Timeout:   p.Timeout,
-			KeepAlive: p.KeepAlive,
-			DualStack: p.DualStack,
-		}).DialContext,
-		TLSHandshakeTimeout:   p.TLSHandshakeTimeout,
-		ResponseHeaderTimeout: p.ResponseHeaderTimeout,
-		ExpectContinueTimeout: p.ExpectContinueTimeout,
-		MaxIdleConns:          p.MaxIdleConns,
-		MaxIdleConnsPerHost:   p.IdleConnectionsPerHost,
-		IdleConnTimeout:       p.CloseIdleConnsPeriod,
-		DisableKeepAlives:     p.DisableHTTPKeepalives,
-		Proxy:                 proxyFromContext,
-	}
+	h2cTr := newTransport(p)
 	h2cTr.Protocols = new(http.Protocols)
 	h2cTr.Protocols.SetUnencryptedHTTP2(true)
+
+	if p.CloseIdleConnsPeriod > 0 {
+		go func() {
+			ticker := time.NewTicker(p.CloseIdleConnsPeriod)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					tr.CloseIdleConnections()
+					h2cTr.CloseIdleConnections()
+				case <-quit:
+					return
+				}
+			}
+		}()
+	}
 
 	m := p.Metrics
 	if m == nil {
@@ -980,6 +942,25 @@ func WithParams(p Params) *Proxy {
 		onPanicSometimes:         rate.Sometimes{First: 3, Interval: 1 * time.Minute},
 		cr:                       cr,
 	}
+}
+
+func newTransport(p Params) *http.Transport {
+	tr := &http.Transport{
+		DialContext: newSkipperDialer(net.Dialer{
+			Timeout:   p.Timeout,
+			KeepAlive: p.KeepAlive,
+			DualStack: p.DualStack,
+		}).DialContext,
+		TLSHandshakeTimeout:   p.TLSHandshakeTimeout,
+		ResponseHeaderTimeout: p.ResponseHeaderTimeout,
+		ExpectContinueTimeout: p.ExpectContinueTimeout,
+		MaxIdleConns:          p.MaxIdleConns,
+		MaxIdleConnsPerHost:   p.IdleConnectionsPerHost,
+		IdleConnTimeout:       p.CloseIdleConnsPeriod,
+		DisableKeepAlives:     p.DisableHTTPKeepalives,
+		Proxy:                 proxyFromContext,
+	}
+	return tr
 }
 
 // applies filters to a request

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -383,6 +383,10 @@ type Params struct {
 	// the provided files.
 	EnableMTLS bool
 
+	// EnableH2cBackends enables h2c (HTTP/2 cleartext) for outgoing connections
+	// to http:// backends. Backends must speak h2c.
+	EnableH2cBackends bool
+
 	// OpenTracing contains parameters related to OpenTracing instrumentation. For default values
 	// check OpenTracingParams
 	OpenTracing *OpenTracingParams
@@ -881,6 +885,13 @@ func WithParams(p Params) *Proxy {
 			}
 			tr.TLSClientConfig.GetClientCertificate = cr.GetClientCertificate
 		}
+	}
+
+	if p.EnableH2cBackends {
+		if tr.Protocols == nil {
+			tr.Protocols = new(http.Protocols)
+		}
+		tr.Protocols.SetUnencryptedHTTP2(true)
 	}
 
 	m := p.Metrics

--- a/proxy/proxy_h2c_test.go
+++ b/proxy/proxy_h2c_test.go
@@ -33,7 +33,7 @@ func TestH2cBackend_ProxyConnectsUsingH2c(t *testing.T) {
 
 	tp, err := newTestProxyWithParams(
 		fmt.Sprintf(`* -> "%s"`, backend.URL),
-		Params{EnableH2cBackends: true},
+		Params{},
 	)
 	if err != nil {
 		t.Fatalf("failed to create test proxy: %v", err)
@@ -65,7 +65,7 @@ func TestH2cBackend_DisabledFallsBackToHTTP1(t *testing.T) {
 
 	tp, err := newTestProxyWithParams(
 		fmt.Sprintf(`* -> "%s"`, backend.URL),
-		Params{EnableH2cBackends: false},
+		Params{},
 	)
 	if err != nil {
 		t.Fatalf("failed to create test proxy: %v", err)
@@ -200,7 +200,7 @@ func TestH2cServer_TransportProtocolSet(t *testing.T) {
 
 	tp, err := newTestProxyWithParams(
 		fmt.Sprintf(`* -> "%s"`, backend.URL),
-		Params{EnableH2cBackends: true},
+		Params{},
 	)
 	if err != nil {
 		t.Fatalf("failed to create test proxy: %v", err)

--- a/proxy/proxy_h2c_test.go
+++ b/proxy/proxy_h2c_test.go
@@ -1,0 +1,122 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newH2cBackend starts an h2c (HTTP/2 cleartext) backend server.
+// It records the incoming request protocol and serves a 200 response.
+func newH2cBackend(t *testing.T, gotProto *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotProto != nil {
+			*gotProto = r.Proto
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Config.Protocols = new(http.Protocols)
+	srv.Config.Protocols.SetHTTP1(true)
+	srv.Config.Protocols.SetUnencryptedHTTP2(true)
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestH2cBackend_ProxyConnectsUsingH2c verifies that when EnableH2cBackends is
+// true the proxy forwards to the backend over HTTP/2 cleartext.
+func TestH2cBackend_ProxyConnectsUsingH2c(t *testing.T) {
+	var gotProto string
+	backend := newH2cBackend(t, &gotProto)
+
+	tp, err := newTestProxyWithParams(
+		fmt.Sprintf(`* -> "%s"`, backend.URL),
+		Params{EnableH2cBackends: true},
+	)
+	if err != nil {
+		t.Fatalf("failed to create test proxy: %v", err)
+	}
+	defer tp.close()
+
+	ps := httptest.NewServer(tp.proxy)
+	defer ps.Close()
+
+	rsp, err := ps.Client().Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", rsp.StatusCode)
+	}
+	if gotProto != "HTTP/2.0" {
+		t.Errorf("expected backend to receive HTTP/2.0, got %q", gotProto)
+	}
+}
+
+// TestH2cBackend_DisabledFallsBackToHTTP1 verifies that when EnableH2cBackends
+// is false the proxy uses HTTP/1.x to reach the backend.
+func TestH2cBackend_DisabledFallsBackToHTTP1(t *testing.T) {
+	var gotProto string
+	backend := newH2cBackend(t, &gotProto)
+
+	tp, err := newTestProxyWithParams(
+		fmt.Sprintf(`* -> "%s"`, backend.URL),
+		Params{EnableH2cBackends: false},
+	)
+	if err != nil {
+		t.Fatalf("failed to create test proxy: %v", err)
+	}
+	defer tp.close()
+
+	ps := httptest.NewServer(tp.proxy)
+	defer ps.Close()
+
+	rsp, err := ps.Client().Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", rsp.StatusCode)
+	}
+	if gotProto == "HTTP/2.0" {
+		t.Errorf("expected HTTP/1.x on backend, got %q", gotProto)
+	}
+}
+
+// TestH2cServer_AcceptsH2cClient verifies that when EnableH2cBackends is set,
+// the proxy transport is configured to use h2c (SetUnencryptedHTTP2 is set).
+func TestH2cServer_TransportProtocolSet(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	tp, err := newTestProxyWithParams(
+		fmt.Sprintf(`* -> "%s"`, backend.URL),
+		Params{EnableH2cBackends: true},
+	)
+	if err != nil {
+		t.Fatalf("failed to create test proxy: %v", err)
+	}
+	defer tp.close()
+
+	// Access the underlying transport via the proxy's roundTripper.
+	// The proxy stores it as an http.RoundTripper; we can type-assert to
+	// *http.Transport to inspect the Protocols field.
+	ht, ok := tp.proxy.roundTripper.(*http.Transport)
+	if !ok {
+		t.Skip("roundTripper is not *http.Transport, skipping protocol check")
+	}
+	if ht.Protocols == nil {
+		t.Fatal("expected Protocols to be set on the transport, got nil")
+	}
+	if !ht.Protocols.UnencryptedHTTP2() {
+		t.Error("expected UnencryptedHTTP2 to be true on the transport")
+	}
+}

--- a/proxy/proxy_h2c_test.go
+++ b/proxy/proxy_h2c_test.go
@@ -25,102 +25,59 @@ func newH2cBackend(t *testing.T, gotProto *string) *httptest.Server {
 	return srv
 }
 
-// TestH2cBackend_ProxyConnectsUsingH2c verifies that when EnableH2cBackends is
-// true the proxy forwards to the backend over HTTP/2 cleartext.
-func TestH2cBackend_ProxyConnectsUsingH2c(t *testing.T) {
-	var gotProto string
-	backend := newH2cBackend(t, &gotProto)
+// TestH2cProxy verifies that a route with an h2c:// backend URL reaches the
+// backend over HTTP/2 cleartext, while http:// backends use HTTP/1.x.
+func TestH2cProxy(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		useH2cURL bool
+		wantProto string
+	}{
+		{
+			name:      "h2c scheme reaches backend via HTTP/2",
+			useH2cURL: true,
+			wantProto: "HTTP/2.0",
+		},
+		{
+			name:      "http scheme uses HTTP/1",
+			useH2cURL: false,
+			wantProto: "HTTP/1.1",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotProto string
+			backend := newH2cBackend(t, &gotProto)
 
-	tp, err := newTestProxyWithParams(
-		fmt.Sprintf(`* -> "%s"`, backend.URL),
-		Params{},
-	)
-	if err != nil {
-		t.Fatalf("failed to create test proxy: %v", err)
-	}
-	defer tp.close()
+			backendURL := backend.URL
+			if tt.useH2cURL {
+				backendURL = "h2c" + backendURL[len("http"):]
+			}
 
-	ps := httptest.NewServer(tp.proxy)
-	defer ps.Close()
+			tp, err := newTestProxyWithParams(
+				fmt.Sprintf(`* -> "%s"`, backendURL),
+				Params{},
+			)
+			if err != nil {
+				t.Fatalf("failed to create test proxy: %v", err)
+			}
+			defer tp.close()
 
-	rsp, err := ps.Client().Get(ps.URL + "/")
-	if err != nil {
-		t.Fatalf("proxy request failed: %v", err)
-	}
-	rsp.Body.Close()
+			ps := httptest.NewServer(tp.proxy)
+			defer ps.Close()
 
-	if rsp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200, got %d", rsp.StatusCode)
-	}
-	if gotProto != "HTTP/2.0" {
-		t.Errorf("expected backend to receive HTTP/2.0, got %q", gotProto)
-	}
-}
+			rsp, err := ps.Client().Get(ps.URL + "/")
+			if err != nil {
+				t.Fatalf("proxy request failed: %v", err)
+			}
+			rsp.Body.Close()
 
-// TestH2cBackend_DisabledFallsBackToHTTP1 verifies that when EnableH2cBackends
-// is false the proxy uses HTTP/1.x to reach the backend.
-func TestH2cBackend_DisabledFallsBackToHTTP1(t *testing.T) {
-	var gotProto string
-	backend := newH2cBackend(t, &gotProto)
-
-	tp, err := newTestProxyWithParams(
-		fmt.Sprintf(`* -> "%s"`, backend.URL),
-		Params{},
-	)
-	if err != nil {
-		t.Fatalf("failed to create test proxy: %v", err)
-	}
-	defer tp.close()
-
-	ps := httptest.NewServer(tp.proxy)
-	defer ps.Close()
-
-	rsp, err := ps.Client().Get(ps.URL + "/")
-	if err != nil {
-		t.Fatalf("proxy request failed: %v", err)
-	}
-	rsp.Body.Close()
-
-	if rsp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200, got %d", rsp.StatusCode)
-	}
-	if gotProto == "HTTP/2.0" {
-		t.Errorf("expected HTTP/1.x on backend, got %q", gotProto)
-	}
-}
-
-// TestH2cScheme_RouteUsesH2cTransport verifies that a route with an h2c:// backend
-// URL reaches the backend via HTTP/2 cleartext without any flag set.
-func TestH2cScheme_RouteUsesH2cTransport(t *testing.T) {
-	var gotProto string
-	backend := newH2cBackend(t, &gotProto)
-
-	// Replace http:// with h2c:// in the backend URL.
-	h2cURL := "h2c" + backend.URL[len("http"):]
-
-	tp, err := newTestProxyWithParams(
-		fmt.Sprintf(`* -> "%s"`, h2cURL),
-		Params{},
-	)
-	if err != nil {
-		t.Fatalf("failed to create test proxy: %v", err)
-	}
-	defer tp.close()
-
-	ps := httptest.NewServer(tp.proxy)
-	defer ps.Close()
-
-	rsp, err := ps.Client().Get(ps.URL + "/")
-	if err != nil {
-		t.Fatalf("proxy request failed: %v", err)
-	}
-	rsp.Body.Close()
-
-	if rsp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200, got %d", rsp.StatusCode)
-	}
-	if gotProto != "HTTP/2.0" {
-		t.Errorf("expected backend to receive HTTP/2.0, got %q", gotProto)
+			if rsp.StatusCode != http.StatusOK {
+				t.Errorf("expected 200, got %d", rsp.StatusCode)
+			}
+			if gotProto != tt.wantProto {
+				t.Errorf("expected backend to receive %q, got %q", tt.wantProto, gotProto)
+			}
+		})
 	}
 }
 
@@ -158,41 +115,9 @@ func TestH2cScheme_LBEndpointUsesH2cTransport(t *testing.T) {
 	}
 }
 
-// TestH2cScheme_HttpBackendStillUsesHTTP1 verifies that plain http:// backends
-// are unaffected by h2c:// scheme support (no flag, no upgrade).
-func TestH2cScheme_HttpBackendStillUsesHTTP1(t *testing.T) {
-	var gotProto string
-	backend := newH2cBackend(t, &gotProto)
-
-	tp, err := newTestProxyWithParams(
-		fmt.Sprintf(`* -> "%s"`, backend.URL),
-		Params{},
-	)
-	if err != nil {
-		t.Fatalf("failed to create test proxy: %v", err)
-	}
-	defer tp.close()
-
-	ps := httptest.NewServer(tp.proxy)
-	defer ps.Close()
-
-	rsp, err := ps.Client().Get(ps.URL + "/")
-	if err != nil {
-		t.Fatalf("proxy request failed: %v", err)
-	}
-	rsp.Body.Close()
-
-	if rsp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200, got %d", rsp.StatusCode)
-	}
-	if gotProto == "HTTP/2.0" {
-		t.Errorf("expected HTTP/1.x for http:// backend, got %q", gotProto)
-	}
-}
-
-// TestH2cServer_AcceptsH2cClient verifies that when EnableH2cBackends is set,
-// the proxy transport is configured to use h2c (SetUnencryptedHTTP2 is set).
-func TestH2cServer_TransportProtocolSet(t *testing.T) {
+// TestH2cServer_H2cTransportConfigured verifies that the proxy's h2c round-tripper
+// has UnencryptedHTTP2 enabled.
+func TestH2cServer_H2cTransportConfigured(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -207,17 +132,14 @@ func TestH2cServer_TransportProtocolSet(t *testing.T) {
 	}
 	defer tp.close()
 
-	// Access the underlying transport via the proxy's roundTripper.
-	// The proxy stores it as an http.RoundTripper; we can type-assert to
-	// *http.Transport to inspect the Protocols field.
-	ht, ok := tp.proxy.roundTripper.(*http.Transport)
+	ht, ok := tp.proxy.h2cRoundTripper.(*http.Transport)
 	if !ok {
-		t.Skip("roundTripper is not *http.Transport, skipping protocol check")
+		t.Skip("h2cRoundTripper is not *http.Transport, skipping protocol check")
 	}
 	if ht.Protocols == nil {
-		t.Fatal("expected Protocols to be set on the transport, got nil")
+		t.Fatal("expected Protocols to be set on h2c transport, got nil")
 	}
 	if !ht.Protocols.UnencryptedHTTP2() {
-		t.Error("expected UnencryptedHTTP2 to be true on the transport")
+		t.Error("expected UnencryptedHTTP2 to be true on h2c transport")
 	}
 }

--- a/proxy/proxy_h2c_test.go
+++ b/proxy/proxy_h2c_test.go
@@ -134,12 +134,17 @@ func TestH2cServer_H2cTransportConfigured(t *testing.T) {
 
 	ht, ok := tp.proxy.h2cRoundTripper.(*http.Transport)
 	if !ok {
-		t.Skip("h2cRoundTripper is not *http.Transport, skipping protocol check")
+		t.Fatalf("h2cRoundTripper is not *http.Transport, got %T", tp.proxy.h2cRoundTripper)
 	}
 	if ht.Protocols == nil {
 		t.Fatal("expected Protocols to be set on h2c transport, got nil")
 	}
 	if !ht.Protocols.UnencryptedHTTP2() {
 		t.Error("expected UnencryptedHTTP2 to be true on h2c transport")
+	}
+
+	rt, ok := tp.proxy.roundTripper.(*http.Transport)
+	if ok && rt.Protocols != nil && rt.Protocols.UnencryptedHTTP2() {
+		t.Error("standard roundTripper must NOT have UnencryptedHTTP2 set")
 	}
 }

--- a/proxy/proxy_h2c_test.go
+++ b/proxy/proxy_h2c_test.go
@@ -89,6 +89,107 @@ func TestH2cBackend_DisabledFallsBackToHTTP1(t *testing.T) {
 	}
 }
 
+// TestH2cScheme_RouteUsesH2cTransport verifies that a route with an h2c:// backend
+// URL reaches the backend via HTTP/2 cleartext without any flag set.
+func TestH2cScheme_RouteUsesH2cTransport(t *testing.T) {
+	var gotProto string
+	backend := newH2cBackend(t, &gotProto)
+
+	// Replace http:// with h2c:// in the backend URL.
+	h2cURL := "h2c" + backend.URL[len("http"):]
+
+	tp, err := newTestProxyWithParams(
+		fmt.Sprintf(`* -> "%s"`, h2cURL),
+		Params{},
+	)
+	if err != nil {
+		t.Fatalf("failed to create test proxy: %v", err)
+	}
+	defer tp.close()
+
+	ps := httptest.NewServer(tp.proxy)
+	defer ps.Close()
+
+	rsp, err := ps.Client().Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", rsp.StatusCode)
+	}
+	if gotProto != "HTTP/2.0" {
+		t.Errorf("expected backend to receive HTTP/2.0, got %q", gotProto)
+	}
+}
+
+// TestH2cScheme_LBEndpointUsesH2cTransport verifies that LB endpoints with h2c://
+// scheme reach the backend via HTTP/2 cleartext without any flag set.
+func TestH2cScheme_LBEndpointUsesH2cTransport(t *testing.T) {
+	var gotProto string
+	backend := newH2cBackend(t, &gotProto)
+
+	h2cURL := "h2c" + backend.URL[len("http"):]
+
+	tp, err := newTestProxyWithParams(
+		fmt.Sprintf(`* -> <"%s">`, h2cURL),
+		Params{},
+	)
+	if err != nil {
+		t.Fatalf("failed to create test proxy: %v", err)
+	}
+	defer tp.close()
+
+	ps := httptest.NewServer(tp.proxy)
+	defer ps.Close()
+
+	rsp, err := ps.Client().Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", rsp.StatusCode)
+	}
+	if gotProto != "HTTP/2.0" {
+		t.Errorf("expected backend to receive HTTP/2.0, got %q", gotProto)
+	}
+}
+
+// TestH2cScheme_HttpBackendStillUsesHTTP1 verifies that plain http:// backends
+// are unaffected by h2c:// scheme support (no flag, no upgrade).
+func TestH2cScheme_HttpBackendStillUsesHTTP1(t *testing.T) {
+	var gotProto string
+	backend := newH2cBackend(t, &gotProto)
+
+	tp, err := newTestProxyWithParams(
+		fmt.Sprintf(`* -> "%s"`, backend.URL),
+		Params{},
+	)
+	if err != nil {
+		t.Fatalf("failed to create test proxy: %v", err)
+	}
+	defer tp.close()
+
+	ps := httptest.NewServer(tp.proxy)
+	defer ps.Close()
+
+	rsp, err := ps.Client().Get(ps.URL + "/")
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", rsp.StatusCode)
+	}
+	if gotProto == "HTTP/2.0" {
+		t.Errorf("expected HTTP/1.x for http:// backend, got %q", gotProto)
+	}
+}
+
 // TestH2cServer_AcceptsH2cClient verifies that when EnableH2cBackends is set,
 // the proxy transport is configured to use h2c (SetUnencryptedHTTP2 is set).
 func TestH2cServer_TransportProtocolSet(t *testing.T) {

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Build and test all packages:
 
     make deps
     make install
+    make fmt
     make lint
     make shortcheck
 

--- a/skipper.go
+++ b/skipper.go
@@ -795,12 +795,7 @@ type Options struct {
 	ExperimentalUpgradeAudit bool
 
 	// EnableH2cServer enables h2c (HTTP/2 cleartext) on the incoming listener.
-	// No effect when TLS is configured (use TLS ALPN HTTP/2 instead).
 	EnableH2cServer bool
-
-	// EnableH2cBackends enables h2c (HTTP/2 cleartext) for outgoing backend connections.
-	// Backends must speak h2c.
-	EnableH2cBackends bool
 
 	// MaxLoopbacks defines the maximum number of loops that the proxy can execute when the routing table
 	// contains loop backends (<loopback>).
@@ -1613,7 +1608,7 @@ func listenAndServeQuit(
 		ErrorLog:          newServerErrorLog(),
 	}
 
-	if o.EnableH2cServer && !serveTLS {
+	if o.EnableH2cServer {
 		if srv.Protocols == nil {
 			srv.Protocols = new(http.Protocols)
 		}
@@ -2603,7 +2598,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		ClientKeyFile:                    o.ClientKeyFile,
 		ClientCertRefreshInterval:        o.ClientCertRefreshInterval,
 		EnableMTLS:                       o.EnableMTLS,
-		EnableH2cBackends:                o.EnableH2cBackends,
 		CustomHttpRoundTripperWrap:       o.CustomHttpRoundTripperWrap,
 		RateLimiters:                     ratelimitRegistry,
 		EndpointRegistry:                 endpointRegistry,

--- a/skipper.go
+++ b/skipper.go
@@ -794,6 +794,14 @@ type Options struct {
 	// and the response messages during web socket upgrades.
 	ExperimentalUpgradeAudit bool
 
+	// EnableH2cServer enables h2c (HTTP/2 cleartext) on the incoming listener.
+	// No effect when TLS is configured (use TLS ALPN HTTP/2 instead).
+	EnableH2cServer bool
+
+	// EnableH2cBackends enables h2c (HTTP/2 cleartext) for outgoing backend connections.
+	// Backends must speak h2c.
+	EnableH2cBackends bool
+
 	// MaxLoopbacks defines the maximum number of loops that the proxy can execute when the routing table
 	// contains loop backends (<loopback>).
 	MaxLoopbacks int
@@ -1603,6 +1611,15 @@ func listenAndServeQuit(
 		IdleTimeout:       o.IdleTimeoutServer,
 		MaxHeaderBytes:    o.MaxHeaderBytes,
 		ErrorLog:          newServerErrorLog(),
+	}
+
+	if o.EnableH2cServer && !serveTLS {
+		if srv.Protocols == nil {
+			srv.Protocols = new(http.Protocols)
+		}
+		srv.Protocols.SetHTTP1(true)
+		srv.Protocols.SetUnencryptedHTTP2(true)
+		log.Info("h2c (HTTP/2 cleartext) enabled on listener")
 	}
 
 	cm := &skpnet.ConnManager{
@@ -2586,6 +2603,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		ClientKeyFile:                    o.ClientKeyFile,
 		ClientCertRefreshInterval:        o.ClientCertRefreshInterval,
 		EnableMTLS:                       o.EnableMTLS,
+		EnableH2cBackends:                o.EnableH2cBackends,
 		CustomHttpRoundTripperWrap:       o.CustomHttpRoundTripperWrap,
 		RateLimiters:                     ratelimitRegistry,
 		EndpointRegistry:                 endpointRegistry,

--- a/skipper_h2c_test.go
+++ b/skipper_h2c_test.go
@@ -1,100 +1,50 @@
 package skipper
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/zalando/skipper/dataclients/routestring"
 	"github.com/zalando/skipper/filters/builtin"
 	"github.com/zalando/skipper/metrics/metricstest"
 	"github.com/zalando/skipper/proxy"
 	"github.com/zalando/skipper/routing"
 )
 
-// TestH2cServer_ProtocolsConfigured verifies that when EnableH2cServer is true
-// and TLS is not active, the http.Server has Protocols configured with both
-// HTTP/1 and UnencryptedHTTP2.
-func TestH2cServer_ProtocolsConfigured(t *testing.T) {
-	o := &Options{
-		EnableH2cServer: true,
-		// No TLS config, so serveTLS == false.
-	}
-
-	tlsCfg, err := o.TlsConfig(nil)
-	if err != nil {
-		t.Fatalf("TlsConfig returned error: %v", err)
-	}
-	serveTLS := tlsCfg != nil
-
-	srv := &http.Server{}
-	if o.EnableH2cServer && !serveTLS {
-		if srv.Protocols == nil {
-			srv.Protocols = new(http.Protocols)
+func newH2cListenerBackend(t *testing.T, gotProto *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotProto != nil {
+			*gotProto = r.Proto
 		}
-		srv.Protocols.SetHTTP1(true)
-		srv.Protocols.SetUnencryptedHTTP2(true)
-	}
-
-	if srv.Protocols == nil {
-		t.Fatal("expected srv.Protocols to be set")
-	}
-	if !srv.Protocols.HTTP1() {
-		t.Error("expected HTTP1 to be true")
-	}
-	if !srv.Protocols.UnencryptedHTTP2() {
-		t.Error("expected UnencryptedHTTP2 to be true")
-	}
-}
-
-// TestH2cServer_ProtocolsNotConfiguredWhenTLS verifies that EnableH2cServer
-// has no effect when TLS is configured (TLS ALPN handles HTTP/2 then).
-func TestH2cServer_ProtocolsNotConfiguredWhenTLS(t *testing.T) {
-	o := &Options{
-		EnableH2cServer: true,
-		CertPathTLS:     "fixtures/test.crt",
-		KeyPathTLS:      "fixtures/test.key",
-	}
-
-	tlsCfg, err := o.TlsConfig(nil)
-	if err != nil {
-		t.Fatalf("TlsConfig returned error: %v", err)
-	}
-	serveTLS := tlsCfg != nil
-
-	srv := &http.Server{}
-	if o.EnableH2cServer && !serveTLS {
-		if srv.Protocols == nil {
-			srv.Protocols = new(http.Protocols)
-		}
-		srv.Protocols.SetHTTP1(true)
-		srv.Protocols.SetUnencryptedHTTP2(true)
-	}
-
-	// With TLS active, the h2c block is skipped; Protocols remains nil.
-	if srv.Protocols != nil && srv.Protocols.UnencryptedHTTP2() {
-		t.Error("expected UnencryptedHTTP2 to NOT be set when TLS is active")
-	}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Config.Protocols = new(http.Protocols)
+	srv.Config.Protocols.SetHTTP1(true)
+	srv.Config.Protocols.SetUnencryptedHTTP2(true)
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 // TestH2cEndToEnd_BackendsAndClient verifies end-to-end h2c: an h2c-capable
-// backend is reached through a skipper proxy that has EnableH2cBackends set,
-// and the proxy itself accepts h2c from the downstream client.
+// backend is reached through a skipper proxy that has EnableH2cServer set.
+// Both legs are checked: client→proxy (h2c) and proxy→backend (h2c).
 func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 	if !testListener() {
 		t.Skip("skipping listener test; pass -args listener to enable")
 	}
 
 	var gotProto string
-	backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotProto = r.Proto
-		w.WriteHeader(http.StatusOK)
-	}))
-	backend.Config.Protocols = new(http.Protocols)
-	backend.Config.Protocols.SetHTTP1(true)
-	backend.Config.Protocols.SetUnencryptedHTTP2(true)
-	backend.Start()
-	defer backend.Close()
+	backend := newH2cListenerBackend(t, &gotProto)
+
+	dc, err := routestring.New(fmt.Sprintf(`r0: * -> "%s"`, "h2c"+backend.URL[len("http"):]))
+	if err != nil {
+		t.Fatalf("failed to create data client: %v", err)
+	}
 
 	MuFindAddress.Lock()
 	addr := FindAddress(t)
@@ -102,7 +52,7 @@ func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 
 	rt := routing.New(routing.Options{
 		FilterRegistry: builtin.MakeRegistry(),
-		DataClients:    []routing.DataClient{},
+		DataClients:    []routing.DataClient{dc},
 	})
 	defer rt.Close()
 
@@ -120,15 +70,13 @@ func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 
 	go listenAndServe(p, o) //nolint:errcheck
 
+	h2cTransport := &http.Transport{}
+	h2cTransport.Protocols = new(http.Protocols)
+	h2cTransport.Protocols.SetHTTP1(true)
+	h2cTransport.Protocols.SetUnencryptedHTTP2(true)
 	h2cClient := &http.Client{
-		Transport: func() *http.Transport {
-			tr := &http.Transport{}
-			tr.Protocols = new(http.Protocols)
-			tr.Protocols.SetHTTP1(true)
-			tr.Protocols.SetUnencryptedHTTP2(true)
-			return tr
-		}(),
-		Timeout: 5 * time.Second,
+		Transport: h2cTransport,
+		Timeout:   5 * time.Second,
 	}
 
 	var rsp *http.Response
@@ -145,9 +93,10 @@ func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 	}
 	defer rsp.Body.Close()
 
-	// The proxy has no routes so it returns 404; we're checking the h2c transport.
 	if rsp.Proto != "HTTP/2.0" {
-		t.Errorf("expected h2c response proto HTTP/2.0, got %q", rsp.Proto)
+		t.Errorf("expected client-to-proxy h2c proto HTTP/2.0, got %q", rsp.Proto)
 	}
-	_ = gotProto
+	if gotProto != "HTTP/2.0" {
+		t.Errorf("expected proxy-to-backend h2c proto HTTP/2.0, got %q", gotProto)
+	}
 }

--- a/skipper_h2c_test.go
+++ b/skipper_h2c_test.go
@@ -107,10 +107,9 @@ func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 	defer rt.Close()
 
 	p := proxy.WithParams(proxy.Params{
-		Routing:           rt,
-		Flags:             proxy.Flags(proxy.OptionsNone),
-		Metrics:           &metricstest.MockMetrics{},
-		EnableH2cBackends: true,
+		Routing: rt,
+		Flags:   proxy.Flags(proxy.OptionsNone),
+		Metrics: &metricstest.MockMetrics{},
 	})
 	defer p.Close() //nolint:errcheck
 

--- a/skipper_h2c_test.go
+++ b/skipper_h2c_test.go
@@ -1,0 +1,154 @@
+package skipper
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/metrics/metricstest"
+	"github.com/zalando/skipper/proxy"
+	"github.com/zalando/skipper/routing"
+)
+
+// TestH2cServer_ProtocolsConfigured verifies that when EnableH2cServer is true
+// and TLS is not active, the http.Server has Protocols configured with both
+// HTTP/1 and UnencryptedHTTP2.
+func TestH2cServer_ProtocolsConfigured(t *testing.T) {
+	o := &Options{
+		EnableH2cServer: true,
+		// No TLS config, so serveTLS == false.
+	}
+
+	tlsCfg, err := o.TlsConfig(nil)
+	if err != nil {
+		t.Fatalf("TlsConfig returned error: %v", err)
+	}
+	serveTLS := tlsCfg != nil
+
+	srv := &http.Server{}
+	if o.EnableH2cServer && !serveTLS {
+		if srv.Protocols == nil {
+			srv.Protocols = new(http.Protocols)
+		}
+		srv.Protocols.SetHTTP1(true)
+		srv.Protocols.SetUnencryptedHTTP2(true)
+	}
+
+	if srv.Protocols == nil {
+		t.Fatal("expected srv.Protocols to be set")
+	}
+	if !srv.Protocols.HTTP1() {
+		t.Error("expected HTTP1 to be true")
+	}
+	if !srv.Protocols.UnencryptedHTTP2() {
+		t.Error("expected UnencryptedHTTP2 to be true")
+	}
+}
+
+// TestH2cServer_ProtocolsNotConfiguredWhenTLS verifies that EnableH2cServer
+// has no effect when TLS is configured (TLS ALPN handles HTTP/2 then).
+func TestH2cServer_ProtocolsNotConfiguredWhenTLS(t *testing.T) {
+	o := &Options{
+		EnableH2cServer: true,
+		CertPathTLS:     "fixtures/test.crt",
+		KeyPathTLS:      "fixtures/test.key",
+	}
+
+	tlsCfg, err := o.TlsConfig(nil)
+	if err != nil {
+		t.Fatalf("TlsConfig returned error: %v", err)
+	}
+	serveTLS := tlsCfg != nil
+
+	srv := &http.Server{}
+	if o.EnableH2cServer && !serveTLS {
+		if srv.Protocols == nil {
+			srv.Protocols = new(http.Protocols)
+		}
+		srv.Protocols.SetHTTP1(true)
+		srv.Protocols.SetUnencryptedHTTP2(true)
+	}
+
+	// With TLS active, the h2c block is skipped; Protocols remains nil.
+	if srv.Protocols != nil && srv.Protocols.UnencryptedHTTP2() {
+		t.Error("expected UnencryptedHTTP2 to NOT be set when TLS is active")
+	}
+}
+
+// TestH2cEndToEnd_BackendsAndClient verifies end-to-end h2c: an h2c-capable
+// backend is reached through a skipper proxy that has EnableH2cBackends set,
+// and the proxy itself accepts h2c from the downstream client.
+func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
+	if !testListener() {
+		t.Skip("skipping listener test; pass -args listener to enable")
+	}
+
+	var gotProto string
+	backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProto = r.Proto
+		w.WriteHeader(http.StatusOK)
+	}))
+	backend.Config.Protocols = new(http.Protocols)
+	backend.Config.Protocols.SetHTTP1(true)
+	backend.Config.Protocols.SetUnencryptedHTTP2(true)
+	backend.Start()
+	defer backend.Close()
+
+	MuFindAddress.Lock()
+	addr := FindAddress(t)
+	MuFindAddress.Unlock()
+
+	rt := routing.New(routing.Options{
+		FilterRegistry: builtin.MakeRegistry(),
+		DataClients:    []routing.DataClient{},
+	})
+	defer rt.Close()
+
+	p := proxy.WithParams(proxy.Params{
+		Routing:           rt,
+		Flags:             proxy.Flags(proxy.OptionsNone),
+		Metrics:           &metricstest.MockMetrics{},
+		EnableH2cBackends: true,
+	})
+	defer p.Close() //nolint:errcheck
+
+	o := &Options{
+		Address:         addr,
+		EnableH2cServer: true,
+	}
+
+	go listenAndServe(p, o) //nolint:errcheck
+
+	h2cClient := &http.Client{
+		Transport: func() *http.Transport {
+			tr := &http.Transport{}
+			tr.Protocols = new(http.Protocols)
+			tr.Protocols.SetHTTP1(true)
+			tr.Protocols.SetUnencryptedHTTP2(true)
+			return tr
+		}(),
+		Timeout: 5 * time.Second,
+	}
+
+	var rsp *http.Response
+	var reqErr error
+	for range 20 {
+		rsp, reqErr = h2cClient.Get("http://" + addr + "/")
+		if reqErr == nil {
+			break
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	if reqErr != nil {
+		t.Fatalf("h2c client request failed: %v", reqErr)
+	}
+	defer rsp.Body.Close()
+
+	// The proxy has no routes so it returns 404; we're checking the h2c transport.
+	if rsp.Proto != "HTTP/2.0" {
+		t.Errorf("expected h2c response proto HTTP/2.0, got %q", rsp.Proto)
+	}
+	_ = gotProto
+}

--- a/skipper_h2c_test.go
+++ b/skipper_h2c_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -14,22 +17,6 @@ import (
 	"github.com/zalando/skipper/routing"
 )
 
-func newH2cListenerBackend(t *testing.T, gotProto *string) *httptest.Server {
-	t.Helper()
-	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if gotProto != nil {
-			*gotProto = r.Proto
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	srv.Config.Protocols = new(http.Protocols)
-	srv.Config.Protocols.SetHTTP1(true)
-	srv.Config.Protocols.SetUnencryptedHTTP2(true)
-	srv.Start()
-	t.Cleanup(srv.Close)
-	return srv
-}
-
 // TestH2cEndToEnd_BackendsAndClient verifies end-to-end h2c: an h2c-capable
 // backend is reached through a skipper proxy that has EnableH2cServer set.
 // Both legs are checked: client→proxy (h2c) and proxy→backend (h2c).
@@ -38,8 +25,19 @@ func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 		t.Skip("skipping listener test; pass -args listener to enable")
 	}
 
-	var gotProto string
-	backend := newH2cListenerBackend(t, &gotProto)
+	var mu sync.Mutex
+	var proto string
+	backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		proto = r.Proto
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	backend.Config.Protocols = new(http.Protocols)
+	backend.Config.Protocols.SetHTTP1(true)
+	backend.Config.Protocols.SetUnencryptedHTTP2(true)
+	backend.Start()
+	t.Cleanup(backend.Close)
 
 	dc, err := routestring.New(fmt.Sprintf(`r0: * -> "%s"`, "h2c"+backend.URL[len("http"):]))
 	if err != nil {
@@ -68,7 +66,11 @@ func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 		EnableH2cServer: true,
 	}
 
-	go listenAndServe(p, o) //nolint:errcheck
+	sigs := make(chan os.Signal, 1)
+	go func() {
+		listenAndServeQuit(p, o, sigs, nil, nil, nil) //nolint:errcheck
+	}()
+	t.Cleanup(func() { sigs <- syscall.SIGTERM })
 
 	h2cTransport := &http.Transport{}
 	h2cTransport.Protocols = new(http.Protocols)
@@ -96,6 +98,9 @@ func TestH2cEndToEnd_BackendsAndClient(t *testing.T) {
 	if rsp.Proto != "HTTP/2.0" {
 		t.Errorf("expected client-to-proxy h2c proto HTTP/2.0, got %q", rsp.Proto)
 	}
+	mu.Lock()
+	gotProto := proto
+	mu.Unlock()
 	if gotProto != "HTTP/2.0" {
 		t.Errorf("expected proxy-to-backend h2c proto HTTP/2.0, got %q", gotProto)
 	}


### PR DESCRIPTION
ref: https://github.com/zalando/skipper/issues/4145
ref: https://github.com/zalando/skipper/issues/1253

Test Direct Prior Knowledge:
```
% nghttp -v http://localhost:9001/path
[  0.000] Connected
[  0.000] send SETTINGS frame <length=12, flags=0x00, stream_id=0>
          (niv=2)
          [SETTINGS_MAX_CONCURRENT_STREAMS(0x03):100]
          [SETTINGS_INITIAL_WINDOW_SIZE(0x04):65535]
[  0.001] send PRIORITY frame <length=5, flags=0x00, stream_id=3>
          (dep_stream_id=0, weight=201, exclusive=0)
[  0.001] send PRIORITY frame <length=5, flags=0x00, stream_id=5>
          (dep_stream_id=0, weight=101, exclusive=0)
[  0.001] send PRIORITY frame <length=5, flags=0x00, stream_id=7>
          (dep_stream_id=0, weight=1, exclusive=0)
[  0.001] send PRIORITY frame <length=5, flags=0x00, stream_id=9>
          (dep_stream_id=7, weight=1, exclusive=0)
[  0.001] send PRIORITY frame <length=5, flags=0x00, stream_id=11>
          (dep_stream_id=3, weight=1, exclusive=0)
[  0.001] send HEADERS frame <length=43, flags=0x25, stream_id=13>
          ; END_STREAM | END_HEADERS | PRIORITY
          (padlen=0, dep_stream_id=11, weight=16, exclusive=0)
          ; Open new stream
          :method: GET
          :path: /path
          :scheme: http
          :authority: localhost:9001
          accept: */*
          accept-encoding: gzip, deflate
          user-agent: nghttp2/1.59.0
[  0.001] recv SETTINGS frame <length=30, flags=0x00, stream_id=0>
          (niv=5)
          [SETTINGS_MAX_FRAME_SIZE(0x05):1048576]
          [SETTINGS_MAX_CONCURRENT_STREAMS(0x03):250]
          [SETTINGS_MAX_HEADER_LIST_SIZE(0x06):1048896]
          [SETTINGS_HEADER_TABLE_SIZE(0x01):4096]
          [SETTINGS_INITIAL_WINDOW_SIZE(0x04):1048576]
[  0.001] send SETTINGS frame <length=0, flags=0x01, stream_id=0>
          ; ACK
          (niv=0)
[  0.001] recv SETTINGS frame <length=0, flags=0x01, stream_id=0>
          ; ACK
          (niv=0)
[  0.001] recv WINDOW_UPDATE frame <length=4, flags=0x00, stream_id=0>
          (window_size_increment=983041)
[  0.008] recv (stream_id=13) :status: 201
[  0.008] recv (stream_id=13) date: Tue, 04 Aug 2026 22:19:10 GMT
[  0.008] recv (stream_id=13) server: Skipper
[  0.008] recv HEADERS frame <length=36, flags=0x04, stream_id=13>
          ; END_HEADERS
          (padlen=0)
          ; First response header
[  0.008] recv DATA frame <length=0, flags=0x01, stream_id=13>
          ; END_STREAM
[  0.008] send GOAWAY frame <length=8, flags=0x00, stream_id=0>
          (last_stream_id=0, error_code=NO_ERROR(0x00), opaque_data(0)=[])
```

test with upgrade does not work:
```
% nghttp -uv http://localhost:9001/path
[  0.000] Connected
[  0.000] HTTP Upgrade request
GET /path HTTP/1.1
host: localhost:9001
connection: Upgrade, HTTP2-Settings
upgrade: h2c
http2-settings: AAMAAABkAAQAAP__
accept: */*
user-agent: nghttp2/1.59.0

[  0.002] HTTP Upgrade response
HTTP/1.1 500 Internal Server Error
Content-Length: 22
Content-Type: text/plain; charset=utf-8
Server: Skipper
X-Content-Type-Options: nosniff
Date: Tue, 04 Aug 2026 22:19:39 GMT

Internal Server Error

[ERROR] HTTP Upgrade failed
Some requests were not processed. total=1, processed=0
```