### PR TITLE
otel: support configuring the TracerProvider Sampler

### DIFF
--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -1147,6 +1147,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT="https://telemetry-otlp-endpoint.test:4317" \
 OTEL_EXPORTER_OTLP_HEADERS="telemetry-token=telemetry-token-value" \
 OTEL_RESOURCE_ATTRIBUTES="service.name=skipper-ingress,cluster=production" \
 OTEL_PROPAGATORS="tracecontext,ottrace,b3multi,baggage" \
+OTEL_TRACES_SAMPLER="parentbased_always_on" \
 OTEL_BSP_SCHEDULE_DELAY="5s" \
 OTEL_BSP_EXPORT_TIMEOUT="30s" \
 OTEL_BSP_MAX_QUEUE_SIZE="2048" \
@@ -1168,6 +1169,7 @@ resourceAttributes:
   service.name: skipper-ingress
   cluster: production
 propagators: [tracecontext, ottrace, b3multi, baggage]
+sampler: parentbased_always_on
 batchSpanProcessor:
   scheduleDelay: 5s
   exportTimeout: 30s
@@ -1175,6 +1177,42 @@ batchSpanProcessor:
   maxExportBatchSize: 512
 '
 ```
+
+### Sampler
+
+By default the OTel SDK uses a `parentbased_always_on` Sampler: root spans (no
+incoming trace context) are always sampled, but spans with an incoming
+`traceparent` respect the parent's sampled flag. This means that once an
+upstream hop marks a trace as *not* sampled, Skipper stops sampling for the
+rest of that trace and also stops propagating `sampled=1` downstream.
+
+To make Skipper always record its own spans and always propagate
+`sampled=1` to the backend regardless of the incoming trace context, set
+the sampler to `always_on`, either via the `sampler` field or the
+`OTEL_TRACES_SAMPLER` environment variable:
+
+```sh
+skipper -open-telemetry='
+tracesExporter: otlp
+exporterOtlp:
+  endpoint: "https://telemetry-otlp-endpoint.test:4317"
+sampler: always_on
+'
+```
+
+Supported `sampler` values (matching `OTEL_TRACES_SAMPLER`):
+
+- `always_on`
+- `always_off`
+- `traceidratio` (use `samplerArg`/`OTEL_TRACES_SAMPLER_ARG` to set the ratio, e.g. `0.1`)
+- `parentbased_always_on` (default)
+- `parentbased_always_off`
+- `parentbased_traceidratio` (use `samplerArg`/`OTEL_TRACES_SAMPLER_ARG` to set the ratio)
+
+Note that `always_on` also forces 100% of Skipper's own spans to be
+recorded and exported: the sampled bit controls both whether Skipper
+exports a span and whether it propagates `sampled=1` downstream, these
+are not configured independently.
 
 Skipper creates up to 5 different
 [spans](https://opentelemetry.io/docs/concepts/signals/traces/#spans):

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
@@ -38,6 +39,37 @@ type Options struct {
 	ResourceAttributes map[string]string  `yaml:"resourceAttributes"`
 	Propagators        []string           `yaml:"propagators"`
 	BatchSpanProcessor BatchSpanProcessor `yaml:"batchSpanProcessor"`
+
+	// Sampler configures the Sampler used by the TracerProvider to decide
+	// whether a span is recorded and marked as sampled.
+	//
+	// Supported values, matching the OTEL_TRACES_SAMPLER environment variable:
+	//
+	//   - always_on
+	//   - always_off
+	//   - traceidratio
+	//   - parentbased_always_on (default)
+	//   - parentbased_always_off
+	//   - parentbased_traceidratio
+	//
+	// If empty, the sampler is taken from the OTEL_TRACES_SAMPLER (and
+	// OTEL_TRACES_SAMPLER_ARG) environment variables, falling back to the SDK
+	// default of parentbased_always_on if those are not set either.
+	//
+	// Note that "parentbased_*" samplers respect the sampled flag of an
+	// incoming traceparent header and will stop sampling (and therefore stop
+	// propagating sampled=1) for the rest of the trace once an upstream hop
+	// marks it as not sampled. Use "always_on" to make skipper always record
+	// and always propagate sampled=1 regardless of the incoming trace context.
+	Sampler string `yaml:"sampler"`
+
+	// SamplerArg configures the argument for the Sampler, if applicable.
+	// Only used by the "traceidratio" and "parentbased_traceidratio" samplers,
+	// where it is the sampling ratio in the range [0.0, 1.0].
+	//
+	// If empty, the argument is taken from the OTEL_TRACES_SAMPLER_ARG
+	// environment variable.
+	SamplerArg string `yaml:"samplerArg"`
 }
 
 type ExporterOtlp struct {
@@ -64,6 +96,8 @@ type BatchSpanProcessor struct {
 //   - OTEL_EXPORTER_OTLP_HEADERS
 //   - OTEL_RESOURCE_ATTRIBUTES
 //   - OTEL_PROPAGATORS
+//   - OTEL_TRACES_SAMPLER
+//   - OTEL_TRACES_SAMPLER_ARG
 //   - OTEL_BSP_MAX_QUEUE_SIZE
 //   - OTEL_BSP_MAX_EXPORT_BATCH_SIZE
 //   - OTEL_BSP_SCHEDULE_DELAY
@@ -88,6 +122,8 @@ func Init(ctx context.Context, o *Options) (shutdown func(context.Context) error
 		// "OTEL_EXPORTER_OTLP_HEADERS", // may contain sensitive data
 		"OTEL_RESOURCE_ATTRIBUTES",
 		"OTEL_PROPAGATORS",
+		"OTEL_TRACES_SAMPLER",
+		"OTEL_TRACES_SAMPLER_ARG",
 		"OTEL_BSP_MAX_QUEUE_SIZE",
 		"OTEL_BSP_MAX_EXPORT_BATCH_SIZE",
 		"OTEL_BSP_SCHEDULE_DELAY",
@@ -129,7 +165,12 @@ func Init(ctx context.Context, o *Options) (shutdown func(context.Context) error
 		return handleErr(err)
 	}
 
-	tracerProvider := trace.NewTracerProvider(batcherOpt, resourceOpt)
+	samplerOpt, err := withSampler(o)
+	if err != nil {
+		return handleErr(err)
+	}
+
+	tracerProvider := trace.NewTracerProvider(batcherOpt, resourceOpt, samplerOpt)
 	shutdownFuncs = append(shutdownFuncs, tracerProvider.Shutdown)
 
 	otel.SetTracerProvider(tracerProvider)
@@ -230,6 +271,71 @@ func withResource(o *Options) (trace.TracerProviderOption, error) {
 		}
 	}
 	return trace.WithResource(r), nil
+}
+
+// withSampler configures the Sampler for the TracerProvider based on the
+// provided options. If Options.Sampler is empty, trace.WithSampler(nil) is
+// returned, which is a no-op: the TracerProvider then falls back to the
+// OTEL_TRACES_SAMPLER/OTEL_TRACES_SAMPLER_ARG environment variables, or the
+// SDK default (parentbased_always_on) if those are not set either.
+func withSampler(o *Options) (trace.TracerProviderOption, error) {
+	s, err := samplerFromOptions(o)
+	if err != nil {
+		return nil, err
+	}
+	return trace.WithSampler(s), nil
+}
+
+// samplerFromOptions builds a [trace.Sampler] out of Options.Sampler and
+// Options.SamplerArg. It returns a nil Sampler and no error if Options.Sampler
+// is empty, letting the caller fall back to environment variables or the SDK
+// default.
+func samplerFromOptions(o *Options) (trace.Sampler, error) {
+	switch o.Sampler {
+	case "":
+		return nil, nil
+	case "always_on":
+		return trace.AlwaysSample(), nil
+	case "always_off":
+		return trace.NeverSample(), nil
+	case "traceidratio":
+		ratio, err := samplerRatio(o.SamplerArg)
+		if err != nil {
+			return nil, err
+		}
+		return trace.TraceIDRatioBased(ratio), nil
+	case "parentbased_always_on":
+		return trace.ParentBased(trace.AlwaysSample()), nil
+	case "parentbased_always_off":
+		return trace.ParentBased(trace.NeverSample()), nil
+	case "parentbased_traceidratio":
+		ratio, err := samplerRatio(o.SamplerArg)
+		if err != nil {
+			return nil, err
+		}
+		return trace.ParentBased(trace.TraceIDRatioBased(ratio)), nil
+	default:
+		return nil, fmt.Errorf("invalid sampler %q - should be one of "+
+			"['always_on', 'always_off', 'traceidratio', 'parentbased_always_on', "+
+			"'parentbased_always_off', 'parentbased_traceidratio']", o.Sampler)
+	}
+}
+
+// samplerRatio parses arg as the sampling ratio used by the traceidratio and
+// parentbased_traceidratio samplers. An empty arg defaults to a ratio of 1.0,
+// matching the OTEL_TRACES_SAMPLER_ARG behavior in the OTel SDK.
+func samplerRatio(arg string) (float64, error) {
+	if arg == "" {
+		return 1.0, nil
+	}
+	ratio, err := strconv.ParseFloat(arg, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid sampler argument %q: %w", arg, err)
+	}
+	if ratio < 0.0 || ratio > 1.0 {
+		return 0, fmt.Errorf("invalid sampler argument %q: trace ID ratio must be in range [0.0, 1.0]", arg)
+	}
+	return ratio, nil
 }
 
 // textMapPropagator creates a composite TextMapPropagator using

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -118,6 +118,92 @@ func TestOtel(t *testing.T) {
 				TracesExporter: "console",
 				Propagators:    []string{"baggage"},
 			},
+		},
+		{
+			name: "test otel sampler always_on",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "always_on",
+			},
+		},
+		{
+			name: "test otel sampler always_off",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "always_off",
+			},
+		},
+		{
+			name: "test otel sampler traceidratio without arg",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "traceidratio",
+			},
+		},
+		{
+			name: "test otel sampler traceidratio with arg",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "traceidratio",
+				SamplerArg:     "0.5",
+			},
+		},
+		{
+			name: "test otel sampler parentbased_always_on",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "parentbased_always_on",
+			},
+		},
+		{
+			name: "test otel sampler parentbased_always_off",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "parentbased_always_off",
+			},
+		},
+		{
+			name: "test otel sampler parentbased_traceidratio",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "parentbased_traceidratio",
+				SamplerArg:     "0.1",
+			},
+		},
+		{
+			name: "test otel sampler unknown",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "unknown",
+			},
+			errString: "invalid sampler \"unknown\" - should be one of ['always_on', 'always_off', 'traceidratio', 'parentbased_always_on', 'parentbased_always_off', 'parentbased_traceidratio']",
+		},
+		{
+			name: "test otel sampler traceidratio with invalid arg",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "traceidratio",
+				SamplerArg:     "not-a-float",
+			},
+			errString: `invalid sampler argument "not-a-float": strconv.ParseFloat: parsing "not-a-float": invalid syntax`,
+		},
+		{
+			name: "test otel sampler traceidratio with out of range arg",
+			opt: &Options{
+				TracesExporter: "console",
+				Sampler:        "traceidratio",
+				SamplerArg:     "1.5",
+			},
+			errString: `invalid sampler argument "1.5": trace ID ratio must be in range [0.0, 1.0]`,
+		},
+		{
+			name: "test otel sampler empty falls back to env",
+			opt: &Options{
+				TracesExporter: "console",
+			},
+			env: map[string]string{
+				"OTEL_TRACES_SAMPLER": "always_on",
+			},
 		}} {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.env {


### PR DESCRIPTION
Without trace.WithSampler(...), the SDK defaults to ParentBased(AlwaysSample), which respects an upstream trace's sampled flag. Once one hop marks a trace as not sampled, skipper stops sampling its own spans and stops propagating sampled=1 downstream, letting an upstream decision cascade through the rest of the chain.

Add Options.Sampler / Options.SamplerArg (yaml: sampler / samplerArg), mirroring OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG. Setting sampler: always_on makes skipper always record and always propagate sampled=1 regardless of the incoming trace context. Empty Sampler preserves current behavior (backward compatible).