### PR TITLE
docs: document data client latency metric

### DIFF
--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -1092,10 +1092,10 @@ These metrics are particularly useful for:
 
 ### Data client metrics
 
-* `routes.<client>.load_all`: timer measuring execution time for loading all routes from the data client.
-* `routes.<client>.load_update`: timer measuring execution time for loading incremental route updates from the data client.
+* `routes.load_all.<client>`: timer measuring execution time for loading all routes from the data client.
+* `routes.load_update.<client>`: timer measuring execution time for loading incremental route updates from the data client.
 
-The `<client>` part is the name of the data client (e.g., `kubernetes` or `inline`), resolved via `NamedDataClient.Name()`. Data clients that do not implement the `NamedDataClient` interface are reported as `unknown` (e.g., `routes.unknown.load_all`).
+The `<client>` part is the name of the data client (e.g., `kubernetes` or `inline`), resolved via `NamedDataClient.Name()`. Data clients that do not implement the `NamedDataClient` interface are reported as `unknown` (e.g., `routes.load_all.unknown`).
 
 ## OpenTracing
 

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -1090,6 +1090,13 @@ These metrics are particularly useful for:
 - Historical analysis of route stability (metrics set to 0 when fixed, preserving time series)
 - Trend analysis over your retention period (e.g., 30 days)
 
+### Data client metrics
+
+* `routes.<client>.load_all`: timer measuring execution time for loading all routes from the data client.
+* `routes.<client>.load_update`: timer measuring execution time for loading incremental route updates from the data client.
+
+The `<client>` part is the name of the data client (e.g., `kubernetes` or `inline`), resolved via `NamedDataClient.Name()`. Data clients that do not implement the `NamedDataClient` interface are reported as `unknown` (e.g., `routes.unknown.load_all`).
+
 ## OpenTracing
 
 Skipper has support for different [OpenTracing API](http://opentracing.io/) vendors, including


### PR DESCRIPTION
## Description
This PR documents the data client runtime timing metrics introduced in #4087 in the operations guide (`docs/operation/operation.md`). These metrics measure execution time for loading initial routes and applying incremental route updates across data clients, providing better observability into route sync latency.

cc @MustafaSaber, please take a look when you get a chance!

## Changes
Added documentation under `## Monitoring` -> `### Data client metrics` for:
- `routes.load_all.<client>`: Timer measuring execution time for loading all routes from the data client.
- `routes.load_update.<client>`: Timer measuring execution time for loading incremental route updates from the data client.

Included details clarifying that `<client>` is resolved via `NamedDataClient.Name()` (e.g., `kubernetes` or `inline`), and that data clients not implementing the `NamedDataClient` interface report as `unknown` (e.g., `routes.load_all.unknown`).

## Related Issues
- Closes #4087
- Fixes #4102
- Supersedes #4104