### PR TITLE
feat(proxy): Forward Trailers in responses

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1571,6 +1571,9 @@ func (p *Proxy) serveResponse(ctx *context) {
 		p.tracing.logStreamEvent(ctx.proxySpan, StreamHeadersEvent, StartEvent)
 	}
 	copyHeader(ctx.responseWriter.Header(), ctx.response.Header)
+	for k := range ctx.response.Trailer {
+		ctx.responseWriter.Header().Add("Trailer", k)
+	}
 
 	if err := ctx.Request().Context().Err(); err != nil {
 		// deadline exceeded or canceled in stdlib, client closed request
@@ -1600,6 +1603,12 @@ func (p *Proxy) serveResponse(ctx *context) {
 		n, err = copyStreamPooled(ctx.responseWriter, ctx.response.Body)
 	} else {
 		n, err = copyStream(ctx.responseWriter, ctx.response.Body)
+	}
+
+	for k, vs := range ctx.response.Trailer {
+		for _, v := range vs {
+			ctx.responseWriter.Header().Add(http.TrailerPrefix+k, v)
+		}
 	}
 
 	responseStopWatch.Start()

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2334,6 +2334,100 @@ func BenchmarkAccessLogEnablePrint(b *testing.B) {
 }
 func BenchmarkAccessLogEnable(b *testing.B) { benchmarkAccessLog(b, "enableAccessLog(1,3)", 200) }
 
+func TestTrailerForwarding(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		backend        func(w http.ResponseWriter)
+		wantTrailers   http.Header
+		copyStreamPool bool
+	}{
+		{
+			name: "single trailer",
+			backend: func(w http.ResponseWriter) {
+				w.Header().Set("Trailer", "Grpc-Status")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "body")
+				w.(http.Flusher).Flush()
+				w.Header().Set("Grpc-Status", "2")
+			},
+			wantTrailers: http.Header{"Grpc-Status": {"2"}},
+		},
+		{
+			name: "multiple trailers",
+			backend: func(w http.ResponseWriter) {
+				w.Header().Set("Trailer", "Grpc-Status")
+				w.Header().Add("Trailer", "Grpc-Message")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "body")
+				w.(http.Flusher).Flush()
+				w.Header().Set("Grpc-Status", "2")
+				w.Header().Set("Grpc-Message", "unknown error")
+			},
+			wantTrailers: http.Header{
+				"Grpc-Status":  {"2"},
+				"Grpc-Message": {"unknown error"},
+			},
+		},
+		{
+			name: "no trailers",
+			backend: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "body")
+			},
+			wantTrailers: nil,
+		},
+		{
+			name: "trailer declared without value",
+			backend: func(w http.ResponseWriter) {
+				w.Header().Set("Trailer", "Grpc-Status")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "body")
+				w.(http.Flusher).Flush()
+				// Grpc-Status declared but not sent
+			},
+			wantTrailers: http.Header{"Grpc-Status": nil},
+		},
+		{
+			name:           "single trailer with copy stream pool",
+			copyStreamPool: true,
+			backend: func(w http.ResponseWriter) {
+				w.Header().Set("Trailer", "Grpc-Status")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "body")
+				w.(http.Flusher).Flush()
+				w.Header().Set("Grpc-Status", "2")
+			},
+			wantTrailers: http.Header{"Grpc-Status": {"2"}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				tt.backend(w)
+			}))
+			defer backend.Close()
+
+			doc := fmt.Sprintf(`r: * -> "%s"`, backend.URL)
+			tp, err := newTestProxyWithParams(doc, Params{
+				Flags:                            FlagsNone,
+				EnableCopyStreamPoolExperimental: tt.copyStreamPool,
+			})
+			require.NoError(t, err)
+			defer tp.close()
+
+			ps := httptest.NewServer(tp.proxy)
+			defer ps.Close()
+
+			rsp, err := http.DefaultClient.Get(ps.URL)
+			require.NoError(t, err)
+
+			io.Copy(io.Discard, rsp.Body)
+			rsp.Body.Close()
+
+			assert.Equal(t, tt.wantTrailers, rsp.Trailer)
+		})
+	}
+}
+
 func TestInitPassiveHealthChecker(t *testing.T) {
 	for i, ti := range []struct {
 		inputArg        map[string]string


### PR DESCRIPTION
## What does this MR do?

This pull request allows Trailers to be properly forwarded in chunked transfer encoding in HTTP/1.1 and for HTTP/2 in HEADERS frames after DATA frames.

## Why is it needed?

To enable gRPC traffic to be proxied via skipper, the Trailers need to be properly forwarded for HTTP/2 traffic.

## Open Questions

 * Should filters have the option to modify Trailers? If yes, how should that look like?
   Technically filters can already add Trailers by setting them in the `Trailers` map of the response. As this happens before Headers are written they'll be picked up correctly. I've not tested removing Trailers yet. Also, at least in HTTP/2 it's not mandatory to know the Trailers before the body was streamed, so there could be new ones appearing.
 * Should this be guarded by a feature flag?