### PR TITLE
filters/cache: eliminate allocs in matchesETag (fixes #4210)

### DIFF
--- a/filters/cache/filter.go
+++ b/filters/cache/filter.go
@@ -849,7 +849,7 @@ func matchesETag(ifNoneMatch, etag string) bool {
 		return strings.TrimPrefix(strings.TrimSpace(e), "W/")
 	}
 	normEtag := normalise(etag)
-	for _, token := range strings.Split(ifNoneMatch, ",") {
+	for token := range strings.SplitSeq(ifNoneMatch, ",") {
 		if normalise(token) == normEtag {
 			return true
 		}

--- a/filters/cache/filter_test.go
+++ b/filters/cache/filter_test.go
@@ -2563,3 +2563,11 @@ func TestCacheFilter_PureRFCMode_ZeroArgs_NoUpstreamDirective_NotCached(t *testi
 		t.Fatal("pure RFC mode: response with no freshness directives must not be cached")
 	}
 }
+
+func Benchmark_malicious_matchesETag(b *testing.B) {
+	ifNoneMatch := strings.Repeat(",", http.DefaultMaxHeaderBytes)
+	b.ReportAllocs()
+	for b.Loop() {
+		matchesETag(ifNoneMatch, "foobar")
+	}
+}


### PR DESCRIPTION
Rely on `strings.SplitSeq` rather than on `strings.Split`.

Some benchmark results:

```text
goos: darwin
goarch: arm64
pkg: github.com/zalando/skipper/filters/cache
cpu: Apple M4
                          │     old     │                new                 │
                          │   sec/op    │   sec/op     vs base               │
_malicious_matchesETag-10   19.24m ± 1%   19.36m ± 0%  +0.64% (p=0.005 n=20)

                          │     old      │                 new                  │
                          │     B/op     │    B/op      vs base                 │
_malicious_matchesETag-10   16.01Mi ± 0%   0.00Mi ± 0%  -100.00% (p=0.000 n=20)

                          │    old     │                 new                 │
                          │ allocs/op  │ allocs/op   vs base                 │
_malicious_matchesETag-10   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=20)
```