### PR TITLE
feature: implement leastRequests LB algorithm

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -585,7 +585,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.KubernetesValkeyServiceName, "kubernetes-valkey-service-name", "", "Sets name for valkey to be used to lookup endpoints")
 	flag.IntVar(&cfg.KubernetesValkeyServicePort, "kubernetes-valkey-service-port", 6379, "Sets the port for valkey to be used to lookup endpoints")
 	flag.StringVar(&cfg.KubernetesBackendTrafficAlgorithmString, "kubernetes-backend-traffic-algorithm", kubernetes.TrafficPredicateAlgorithm.String(), "sets the algorithm to be used for traffic splitting between backends: traffic-predicate or traffic-segment-predicate")
-	flag.StringVar(&cfg.KubernetesDefaultLoadBalancerAlgorithm, "kubernetes-default-lb-algorithm", kubernetes.DefaultLoadBalancerAlgorithm, "sets the default algorithm to be used for load balancing between backend endpoints, available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin")
+	flag.StringVar(&cfg.KubernetesDefaultLoadBalancerAlgorithm, "kubernetes-default-lb-algorithm", kubernetes.DefaultLoadBalancerAlgorithm, "sets the default algorithm to be used for load balancing between backend endpoints, available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin, leastRequests")
 	flag.BoolVar(&cfg.KubernetesForceService, "kubernetes-force-service", false, "overrides default Skipper functionality and routes traffic using Kubernetes Services instead of Endpoints")
 	flag.StringVar(&cfg.KubernetesStatusFromService, "kubernetes-status-from-service", "", "when set to <namespace>/<name>, updates Ingress status.loadBalancer.ingress from the referenced service")
 

--- a/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
+++ b/dataclients/kubernetes/deploy/apply/routegroups_crd.yaml
@@ -68,12 +68,14 @@ spec:
                         `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to prevent popular keys from overloading a single backend endpoint.
                         `powerOfRandomNChoices` - backend is chosen by selecting N random endpoints and picking the one with least outstanding requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
                         `weightedRoundRobin` - backend is chosen by smooth weighted round robin with dynamic weights based on the ratio of successful round trips per endpoint, weights are updated by the passive health check when enabled.
+                        `leastRequests` - backend is chosen as the endpoint with the lowest load factor (inflight requests divided by endpoint weight); ties are broken by smooth weighted round-robin over the tied set.
                       enum:
                       - roundRobin
                       - random
                       - consistentHash
                       - powerOfRandomNChoices
                       - weightedRoundRobin
+                      - leastRequests
                       type: string
                     endpoints:
                       description: Endpoints is required for type `lb`

--- a/dataclients/kubernetes/kube.go
+++ b/dataclients/kubernetes/kube.go
@@ -257,7 +257,8 @@ type Options struct {
 	BackendTrafficAlgorithm BackendTrafficAlgorithm
 
 	// DefaultLoadBalancerAlgorithm sets the default algorithm to be used for load balancing between backend endpoints,
-	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin
+	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices,
+	// weightedRoundRobin, leastRequests
 	DefaultLoadBalancerAlgorithm string
 
 	// ForwardBackendURL allows to use <forward> backend via kubernetes, for example routegroup backend `type: forward`.

--- a/docs/kubernetes/routegroup-crd.md
+++ b/docs/kubernetes/routegroup-crd.md
@@ -72,7 +72,7 @@ fields are the name and the type, while the rest of the fields may be required b
   name: <string>
   type: <string>            one of "service|shunt|loopback|dynamic|lb|network|forward"
   address: <string>         optional, required for type=network
-  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash|powerOfRandomNChoices|weightedRoundRobin
+  algorithm: <string>       optional, valid for type=lb|service, values=roundRobin|random|consistentHash|powerOfRandomNChoices|weightedRoundRobin|leastRequests
   endpoints: <stringarray>  optional, required for type=lb
   serviceName: <string>     optional, required for type=service
   servicePort: <number>     optional, required for type=service

--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -298,6 +298,7 @@ Current implemented algorithms:
 - `consistentHash`: backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to prevent popular keys from overloading a single backend endpoint.
 - `powerOfRandomNChoices`: backend is chosen by powerOfRandomNChoices algorithm with selecting N random endpoints and picking the one with least outstanding requests from them. (http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf)
 - `weightedRoundRobin`: backend is chosen by [smooth weighted round robin](https://github.com/nginx/nginx/commit/52327e0627f49dbda1e8db695e63a4b0af4448b1) with dynamic weights based on the ratio of successful round trips per endpoint. Weights are updated by the [passive health check](../operation/operation.md) stats loop, so they only change when the passive health check is enabled; with equal weights it behaves like `roundRobin`.
+- `leastRequests`: backend is chosen as the endpoint with the lowest load factor, defined as inflight requests divided by endpoint weight. Ties are broken by smooth weighted round-robin over the tied set proportional to endpoint weights. With equal weights and no inflight requests it behaves like `roundRobin`.
 - __TODO__: https://github.com/zalando/skipper/issues/557
 
 Route example with 2 backends and the `roundRobin` algorithm:
@@ -323,6 +324,11 @@ r0: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997
 Route example with 2 backends and the `weightedRoundRobin` algorithm:
 ```
 r0: * -> <weightedRoundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+```
+
+Route example with 2 backends and the `leastRequests` algorithm:
+```
+r0: * -> <leastRequests, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 ```
 
 Proxy with `roundRobin` loadbalancer and two backends:

--- a/loadbalancer/algorithm.go
+++ b/loadbalancer/algorithm.go
@@ -39,6 +39,11 @@ const (
 	// WeightedRoundRobin distributes requests proportionally to the dynamic
 	// endpoint weights derived from observed failed round trips.
 	WeightedRoundRobin
+
+	// LeastRequests routes each request to the endpoint with the lowest load
+	// factor, defined as inflight requests divided by the endpoint weight.
+	// Ties are broken by smooth weighted round-robin over the tied endpoints.
+	LeastRequests
 )
 
 const powerOfRandomNChoicesDefaultN = 2
@@ -54,6 +59,7 @@ var (
 		ConsistentHash:        newConsistentHash,
 		PowerOfRandomNChoices: newPowerOfRandomNChoices,
 		WeightedRoundRobin:    newWeightedRoundRobin,
+		LeastRequests:         newLeastRequests,
 	}
 	defaultAlgorithm = newRoundRobin
 )
@@ -325,6 +331,88 @@ func (w *weightedRoundRobin) Apply(ctx *routing.LBContext) routing.LBEndpoint {
 	return ctx.LBEndpoints[best]
 }
 
+func newLeastRequests(endpoints []string) routing.LBAlgorithm {
+	return &leastRequests{
+		rnd:            rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0)), // #nosec
+		currentWeights: make(map[string]float64, len(endpoints)),
+	}
+}
+
+type leastRequests struct {
+	mu             sync.Mutex
+	rnd            *rand.Rand
+	currentWeights map[string]float64
+}
+
+// Apply implements routing.LBAlgorithm by selecting the endpoint with the
+// lowest load factor (inflight requests divided by weight). When multiple
+// endpoints share the same load factor, ties are broken using smooth weighted
+// round-robin over the tied set.
+// Iteration within the tied set starts at a random offset to avoid bias
+// toward the first endpoint in the list.
+func (l *leastRequests) Apply(ctx *routing.LBContext) routing.LBEndpoint {
+	ne := len(ctx.LBEndpoints)
+	if ne == 1 {
+		return ctx.LBEndpoints[0]
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	bestByLoadFactorIdx, tie := l.findBestByLoadFactor(ctx.LBEndpoints)
+	if !tie {
+		return ctx.LBEndpoints[bestByLoadFactorIdx]
+	}
+	bestLoadFactor := getLoadFactor(ctx.LBEndpoints[bestByLoadFactorIdx])
+
+	total := 0.0
+	best := 0
+	bestWeight := math.Inf(-1)
+	offset := l.rnd.IntN(ne - bestByLoadFactorIdx) // #nosec
+	for k := 0; k < ne-bestByLoadFactorIdx; k++ {
+		i := bestByLoadFactorIdx + (offset+k)%(ne-bestByLoadFactorIdx)
+		e := ctx.LBEndpoints[i]
+
+		if getLoadFactor(e) != bestLoadFactor {
+			continue
+		}
+
+		weight := e.Metrics.Weight()
+		total += weight
+
+		cw := l.currentWeights[e.Host] + weight
+		l.currentWeights[e.Host] = cw
+		if cw > bestWeight {
+			bestWeight = cw
+			best = i
+		}
+	}
+	l.currentWeights[ctx.LBEndpoints[best].Host] -= total
+
+	return ctx.LBEndpoints[best]
+
+}
+
+func (l *leastRequests) findBestByLoadFactor(endpoints []routing.LBEndpoint) (i int, tie bool) {
+	best := getLoadFactor(endpoints[0])
+	for j := 1; j < len(endpoints); j++ {
+		f := getLoadFactor(endpoints[j])
+		switch {
+		case f < best:
+			i = j
+			best = f
+			tie = false
+		case f == best:
+			tie = true
+		}
+	}
+	return i, tie
+}
+
+func getLoadFactor(ep routing.LBEndpoint) float64 {
+	return float64(ep.Metrics.InflightRequests()) / ep.Metrics.Weight()
+}
+
 type (
 	algorithmProvider   struct{}
 	initializeAlgorithm func(endpoints []string) routing.LBAlgorithm
@@ -353,6 +441,8 @@ func AlgorithmFromString(a string) (Algorithm, error) {
 		return PowerOfRandomNChoices, nil
 	case "weightedRoundRobin":
 		return WeightedRoundRobin, nil
+	case "leastRequests":
+		return LeastRequests, nil
 	default:
 		return None, errors.New("unsupported algorithm")
 	}
@@ -371,6 +461,8 @@ func (a Algorithm) String() string {
 		return "powerOfRandomNChoices"
 	case WeightedRoundRobin:
 		return "weightedRoundRobin"
+	case LeastRequests:
+		return "leastRequests"
 	default:
 		return ""
 	}

--- a/loadbalancer/algorithm_test.go
+++ b/loadbalancer/algorithm_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -288,6 +290,11 @@ func TestApply(t *testing.T) {
 			expected:      N,
 			algorithm:     newWeightedRoundRobin(eps),
 			algorithmName: "weightedRoundRobin",
+		}, {
+			name:          "leastRequests algorithm",
+			expected:      N,
+			algorithm:     newLeastRequests(eps),
+			algorithmName: "leastRequests",
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
@@ -618,6 +625,206 @@ func applyAndCountSelections(t *testing.T, route *routing.Route, rounds int) map
 		selectionCounts[route.LBAlgorithm.Apply(lbContext).Host]++
 	}
 	return selectionCounts
+}
+
+func TestLeastRequestsDistribution(t *testing.T) {
+	type endpointCfg struct {
+		endpoint     string
+		weight       float64
+		inflightReqs int
+	}
+
+	tests := []struct {
+		name      string
+		endpoints []endpointCfg
+	}{
+		{
+			name: "no inflight requests with equal weights, do round robin",
+			endpoints: []endpointCfg{
+				{"http://127.0.0.1:1231/foo", 1.0, 0},
+				{"http://127.0.0.1:1232/foo", 1.0, 0},
+				{"http://127.0.0.1:1233/foo", 1.0, 0},
+			},
+		},
+		{
+			name: "single endpoint with load, rest without, do round robin over the rest",
+			endpoints: []endpointCfg{
+				{"http://127.0.0.1:1231/foo", 1.0, 1},
+				{"http://127.0.0.1:1232/foo", 1.0, 0},
+				{"http://127.0.0.1:1233/foo", 1.0, 0},
+			},
+		},
+		{
+			name: "higher weight endpoint preferred",
+			endpoints: []endpointCfg{
+				{"http://127.0.0.1:1231/foo", 0.2, 10},
+				{"http://127.0.0.1:1232/foo", 0.8, 5},
+				{"http://127.0.0.1:1233/foo", 1.0, 7},
+			},
+		},
+		{
+			name: "equal weights, lowest inflight preferred",
+			endpoints: []endpointCfg{
+				{"http://127.0.0.1:1231/foo", 1.0, 10},
+				{"http://127.0.0.1:1232/foo", 1.0, 6},
+				{"http://127.0.0.1:1233/foo", 1.0, 2},
+			},
+		},
+		{
+			name: "when tie, do weighted round robin",
+			endpoints: []endpointCfg{
+				{"http://127.0.0.1:1231/foo", 1.0, 10},
+				{"http://127.0.0.1:1232/foo", 0.5, 2},
+				{"http://127.0.0.1:1233/foo", 1.0, 4},
+			},
+		},
+		{
+			name: "when tie with equal weights, do round robin",
+			endpoints: []endpointCfg{
+				{"http://127.0.0.1:1231/foo", 1.0, 10},
+				{"http://127.0.0.1:1232/foo", 1.0, 4},
+				{"http://127.0.0.1:1233/foo", 1.0, 4},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoints := make([]string, len(tt.endpoints))
+			for i, ep := range tt.endpoints {
+				endpoints[i] = ep.endpoint
+			}
+
+			r, _ := http.NewRequest("GET", "http://127.0.0.1:1234/foo", nil)
+			route := NewAlgorithmProvider().Do([]*routing.Route{{
+				Route: eskip.Route{
+					BackendType: eskip.LBBackend,
+					LBAlgorithm: LeastRequests.String(),
+					LBEndpoints: eskip.NewLBEndpoints(endpoints),
+				},
+			}})[0]
+
+			endpointRegistry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+			defer endpointRegistry.Close()
+			endpointRegistry.Do([]*routing.Route{route})
+			for i := range route.LBEndpoints {
+				addInflightRequests(
+					endpointRegistry,
+					route.LBEndpoints[i],
+					tt.endpoints[i].inflightReqs,
+				)
+			}
+			for i := range route.LBEndpoints {
+				route.LBEndpoints[i].Metrics = fixedWeightMetrics{
+					Metrics: route.LBEndpoints[i].Metrics,
+					weight:  tt.endpoints[i].weight,
+				}
+			}
+
+			scores := make([]float64, len(tt.endpoints))
+			for i, ep := range tt.endpoints {
+				scores[i] = float64(ep.inflightReqs) / ep.weight
+			}
+
+			minScore := slices.Min(scores)
+
+			expected := make(map[string]bool)
+			for i, s := range scores {
+				if s == minScore {
+					expected[mustParseHost(t, endpoints[i])] = true
+				}
+			}
+
+			lr := route.LBAlgorithm.(*leastRequests)
+			ctx := &routing.LBContext{
+				Request:     r,
+				Route:       route,
+				LBEndpoints: route.LBEndpoints,
+			}
+
+			const rounds = 1000
+			selectionCounts := make(map[string]int)
+			for range rounds {
+				selectionCounts[lr.Apply(ctx).Host]++
+			}
+
+			for ep := range selectionCounts {
+				if !expected[ep] {
+					t.Errorf("unexpected endpoint selected %s, expected %v", ep, expected)
+				}
+			}
+
+			if len(selectionCounts) > 1 {
+				var tiedEndpoints []endpointCfg
+				for _, e := range tt.endpoints {
+					if _, ok := selectionCounts[mustParseHost(t, e.endpoint)]; ok {
+						tiedEndpoints = append(tiedEndpoints, e)
+					}
+				}
+
+				totalWeight := 0.0
+				for _, e := range tiedEndpoints {
+					totalWeight += e.weight
+				}
+				for i, e := range tiedEndpoints {
+					expectedSelections := rounds * e.weight / totalWeight
+					assert.InDelta(
+						t,
+						expectedSelections,
+						selectionCounts[mustParseHost(t, e.endpoint)],
+						1.0,
+						"endpoint %d",
+						i,
+					)
+				}
+			}
+		})
+	}
+}
+
+func mustParseHost(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fail()
+	}
+	return u.Host
+}
+
+func BenchmarkLeastRequestsAlgorithm(b *testing.B) {
+	for _, numberOfEndpoints := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("%d_endpoints", numberOfEndpoints), func(b *testing.B) {
+			endpointAddresses := make([]string, numberOfEndpoints)
+			for i := range numberOfEndpoints {
+				endpointAddresses[i] = fmt.Sprintf("10.0.%d.%d:8080", i/256, i%256)
+			}
+
+			registry := routing.NewEndpointRegistry(routing.RegistryOptions{})
+			defer registry.Close()
+
+			algorithm := newLeastRequests(endpointAddresses)
+
+			endpoints := make([]routing.LBEndpoint, len(endpointAddresses))
+			for i := range len(endpointAddresses) {
+				endpoints[i] = routing.LBEndpoint{
+					Scheme:  "http",
+					Host:    endpointAddresses[i],
+					Metrics: registry.GetMetrics(endpointAddresses[i]),
+				}
+			}
+
+			lbContext := &routing.LBContext{
+				Route:       &routing.Route{},
+				LBEndpoints: endpoints,
+			}
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				algorithm.Apply(lbContext)
+			}
+		})
+	}
 }
 
 func TestWeightedRoundRobinDistribution(t *testing.T) {

--- a/loadbalancer/doc.go
+++ b/loadbalancer/doc.go
@@ -35,6 +35,16 @@ weightedRoundRobin Algorithm
 	check to be enabled to be updated. With equal weights it behaves
 	like the roundRobin algorithm.
 
+leastRequests Algorithm
+
+	The leastRequests algorithm routes each request to the endpoint
+	with the lowest load factor, defined as inflight requests divided
+	by the endpoint weight. When multiple endpoints share the lowest
+	load factor, ties are broken using smooth weighted round-robin
+	over the tied set, proportional to their endpoint weights. With
+	equal weights and no inflight requests it behaves like the
+	roundRobin algorithm.
+
 The load balancing algorithms also provide fade-in behavior for LB endpoints of routes where the
 fade-in duration was configured. This feature can be used to gradually add traffic to new instances of
 applications that require a certain amount of warm-up time.
@@ -46,6 +56,7 @@ Eskip example:
 	r3: * -> <random, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 	r4: * -> <powerOfRandomNChoices, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 	r5: * -> <weightedRoundRobin, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
+	r6: * -> <leastRequests, "http://127.0.0.1:9998", "http://127.0.0.1:9997">;
 
 Package loadbalancer also implements health checking of pool members for
 a group of routes, if backend calls are reported to the loadbalancer.

--- a/packaging/helm/skipper-aws/crds/routegroups.yaml
+++ b/packaging/helm/skipper-aws/crds/routegroups.yaml
@@ -59,6 +59,7 @@ spec:
                       - consistentHash
                       - powerOfRandomNChoices
                       - weightedRoundRobin
+                      - leastRequests
                       type: string
                     endpoints:
                       description: Endpoints is required for Type lb

--- a/skipper.go
+++ b/skipper.go
@@ -352,7 +352,7 @@ type Options struct {
 	KubernetesBackendTrafficAlgorithm kubernetes.BackendTrafficAlgorithm
 
 	// KubernetesDefaultLoadBalancerAlgorithm sets the default algorithm to be used for load balancing between backend endpoints,
-	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin
+	// available options: roundRobin, consistentHash, random, powerOfRandomNChoices, weightedRoundRobin, leastRequests
 	KubernetesDefaultLoadBalancerAlgorithm string
 
 	// File containing static route definitions. Multiple may be given comma separated.


### PR DESCRIPTION
Implements a new LB algorithm that routes each request to the endpoint with the lowest load factor, defined as inflight requests divided by endpoint weight. When multiple endpoints share the lowest load factor, ties are broken using smooth weighted round-robin over the tied set, proportional to endpoint weights. 
With equal weights and no inflight requests it behaves like roundRobin.

ref https://github.com/zalando/skipper/issues/557

## How to test

1. Start proxy that listens on 9999 port that proxies to 4 backends using leastRequests LB algorithm:
```bash
./bin/skipper -inline-routes='r1: * -> <leastRequests, "http://127.0.0.1:9001", "http://127.0.0.1:9002", "http://127.0.0.1:9003", "http://127.0.0.1:9004">' --address :9999
```

2. Start 4 backends, each responding with it's ID (1-4) and add artificial latency to the each:
```bash
./bin/skipper -inline-routes='r1: * -> latency("25s") -> inlineContent("1") -> <shunt>' --address :9001 &
./bin/skipper -inline-routes='r1: * -> latency("10s") -> inlineContent("2") -> <shunt>' --address :9002 & 
./bin/skipper -inline-routes='r1: * -> latency("5s") -> inlineContent("3") -> <shunt>' --address :9003 & 
./bin/skipper -inline-routes='r1: * -> latency("1s") -> inlineContent("4") -> <shunt>' --address :9004

```

3. Attack the proxy with vegeta:
```bash
echo "GET http://localhost:9999" | vegeta attack -duration=30s -rate=200 | vegeta encode | jq -r '.body | @base64d' | sort | uniq -c | sort -rn | awk 'BEGIN {print "count server"} {print $1, $2}' | column -t

count  server
4299   4
927    3
478    2
296    1
```

## Benchmark results
```bash
go test -bench=BenchmarkLeastRequestsAlgorithm -benchmem -run='^$' -cpu 1,2,4,8,16 ./loadbalancer
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/loadbalancer
cpu: Apple M1 Max
BenchmarkLeastRequestsAlgorithm/10_endpoints                     3001717               385.7 ns/op             0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10_endpoints-2                   3078313               402.7 ns/op             0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10_endpoints-4                   3115698               385.1 ns/op             0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10_endpoints-8                   3117997               385.5 ns/op             0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10_endpoints-16                  3111014               384.8 ns/op             0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/100_endpoints                     329112              3642 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/100_endpoints-2                   333442              3624 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/100_endpoints-4                   322792              3557 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/100_endpoints-8                   337102              3594 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/100_endpoints-16                  326228              3802 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/1000_endpoints                     29665             40382 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/1000_endpoints-2                   29586             40255 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/1000_endpoints-4                   29678             40373 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/1000_endpoints-8                   29643             40328 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/1000_endpoints-16                  29624             40184 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10000_endpoints                     2755            437176 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10000_endpoints-2                   2751            437743 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10000_endpoints-4                   2754            436034 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10000_endpoints-8                   2748            436233 ns/op               0 B/op          0 allocs/op
BenchmarkLeastRequestsAlgorithm/10000_endpoints-16                  2745            437377 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/zalando/skipper/loadbalancer 29.709s

```