### PR TITLE
feat(tls): support KeyLogWriter and VerifyConnection in TLS config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -272,6 +273,10 @@ type Config struct {
 	// TLS version
 	TLSMinVersion string             `yaml:"tls-min-version"`
 	TLSClientAuth tls.ClientAuthType `yaml:"tls-client-auth"`
+
+	// TLS debugging
+	TLSKeyLogFile   string    `yaml:"tls-key-log-file"`
+	TLSKeyLogWriter io.Writer `yaml:"-"`
 
 	// Exclude insecure cipher suites
 	ExcludeInsecureCipherSuites bool `yaml:"exclude-insecure-cipher-suites"`
@@ -661,6 +666,8 @@ func NewConfig() *Config {
 	flag.Func("tls-client-auth", "TLS client authentication policy for server, one of: "+
 		"NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven or RequireAndVerifyClientCert. "+
 		"See https://pkg.go.dev/crypto/tls#ClientAuthType for details.", cfg.setTLSClientAuth)
+	flag.StringVar(&cfg.TLSKeyLogFile, "tls-key-log-file", "", "path to a file where TLS master secrets are logged in NSS Key Log Format for debugging with tools like Wireshark. "+
+		"WARNING: anyone with access to this file can decrypt all TLS traffic — never use in production")
 
 	// Exclude insecure cipher suites
 	flag.BoolVar(&cfg.ExcludeInsecureCipherSuites, "exclude-insecure-cipher-suites", false, "excludes insecure cipher suites")
@@ -884,6 +891,14 @@ func (c *Config) ParseArgs(progname string, args []string) error {
 		}
 
 		c.Certificates = certificates
+	}
+
+	if c.TLSKeyLogFile != "" {
+		f, err := os.OpenFile(c.TLSKeyLogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+		if err != nil {
+			return fmt.Errorf("failed to open TLS key log file: %w", err)
+		}
+		c.TLSKeyLogWriter = f
 	}
 
 	if c.MtlsAuthnAppendCA {
@@ -1266,6 +1281,7 @@ func (c *Config) ToOptions() skipper.Options {
 	options.ClientKeyFile = c.ClientKeyFile
 	options.ClientCertRefreshInterval = c.ClientCertRefreshInterval
 	options.MtlsAuthnCA = c.MtlsAuthnCA
+	options.KeyLogWriter = c.TLSKeyLogWriter
 
 	var wrappers []func(handler http.Handler) http.Handler
 	options.CustomHttpHandlerWrap = func(handler http.Handler) http.Handler {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -543,6 +544,57 @@ func TestExcludeInsecureCipherSuites(t *testing.T) {
 		if cfg.filterCipherSuites() == nil {
 			t.Error(`Failed to get list of filtered cipher suites`)
 		}
+	})
+}
+
+func TestTLSKeyLogFile(t *testing.T) {
+	t.Run("test default has no key log writer", func(t *testing.T) {
+		cfg := NewConfig()
+		err := cfg.ParseArgs("skipper", nil)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.TLSKeyLogWriter)
+	})
+
+	t.Run("test tls-key-log-file flag opens file and sets writer", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keylog.txt")
+
+		cfg := NewConfig()
+		err := cfg.ParseArgs("skipper", []string{"-tls-key-log-file=" + path})
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg.TLSKeyLogWriter)
+		assert.Equal(t, path, cfg.TLSKeyLogFile)
+
+		n, err := cfg.TLSKeyLogWriter.Write([]byte("test-secret-line\n"))
+		require.NoError(t, err)
+		assert.Equal(t, len("test-secret-line\n"), n)
+
+		if f, ok := cfg.TLSKeyLogWriter.(*os.File); ok {
+			require.NoError(t, f.Close())
+		}
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "test-secret-line")
+	})
+
+	t.Run("test invalid path returns error", func(t *testing.T) {
+		cfg := NewConfig()
+		err := cfg.ParseArgs("skipper", []string{"-tls-key-log-file=/nonexistent-dir/keylog.txt"})
+		require.Error(t, err)
+	})
+
+	t.Run("test ToOptions propagates KeyLogWriter", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keylog.txt")
+
+		cfg := NewConfig()
+		err := cfg.ParseArgs("skipper", []string{"-tls-key-log-file=" + path})
+		require.NoError(t, err)
+
+		opts := cfg.ToOptions()
+		assert.Same(t, cfg.TLSKeyLogWriter, opts.KeyLogWriter)
 	})
 }
 

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -1720,6 +1720,23 @@ predicates and filters involved in the route processing:
 }
 ```
 
+### Debugging TLS
+
+Skipper supports logging TLS master secrets in NSS Key Log Format,
+which allows tools like Wireshark to decrypt captured HTTPS traffic
+during troubleshooting.
+
+To enable TLS key logging, pass the `-tls-key-log-file` flag with the
+target output file path:
+
+```bash
+skipper -tls-key-log-file=/path/to/tls-secrets.log
+```
+
+> **WARNING:** Anyone with access to this file can decrypt all TLS
+> traffic passing through Skipper. Never use this flag in production
+> environments.
+
 ## Profiling
 
 Go profiling is explained in Go's

--- a/skipper.go
+++ b/skipper.go
@@ -744,6 +744,13 @@ type Options struct {
 	// Client TLS to connect to Backends
 	ClientTLS *tls.Config
 
+	// KeyLogWriter optionally specifies a destination for TLS master keys
+	// in NSS Key Log Format.
+	KeyLogWriter io.Writer
+
+	// VerifyConnection is called after normal certificate verification.
+	VerifyConnection func(tls.ConnectionState) error
+
 	// ClientCertFile is the path to a PEM-encoded client certificate for mTLS to backends.
 	// Must be set together with ClientKeyFile. When set, certificate rotation is enabled.
 	ClientCertFile string
@@ -1467,8 +1474,10 @@ func (o *Options) TlsConfig(cr *certregistry.CertRegistry) (*tls.Config, error) 
 	}
 
 	config := &tls.Config{
-		MinVersion: o.TLSMinVersion,
-		ClientAuth: o.TLSClientAuth,
+		MinVersion:       o.TLSMinVersion,
+		ClientAuth:       o.TLSClientAuth,
+		KeyLogWriter:     o.KeyLogWriter,
+		VerifyConnection: o.VerifyConnection,
 	}
 
 	if o.CipherSuites != nil {

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -1,6 +1,7 @@
 package skipper
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -227,6 +228,22 @@ func TestOptionsTLSConfig(t *testing.T) {
 	c, err = o.TlsConfig(cr)
 	require.NoError(t, err)
 	assert.Equal(t, len(c.CipherSuites), 1)
+
+	// KeyLogWriter
+	keyLogWriter := &bytes.Buffer{}
+	verifyConnection := func(tls.ConnectionState) error {
+		return nil
+	}
+
+	o = &Options{
+		KeyLogWriter:     keyLogWriter,
+		VerifyConnection: verifyConnection,
+	}
+	c, err = o.TlsConfig(cr)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Same(t, keyLogWriter, c.KeyLogWriter)
+	assert.NotNil(t, c.VerifyConnection)
 
 }
 


### PR DESCRIPTION
## Description

Added support for `KeyLogWriter` and `VerifyConnection` configurations in `skipper.Options` and mapped them directly into `crypto/tls.Config`. This enables TLS master key logging for debugging purposes and allows custom connection verification logic during TLS handshakes.

cc @MustafaSaber @szuecs, please take a look when you get a chance!

## Changes

* **`skipper/skipper.go`**:
 Extended `Options` struct with two new fields: `KeyLogWriter` (`io.Writer`) and `VerifyConnection` (`func(tls.ConnectionState) error`).
 Updated `(o *Options) TlsConfig(...)` to populate `config.KeyLogWriter` and `config.VerifyConnection` on the generated `tls.Config` object.

* **`skipper/skipper_test.go`**:
 Added unit test assertions in `TestOptionsTLSConfig` to verify that `KeyLogWriter` and `VerifyConnection` are correctly passed through to the resulting `tls.Config`.

## Related Issues

* Closes #4045