### PR TITLE
Store routes compressed-only, decompress on demand

### DIFF
--- a/routesrv/eskipbytes.go
+++ b/routesrv/eskipbytes.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -53,8 +54,6 @@ var (
 // serve as an HTTP handler exposing its content.
 type eskipBytes struct {
 	mu               sync.RWMutex
-	data             []byte
-	zoneData         map[string][]byte
 	hash             string
 	zoneHash         map[string]string
 	lastModified     time.Time
@@ -84,10 +83,12 @@ func (e *eskipBytes) formatAndSet(routes []*eskip.Route, zoneAwareRoutes map[str
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	updated = !bytes.Equal(e.data, data)
+	hash := fmt.Sprintf("%x", sha256.Sum256(data))
+	updated = hash != e.hash
+
 	if updated {
 		now := e.now()
-		e.zoneData, e.zoneDataCompressed, e.zoneCount = make(map[string][]byte), make(map[string][]byte), make(map[string]int)
+		e.zoneDataCompressed, e.zoneCount = make(map[string][]byte), make(map[string]int)
 		e.zoneHash = make(map[string]string)
 		e.zoneLastModified = make(map[string]time.Time)
 		for zone, routes := range zoneAwareRoutes {
@@ -95,21 +96,19 @@ func (e *eskipBytes) formatAndSet(routes []*eskip.Route, zoneAwareRoutes map[str
 			eskip.Fprint(zoneBuf, eskip.PrettyPrintInfo{Pretty: false, IndentStr: ""}, routes...)
 			zoneData := zoneBuf.Bytes()
 			e.zoneLastModified[zone] = now
-			e.zoneData[zone] = zoneData
 			e.zoneDataCompressed[zone] = e.compressLocked(zoneData)
 			e.zoneHash[zone] = fmt.Sprintf("%x", sha256.Sum256(zoneData))
 			e.zoneCount[zone] = len(routes)
 		}
 		e.lastModified = now
-		e.data = data
 		e.zdata = e.compressLocked(data)
-		e.hash = fmt.Sprintf("%x", sha256.Sum256(e.data))
+		e.hash = hash
 		e.count = len(routes)
 	}
 	initialized = !e.initialized
 	e.initialized = true
 
-	return len(e.data), e.hash, initialized, updated
+	return len(data), e.hash, initialized, updated
 }
 
 // compressLocked compresses the data with gzip and returns
@@ -129,6 +128,15 @@ func (e *eskipBytes) compressLocked(data []byte) []byte {
 		return nil
 	}
 	return buf.Bytes()
+}
+
+func decompress(data []byte) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+	return io.ReadAll(zr)
 }
 
 func (e *eskipBytes) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
@@ -156,7 +164,6 @@ func (e *eskipBytes) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	e.mu.RLock()
 	count := e.count
-	data := e.data
 	zdata := e.zdata
 	hash := e.hash
 	lastModified := e.lastModified
@@ -167,9 +174,8 @@ func (e *eskipBytes) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	// we check for three endpoints because three is good choice for availability; it guarantees that at least one endpoint will be healthy even if the others are on update or have some issues
 	zone := r.PathValue("zone")
 	if zone != "" {
-		if zd, ok := e.zoneData[zone]; ok {
-			data = zd
-			zdata = e.zoneDataCompressed[zone]
+		if zd, ok := e.zoneDataCompressed[zone]; ok {
+			zdata = zd
 			count = e.zoneCount[zone]
 			hash = e.zoneHash[zone]
 			lastModified = e.zoneLastModified[zone]
@@ -187,6 +193,11 @@ func (e *eskipBytes) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Encoding", "gzip")
 			http.ServeContent(w, r, "", lastModified, bytes.NewReader(zdata))
 		} else {
+			data, err := decompress(zdata)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			w.Header().Set("Etag", `"`+hash+`"`)
 			http.ServeContent(w, r, "", lastModified, bytes.NewReader(data))
 		}

--- a/routesrv/eskipbytes_test.go
+++ b/routesrv/eskipbytes_test.go
@@ -1,0 +1,104 @@
+package routesrv
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/zalando/skipper/eskip"
+)
+
+// benchRoutes synthesizes n LB-backend routes whose endpoints are spread across
+// the given zones, mirroring the shape of the profiled route table (each route
+// carries a host predicate, a filter and per-zone endpoints).
+func benchRoutes(n, endpointsPerZone int, zones []string) []*eskip.Route {
+	routes := make([]*eskip.Route, n)
+	for i := range routes {
+		eps := make([]*eskip.LBEndpoint, 0, len(zones)*endpointsPerZone)
+		for _, z := range zones {
+			for j := range endpointsPerZone {
+				eps = append(eps, &eskip.LBEndpoint{
+					Address: fmt.Sprintf("https://10.%d.%d.%d:8080", i%256, j, len(z)),
+					Zone:    z,
+				})
+			}
+		}
+		routes[i] = &eskip.Route{
+			Id:          fmt.Sprintf("kube_namespace__ingress%d__example_org___svc%d", i, i),
+			HostRegexps: []string{fmt.Sprintf("^svc%d[.]example[.]org$", i)},
+			Filters:     []*eskip.Filter{{Name: "setRequestHeader", Args: []any{"X-Svc", fmt.Sprintf("svc%d", i)}}},
+			BackendType: eskip.LBBackend,
+			LBAlgorithm: "consistentHash",
+			LBEndpoints: eps,
+		}
+	}
+	return routes
+}
+
+// retainedBytes sums the length of every []byte and map[string][]byte field in
+// eskipBytes via reflection, so it counts whatever route-table bytes the struct
+// keeps resident without naming fields. This makes it deterministic and valid on
+// both the pre-change struct (which also holds the uncompressed data/zoneData)
+// and the current compressed-only struct.
+func retainedBytes(e *eskipBytes) int {
+	total := 0
+	v := reflect.ValueOf(e).Elem()
+	for _, f := range v.Fields() {
+		switch f.Kind() {
+		case reflect.Slice:
+			if f.Type().Elem().Kind() == reflect.Uint8 {
+				total += f.Len()
+			}
+		case reflect.Map:
+			et := f.Type().Elem()
+			if et.Kind() == reflect.Slice && et.Elem().Kind() == reflect.Uint8 {
+				for iter := f.MapRange(); iter.Next(); {
+					total += iter.Value().Len()
+				}
+			}
+		}
+	}
+	return total
+}
+
+// BenchmarkFormatAndSet reports per-call allocation (via -benchmem) and
+// retained_MB: the total route-table bytes the stored eskipBytes keeps resident
+// (see retainedBytes). This drops when the base and per-zone tables are stored
+// compressed-only instead of uncompressed, so run it before and after the change
+// (e.g. across a git stash of the source) to see the difference. It is
+// deterministic — no GC/heap-sampling noise.
+func BenchmarkFormatAndSet(b *testing.B) {
+	zones := []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"}
+	routes := benchRoutes(20000, 3, zones)
+	zoneAware := filterRoutesByZone(routes)
+
+	b.ReportAllocs()
+	var e *eskipBytes
+	for b.Loop() {
+		e = &eskipBytes{now: time.Now}
+		e.formatAndSet(routes, zoneAware)
+	}
+	b.StopTimer()
+
+	b.ReportMetric(float64(retainedBytes(e))/1e6, "retained_MB")
+}
+
+// BenchmarkFormatAndSetNoChange measures the poll path where the serialized
+// table is unchanged (updated == false) — the only place this change adds CPU:
+// the current code computes a SHA-256 of the base table every call for change
+// detection, where the pre-change code did a bytes.Equal. The base is
+// re-serialized in both revisions, so that cost is shared.
+func BenchmarkFormatAndSetNoChange(b *testing.B) {
+	zones := []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"}
+	routes := benchRoutes(20000, 3, zones)
+	zoneAware := filterRoutesByZone(routes)
+
+	e := &eskipBytes{now: time.Now}
+	e.formatAndSet(routes, zoneAware) // prime, so subsequent calls see no change
+
+	b.ReportAllocs()
+	for b.Loop() {
+		e.formatAndSet(routes, zoneAware)
+	}
+}

--- a/routesrv/routesrv.go
+++ b/routesrv/routesrv.go
@@ -81,7 +81,6 @@ func New(opts skipper.Options) (*RouteServer, error) {
 		tracer:             tracer,
 		metrics:            m,
 		now:                time.Now,
-		zoneData:           make(map[string][]byte),
 		zoneDataCompressed: make(map[string][]byte),
 		zoneCount:          make(map[string]int),
 		zoneLastModified:   make(map[string]time.Time),


### PR DESCRIPTION
With the introduction of the zone aware routing memory consumption increased  x4 - instead of one uncompressed routeTree + compressed buffer, we additionally store same routetree for every az - the route data is the same, only engpoints are changing.

An easy win is - not store the uncompressed buffed and decomress it on demand. Majority of the clients use compression, so the change will not affect cpu drasticlally.

Included benchmark shows small difference in allocations and timings

master branch
```
go test ./routesrv/ -run '^$' -bench '^BenchmarkFormatAndSet$' -benchmem -benchtime=1x -count=1
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/routesrv
cpu: Apple M1 Max
BenchmarkFormatAndSet-10               1         268640667 ns/op                30.66 retained_MB       242449992 B/op   2620204 allocs/op
PASS
ok      github.com/zalando/skipper/routesrv     1.963s
```
and on this branch
```
» go test ./routesrv/ -run '^$' -bench '^BenchmarkFormatAndSet$' -benchmem -benchtime=1x -count=1
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/routesrv
cpu: Apple M1 Max
BenchmarkFormatAndSet-10               1         269234917 ns/op                 1.998 retained_MB      242448480 B/op   2620197 allocs/op
PASS
ok      github.com/zalando/skipper/routesrv     2.188s
```

`BenchmarkFormatAndSetNoChange` shows the effect of computing the hashes on every pull
 on master branch
```
go test ./routesrv/ -run '^$' -bench '^BenchmarkFormatAndSetNoChange$' -benchmem -benchtime=1x -count=1
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/routesrv
cpu: Apple M1 Max
BenchmarkFormatAndSetNoChange-10               1          41434542 ns/op        91490328 B/op     760026 allocs/op
PASS
ok      github.com/zalando/skipper/routesrv     2.241s
``` 
on this branch
```
go test ./routesrv/ -run '^$' -bench '^BenchmarkFormatAndSetNoChange$' -benchmem -benchtime=1x -count=1
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/routesrv
cpu: Apple M1 Max
BenchmarkFormatAndSetNoChange-10               1          45769250 ns/op        91490304 B/op     760027 allocs/op
PASS
ok      github.com/zalando/skipper/routesrv     2.058s
```

