### PR TITLE
fix(oidc flow): Referer header could be deleted, use Cookie instead

### DIFF
--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -469,10 +469,13 @@ func (f *tokenOidcFilter) doOauthRedirect(ctx filters.FilterContext, cookies []*
 		return
 	}
 
-	opts := f.authCodeOptions
+	verifier := oauth2.GenerateVerifier()
+
+	opts := append(f.authCodeOptions, oauth2.S256ChallengeOption(verifier))
 	if f.queryParams != nil {
-		opts = make([]oauth2.AuthCodeOption, len(f.authCodeOptions), len(f.authCodeOptions)+len(f.queryParams))
+		opts = make([]oauth2.AuthCodeOption, len(f.authCodeOptions), len(f.authCodeOptions)+len(f.queryParams)+1)
 		copy(opts, f.authCodeOptions)
+		opts = append(opts, oauth2.S256ChallengeOption(verifier))
 		for _, p := range f.queryParams {
 			if v := ctx.Request().URL.Query().Get(p); v != "" {
 				opts = append(opts, oauth2.SetAuthURLParam(p, v))
@@ -482,6 +485,30 @@ func (f *tokenOidcFilter) doOauthRedirect(ctx filters.FilterContext, cookies []*
 
 	stateEncHex := fmt.Sprintf("%x", stateEnc)
 	oauth2URL := f.config.AuthCodeURL(stateEncHex, opts...)
+
+	r := ctx.Request()
+	host := extractDomainFromHost(r.Host, f.subdomainsToRemove)
+	secureCookie := !strings.HasPrefix(f.config.RedirectURL, "http://")
+	stateCookie := &http.Cookie{
+		Name:     f.cookiename + "-state",
+		Value:    stateEncHex,
+		Path:     "/",
+		Domain:   host,
+		MaxAge:   int(time.Hour.Seconds()),
+		HttpOnly: true,
+		Secure:   secureCookie,
+		SameSite: http.SameSiteLaxMode,
+	}
+	verifierCookie := &http.Cookie{
+		Name:     f.cookiename + "-verifier",
+		Value:    verifier,
+		Path:     "/",
+		Domain:   host,
+		MaxAge:   int(time.Hour.Seconds()),
+		HttpOnly: true,
+		Secure:   secureCookie,
+		SameSite: http.SameSiteLaxMode,
+	}
 
 	rsp := &http.Response{
 		Header: http.Header{
@@ -493,6 +520,8 @@ func (f *tokenOidcFilter) doOauthRedirect(ctx filters.FilterContext, cookies []*
 	for _, cookie := range cookies {
 		rsp.Header.Add("Set-Cookie", cookie.String())
 	}
+	rsp.Header.Add("Set-Cookie", stateCookie.String())
+	rsp.Header.Add("Set-Cookie", verifierCookie.String())
 	ctx.Logger().Debugf("serve redirect: plaintextState:%s to Location: %s", statePlain, rsp.Header.Get("Location"))
 	ctx.Serve(rsp)
 }
@@ -600,6 +629,9 @@ func (f *tokenOidcFilter) doDownstreamRedirect(ctx filters.FilterContext, oidcSt
 	for _, cookie := range oidcCookies {
 		r.Header.Add("Set-Cookie", cookie.String())
 	}
+	// Delete the CSRF helper cookies now that the flow is complete.
+	r.Header.Add("Set-Cookie", f.deleteOidcCookie(ctx, f.cookiename+"-state").String())
+	r.Header.Add("Set-Cookie", f.deleteOidcCookie(ctx, f.cookiename+"-verifier").String())
 	ctx.Serve(r)
 }
 
@@ -627,6 +659,22 @@ func (f *tokenOidcFilter) validateCookie(cookie *http.Cookie) ([]byte, bool) {
 	return decompressedCookie, true
 }
 
+// callbackUnauthorized serves a 401 and deletes the CSRF helper cookies so they
+// don't linger in the browser after a failed callback.
+func (f *tokenOidcFilter) callbackUnauthorized(ctx filters.FilterContext, host, debuginfo string) {
+	ctx.Logger().Debugf("Rejected callback: %s, info: %s.", host, debuginfo)
+	rsp := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     make(map[string][]string),
+	}
+	if host != "" {
+		rsp.Header.Add("WWW-Authenticate", host)
+	}
+	rsp.Header.Add("Set-Cookie", f.deleteOidcCookie(ctx, f.cookiename+"-state").String())
+	rsp.Header.Add("Set-Cookie", f.deleteOidcCookie(ctx, f.cookiename+"-verifier").String())
+	ctx.Serve(rsp)
+}
+
 // https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps
 // 5. Authorization Server sends the End-User back to the Client with an Authorization Code.
 func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
@@ -646,15 +694,7 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 		if _, ok := err.(*requestError); !ok {
 			ctx.Logger().Errorf("Error while retrieving callback state: %v.", err)
 		}
-
-		unauthorized(
-			ctx,
-			"",
-			invalidToken,
-			r.Host,
-			fmt.Sprintf("Failed to get state from callback: %v.", err),
-		)
-
+		f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get state from callback: %v.", err))
 		return
 	}
 
@@ -663,15 +703,7 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 		if _, ok := err.(*requestError); !ok {
 			ctx.Logger().Errorf("Error while getting token in callback: %v.", err)
 		}
-
-		unauthorized(
-			ctx,
-			"",
-			invalidClaim,
-			r.Host,
-			fmt.Sprintf("Failed to get token in callback: %v.", err),
-		)
-
+		f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get token in callback: %v.", err))
 		return
 	}
 
@@ -682,15 +714,8 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 			// error coming from an external library and the possible error reasons are
 			// not documented explicitly, so we assume that the cause is always rooted
 			// in the incoming request, and only log it with a debug flag, via calling
-			// unauthorized().
-			unauthorized(
-				ctx,
-				"",
-				invalidToken,
-				r.Host,
-				fmt.Sprintf("Failed to get userinfo: %v.", err),
-			)
-
+			// callbackUnauthorized().
+			f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get userinfo: %v.", err))
 			return
 		}
 		oidcIDToken, err = f.getidtoken(oauth2Token)
@@ -698,27 +723,13 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 			if _, ok := err.(*requestError); !ok {
 				ctx.Logger().Errorf("Error while getting id token: %v", err)
 			}
-
-			unauthorized(
-				ctx,
-				"",
-				invalidClaim,
-				r.Host,
-				fmt.Sprintf("Failed to get id token: %v", err),
-			)
-
+			f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get id token: %v", err))
 			return
 		}
 		sub = userInfo.Subject
 		claimsMap, _, err = f.tokenClaims(ctx, oauth2Token)
 		if err != nil {
-			unauthorized(
-				ctx,
-				"",
-				invalidToken,
-				r.Host,
-				fmt.Sprintf("Failed to get claims: %v.", err),
-			)
+			f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get claims: %v.", err))
 			return
 		}
 	case checkOIDCAnyClaims, checkOIDCAllClaims:
@@ -727,15 +738,7 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 			if _, ok := err.(*requestError); !ok {
 				ctx.Logger().Errorf("Error while getting id token: %v", err)
 			}
-
-			unauthorized(
-				ctx,
-				"",
-				invalidClaim,
-				r.Host,
-				fmt.Sprintf("Failed to get id token: %v", err),
-			)
-
+			f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get id token: %v", err))
 			return
 		}
 		claimsMap, sub, err = f.tokenClaims(ctx, oauth2Token)
@@ -743,19 +746,7 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 			if _, ok := err.(*requestError); !ok {
 				ctx.Logger().Errorf("Failed to get claims with error: %v", err)
 			}
-
-			unauthorized(
-				ctx,
-				"",
-				invalidToken,
-				r.Host,
-				fmt.Sprintf(
-					"Failed to get claims: %s, %v",
-					f.claims,
-					err,
-				),
-			)
-
+			f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get claims: %s, %v", f.claims, err))
 			return
 		}
 	}
@@ -770,14 +761,7 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 	data, err = json.Marshal(resp)
 	if err != nil {
 		log.Errorf("Failed to serialize claims: %v.", err)
-		unauthorized(
-			ctx,
-			"",
-			invalidSub,
-			r.Host,
-			"Failed to serialize claims.",
-		)
-
+		f.callbackUnauthorized(ctx, r.Host, "Failed to serialize claims.")
 		return
 	}
 
@@ -788,14 +772,7 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 	encryptedData, err := f.encrypter.Encrypt(compressedData)
 	if err != nil {
 		log.Errorf("Failed to encrypt the returned oidc data: %v.", err)
-		unauthorized(
-			ctx,
-			"",
-			invalidSub,
-			r.Host,
-			"Failed to encrypt the returned oidc data.",
-		)
-
+		f.callbackUnauthorized(ctx, r.Host, "Failed to encrypt the returned oidc data.")
 		return
 	}
 
@@ -823,11 +800,20 @@ func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
 	)
 	r := ctx.Request()
 
-	// Retrieve skipperOauthOidc cookie for processing and remove it from downstream request
+	// Retrieve skipperOauthOidc session cookie chunks for processing and remove
+	// them from the downstream request. The -state and -verifier CSRF cookies are
+	// stashed in the state bag so callbackEndpoint can read them without forwarding
+	// them to the backend.
+	stateCookieName := f.cookiename + "-state"
+	verifierCookieName := f.cookiename + "-verifier"
 	rCookies := r.Cookies()
 	r.Header.Del("Cookie")
 	for _, cookie := range rCookies {
-		if strings.HasPrefix(cookie.Name, f.cookiename) {
+		if cookie.Name == stateCookieName {
+			ctx.StateBag()[stateCookieName] = cookie.Value
+		} else if cookie.Name == verifierCookieName {
+			ctx.StateBag()[verifierCookieName] = cookie.Value
+		} else if strings.HasPrefix(cookie.Name, f.cookiename) {
 			cookies = append(cookies, cookie)
 		} else {
 			r.AddCookie(cookie)
@@ -990,14 +976,12 @@ func (f *tokenOidcFilter) getCallbackState(ctx filters.FilterContext) (*OauthSta
 		return nil, requestErrorf("failed to deserialize state: %v", err)
 	}
 
-	// CSRF protection: verify the request was redirected from the OIDC provider
-	// by checking the Referer header matches the provider's authorization endpoint.
-	// A browser that never started the flow (e.g. a CSRF victim following a crafted
-	// link) arrives without a Referer, while a legitimate redirect from the provider
-	// carries Referer set to the provider's auth URL.
-	referer := r.Header.Get("Referer")
-	if !strings.HasPrefix(referer, f.config.Endpoint.AuthURL) {
-		return nil, requestErrorf("invalid referer for OIDC callback")
+	// CSRF protection: verify the state cookie (stashed in StateBag by Request())
+	// matches the state query parameter. A browser that never started the flow
+	// holds no cookie and is rejected here.
+	stateCookieValue, ok := ctx.StateBag()[f.cookiename+"-state"].(string)
+	if !ok || stateCookieValue != stateQueryEncHex {
+		return nil, requestErrorf("missing or invalid state cookie")
 	}
 
 	return state, nil
@@ -1012,10 +996,19 @@ func (f *tokenOidcFilter) getTokenWithExchange(state *OauthState, ctx filters.Fi
 	// authcode flow
 	code := r.URL.Query().Get("code")
 
+	verifierValue, ok := ctx.StateBag()[f.cookiename+"-verifier"].(string)
+	if !ok || verifierValue == "" {
+		return nil, requestErrorf("missing PKCE verifier cookie")
+	}
+
+	exchangeOpts := make([]oauth2.AuthCodeOption, len(f.authCodeOptions)+1)
+	copy(exchangeOpts, f.authCodeOptions)
+	exchangeOpts[len(f.authCodeOptions)] = oauth2.VerifierOption(verifierValue)
+
 	// https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps
 	// 6. Client requests a response using the Authorization Code at the Token Endpoint.
 	// 7. Client receives a response that contains an ID Token and Access Token in the response body.
-	oauth2Token, err := f.config.Exchange(r.Context(), code, f.authCodeOptions...)
+	oauth2Token, err := f.config.Exchange(r.Context(), code, exchangeOpts...)
 	if err != nil {
 		// error coming from an external library and the possible error reasons are
 		// not documented explicitly, so we assume that the cause is always rooted

--- a/filters/auth/oidc_logincsrf_test.go
+++ b/filters/auth/oidc_logincsrf_test.go
@@ -96,10 +96,14 @@ func TestOidcLoginCSRF(t *testing.T) {
 	rsp.Body.Close()
 
 	t.Logf("victim callback response: %d, cookies set: %d", rsp.StatusCode, len(rsp.Cookies()))
+	var sessionCookies []*http.Cookie
 	for _, c := range rsp.Cookies() {
 		t.Logf("  cookie %s (len %d)", c.Name, len(c.Value))
+		if c.Value != "" && c.MaxAge > 0 {
+			sessionCookies = append(sessionCookies, c)
+		}
 	}
 
-	require.Empty(t, rsp.Cookies(),
+	require.Empty(t, sessionCookies,
 		"callbackEndpoint issued a session cookie to a browser that never started the flow")
 }

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -79,15 +79,20 @@ func (jar *insecureCookieJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 		cookieMap[c.Name] = c
 	}
 	for _, c := range cookies {
-		cookieMap[c.Name] = c
+		if c.MaxAge < 0 {
+			// MaxAge < 0 means delete: remove from the map.
+			delete(cookieMap, c.Name)
+		} else {
+			cookieMap[c.Name] = c
+		}
 	}
 
-	cookies = make([]*http.Cookie, 0, len(cookieMap))
+	stored := make([]*http.Cookie, 0, len(cookieMap))
 	for _, c := range cookieMap {
-		cookies = append(cookies, c)
+		stored = append(stored, c)
 	}
 
-	jar.store[u.Hostname()] = cookies
+	jar.store[u.Hostname()] = stored
 }
 func (jar *insecureCookieJar) Cookies(u *url.URL) []*http.Cookie {
 	return jar.store[u.Hostname()]
@@ -840,7 +845,7 @@ func TestOIDCSetup(t *testing.T) {
 		msg:             "has authType, all claims: valid claims and invalid scope",
 		filter:          `oauthOidcAllClaims("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "invalid", "uid")`,
 		expected:        401,
-		expectNoCookies: true, // 401 returned by OIDC server due to invalid scope before redirect
+		expectNoCookies: true, // 401 returned by OIDC server due to invalid scope before callback
 	}, {
 		msg:      "has authType, all claims valid and invalid",
 		filter:   `oauthOidcAllClaims("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid email", "uid invalid")`,
@@ -1061,7 +1066,14 @@ func TestOIDCSetup(t *testing.T) {
 				t.Logf("Got body: %s", string(b))
 			}
 
-			cookies := client.Jar.Cookies(reqURL)
+			allCookies := client.Jar.Cookies(reqURL)
+			// Filter out CSRF helper cookies (-state, -verifier) when checking for session cookies.
+			var cookies []*http.Cookie
+			for _, c := range allCookies {
+				if !strings.HasSuffix(c.Name, "-state") && !strings.HasSuffix(c.Name, "-verifier") {
+					cookies = append(cookies, c)
+				}
+			}
 			if tc.expectNoCookies {
 				assert.Empty(t, cookies)
 			} else {
@@ -1265,5 +1277,195 @@ func Test_tokenOidcFilter_getMaxAge(t *testing.T) {
 			assert.True(t, got >= tt.want-time.Minute && got <= 2*tt.want,
 				fmt.Sprintf("maxAge has to be within [%s - 1m, %s]", tt.want, tt.want))
 		})
+	}
+}
+
+// setupOIDCProxy creates the shared proxy+oidcServer infrastructure used by
+// the OIDC CSRF and normal-flow tests.
+func setupOIDCProxy(t *testing.T) (proxy *proxytest.TestProxy, oidcServer *httptest.Server, backend *httptest.Server, cleanup func()) {
+	t.Helper()
+
+	backend = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	fd, err := os.CreateTemp("", "testSecrets")
+	if err != nil {
+		backend.Close()
+		t.Fatal(err)
+	}
+	secretsFile := fd.Name()
+
+	fr := make(filters.Registry)
+	fr.Register(NewOAuthOidcAnyClaimsWithOptions(secretsFile, secrettest.NewTestRegistry(), OidcOptions{}))
+
+	dc := testdataclient.New(nil)
+
+	proxy = proxytest.WithRoutingOptions(fr, routing.Options{
+		DataClients: []routing.DataClient{dc},
+	})
+
+	redirectURL, _ := url.Parse(proxy.URL)
+	redirectURL.Path = "/redirect"
+
+	oidcServer = createOIDCServer(redirectURL.String(), "valid-client", "mysec", nil, nil)
+
+	f, err := parseFilter(
+		`oauthOidcAnyClaims("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "", "")`,
+		oidcServer.URL, redirectURL.String())
+	if err != nil {
+		oidcServer.Close()
+		proxy.Close()
+		dc.Close()
+		backend.Close()
+		os.Remove(secretsFile)
+		t.Fatal(err)
+	}
+
+	proxy.Log.Reset()
+	dc.Update([]*eskip.Route{{Filters: f, Backend: backend.URL}}, nil)
+	if err := proxy.Log.WaitFor("route settings applied", 10*time.Second); err != nil {
+		oidcServer.Close()
+		proxy.Close()
+		dc.Close()
+		backend.Close()
+		os.Remove(secretsFile)
+		t.Fatal(err)
+	}
+
+	cleanup = func() {
+		oidcServer.Close()
+		proxy.Close()
+		dc.Close()
+		backend.Close()
+		os.Remove(secretsFile)
+	}
+	return proxy, oidcServer, backend, cleanup
+}
+
+// TestOIDCNormalFlow verifies that a browser completing the full OIDC authorization
+// code flow receives a session cookie and can access the protected resource.
+func TestOIDCNormalFlow(t *testing.T) {
+	proxy, _, _, cleanup := setupOIDCProxy(t)
+	defer cleanup()
+
+	// Use a client that does NOT auto-follow redirects so we can manually drive
+	// each hop and verify the cookie jar is populated correctly.
+	noRedirects := func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	browser := &http.Client{
+		Timeout:       5 * time.Second,
+		Jar:           newInsecureCookieJar(),
+		CheckRedirect: noRedirects,
+	}
+
+	// 1. First unauthenticated request → proxy redirects to OIDC provider and
+	//    sets state + verifier cookies.
+	rsp, err := browser.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatalf("step 1: %v", err)
+	}
+	rsp.Body.Close()
+	if rsp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("step 1: expected 307, got %d", rsp.StatusCode)
+	}
+	oidcAuthURL := rsp.Header.Get("Location")
+	t.Logf("step 1: redirecting to OIDC: %s", oidcAuthURL)
+
+	// 2. Follow to OIDC provider → provider authenticates and redirects to callback.
+	rsp, err = browser.Get(oidcAuthURL)
+	if err != nil {
+		t.Fatalf("step 2: %v", err)
+	}
+	rsp.Body.Close()
+	callbackURL := rsp.Header.Get("Location")
+	t.Logf("step 2: provider returned callback: %s", callbackURL)
+
+	// 3. Follow callback → proxy validates state cookie, exchanges code for token,
+	//    sets session cookie, redirects to original URL.
+	rsp, err = browser.Get(callbackURL)
+	if err != nil {
+		t.Fatalf("step 3: %v", err)
+	}
+	rsp.Body.Close()
+	t.Logf("step 3: callback response %d", rsp.StatusCode)
+	if rsp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("step 3: expected 307 redirect after callback, got %d", rsp.StatusCode)
+	}
+	finalURL := rsp.Header.Get("Location")
+
+	// 4. Follow to original URL with session cookie → backend responds.
+	// The callback redirect Location may be relative (e.g. "/") — resolve it.
+	if !strings.HasPrefix(finalURL, "http") {
+		base, _ := url.Parse(proxy.URL)
+		rel, err := url.Parse(finalURL)
+		if err != nil {
+			t.Fatalf("step 4: bad location %q: %v", finalURL, err)
+		}
+		finalURL = base.ResolveReference(rel).String()
+	}
+	rsp, err = browser.Get(finalURL)
+	if err != nil {
+		t.Fatalf("step 4: %v", err)
+	}
+	rsp.Body.Close()
+	if rsp.StatusCode != http.StatusNoContent {
+		t.Errorf("step 4: expected 204 from backend, got %d", rsp.StatusCode)
+	}
+}
+
+// TestOIDCLoginCSRF verifies that a browser which never started a login flow
+// cannot be authenticated by a callback URL crafted by an attacker.
+// After the cookie-based CSRF protection is in place, the victim's request to
+// the callback endpoint is rejected (no state cookie → 400 Bad Request).
+func TestOIDCLoginCSRF(t *testing.T) {
+	proxy, _, _, cleanup := setupOIDCProxy(t)
+	defer cleanup()
+
+	noRedirects := func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	// 1. Attacker starts the flow on their own browser (no cookie jar → cookies discarded).
+	attacker := &http.Client{Timeout: 5 * time.Second, CheckRedirect: noRedirects}
+
+	rsp, err := attacker.Get(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsp.Body.Close()
+	if rsp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("expected redirect from proxy, got %d", rsp.StatusCode)
+	}
+
+	// 2. Attacker follows to provider, captures the callback URL.
+	rsp, err = attacker.Get(rsp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsp.Body.Close()
+
+	callbackURL := rsp.Header.Get("Location")
+	parsed, err := url.Parse(callbackURL)
+	if err != nil || parsed.Query().Get("code") == "" {
+		t.Fatalf("expected callback URL with code, got: %s", callbackURL)
+	}
+
+	// 3. Victim (no cookie jar) follows the attacker's callback URL.
+	victim := &http.Client{Timeout: 5 * time.Second, CheckRedirect: noRedirects}
+
+	rsp, err = victim.Get(callbackURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsp.Body.Close()
+
+	// The callback must be rejected: no state cookie → Unauthorized.
+	if rsp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 Unauthorized for victim without state cookie, got %d", rsp.StatusCode)
+	}
+	// CSRF cookie cleanup (MaxAge=0, empty value) may be present in the response;
+	// ensure no session cookies (non-empty value, positive MaxAge) were issued.
+	for _, c := range rsp.Cookies() {
+		if c.Value != "" && c.MaxAge > 0 {
+			t.Errorf("victim received unexpected session cookie: %v", c)
+		}
 	}
 }


### PR DESCRIPTION
fix: Referer header could be deleted by privacy enhancements in the browser, so move the protection to use cookies, which are required for session anyways

follow up on https://github.com/zalando/skipper/pull/4195

thanks @kanywst for the hint