### PR TITLE
fix: skipper startup panic caused by valkey ring not initialized 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ CURRENT_VERSION     = $(shell git describe --tags --always --dirty)
 VERSION            ?= $(CURRENT_VERSION)
 COMMIT_HASH         = $(shell git rev-parse --short HEAD)
 LIMIT_FDS           = $(shell ulimit -n)
-TEST_ETCD_VERSION  ?= v3.6.12
-TEST_ETCD_CHECKSUM ?= d2564bb50b58e52fbaf3bde4a9561a1d04e20cdc761f795580e4d615d5d41355
+TEST_ETCD_VERSION  ?= v3.6.14
+TEST_ETCD_CHECKSUM ?= ffe840ff9295808e88cce2794a18a5ac87f12a5203c8314d0bf6aa119b41bac5
 TEST_PLUGINS       = _test_plugins/filter_noop.so \
 		     _test_plugins/predicate_match_none.so \
 		     _test_plugins/dataclient_noop.so \

--- a/dataclients/kubernetes/kubernetestest/api.go
+++ b/dataclients/kubernetes/kubernetestest/api.go
@@ -41,6 +41,10 @@ type api struct {
 	resourceList []byte
 }
 
+type KubeTestAPI interface {
+	UpdateSpec(specs ...io.Reader) error
+}
+
 func NewAPI(o TestAPIOptions, specs ...io.Reader) (*api, error) {
 	a := &api{
 		namespaces: make(map[string]namespace),
@@ -65,6 +69,12 @@ func NewAPI(o TestAPIOptions, specs ...io.Reader) (*api, error) {
 
 	a.resourceList = clrb
 
+	err = a.update(specs...)
+
+	return a, err
+}
+
+func (a *api) update(specs ...io.Reader) error {
 	namespaces := make(map[string]map[string][]interface{})
 	all := make(map[string][]interface{})
 
@@ -106,50 +116,54 @@ func NewAPI(o TestAPIOptions, specs ...io.Reader) (*api, error) {
 			if err := d.Decode(&o); err == io.EOF || err == nil && len(o) == 0 {
 				break
 			} else if err != nil {
-				return nil, err
+				return err
 			}
 
 			kind, ok := o["kind"].(string)
 			if !ok {
-				return nil, errInvalidFixture
+				return errInvalidFixture
 			}
 
 			if kind == "List" {
 				items, ok := o["items"].([]interface{})
 				if !ok {
-					return nil, errInvalidFixture
+					return errInvalidFixture
 				}
 				for _, item := range items {
 					o, ok := item.(map[interface{}]interface{})
 					if !ok {
-						return nil, errInvalidFixture
+						return errInvalidFixture
 					}
 					if err := addObject(o); err != nil {
-						return nil, err
+						return err
 					}
 				}
 			} else {
 				if err := addObject(o); err != nil {
-					return nil, err
+					return err
 				}
 			}
 		}
 	}
 
+	var err error
 	for ns, kinds := range namespaces {
-		var err error
 		a.namespaces[ns], err = initNamespace(kinds)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	a.all, err = initNamespace(all)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return a, nil
+	return nil
+}
+
+func (a *api) UpdateSpec(specs ...io.Reader) error {
+	return a.update(specs...)
 }
 
 func (a *api) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/dataclients/kubernetes/kubernetestest/api.go
+++ b/dataclients/kubernetes/kubernetestest/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v2"
 	yaml2 "sigs.k8s.io/yaml"
@@ -33,6 +34,7 @@ type namespace struct {
 }
 
 type api struct {
+	mu           sync.Mutex
 	failOn       map[string]bool
 	findNot      map[string]bool
 	namespaces   map[string]namespace
@@ -75,6 +77,9 @@ func NewAPI(o TestAPIOptions, specs ...io.Reader) (*api, error) {
 }
 
 func (a *api) update(specs ...io.Reader) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	namespaces := make(map[string]map[string][]interface{})
 	all := make(map[string][]interface{})
 
@@ -163,6 +168,8 @@ func (a *api) UpdateSpec(specs ...io.Reader) error {
 }
 
 func (a *api) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if r.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/dataclients/kubernetes/kubernetestest/api.go
+++ b/dataclients/kubernetes/kubernetestest/api.go
@@ -155,11 +155,7 @@ func (a *api) update(specs ...io.Reader) error {
 	}
 
 	a.all, err = initNamespace(all)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (a *api) UpdateSpec(specs ...io.Reader) error {

--- a/redis_test.go
+++ b/redis_test.go
@@ -533,13 +533,21 @@ spec:
 func createApiserver(t *testing.T, spec string) *stdlibhttptest.Server {
 	t.Helper()
 
+	apiServer, _ := createApiserverAndKuberntesAPI(t, spec)
+
+	return apiServer
+}
+
+func createApiserverAndKuberntesAPI(t *testing.T, spec string) (*stdlibhttptest.Server, kubernetestest.KubeTestAPI) {
+	t.Helper()
+
 	api, err := kubernetestest.NewAPI(kubernetestest.TestAPIOptions{}, bytes.NewBufferString(spec))
 	require.NoError(t, err)
 
 	apiServer := stdlibhttptest.NewServer(api)
 	t.Cleanup(apiServer.Close)
 
-	return apiServer
+	return apiServer, api
 }
 
 func createFilterRegistry(specs ...filters.Spec) filters.Registry {

--- a/skipper.go
+++ b/skipper.go
@@ -1724,7 +1724,7 @@ func getKubernetesAddrUpdater(kdc *kubernetes.Client, loaded bool, ns, name stri
 
 func joinPort(addrs []string, port int) []string {
 	p := strconv.Itoa(port)
-	for i := 0; i < len(addrs); i++ {
+	for i := range addrs {
 		addrs[i] = net.JoinHostPort(addrs[i], p)
 	}
 	return addrs
@@ -2153,8 +2153,9 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 			if kdc != nil {
 				kdc.LoadAll()
 				valkeyOptions.AddrUpdater = getKubernetesAddrUpdater(kdc, true, o.KubernetesValkeyServiceNamespace, o.KubernetesValkeyServiceName, o.KubernetesValkeyServicePort)
+				defer kdc.Close()
 			} else {
-				kdc, err := kubernetes.New(o.KubernetesDataClientOptions())
+				kdc, err = kubernetes.New(o.KubernetesDataClientOptions())
 				if err != nil {
 					return err
 				}
@@ -2163,22 +2164,17 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 				valkeyOptions.AddrUpdater = getKubernetesAddrUpdater(kdc, false, o.KubernetesValkeyServiceNamespace, o.KubernetesValkeyServiceName, o.KubernetesValkeyServicePort)
 			}
 
-			res, err := valkeyOptions.AddrUpdater()
-			if err != nil {
-				log.Errorf("Failed to update valkey addresses from kubernetes: %v", err)
+			log.Infof("start initialValkeyAddressUpdate")
+			if err := initialValkeyAddressUpdate(valkeyOptions, kdc); err != nil {
 				return err
 			}
-			log.Infof("Initial valkey address kubernetes update got %d shards", len(res))
 
 		} else if valkeyOptions != nil && o.SwarmValkeyEndpointsRemoteURL != "" {
 			log.Infof("Use remote address %q to fetch updates valkey shards", o.SwarmValkeyEndpointsRemoteURL)
 			valkeyOptions.AddrUpdater = getRemoteURLShardAddrUpdater(o.SwarmValkeyEndpointsRemoteURL)
-			res, err := valkeyOptions.AddrUpdater()
-			if err != nil {
-				log.Errorf("Failed to update valkey addresses from URL: %v", err)
+			if err := initialValkeyAddressUpdate(valkeyOptions, nil); err != nil {
 				return err
 			}
-			log.Infof("Initial valkey address remote update got %d shards", len(res))
 		}
 
 		// in case we have kubernetes dataclient and we can detect redis instances, we patch redisOptions
@@ -2670,6 +2666,31 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	}
 
 	return listenAndServeQuit(o.CustomHttpHandlerWrap(proxy), &o, sig, idleConnsCH, mtr, cr)
+}
+
+func initialValkeyAddressUpdate(valkeyOptions *skpnet.ValkeyOptions, dc routing.DataClient) error {
+	var (
+		err error
+		res []string
+	)
+	N := 12
+	for i := range N {
+		log.Infof("%d attempt -> %d", i, len(res))
+		res, err = valkeyOptions.AddrUpdater()
+		if err != nil {
+			log.Errorf("Failed to update valkey addresses: %v", err)
+			return err
+		}
+		if len(res) > 0 {
+			log.Infof("Initial valkey address update got %d shards after %d attempts", len(res), i)
+			return nil
+		}
+		if dc != nil {
+			dc.LoadAll() // enforce state update
+		}
+		time.Sleep(valkeyOptions.UpdateInterval + 1)
+	}
+	return fmt.Errorf("failed to get valkey addresses after %d attempts", N)
 }
 
 func ensureExpectedDataclients(o Options, dataClients []routing.DataClient) error {

--- a/skipper.go
+++ b/skipper.go
@@ -2671,18 +2671,18 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 func initialValkeyAddressUpdate(valkeyOptions *skpnet.ValkeyOptions, dc routing.DataClient) error {
 	var (
 		err error
-		res []string
+		a   []string
 	)
 	N := 12
 	for i := range N {
-		log.Infof("%d attempt -> %d", i, len(res))
-		res, err = valkeyOptions.AddrUpdater()
+		log.Infof("%d attempt -> %d", i, len(a))
+		a, err = valkeyOptions.AddrUpdater()
 		if err != nil {
 			log.Errorf("Failed to update valkey addresses: %v", err)
 			return err
 		}
-		if len(res) > 0 {
-			log.Infof("Initial valkey address update got %d shards after %d attempts", len(res), i)
+		if len(a) > 0 {
+			log.Infof("Initial valkey address update got %d shards after %d attempts", len(a), i)
 			return nil
 		}
 		if dc != nil {

--- a/valkey_test.go
+++ b/valkey_test.go
@@ -1,6 +1,7 @@
 package skipper_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/zalando/skipper"
 	flog "github.com/zalando/skipper/filters/accesslog"
 	fscheduler "github.com/zalando/skipper/filters/scheduler"
@@ -500,6 +502,65 @@ spec:
 		assert.NoError(t, <-runResult)
 	})
 
+	t.Run("kubernetes dataclient and valkey starts late", func(t *testing.T) {
+		valkey1, done1 := valkeytest.NewTestValkey(t)
+		valkey2, done2 := valkeytest.NewTestValkey(t)
+		valkey3, done3 := valkeytest.NewTestValkey(t)
+		valkey4, done4 := valkeytest.NewTestValkey(t)
+		defer done1()
+		defer done2()
+		defer done3()
+		defer done4()
+
+		spec := kubeSpec
+		updateSpec := kubeSpec + createValkeyEndpointsSpec(t, valkey1, valkey2, valkey3, valkey4)
+		apiServer, kubeAPI := createApiserverAndKuberntesAPI(t, spec)
+
+		metrics := &metricstest.MockMetrics{}
+
+		skipper.MuFindAddress.Lock()
+		o := skipper.Options{
+			Address:                          skipper.FindAddress(t),
+			EnableRatelimiters:               true,
+			EnableSwarm:                      true,
+			Kubernetes:                       true, // enable kubernetes dataclient
+			KubernetesURL:                    apiServer.URL,
+			KubernetesValkeyServiceNamespace: "skipper",
+			KubernetesValkeyServiceName:      "valkey",
+			KubernetesValkeyServicePort:      6379,
+			SwarmValkeyUpdateInterval:        valkeyUpdateInterval,
+			MetricsBackend:                   metrics,
+		}
+
+		runResult := make(chan error)
+		sigs := make(chan os.Signal, 1)
+		go func() { runResult <- skipper.RunWithShutdown(o, sigs, nil) }()
+
+		go func() {
+			time.Sleep(valkeyUpdateInterval)
+			err := kubeAPI.UpdateSpec(bytes.NewBufferString(updateSpec))
+			if err != nil {
+				logrus.Errorf("Failed to update kubernetes spec: %v", err)
+			} else {
+				logrus.Infof("Updated kubernetes spec")
+			}
+		}()
+
+		waitForOK(t, "http://"+o.Address+"/test", 1*time.Second)
+		skipper.MuFindAddress.Unlock()
+		time.Sleep(2 * valkeyUpdateInterval)
+
+		metrics.WithGauges(func(g map[string]float64) {
+			t.Logf("gauges: %v", g)
+
+			assert.Equal(t, 1.0, g["routes.total"], "expected only the /test route")
+			assert.Equal(t, 4.0, g["swarm.valkey.shards"])
+		})
+
+		sigs <- syscall.SIGTERM
+		assert.NoError(t, <-runResult)
+	})
+
 	t.Run("remote url", func(t *testing.T) {
 		valkey1, done1 := valkeytest.NewTestValkey(t)
 		valkey2, done2 := valkeytest.NewTestValkey(t)
@@ -544,6 +605,60 @@ spec:
 
 			assert.Equal(t, 1.0, g["routes.total"], "expected only the /ready route")
 			assert.Equal(t, 3.0, g["swarm.valkey.shards"])
+		})
+
+		sigs <- syscall.SIGTERM
+		assert.NoError(t, <-runResult)
+	})
+
+	t.Run("remote url and valkey starts late", func(t *testing.T) {
+		valkey1, done1 := valkeytest.NewTestValkey(t)
+		defer done1()
+
+		attempt := 0
+		eps := stdlibhttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempt++
+
+			if attempt > 3 {
+				fmt.Fprintf(w, `{
+				"endpoints": [
+					{"address": "%s"}
+				]
+			}`, valkey1)
+			} else {
+				fmt.Fprint(w, `{
+				"endpoints": []
+			}`)
+			}
+		}))
+		defer eps.Close()
+
+		metrics := &metricstest.MockMetrics{}
+
+		skipper.MuFindAddress.Lock()
+		o := skipper.Options{
+			Address:                       skipper.FindAddress(t),
+			EnableRatelimiters:            true,
+			EnableSwarm:                   true,
+			SwarmValkeyEndpointsRemoteURL: eps.URL,
+			SwarmValkeyUpdateInterval:     valkeyUpdateInterval,
+			InlineRoutes:                  `Path("/ready") -> inlineContent("OK") -> <shunt>`,
+			MetricsBackend:                metrics,
+		}
+
+		runResult := make(chan error)
+		sigs := make(chan os.Signal, 1)
+		go func() { runResult <- skipper.RunWithShutdown(o, sigs, nil) }()
+
+		waitForOK(t, "http://"+o.Address+"/ready", 10*time.Second)
+		skipper.MuFindAddress.Unlock()
+		time.Sleep(1 * valkeyUpdateInterval)
+
+		metrics.WithGauges(func(g map[string]float64) {
+			t.Logf("gauges: %v", g)
+
+			assert.Equal(t, 1.0, g["routes.total"], "expected only the /ready route")
+			assert.Equal(t, 1.0, g["swarm.valkey.shards"])
 		})
 
 		sigs <- syscall.SIGTERM


### PR DESCRIPTION
fix: valkey startup in case of remote url or kubernetes dataclient. The updater makes now sure that we get non zero shards, such that the ring client is successfully initialized