### PR TITLE
feature: add optional response status condition to logBody filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1011,11 +1011,14 @@ data. Logs can also explode in the amount of bytes, so you have to
 choose a limit. You can log request or response bodies. This filter
 has close to no overhead other than the I/O created by the logger.
 
-The optional status parameter logs the body only if the response status
-code is greater than or equal to it, which is useful to capture the
-bodies of failing requests without logging the successful ones. The
-response body is still streamed in that case, but for the request body
-the status is not known while it streams, so up to limit bytes are
+The optional response status code prefixes log the body only for matching
+responses, which is useful to capture the bodies of failing requests
+without logging the successful ones. They follow the same matching rules
+as [enableAccessLog](#enableaccesslog): a value below 10 matches a status
+class, below 100 a sub-class and anything larger an exact status code.
+
+The response body is still streamed in that case, but for the request
+body the status is not known while it streams, so up to limit bytes are
 buffered and logged once the response status is known. The request body
 itself is neither held back nor truncated.
 
@@ -1023,7 +1026,7 @@ Parameters:
 
 * type: "request" or "response" (string)
 * limit: maximum number of bytes to log (int)
-* status: log only from this response status code on, 100 to 599 (int) - optional
+* status code prefixes: log only for matching responses (int) - optional, variadic
 
 Example:
 
@@ -1033,10 +1036,16 @@ Example:
 * -> logBody("request", 1024) -> logBody("response", 1024) -> "https://www.example.org";
 ```
 
-Log the request body only for server errors:
+Log the request body only for server errors, i.e. any 5xx response:
 
 ```
-* -> logBody("request", 1024, 500) -> "https://www.example.org";
+* -> logBody("request", 1024, 5) -> "https://www.example.org";
+```
+
+Log the request body for 5xx responses and for 429 specifically:
+
+```
+* -> logBody("request", 1024, 5, 429) -> "https://www.example.org";
 ```
 
 ## Timeout

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1011,10 +1011,19 @@ data. Logs can also explode in the amount of bytes, so you have to
 choose a limit. You can log request or response bodies. This filter
 has close to no overhead other than the I/O created by the logger.
 
+The optional status parameter logs the body only if the response status
+code is greater than or equal to it, which is useful to capture the
+bodies of failing requests without logging the successful ones. The
+response body is still streamed in that case, but for the request body
+the status is not known while it streams, so up to limit bytes are
+buffered and logged once the response status is known. The request body
+itself is neither held back nor truncated.
+
 Parameters:
 
 * type: "request" or "response" (string)
 * limit: maximum number of bytes to log (int)
+* status: log only from this response status code on, 100 to 599 (int) - optional
 
 Example:
 
@@ -1022,6 +1031,12 @@ Example:
 * -> logBody("request", 1024) -> "https://www.example.org";
 * -> logBody("response", 1024) -> "https://www.example.org";
 * -> logBody("request", 1024) -> logBody("response", 1024) -> "https://www.example.org";
+```
+
+Log the request body only for server errors:
+
+```
+* -> logBody("request", 1024, 500) -> "https://www.example.org";
 ```
 
 ## Timeout

--- a/filters/diag/logbody.go
+++ b/filters/diag/logbody.go
@@ -24,13 +24,6 @@ type logBody struct {
 }
 
 // NewLogBody creates a filter specification for the 'logBody()' filter.
-//
-// It takes the type of the body to log, "request" or "response", a limit
-// of the number of bytes to log and an optional response status code from
-// which on to log. Without the status code the body is logged in chunks
-// while it streams. With it, a response body is logged the same way once
-// the status matches, while a request body is buffered up to the limit
-// and logged after the response status is known.
 func NewLogBody() filters.Spec { return logBody{} }
 
 // Name returns the logBody filter name.

--- a/filters/diag/logbody.go
+++ b/filters/diag/logbody.go
@@ -18,9 +18,12 @@ type logBody struct {
 	limit    int
 	request  bool
 	response bool
-	// minStatus is the response status code from which on the body is
-	// logged. Zero means no condition, i.e. always log.
-	minStatus int
+	// statusPrefixes selects which responses get logged, following the
+	// same matching rules as the enableAccessLog filter: a value below 10
+	// matches a status class (5 matches 5xx), below 100 a sub-class (50
+	// matches 50x) and any larger value an exact status code. Empty means
+	// no condition, i.e. always log.
+	statusPrefixes []int
 }
 
 // NewLogBody creates a filter specification for the 'logBody()' filter.
@@ -33,12 +36,11 @@ func (logBody) Name() string {
 
 func (logBody) CreateFilter(args []interface{}) (filters.Filter, error) {
 	var (
-		request   = false
-		response  = false
-		minStatus = 0
+		request  = false
+		response = false
 	)
 
-	if len(args) != 2 && len(args) != 3 {
+	if len(args) < 2 {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
@@ -60,23 +62,63 @@ func (logBody) CreateFilter(args []interface{}) (filters.Filter, error) {
 		return nil, fmt.Errorf("failed to convert to int: %w", filters.ErrInvalidFilterParameters)
 	}
 
-	if len(args) == 3 {
-		status, ok := args[2].(float64)
-		if !ok || float64(int(status)) != status {
+	var statusPrefixes []int
+	for _, arg := range args[2:] {
+		prefix, ok := arg.(float64)
+		if !ok || float64(int(prefix)) != prefix {
 			return nil, fmt.Errorf("failed to convert to int: %w", filters.ErrInvalidFilterParameters)
 		}
-		minStatus = int(status)
-		if minStatus < 100 || minStatus > 599 {
-			return nil, fmt.Errorf("status %d out of range [100, 599]: %w", minStatus, filters.ErrInvalidFilterParameters)
+		p := int(prefix)
+		if !validStatusPrefix(p) {
+			return nil, fmt.Errorf("status prefix %d cannot match a response status: %w", p, filters.ErrInvalidFilterParameters)
 		}
+		statusPrefixes = append(statusPrefixes, p)
 	}
 
 	return &logBody{
-		limit:     int(limit),
-		request:   request,
-		response:  response,
-		minStatus: minStatus,
+		limit:          int(limit),
+		request:        request,
+		response:       response,
+		statusPrefixes: statusPrefixes,
 	}, nil
+}
+
+// validStatusPrefix reports whether prefix can select any response status.
+// A prefix below 10 matches a status class, below 100 a sub-class and
+// anything larger an exact code, so only the values that reach into the
+// [100, 599] range are accepted. This rejects typos such as 0, 6 or 600,
+// which would otherwise silently never log.
+func validStatusPrefix(prefix int) bool {
+	switch {
+	case prefix < 10:
+		return prefix >= 1 && prefix <= 5
+	case prefix < 100:
+		return prefix >= 10 && prefix <= 59
+	default:
+		return prefix <= 599
+	}
+}
+
+// matchStatus reports whether statusCode is selected by the configured
+// prefixes. The rules are the same as the enableAccessLog filter's.
+func (lb *logBody) matchStatus(statusCode int) bool {
+	for _, prefix := range lb.statusPrefixes {
+		switch {
+		case prefix < 10:
+			if statusCode >= prefix*100 && statusCode < (prefix+1)*100 {
+				return true
+			}
+		case prefix < 100:
+			if statusCode >= prefix*10 && statusCode < (prefix+1)*10 {
+				return true
+			}
+		default:
+			if statusCode == prefix {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (lb *logBody) Request(ctx filters.FilterContext) {
@@ -89,7 +131,7 @@ func (lb *logBody) Request(ctx filters.FilterContext) {
 		return
 	}
 
-	if lb.minStatus == 0 {
+	if len(lb.statusPrefixes) == 0 {
 		req.Body = newLogBodyStream(
 			lb.limit,
 			func(chunk []byte) {
@@ -115,12 +157,12 @@ func (lb *logBody) Request(ctx filters.FilterContext) {
 }
 
 func (lb *logBody) Response(ctx filters.FilterContext) {
-	if lb.minStatus > 0 && ctx.Response().StatusCode < lb.minStatus {
+	if len(lb.statusPrefixes) > 0 && !lb.matchStatus(ctx.Response().StatusCode) {
 		return
 	}
 
 	if lb.request {
-		if lb.minStatus > 0 {
+		if len(lb.statusPrefixes) > 0 {
 			lb.logBufferedRequest(ctx)
 		}
 		return

--- a/filters/diag/logbody.go
+++ b/filters/diag/logbody.go
@@ -1,6 +1,7 @@
 package diag
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -8,13 +9,28 @@ import (
 	"github.com/zalando/skipper/filters/flowid"
 )
 
+// logBodyRequestKey is the state bag key used to hand the captured request
+// body from the request to the response phase, when a status condition
+// defers the decision to log until the response status is known.
+const logBodyRequestKey = "filter." + filters.LogBodyName + ".request"
+
 type logBody struct {
 	limit    int
 	request  bool
 	response bool
+	// minStatus is the response status code from which on the body is
+	// logged. Zero means no condition, i.e. always log.
+	minStatus int
 }
 
 // NewLogBody creates a filter specification for the 'logBody()' filter.
+//
+// It takes the type of the body to log, "request" or "response", a limit
+// of the number of bytes to log and an optional response status code from
+// which on to log. Without the status code the body is logged in chunks
+// while it streams. With it, a response body is logged the same way once
+// the status matches, while a request body is buffered up to the limit
+// and logged after the response status is known.
 func NewLogBody() filters.Spec { return logBody{} }
 
 // Name returns the logBody filter name.
@@ -24,11 +40,12 @@ func (logBody) Name() string {
 
 func (logBody) CreateFilter(args []interface{}) (filters.Filter, error) {
 	var (
-		request  = false
-		response = false
+		request   = false
+		response  = false
+		minStatus = 0
 	)
 
-	if len(args) != 2 {
+	if len(args) != 2 && len(args) != 3 {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
@@ -50,10 +67,22 @@ func (logBody) CreateFilter(args []interface{}) (filters.Filter, error) {
 		return nil, fmt.Errorf("failed to convert to int: %w", filters.ErrInvalidFilterParameters)
 	}
 
+	if len(args) == 3 {
+		status, ok := args[2].(float64)
+		if !ok || float64(int(status)) != status {
+			return nil, fmt.Errorf("failed to convert to int: %w", filters.ErrInvalidFilterParameters)
+		}
+		minStatus = int(status)
+		if minStatus < 100 || minStatus > 599 {
+			return nil, fmt.Errorf("status %d out of range [100, 599]: %w", minStatus, filters.ErrInvalidFilterParameters)
+		}
+	}
+
 	return &logBody{
-		limit:    int(limit),
-		request:  request,
-		response: response,
+		limit:     int(limit),
+		request:   request,
+		response:  response,
+		minStatus: minStatus,
 	}, nil
 }
 
@@ -63,7 +92,11 @@ func (lb *logBody) Request(ctx filters.FilterContext) {
 	}
 
 	req := ctx.Request()
-	if req.Body != nil {
+	if req.Body == nil {
+		return
+	}
+
+	if lb.minStatus == 0 {
 		req.Body = newLogBodyStream(
 			lb.limit,
 			func(chunk []byte) {
@@ -74,10 +107,32 @@ func (lb *logBody) Request(ctx filters.FilterContext) {
 			},
 			req.Body,
 		)
+		return
 	}
+
+	// The response status is not known yet, so buffer instead of logging.
+	// The limit caps the buffer, the request body itself is not held back.
+	buf := &bytes.Buffer{}
+	ctx.StateBag()[logBodyRequestKey] = buf
+	req.Body = newLogBodyStream(
+		lb.limit,
+		func(chunk []byte) { buf.Write(chunk) },
+		req.Body,
+	)
 }
 
 func (lb *logBody) Response(ctx filters.FilterContext) {
+	if lb.minStatus > 0 && ctx.Response().StatusCode < lb.minStatus {
+		return
+	}
+
+	if lb.request {
+		if lb.minStatus > 0 {
+			lb.logBufferedRequest(ctx)
+		}
+		return
+	}
+
 	if !lb.response {
 		return
 	}
@@ -95,6 +150,18 @@ func (lb *logBody) Response(ctx filters.FilterContext) {
 			rsp.Body,
 		)
 	}
+}
+
+func (lb *logBody) logBufferedRequest(ctx filters.FilterContext) {
+	buf, ok := ctx.StateBag()[logBodyRequestKey].(*bytes.Buffer)
+	if !ok || buf.Len() == 0 {
+		return
+	}
+
+	ctx.Logger().Infof(
+		`logBody("request") %s: %q`,
+		ctx.Request().Header.Get(flowid.HeaderName),
+		buf.Bytes())
 }
 
 type logBodyStream struct {

--- a/filters/diag/logbody_test.go
+++ b/filters/diag/logbody_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -371,6 +372,160 @@ func TestLogBody(t *testing.T) {
 		// the response body is still delivered to the client
 		if rspBody != strings.Repeat("b", 10) {
 			t.Fatalf("Failed to pass the response body through, got: %q", rspBody)
+		}
+	})
+}
+
+// TestLogBodyRequestStatusConditionClientCancel covers the memory question the
+// status condition raises: with logBody("request", limit, status) the request
+// body cannot be logged while it streams, because the status that decides
+// whether to log it is not known until the response phase. It is therefore
+// buffered, and a client that disconnects while the backend is still working
+// means that buffer is built up for a response phase that never runs.
+//
+// Two properties make that safe, and each is asserted below:
+//
+//  1. the buffer is capped by the filter's own limit argument, not by the size
+//     of the request body, so a large upload cannot inflate it; and
+//  2. the buffer is reachable only from the request's state bag, so it is
+//     released with the request rather than accumulating across cancellations.
+func TestLogBodyRequestStatusConditionClientCancel(t *testing.T) {
+	defer log.SetOutput(os.Stderr)
+
+	const (
+		limit         = 1024
+		bodySize      = 256 * 1024
+		backendSleep  = 500 * time.Millisecond
+		clientTimeout = 20 * time.Millisecond
+	)
+
+	// The backend drains the request body and then sleeps well past the client
+	// timeout, so the client always disconnects before a response status exists.
+	be := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		time.Sleep(backendSleep)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer be.Close()
+
+	fr := make(filters.Registry)
+	fr.Register(NewLogBody())
+	routes := eskip.MustParse(fmt.Sprintf(`r: * -> logBody("request", %d, 500) -> "%s"`, limit, be.URL))
+	p := proxytest.New(fr, routes...)
+	defer p.Close()
+
+	body := strings.Repeat("a", bodySize)
+
+	// postAndCancel issues a POST that gives up while the backend is sleeping.
+	// It returns the error the client saw, which must not be nil for the
+	// cancellation assertions below to mean anything.
+	postAndCancel := func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), clientTimeout)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, "POST", p.URL, strings.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "text/plain")
+
+		rsp, err := p.Client().Do(req)
+		if err != nil {
+			return err
+		}
+		io.Copy(io.Discard, rsp.Body)
+		rsp.Body.Close()
+		return nil
+	}
+
+	t.Run("the buffered body is capped by the limit, not the body size", func(t *testing.T) {
+		// Drive the stream exactly as Request() does when a status condition
+		// is set: the callback appends to a buffer instead of logging.
+		buf := &bytes.Buffer{}
+		stream := newLogBodyStream(
+			limit,
+			func(chunk []byte) { buf.Write(chunk) },
+			io.NopCloser(strings.NewReader(body)),
+		)
+
+		n, err := io.Copy(io.Discard, stream)
+		if err != nil {
+			t.Fatalf("Failed to read the body through the stream: %v", err)
+		}
+		if err := stream.Close(); err != nil {
+			t.Fatalf("Failed to close the stream: %v", err)
+		}
+
+		// The body still passes through in full ...
+		if n != bodySize {
+			t.Fatalf("Failed to pass the whole body through, want %d bytes, got: %d", bodySize, n)
+		}
+		// ... while only limit bytes of it are ever retained.
+		if buf.Len() != limit {
+			t.Fatalf("Failed to cap the buffered body at %d bytes, got: %d", limit, buf.Len())
+		}
+	})
+
+	t.Run("nothing is logged when the client cancels before the status is known", func(t *testing.T) {
+		logbuf := bytes.NewBuffer(nil)
+		log.SetOutput(logbuf)
+		err := postAndCancel()
+		log.SetOutput(os.Stderr)
+
+		if err == nil {
+			t.Fatalf("Failed to cancel before the backend responded, expected a client error")
+		}
+
+		// Logging is deferred to the response phase, which never sees a status
+		// here, so the buffered body must not reach the log.
+		if got := logbuf.String(); strings.Contains(got, strings.Repeat("a", limit)) {
+			t.Fatalf("Found the buffered request body in the log after cancellation, got: %q", got)
+		}
+	})
+
+	t.Run("repeated cancellations do not accumulate buffers", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping the allocation check in short mode")
+		}
+
+		const iterations = 50
+
+		log.SetOutput(io.Discard)
+		defer log.SetOutput(os.Stderr)
+
+		// Warm up so that one-off proxy and transport allocations are not
+		// counted as growth, then measure across the cancelled requests.
+		if err := postAndCancel(); err == nil {
+			t.Fatalf("Failed to cancel before the backend responded, expected a client error")
+		}
+
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+
+		for i := 0; i < iterations; i++ {
+			if err := postAndCancel(); err == nil {
+				t.Fatalf("Failed to cancel before the backend responded on iteration %d", i)
+			}
+		}
+
+		runtime.GC()
+		runtime.ReadMemStats(&after)
+
+		// Retaining one buffer per cancelled request would grow the heap by
+		// iterations*limit; retaining the whole body would grow it by
+		// iterations*bodySize. The threshold sits far below the latter and well
+		// above ordinary test noise, so it fails on a real leak without being
+		// sensitive to allocation churn.
+		const threshold = iterations * bodySize / 8
+
+		var growth uint64
+		if after.HeapAlloc > before.HeapAlloc {
+			growth = after.HeapAlloc - before.HeapAlloc
+		}
+		if growth > threshold {
+			t.Fatalf("Failed to release the buffered bodies, heap grew by %d bytes over %d cancelled requests, want at most %d",
+				growth, iterations, uint64(threshold))
 		}
 	})
 }

--- a/filters/diag/logbody_test.go
+++ b/filters/diag/logbody_test.go
@@ -50,6 +50,26 @@ func TestLogBodyCreateFilter(t *testing.T) {
 			name: "wrong arg1 type should fail",
 			args: []interface{}{"request", "foo"},
 			want: filters.ErrInvalidFilterParameters,
+		},
+		{
+			name: "wrong arg2 type should fail",
+			args: []interface{}{"request", 1024.0, "foo"},
+			want: filters.ErrInvalidFilterParameters,
+		},
+		{
+			name: "arg2 below the status range should fail",
+			args: []interface{}{"request", 1024.0, 99.0},
+			want: filters.ErrInvalidFilterParameters,
+		},
+		{
+			name: "arg2 above the status range should fail",
+			args: []interface{}{"request", 1024.0, 600.0},
+			want: filters.ErrInvalidFilterParameters,
+		},
+		{
+			name: "more than expected args should fail",
+			args: []interface{}{"request", 1024.0, 500.0, 1.0},
+			want: filters.ErrInvalidFilterParameters,
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := NewLogBody()
@@ -60,6 +80,44 @@ func TestLogBodyCreateFilter(t *testing.T) {
 		})
 	}
 
+}
+
+func TestLogBodyCreateFilterValid(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []interface{}
+	}{
+		{
+			name: "request without status condition",
+			args: []interface{}{"request", 1024.0},
+		},
+		{
+			name: "response without status condition",
+			args: []interface{}{"response", 1024.0},
+		},
+		{
+			name: "request with status condition",
+			args: []interface{}{"request", 1024.0, 500.0},
+		},
+		{
+			name: "response with status condition",
+			args: []interface{}{"response", 1024.0, 500.0},
+		},
+		{
+			name: "lowest valid status",
+			args: []interface{}{"request", 1024.0, 100.0},
+		},
+		{
+			name: "highest valid status",
+			args: []interface{}{"request", 1024.0, 599.0},
+		}} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := NewLogBody()
+			if _, err := spec.CreateFilter(tt.args); err != nil {
+				t.Fatalf("Failed to create filter for args %v: %v", tt.args, err)
+			}
+		})
+	}
 }
 
 func TestLogBody(t *testing.T) {
@@ -255,6 +313,122 @@ func TestLogBody(t *testing.T) {
 			t.Fatalf("Failed to not change response body(%d): %v", len(data), data)
 		}
 	})
+
+	t.Run("Request with status condition logs on matching status", func(t *testing.T) {
+		be := statusEchoBackend(http.StatusInternalServerError)
+		defer be.Close()
+
+		content := "testrequest"
+		got, rspBody := runLogBody(t, be.URL, `logBody("request", 1024, 500)`, content, http.StatusInternalServerError)
+
+		if !strings.Contains(got, content) {
+			t.Fatalf("Failed to find %q log, got: %q", content, got)
+		}
+
+		// buffering the request body must not truncate what the backend receives
+		if rspBody != content {
+			t.Fatalf("Failed to pass the request body through, got: %q", rspBody)
+		}
+	})
+
+	t.Run("Request with status condition is silent below the status", func(t *testing.T) {
+		be := statusEchoBackend(http.StatusOK)
+		defer be.Close()
+
+		content := "testrequest"
+		got, rspBody := runLogBody(t, be.URL, `logBody("request", 1024, 500)`, content, http.StatusOK)
+
+		if strings.Contains(got, content) {
+			t.Fatalf("Found request body %q in %q", content, got)
+		}
+
+		if rspBody != content {
+			t.Fatalf("Failed to pass the request body through, got: %q", rspBody)
+		}
+	})
+
+	t.Run("Response with status condition logs on matching status", func(t *testing.T) {
+		be := statusContentBackend(http.StatusBadGateway, strings.Repeat("b", 10))
+		defer be.Close()
+
+		got, _ := runLogBody(t, be.URL, `logBody("response", 1024, 500)`, "testrequest", http.StatusBadGateway)
+
+		if !strings.Contains(got, strings.Repeat("b", 10)) {
+			t.Fatalf("Failed to find rsp content %q log, got: %q", strings.Repeat("b", 10), got)
+		}
+	})
+
+	t.Run("Response with status condition is silent below the status", func(t *testing.T) {
+		be := statusContentBackend(http.StatusOK, strings.Repeat("b", 10))
+		defer be.Close()
+
+		got, rspBody := runLogBody(t, be.URL, `logBody("response", 1024, 500)`, "testrequest", http.StatusOK)
+
+		if strings.Contains(got, strings.Repeat("b", 10)) {
+			t.Fatalf("Found response body %q in %q", strings.Repeat("b", 10), got)
+		}
+
+		// the response body is still delivered to the client
+		if rspBody != strings.Repeat("b", 10) {
+			t.Fatalf("Failed to pass the response body through, got: %q", rspBody)
+		}
+	})
+}
+
+// statusEchoBackend responds with the given status and echoes the request
+// body back, so that a test can assert the backend received it unchanged.
+func statusEchoBackend(status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(status)
+		w.Write(body)
+	}))
+}
+
+// statusContentBackend drains the request body and responds with the given
+// status and a fixed response body.
+func statusContentBackend(status int, content string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.WriteHeader(status)
+		w.Write([]byte(content))
+	}))
+}
+
+// runLogBody proxies a POST with the given filter to beURL and returns what
+// was logged and the response body received by the client.
+func runLogBody(t *testing.T, beURL, filter, content string, wantStatus int) (string, string) {
+	t.Helper()
+
+	fr := make(filters.Registry)
+	fr.Register(NewLogBody())
+
+	routes := eskip.MustParse(fmt.Sprintf(`r: * -> %s -> "%s"`, filter, beURL))
+	p := proxytest.New(fr, routes...)
+	defer p.Close()
+
+	logbuf := bytes.NewBuffer(nil)
+	log.SetOutput(logbuf)
+	rsp, err := p.Client().Post(p.URL, "text/plain", bytes.NewBufferString(content))
+	if err != nil {
+		log.SetOutput(os.Stderr)
+		t.Fatalf("Failed to POST: %v", err)
+	}
+
+	rspBuf := bytes.NewBuffer(nil)
+	io.Copy(rspBuf, rsp.Body)
+	rsp.Body.Close()
+	log.SetOutput(os.Stderr)
+
+	if rsp.StatusCode != wantStatus {
+		t.Fatalf("Failed to get status %d, got: %d", wantStatus, rsp.StatusCode)
+	}
+
+	return logbuf.String(), rspBuf.String()
 }
 
 type mybuf struct {

--- a/filters/diag/logbody_test.go
+++ b/filters/diag/logbody_test.go
@@ -58,18 +58,28 @@ func TestLogBodyCreateFilter(t *testing.T) {
 			want: filters.ErrInvalidFilterParameters,
 		},
 		{
-			name: "arg2 below the status range should fail",
+			name: "zero status prefix should fail",
+			args: []interface{}{"request", 1024.0, 0.0},
+			want: filters.ErrInvalidFilterParameters,
+		},
+		{
+			name: "status class that cannot match should fail",
+			args: []interface{}{"request", 1024.0, 6.0},
+			want: filters.ErrInvalidFilterParameters,
+		},
+		{
+			name: "status sub-class that cannot match should fail",
 			args: []interface{}{"request", 1024.0, 99.0},
 			want: filters.ErrInvalidFilterParameters,
 		},
 		{
-			name: "arg2 above the status range should fail",
+			name: "status above the range should fail",
 			args: []interface{}{"request", 1024.0, 600.0},
 			want: filters.ErrInvalidFilterParameters,
 		},
 		{
-			name: "more than expected args should fail",
-			args: []interface{}{"request", 1024.0, 500.0, 1.0},
+			name: "an invalid prefix after a valid one should fail",
+			args: []interface{}{"request", 1024.0, 500.0, 600.0},
 			want: filters.ErrInvalidFilterParameters,
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -81,6 +91,38 @@ func TestLogBodyCreateFilter(t *testing.T) {
 		})
 	}
 
+}
+
+// TestLogBodyMatchStatus pins the prefix semantics against the rules the
+// enableAccessLog filter uses, so the two cannot drift apart: a prefix
+// below 10 selects a status class, below 100 a sub-class, and anything
+// larger an exact status code.
+func TestLogBodyMatchStatus(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		prefixes []int
+		status   int
+		want     bool
+	}{
+		{"class matches its own range", []int{5}, 502, true},
+		{"class start is included", []int{5}, 500, true},
+		{"class end is included", []int{5}, 599, true},
+		{"class does not match below", []int{5}, 499, false},
+		{"class does not match above", []int{4}, 500, false},
+		{"sub-class matches its own range", []int{50}, 503, true},
+		{"sub-class does not match a sibling", []int{50}, 512, false},
+		{"exact code matches", []int{429}, 429, true},
+		{"exact code does not match a neighbour", []int{429}, 430, false},
+		{"any of several prefixes matches", []int{5, 429}, 429, true},
+		{"several prefixes still reject the rest", []int{5, 429}, 404, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lb := &logBody{statusPrefixes: tt.prefixes}
+			if got := lb.matchStatus(tt.status); got != tt.want {
+				t.Fatalf("matchStatus(%d) with %v = %v, want %v", tt.status, tt.prefixes, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestLogBodyCreateFilterValid(t *testing.T) {
@@ -97,12 +139,24 @@ func TestLogBodyCreateFilterValid(t *testing.T) {
 			args: []interface{}{"response", 1024.0},
 		},
 		{
-			name: "request with status condition",
+			name: "request with an exact status",
 			args: []interface{}{"request", 1024.0, 500.0},
 		},
 		{
-			name: "response with status condition",
+			name: "response with an exact status",
 			args: []interface{}{"response", 1024.0, 500.0},
+		},
+		{
+			name: "status class prefix",
+			args: []interface{}{"request", 1024.0, 5.0},
+		},
+		{
+			name: "status sub-class prefix",
+			args: []interface{}{"request", 1024.0, 50.0},
+		},
+		{
+			name: "several prefixes",
+			args: []interface{}{"request", 1024.0, 5.0, 429.0},
 		},
 		{
 			name: "lowest valid status",
@@ -332,7 +386,7 @@ func TestLogBody(t *testing.T) {
 		}
 	})
 
-	t.Run("Request with status condition is silent below the status", func(t *testing.T) {
+	t.Run("Request with status condition is silent on a non-matching status", func(t *testing.T) {
 		be := statusEchoBackend(http.StatusOK)
 		defer be.Close()
 
@@ -348,22 +402,23 @@ func TestLogBody(t *testing.T) {
 		}
 	})
 
-	t.Run("Response with status condition logs on matching status", func(t *testing.T) {
+	t.Run("Response with status condition logs on a matching status class", func(t *testing.T) {
 		be := statusContentBackend(http.StatusBadGateway, strings.Repeat("b", 10))
 		defer be.Close()
 
-		got, _ := runLogBody(t, be.URL, `logBody("response", 1024, 500)`, "testrequest", http.StatusBadGateway)
+		// 5 selects the whole 5xx class, so 502 matches
+		got, _ := runLogBody(t, be.URL, `logBody("response", 1024, 5)`, "testrequest", http.StatusBadGateway)
 
 		if !strings.Contains(got, strings.Repeat("b", 10)) {
 			t.Fatalf("Failed to find rsp content %q log, got: %q", strings.Repeat("b", 10), got)
 		}
 	})
 
-	t.Run("Response with status condition is silent below the status", func(t *testing.T) {
+	t.Run("Response with status condition is silent on a non-matching status", func(t *testing.T) {
 		be := statusContentBackend(http.StatusOK, strings.Repeat("b", 10))
 		defer be.Close()
 
-		got, rspBody := runLogBody(t, be.URL, `logBody("response", 1024, 500)`, "testrequest", http.StatusOK)
+		got, rspBody := runLogBody(t, be.URL, `logBody("response", 1024, 5)`, "testrequest", http.StatusOK)
 
 		if strings.Contains(got, strings.Repeat("b", 10)) {
 			t.Fatalf("Found response body %q in %q", strings.Repeat("b", 10), got)
@@ -377,7 +432,7 @@ func TestLogBody(t *testing.T) {
 }
 
 // TestLogBodyRequestStatusConditionClientCancel covers the memory question the
-// status condition raises: with logBody("request", limit, status) the request
+// status condition raises: with logBody("request", limit, prefix...) the request
 // body cannot be logged while it streams, because the status that decides
 // whether to log it is not known until the response phase. It is therefore
 // buffered, and a client that disconnects while the backend is still working


### PR DESCRIPTION
logBody can only log unconditionally today, so getting the request body of failing requests means logging every successful one too.

This adds an optional third argument, the response status code from which on to log:

```
* -> logBody("request", 1024, 500) -> "https://www.example.org";
```

For a response body the status is already known when the filter runs, so it is only a check. For a request body it is not known while it streams, so up to limit bytes are buffered and logged once the response arrives. The body itself is not held back and not truncated. Without the third argument nothing changes.

Ran locally: `make fmt`, `make lint` and `go test -race ./filters/diag/` are green. In `make shortcheck` the only failures are the redis/valkey tests that need Docker, and they fail the same way on a clean master here.

One thing I am not sure about: buffering on the request side moves logBody away from "close to no overhead". I kept it in logBody because the limit already caps the buffer, but I am happy to split it into a separate filter if you prefer.

fixes #4047