### PR TITLE
fix: linter SA1019 error that shows Go stdlib deprecations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -705,7 +705,7 @@ func NewConfig() *Config {
 	flag.DurationVar(&cfg.TimeoutBackend, "timeout-backend", 60*time.Second, "sets the TCP client connection timeout for backend connections")
 	flag.DurationVar(&cfg.UpgradeDialTimeout, "upgrade-dial-timeout", 0, "sets the explicit connect-time ceiling for websocket/spdy upgrade backend connections. Zero falls back to the built-in 30s default; negative disables the ceiling entirely")
 	flag.DurationVar(&cfg.KeepaliveBackend, "keepalive-backend", 30*time.Second, "sets the keepalive for backend connections")
-	flag.BoolVar(&cfg.EnableDualstackBackend, "enable-dualstack-backend", true, "enables DualStack for backend connections")
+	flag.BoolVar(&cfg.EnableDualstackBackend, "enable-dualstack-backend", true, "*deprecated* and has no effect, enabled DualStack for backend connections")
 	flag.DurationVar(&cfg.TlsHandshakeTimeoutBackend, "tls-timeout-backend", 60*time.Second, "sets the TLS handshake timeout for backend connections")
 	flag.DurationVar(&cfg.ResponseHeaderTimeoutBackend, "response-header-timeout-backend", 60*time.Second, "sets the HTTP response header timeout for backend connections")
 	flag.DurationVar(&cfg.ExpectContinueTimeoutBackend, "expect-continue-timeout-backend", 30*time.Second, "sets the HTTP expect continue timeout for backend connections")
@@ -999,7 +999,6 @@ func (c *Config) ToOptions() skipper.Options {
 		OpenTracingLogStreamEvents:          c.OpentracingLogStreamEvents,
 		OpenTracingClientTraceByTag:         c.OpenTracingClientTraceByTag,
 		OpenTracingLogFilterLifecycleEvents: c.OpentracingLogFilterLifecycleEvents,
-		MetricsListener:                     c.MetricsListener,
 		MetricsPrefix:                       c.MetricsPrefix,
 		EnableProfile:                       c.EnableProfile,
 		BlockProfileRate:                    c.BlockProfileRate,
@@ -1167,7 +1166,6 @@ func (c *Config) ToOptions() skipper.Options {
 		TimeoutBackend:               c.TimeoutBackend,
 		UpgradeDialTimeout:           c.UpgradeDialTimeout,
 		KeepAliveBackend:             c.KeepaliveBackend,
-		DualStackBackend:             c.EnableDualstackBackend,
 		TLSHandshakeTimeoutBackend:   c.TlsHandshakeTimeoutBackend,
 		ResponseHeaderTimeoutBackend: c.ResponseHeaderTimeoutBackend,
 		ExpectContinueTimeoutBackend: c.ExpectContinueTimeoutBackend,
@@ -1248,6 +1246,11 @@ func (c *Config) ToOptions() skipper.Options {
 	for _, rcci := range c.EditRoute {
 		eskipEdit := eskip.NewEditor(rcci.Reg, rcci.Repl)
 		options.EditRoute = append(options.EditRoute, eskipEdit)
+	}
+
+	if c.MetricsListener != "" && c.SupportListener == "" {
+		log.Warn("Deprecated use of -metrics-listener found, please use -support-listener instead")
+		c.SupportListener = c.MetricsListener
 	}
 
 	if c.PluginDir != "" {

--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -109,7 +109,6 @@ func buildHTTPClient(certFilePath string, inCluster bool, quit <-chan struct{}) 
 		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).DialContext,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 10 * time.Second,

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -22,11 +22,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -140,9 +142,9 @@ func New(o Options) (*Client, error) {
 	if o.Insecure {
 		httpClient.Transport = &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
-			Dial: (&net.Dialer{
+			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second}).Dial,
+				KeepAlive: 30 * time.Second}).DialContext,
 			TLSHandshakeTimeout: 10 * time.Second,
 			/* #nosec */
 			TLSClientConfig: &tls.Config{
@@ -387,7 +389,7 @@ func infoToRoutesLogged(info []*eskip.RouteInfo) []*eskip.Route {
 	return routes
 }
 
-// Returns all the route definitions currently stored in etcd,
+// LoadAndParseAll returns all the route definitions currently stored in etcd,
 // or the parsing error in case of failure.
 func (c *Client) LoadAndParseAll() ([]*eskip.RouteInfo, error) {
 	response, err := c.etcdGet()
@@ -412,7 +414,7 @@ func (c *Client) LoadAndParseAll() ([]*eskip.RouteInfo, error) {
 	return parseRoutes(data), nil
 }
 
-// Returns all the route definitions currently stored in etcd.
+// LoadAll returns all the route definitions currently stored in etcd.
 func (c *Client) LoadAll() ([]*eskip.Route, error) {
 	routeInfo, err := c.LoadAndParseAll()
 	if err != nil {
@@ -422,7 +424,7 @@ func (c *Client) LoadAll() ([]*eskip.Route, error) {
 	return infoToRoutesLogged(routeInfo), nil
 }
 
-// Returns the updates (upserts and deletes) since the last initial request
+// LoadUpdate returns the updates (upserts and deletes) since the last initial request
 // or update.
 //
 // It uses etcd's watch functionality that results in blocking this call
@@ -472,7 +474,7 @@ func (c *Client) LoadUpdate() ([]*eskip.Route, []string, error) {
 	return routes, deletedIds, nil
 }
 
-// Inserts or updates a route in etcd.
+// Upsert does an insert or update a route in etcd.
 func (c *Client) Upsert(r *eskip.Route) error {
 	if r.Id == "" {
 		return errMissingRouteId
@@ -481,7 +483,7 @@ func (c *Client) Upsert(r *eskip.Route) error {
 	return c.etcdSet(r)
 }
 
-// Deletes a route from etcd.
+// Delete a route from etcd.
 func (c *Client) Delete(id string) error {
 	if id == "" {
 		return errMissingRouteId
@@ -497,8 +499,7 @@ func (c *Client) Delete(id string) error {
 
 func (c *Client) UpsertAll(routes []*eskip.Route) error {
 	for _, r := range routes {
-		//lint:ignore SA1019 due to backward compatibility
-		r.Id = eskip.GenerateIfNeeded(r.Id)
+		r.Id = generateIfNeeded(r.Id)
 		err := c.Upsert(r)
 		if err != nil {
 			return err
@@ -521,4 +522,28 @@ func (c *Client) DeleteAllIf(routes []*eskip.Route, cond eskip.RoutePredicate) e
 	}
 
 	return nil
+}
+
+const (
+	randomIDLength = 16
+	// does not contain underscore to produce compatible output with previously used flow id generator
+	alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+// generateIfNeeded generates a weak random id for a route if
+// it doesn't have one.
+func generateIfNeeded(existingID string) string {
+	if existingID != "" {
+		return existingID
+	}
+
+	var sb strings.Builder
+	sb.WriteString("route")
+
+	for range randomIDLength {
+		ai := rand.IntN(len(alphabet)) // #nosec
+		sb.WriteByte(alphabet[ai])
+	}
+
+	return sb.String()
 }

--- a/net/httpclient_example_test.go
+++ b/net/httpclient_example_test.go
@@ -98,7 +98,6 @@ func ExampleClient_withTransport() {
 	d := stdlibnet.Dialer{
 		Timeout:   3 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}
 	f := d.DialContext
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -295,6 +295,8 @@ type Params struct {
 	EnableCopyStreamPoolExperimental bool
 
 	// DualStack sets if the proxy TCP connections to the backend should be dual stack
+	//
+	// Deprecated: see go net.Dialer.DualStack
 	DualStack bool
 
 	// DefaultHTTPStatus is the HTTP status used when no routes are found
@@ -949,7 +951,6 @@ func newTransport(p Params) *http.Transport {
 		DialContext: newSkipperDialer(net.Dialer{
 			Timeout:   p.Timeout,
 			KeepAlive: p.KeepAlive,
-			DualStack: p.DualStack,
 		}).DialContext,
 		TLSHandshakeTimeout:   p.TLSHandshakeTimeout,
 		ResponseHeaderTimeout: p.ResponseHeaderTimeout,

--- a/skipper.go
+++ b/skipper.go
@@ -479,6 +479,8 @@ type Options struct {
 
 	// DualStackBackend sets if the proxy TCP connections to the
 	// backend should be dual stack.
+	//
+	// Deprecated: see go net.Dialer.DualStack
 	DualStackBackend bool
 
 	// TLSHandshakeTimeoutBackend sets the TLS handshake timeout
@@ -2586,7 +2588,6 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		ResponseHeaderTimeout:            o.ResponseHeaderTimeoutBackend,
 		ExpectContinueTimeout:            o.ExpectContinueTimeoutBackend,
 		KeepAlive:                        o.KeepAliveBackend,
-		DualStack:                        o.DualStackBackend,
 		TLSHandshakeTimeout:              o.TLSHandshakeTimeoutBackend,
 		MaxIdleConns:                     o.MaxIdleConnsBackend,
 		DisableHTTPKeepalives:            o.DisableHTTPKeepalives,
@@ -2622,6 +2623,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 
 	// Backward compatibility
 	if supportListener == "" {
+		log.Warn("Deprecated use of MetricsListener found, please use SupportListener instead")
 		supportListener = o.MetricsListener
 	}
 

--- a/swarm/kubernetes.go
+++ b/swarm/kubernetes.go
@@ -140,7 +140,6 @@ func buildHTTPClient(certFilePath string, inCluster bool, quit chan struct{}) (*
 		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: false,
 		}).DialContext,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 10 * time.Second,


### PR DESCRIPTION
We have net package error.Temporary in use, which is the last we need to get rid of