### PR TITLE
Avoid double parsing in routegroups loading

### DIFF
--- a/dataclients/kubernetes/definitions/routegroups.go
+++ b/dataclients/kubernetes/definitions/routegroups.go
@@ -63,6 +63,55 @@ type RouteGroupSpec struct {
 	// TLS specifies the list of Kubernetes TLS secrets to
 	// be used to terminate the TLS connection
 	TLS []*RouteTLSSpec `json:"tls,omitempty"`
+
+	// parsedFilters and parsedPredicates cache the result of parsing a filter or
+	// predicate definition string, keyed by that string. Because the same strings
+	// repeat across the routes of a RouteGroup, validation and conversion parse
+	// each distinct string at most once per RouteGroup. The parsed objects are
+	// shared by every route that references the string and MUST NOT be mutated in
+	// place.
+	parsedFilters    map[string]*eskip.Filter
+	parsedPredicates map[string]*eskip.Predicate
+}
+
+func (rg *RouteGroupSpec) ParseFilter(s string) (*eskip.Filter, error) {
+	if f, ok := rg.parsedFilters[s]; ok {
+		return f, nil
+	}
+
+	filters, err := eskip.ParseFilters(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(filters) != 1 {
+		return nil, fmt.Errorf("%w at %q", errSingleFilterExpected, s)
+	}
+
+	if rg.parsedFilters == nil {
+		rg.parsedFilters = make(map[string]*eskip.Filter)
+	}
+	rg.parsedFilters[s] = filters[0]
+	return filters[0], nil
+}
+
+func (rg *RouteGroupSpec) ParsePredicate(s string) (*eskip.Predicate, error) {
+	if p, ok := rg.parsedPredicates[s]; ok {
+		return p, nil
+	}
+
+	predicates, err := eskip.ParsePredicates(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(predicates) != 1 {
+		return nil, fmt.Errorf("%w at %q", errSinglePredicateExpected, s)
+	}
+
+	if rg.parsedPredicates == nil {
+		rg.parsedPredicates = make(map[string]*eskip.Predicate)
+	}
+	rg.parsedPredicates[s] = predicates[0]
+	return predicates[0], nil
 }
 
 // SkipperBackend is the type safe version of skipperBackendParser

--- a/dataclients/kubernetes/definitions/routegroupvalidator.go
+++ b/dataclients/kubernetes/definitions/routegroupvalidator.go
@@ -74,13 +74,9 @@ func (rgv *RouteGroupValidator) validateFilters(item *RouteGroupItem) error {
 	var errs []error
 	for _, r := range item.Spec.Routes {
 		for _, f := range r.Filters {
-			parsedFilters, err := eskip.ParseFilters(f)
+			parsedFilter, err := item.Spec.ParseFilter(f)
 			if err != nil {
 				errs = append(errs, err)
-				continue
-			}
-			if len(parsedFilters) != 1 {
-				errs = append(errs, fmt.Errorf("%w at %q", errSingleFilterExpected, f))
 				continue
 			}
 			if rgv.EnableAdvancedValidation {
@@ -88,7 +84,7 @@ func (rgv *RouteGroupValidator) validateFilters(item *RouteGroupItem) error {
 					Namespace:    item.Metadata.Namespace,
 					Name:         item.Metadata.Name,
 					ResourceType: ResourceTypeRouteGroup,
-				}, rgv.RoutingOptions, parsedFilters); err != nil {
+				}, rgv.RoutingOptions, []*eskip.Filter{parsedFilter}); err != nil {
 					errs = append(errs, fmt.Errorf("invalid filter %q: %w", f, err))
 				}
 			}
@@ -100,18 +96,19 @@ func (rgv *RouteGroupValidator) validateFilters(item *RouteGroupItem) error {
 func (rgv *RouteGroupValidator) validatePredicates(item *RouteGroupItem) error {
 	var errs []error
 	for _, r := range item.Spec.Routes {
-		routePredicates := make([]*eskip.Predicate, 0, len(r.Predicates))
+		var routePredicates []*eskip.Predicate
+		if rgv.EnableAdvancedValidation {
+			routePredicates = make([]*eskip.Predicate, 0, len(r.Predicates))
+		}
 		for _, p := range r.Predicates {
-			parsedPredicates, err := eskip.ParsePredicates(p)
+			parsedPredicate, err := item.Spec.ParsePredicate(p)
 			if err != nil {
 				errs = append(errs, err)
 				continue
 			}
-			if len(parsedPredicates) != 1 {
-				errs = append(errs, fmt.Errorf("%w at %q", errSinglePredicateExpected, p))
-				continue
+			if rgv.EnableAdvancedValidation {
+				routePredicates = append(routePredicates, parsedPredicate)
 			}
-			routePredicates = append(routePredicates, parsedPredicates[0])
 		}
 		if rgv.EnableAdvancedValidation {
 			if err := validatePredicates(ResourceContext{

--- a/dataclients/kubernetes/routegroup.go
+++ b/dataclients/kubernetes/routegroup.go
@@ -55,14 +55,6 @@ type routeContext struct {
 	backend    *definitions.SkipperBackend
 }
 
-func eskipError(typ, e string, err error) error {
-	if len(e) > 48 {
-		e = e[:48]
-	}
-
-	return fmt.Errorf("[eskip] %s, '%s'; %w", typ, e, err)
-}
-
 func targetPortNotFound(serviceName string, servicePort int) error {
 	return fmt.Errorf("target port not found: %s:%d", serviceName, servicePort)
 }
@@ -410,22 +402,22 @@ func transformExplicitGroupRoute(ctx *routeContext) (*eskip.Route, error) {
 	}
 
 	for _, pi := range gr.Predicates {
-		ppi, err := eskip.ParsePredicates(pi)
+		ppi, err := ctx.group.routeGroup.Spec.ParsePredicate(pi)
 		if err != nil {
-			return nil, eskipError("predicate", pi, err)
+			return nil, err
 		}
 
-		r.Predicates = append(r.Predicates, ppi...)
+		r.Predicates = append(r.Predicates, ppi)
 	}
 
 	var f []*eskip.Filter
 	for _, fi := range gr.Filters {
-		ffi, err := eskip.ParseFilters(fi)
+		ffi, err := ctx.group.routeGroup.Spec.ParseFilter(fi)
 		if err != nil {
-			return nil, eskipError("filter", fi, err)
+			return nil, err
 		}
 
-		f = append(f, ffi...)
+		f = append(f, ffi)
 	}
 
 	r.Filters = f

--- a/dataclients/kubernetes/routegroups_bench_test.go
+++ b/dataclients/kubernetes/routegroups_bench_test.go
@@ -1,0 +1,158 @@
+package kubernetes_test
+
+import (
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zalando/skipper/dataclients/kubernetes"
+	"github.com/zalando/skipper/dataclients/kubernetes/kubernetestest"
+)
+
+// BenchmarkRouteGroupsLoadAll drives the full LoadAll path (fetch, validate,
+// convert) over many RouteGroups whose routes carry several predicates and
+// filters, exercising the eskip parse that validation and conversion share.
+func BenchmarkRouteGroupsLoadAll(b *testing.B) {
+	const routeGroups = 200
+
+	var sb strings.Builder
+	sb.WriteString(`apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: svc
+  namespace: default
+subsets:
+- addresses:
+  - ip: 10.2.1.8
+  - ip: 10.2.1.16
+  ports:
+  - port: 80
+`)
+
+	for i := range routeGroups {
+		fmt.Fprintf(&sb, `---
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: rg-%d
+  namespace: default
+spec:
+  hosts:
+  - rg%d.example.org
+  backends:
+  - name: svc
+    type: service
+    serviceName: svc
+    servicePort: 80
+  defaultBackends:
+  - backendName: svc
+  routes:
+  - path: /a
+    methods:
+    - GET
+    - POST
+    predicates:
+    - Header("X-Test", "foo")
+    - Cookie("session", "^v")
+    filters:
+    - setRequestHeader("X-A", "1")
+    - setResponseHeader("X-B", "2")
+    - inlineContent("hello")
+  - path: /b
+    predicates:
+    - QueryParam("q", "^v$")
+    filters:
+    - status(200)
+`, i, i)
+	}
+
+	spec := sb.String()
+
+	a, err := kubernetestest.NewAPI(kubernetestest.TestAPIOptions{}, strings.NewReader(spec))
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := httptest.NewServer(a)
+	defer s.Close()
+
+	c, err := kubernetes.New(kubernetes.Options{KubernetesURL: s.URL})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer c.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := c.LoadAll(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRouteGroupsLoadAllDump drives the same LoadAll path over a real
+// cluster dump instead of synthetic RouteGroups. Create the dump with:
+//
+//	kubectl get routegroups.zalando.org -A -o json > rgs.json
+//
+// then run:
+//
+//	SKIPPER_RG_DUMP=$PWD/rgs.json go test -run=NONE \
+//	  -bench=BenchmarkRouteGroupsLoadAllDump -benchmem ./dataclients/kubernetes/
+//
+// The dump can carry tokens/PII in filter args; keep it local, never commit it.
+func BenchmarkRouteGroupsLoadAllDump(b *testing.B) {
+	path := os.Getenv("SKIPPER_RG_DUMP")
+	if path == "" {
+		b.Skip("set SKIPPER_RG_DUMP=/path/to/rgs.json (kubectl get routegroups.zalando.org -A -o json)")
+	}
+
+	// A real dump can reference Services that no longer exist, and skipper logs
+	// each one. Those logs interleave with the benchmark output, so discard them.
+	logOut := log.StandardLogger().Out
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(logOut)
+
+	f, err := os.Open(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	a, err := kubernetestest.NewAPI(kubernetestest.TestAPIOptions{}, f)
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := httptest.NewServer(a)
+	defer s.Close()
+
+	c, err := kubernetes.New(kubernetes.Options{KubernetesURL: s.URL})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer c.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := c.LoadAll(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
We parse routegroup filters and predicates twice - during validation and later in converter.
The idea is to cache parsing result during validation and reuse in conversion phase.

Benchstat on the data taken from one of the real clusters
```sh
                          │ /tmp/dump-old.txt │         /tmp/dump-new.txt          │
                          │      sec/op       │   sec/op     vs base               │
RouteGroupsLoadAllDump-10         344.5m ± 2%   153.0m ± 2%  -55.60% (p=0.002 n=6)

                          │ /tmp/dump-old.txt │          /tmp/dump-new.txt          │
                          │       B/op        │     B/op      vs base               │
RouteGroupsLoadAllDump-10        206.6Mi ± 0%   137.0Mi ± 0%  -33.71% (p=0.002 n=6)

                          │ /tmp/dump-old.txt │         /tmp/dump-new.txt          │
                          │     allocs/op     │  allocs/op   vs base               │
RouteGroupsLoadAllDump-10         4.669M ± 0%   1.478M ± 0%  -68.33% (p=0.002 n=6)
```