### PR TITLE
fix: deduplicate fifoWithBody and lifoWithBody in the route preprocessor

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -542,15 +542,28 @@ func (r *Registry) PreProcessor() routing.PreProcessor {
 
 type registryPreProcessor struct{}
 
+// isFifoFilter and isLifoFilter report whether the filter shares the per route
+// queue that Registry.Do assigns. fifo() and fifoWithBody() use the same queue,
+// as do lifo() and lifoWithBody(), so instances have to be counted and removed
+// per family rather than per filter name. lifoGroup() is not included, it is
+// keyed by group name instead of route id.
+func isFifoFilter(name string) bool {
+	return name == filters.FifoName || name == filters.FifoWithBodyName
+}
+
+func isLifoFilter(name string) bool {
+	return name == filters.LifoName || name == filters.LifoWithBodyName
+}
+
 func (registryPreProcessor) Do(routes []*eskip.Route) []*eskip.Route {
 	for _, r := range routes {
 		lifoCount := 0
 		fifoCount := 0
 		for _, f := range r.Filters {
-			switch f.Name {
-			case filters.FifoName:
+			switch {
+			case isFifoFilter(f.Name):
 				fifoCount++
-			case filters.LifoName:
+			case isLifoFilter(f.Name):
 				lifoCount++
 			}
 		}
@@ -559,7 +572,7 @@ func (registryPreProcessor) Do(routes []*eskip.Route) []*eskip.Route {
 			old := r.Filters
 			r.Filters = make([]*eskip.Filter, 0, len(old)-fifoCount+1)
 			for _, f := range old {
-				if fifoCount > 1 && f.Name == filters.FifoName {
+				if fifoCount > 1 && isFifoFilter(f.Name) {
 					log.Debugf("Removing non-last %v from %s", f, r.Id)
 					fifoCount--
 				} else {
@@ -572,7 +585,7 @@ func (registryPreProcessor) Do(routes []*eskip.Route) []*eskip.Route {
 			old := r.Filters
 			r.Filters = make([]*eskip.Filter, 0, len(old)-lifoCount+1)
 			for _, f := range old {
-				if lifoCount > 1 && f.Name == filters.LifoName {
+				if lifoCount > 1 && isLifoFilter(f.Name) {
 					log.Debugf("Removing non-last %v from %s", f, r.Id)
 					lifoCount--
 				} else {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -700,6 +700,26 @@ func TestRegistryPreProcessor(t *testing.T) {
 			input:  `* -> lifo(777) -> lifoGroup("g") -> lifo(999) -> lifo() -> setPath("/bar") -> <shunt>`,
 			expect: `* -> lifoGroup("g") -> lifo() -> setPath("/bar") -> <shunt>`,
 		},
+		{
+			name:   "two fifoWithBody",
+			input:  `* -> fifoWithBody(2, 2, "3s") -> fifoWithBody(20, 2, "3s") -> setPath("/foo") -> <shunt>`,
+			expect: `* -> fifoWithBody(20, 2, "3s") -> setPath("/foo") -> <shunt>`,
+		},
+		{
+			name:   "two lifoWithBody",
+			input:  `* -> lifoWithBody(777) -> lifoWithBody() -> setPath("/foo") -> <shunt>`,
+			expect: `* -> lifoWithBody() -> setPath("/foo") -> <shunt>`,
+		},
+		{
+			name:   "fifo and fifoWithBody share a queue",
+			input:  `* -> fifo(2, 2, "3s") -> fifoWithBody(20, 2, "3s") -> setPath("/foo") -> <shunt>`,
+			expect: `* -> fifoWithBody(20, 2, "3s") -> setPath("/foo") -> <shunt>`,
+		},
+		{
+			name:   "lifo and lifoWithBody share a queue",
+			input:  `* -> lifo(777) -> lifoWithBody() -> setPath("/foo") -> <shunt>`,
+			expect: `* -> lifoWithBody() -> setPath("/foo") -> <shunt>`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dc, err := testdataclient.NewDoc(tc.input)


### PR DESCRIPTION
`Registry.Do` keys the queue by route id, so `fifo()` and `fifoWithBody()` on the
same route share one queue, same for `lifo()` and `lifoWithBody()`. The
preprocessor drops all but the last instance to avoid that, but it only counted
`filters.FifoName` and `filters.LifoName`, so the WithBody variants were never
removed. Both then call `Wait()` on the same queue and one request takes two
slots.

A single request to an idle proxy rejects itself:

```bash
./bin/skipper -inline-routes='r: * -> fifoWithBody(1, 0, "1s") -> fifoWithBody(1, 0, "1s") -> "http://127.0.0.1:9001"'

curl -s -o /dev/null -w '%{http_code}\n' localhost:9090
503
```

`lifoWithBody` twice blocks for the timeout and gives 502, and `fifo()` followed
by `fifoWithBody()` gives 503 too. With `fifo()` twice it's 200, since that pair
already gets deduplicated.

Counting per queue family instead of per filter name. `lifoGroup()` stays out of
it, that one is keyed by group name.

## How to test

```
go test ./scheduler/... ./filters/scheduler/...
```

Four cases added to `TestRegistryPreProcessor`. On master:

```
--- FAIL: TestRegistryPreProcessor/two_fifoWithBody
--- FAIL: TestRegistryPreProcessor/two_lifoWithBody
--- FAIL: TestRegistryPreProcessor/fifo_and_fifoWithBody_share_a_queue
--- FAIL: TestRegistryPreProcessor/lifo_and_lifoWithBody_share_a_queue
```

ref #4188
