### PR TITLE
feat(auth): add oauthOidcAnyClaimsDropRegexp filter

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2210,6 +2210,51 @@ Skipper arguments:
 | -------- | --------- | ----------- |
 | `-oidc-cookie-remove-subdomains` | no | Default number of subdomains to remove from the request hostname to derive OIDC cookie domain. The filter parameter overwrites the default when provided. Default: `1`. Example: `-oidc-cookie-remove-subdomains="0"` |
 
+#### oauthOidcAnyClaimsDropRegexp
+
+```
+oauthOidcAnyClaimsDropRegexp("https://oidc-provider.example.com", "client_id", "client_secret",
+    "http://target.example.com/subpath/callback", "email profile", "groups",
+    "", "x-auth-groups:claims.groups", "", "",
+    "groups", "^(LEGACY-|UNRELATED-)")
+```
+
+This filter inherits all `oauthOidcAnyClaims` behavior (provider discovery, authorization-code flow, token validation, distributed-claim resolution, cookie pipeline, and upstream-header mapping). It additionally removes matching values from one configured JSON array claim before serializing the session cookie.
+
+The filter requires exactly 12 string arguments. The first 10 are identical to `oauthOidcAnyClaims`:
+
+* **OpenID Connect Provider URL**
+* **Client ID**
+* **Client Secret**
+* **Callback URL**
+* **Scopes**
+* **Claims** to check for authorization
+* **Auth Code Options** (optional, may be empty)
+* **Upstream Headers** (optional, may be empty)
+* **SubdomainsToRemove** (optional, may be empty)
+* **Cookie Name** (optional, may be empty for auto-generated name)
+* **Claim Name** (required) The name of the JSON array claim to prune, e.g. `"groups"`.
+* **Regexp** (required) A Go regular expression. String values in the claim array for which `regexp.MatchString` returns true are removed. Matching is unanchored unless the expression contains `^` or `$`.
+
+Behavior:
+
+* Only JSON array claims are pruned. A missing claim or a non-array claim is a no-op and does not cause authentication failure.
+* Non-string elements in the array are retained unchanged.
+* Original element order is preserved.
+* When every value is removed, the claim key remains with an empty array. This preserves `oauthOidcAnyClaims` authorization semantics, which check claim-key presence.
+* Pruning applies to both direct ID-token claims and distributed claims (e.g. Azure AD paginated groups).
+* The pruned claims map is used for cookies, StateBag, and upstream headers. The raw signed ID token is not modified.
+
+Cookie name and rollout:
+
+* The claim name and regexp participate in the default cookie-name hash. Changing either forces reauthentication.
+* All route occurrences participating in one OIDC flow must use byte-identical arguments.
+* An explicit custom cookie name (parameter 10) bypasses hash isolation.
+
+Interaction with `oidcClaimsQuery`:
+
+* A subsequent `oidcClaimsQuery` filter will see the pruned values. Do not remove values required by downstream authorization.
+
 #### oauthOidcAllClaims
 
 ```

--- a/filters/auth/auth.go
+++ b/filters/auth/auth.go
@@ -30,6 +30,7 @@ const (
 	checkOIDCAnyClaims
 	checkOIDCAllClaims
 	checkOIDCQueryClaims
+	checkOIDCAnyClaimsDropRegexp
 )
 
 type rejectReason string

--- a/filters/auth/doc.go
+++ b/filters/auth/doc.go
@@ -331,6 +331,17 @@ least one of the claims specified in the filter.
 	a: Path("/") -> oauthOidcAnyClaims("https://accounts.identity-provider.com", "some-client-id", "some-client-secret",
 		"http://callback.com/auth/provider/callback", "scope1 scope2","claim1 claim2 claim3") -> "https://internal.example.org";
 
+# OpenID - oauthOidcAnyClaimsDropRegexp filter
+
+The filter oauthOidcAnyClaimsDropRegexp inherits oauthOidcAnyClaims behavior and additionally removes
+matching string values from one configured JSON array claim before serializing the session cookie.
+This reduces cookie size when claims such as Active Directory group lists contain many irrelevant entries.
+
+	a: Path("/") -> oauthOidcAnyClaimsDropRegexp("https://accounts.identity-provider.com", "some-client-id", "some-client-secret",
+		"http://callback.com/auth/provider/callback", "scope1 scope2", "groups",
+		"", "x-auth-groups:claims.groups", "", "",
+		"groups", "^(LEGACY-|UNRELATED-)") -> "https://internal.example.org";
+
 OpenID - oauthOidcAllClaims filter
 The filter oauthOidcAnyClaims is a filter for OAuth Implicit Flow authentication scheme for users through OpenID Connect.
 It verifies that the token provided by the user upon authentication with the authentication provider contains all

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -86,6 +87,8 @@ const (
 	paramUpstrHeaders
 	paramSubdomainsToRemove
 	paramCookieName
+	paramDropClaimName
+	paramDropClaimValueRegexp
 )
 
 type OidcOptions struct {
@@ -107,28 +110,31 @@ const oidcSecretRefPrefix = "secretRef:"
 
 type (
 	tokenOidcSpec struct {
-		typ             roleCheckType
-		SecretsFile     string
-		secretsRegistry secrets.EncrypterCreator
-		options         OidcOptions
+		typ               roleCheckType
+		SecretsFile       string
+		secretsRegistry   secrets.EncrypterCreator
+		options           OidcOptions
+		dropRegexpVariant bool
 	}
 
 	tokenOidcFilter struct {
-		typ                roleCheckType
-		config             *oauth2.Config
-		provider           *oidc.Provider
-		verifier           *oidc.IDTokenVerifier
-		claims             []string
-		validity           time.Duration
-		cookiename         string
-		redirectPath       string
-		encrypter          secrets.Encryption
-		authCodeOptions    []oauth2.AuthCodeOption
-		queryParams        []string
-		compressor         cookieCompression
-		upstreamHeaders    map[string]string
-		subdomainsToRemove int
-		oidcOptions        OidcOptions
+		typ                  roleCheckType
+		config               *oauth2.Config
+		provider             *oidc.Provider
+		verifier             *oidc.IDTokenVerifier
+		claims               []string
+		validity             time.Duration
+		cookiename           string
+		redirectPath         string
+		encrypter            secrets.Encryption
+		authCodeOptions      []oauth2.AuthCodeOption
+		queryParams          []string
+		compressor           cookieCompression
+		upstreamHeaders      map[string]string
+		subdomainsToRemove   int
+		oidcOptions          OidcOptions
+		dropClaimName        string
+		dropClaimValueRegexp *regexp.Regexp
 	}
 
 	tokenContainer struct {
@@ -173,6 +179,13 @@ func NewOAuthOidcAnyClaims(secretsFile string, secretsRegistry secrets.Encrypter
 // has all the claims specified
 func NewOAuthOidcAllClaimsWithOptions(secretsFile string, secretsRegistry secrets.EncrypterCreator, o OidcOptions) filters.Spec {
 	return &tokenOidcSpec{typ: checkOIDCAllClaims, SecretsFile: secretsFile, secretsRegistry: secretsRegistry, options: o}
+}
+
+// NewOAuthOidcAnyClaimsDropRegexpWithOptions creates a filter spec that behaves like
+// oauthOidcAnyClaims but removes matching values from one configured claim before
+// serializing the session cookie.
+func NewOAuthOidcAnyClaimsDropRegexpWithOptions(secretsFile string, secretsRegistry secrets.EncrypterCreator, o OidcOptions) filters.Spec {
+	return &tokenOidcSpec{typ: checkOIDCAnyClaims, SecretsFile: secretsFile, secretsRegistry: secretsRegistry, options: o, dropRegexpVariant: true}
 }
 
 func (s *tokenOidcSpec) resolveClientCredential(v string) (string, error) {
@@ -365,6 +378,26 @@ func (s *tokenOidcSpec) CreateFilter(args []any) (filters.Filter, error) {
 		log.Debugf("Upstream Headers: %v", f.upstreamHeaders)
 	}
 
+	if s.dropRegexpVariant {
+		if len(sargs) != paramDropClaimValueRegexp+1 {
+			return nil, fmt.Errorf("%w: oauthOidcAnyClaimsDropRegexp requires exactly 12 arguments", filters.ErrInvalidFilterParameters)
+		}
+		claimName := sargs[paramDropClaimName]
+		if claimName == "" {
+			return nil, fmt.Errorf("%w: claim name must not be empty", filters.ErrInvalidFilterParameters)
+		}
+		exprStr := sargs[paramDropClaimValueRegexp]
+		if exprStr == "" {
+			return nil, fmt.Errorf("%w: claim value regexp must not be empty", filters.ErrInvalidFilterParameters)
+		}
+		re, err := regexp.Compile(exprStr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid claim value regexp %q: %v", filters.ErrInvalidFilterParameters, exprStr, err)
+		}
+		f.dropClaimName = claimName
+		f.dropClaimValueRegexp = re
+	}
+
 	return f, nil
 }
 
@@ -373,6 +406,9 @@ func (s *tokenOidcSpec) Name() string {
 	case checkOIDCUserInfo:
 		return filters.OAuthOidcUserInfoName
 	case checkOIDCAnyClaims:
+		if s.dropRegexpVariant {
+			return filters.OAuthOidcAnyClaimsDropRegexpName
+		}
 		return filters.OAuthOidcAnyClaimsName
 	case checkOIDCAllClaims:
 		return filters.OAuthOidcAllClaimsName
@@ -411,6 +447,32 @@ func (f *tokenOidcFilter) validateAllClaims(h map[string]any) bool {
 		}
 	}
 	return true
+}
+
+// dropMatchingClaimValues removes string values matching the configured regexp
+// from the specified claim in the decoded claims map.
+func (f *tokenOidcFilter) dropMatchingClaimValues(claims map[string]any) {
+	if f.dropClaimValueRegexp == nil {
+		return
+	}
+	v, ok := claims[f.dropClaimName]
+	if !ok {
+		return
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		log.Debugf("Claim %q exists but is not an array, skipping pruning", f.dropClaimName)
+		return
+	}
+	result := make([]any, 0, len(arr))
+	for _, elem := range arr {
+		s, ok := elem.(string)
+		if ok && f.dropClaimValueRegexp.MatchString(s) {
+			continue
+		}
+		result = append(result, elem)
+	}
+	claims[f.dropClaimName] = result
 }
 
 type OauthState struct {
@@ -939,6 +1001,8 @@ func (f *tokenOidcFilter) tokenClaims(ctx filters.FilterContext, oauth2Token *oa
 	if err = f.handleDistributedClaims(idToken, oauth2Token, tokenMap); err != nil {
 		return nil, "", requestErrorf("failed to handle distributed claims: %v", err)
 	}
+
+	f.dropMatchingClaimValues(tokenMap)
 
 	return tokenMap, sub, nil
 }

--- a/filters/auth/oidc.go
+++ b/filters/auth/oidc.go
@@ -110,11 +110,10 @@ const oidcSecretRefPrefix = "secretRef:"
 
 type (
 	tokenOidcSpec struct {
-		typ               roleCheckType
-		SecretsFile       string
-		secretsRegistry   secrets.EncrypterCreator
-		options           OidcOptions
-		dropRegexpVariant bool
+		typ             roleCheckType
+		SecretsFile     string
+		secretsRegistry secrets.EncrypterCreator
+		options         OidcOptions
 	}
 
 	tokenOidcFilter struct {
@@ -185,7 +184,7 @@ func NewOAuthOidcAllClaimsWithOptions(secretsFile string, secretsRegistry secret
 // oauthOidcAnyClaims but removes matching values from one configured claim before
 // serializing the session cookie.
 func NewOAuthOidcAnyClaimsDropRegexpWithOptions(secretsFile string, secretsRegistry secrets.EncrypterCreator, o OidcOptions) filters.Spec {
-	return &tokenOidcSpec{typ: checkOIDCAnyClaims, SecretsFile: secretsFile, secretsRegistry: secretsRegistry, options: o, dropRegexpVariant: true}
+	return &tokenOidcSpec{typ: checkOIDCAnyClaimsDropRegexp, SecretsFile: secretsFile, secretsRegistry: secretsRegistry, options: o}
 }
 
 func (s *tokenOidcSpec) resolveClientCredential(v string) (string, error) {
@@ -378,7 +377,7 @@ func (s *tokenOidcSpec) CreateFilter(args []any) (filters.Filter, error) {
 		log.Debugf("Upstream Headers: %v", f.upstreamHeaders)
 	}
 
-	if s.dropRegexpVariant {
+	if s.typ == checkOIDCAnyClaimsDropRegexp {
 		if len(sargs) != paramDropClaimValueRegexp+1 {
 			return nil, fmt.Errorf("%w: oauthOidcAnyClaimsDropRegexp requires exactly 12 arguments", filters.ErrInvalidFilterParameters)
 		}
@@ -406,10 +405,9 @@ func (s *tokenOidcSpec) Name() string {
 	case checkOIDCUserInfo:
 		return filters.OAuthOidcUserInfoName
 	case checkOIDCAnyClaims:
-		if s.dropRegexpVariant {
-			return filters.OAuthOidcAnyClaimsDropRegexpName
-		}
 		return filters.OAuthOidcAnyClaimsName
+	case checkOIDCAnyClaimsDropRegexp:
+		return filters.OAuthOidcAnyClaimsDropRegexpName
 	case checkOIDCAllClaims:
 		return filters.OAuthOidcAllClaimsName
 	}
@@ -794,7 +792,7 @@ func (f *tokenOidcFilter) callbackEndpoint(ctx filters.FilterContext) {
 			f.callbackUnauthorized(ctx, r.Host, fmt.Sprintf("Failed to get claims: %v.", err))
 			return
 		}
-	case checkOIDCAnyClaims, checkOIDCAllClaims:
+	case checkOIDCAnyClaims, checkOIDCAnyClaimsDropRegexp, checkOIDCAllClaims:
 		oidcIDToken, err = f.getidtoken(oauth2Token)
 		if err != nil {
 			if _, ok := err.(*requestError); !ok {
@@ -920,7 +918,7 @@ func (f *tokenOidcFilter) Request(ctx filters.FilterContext) {
 		if container.OAuth2Token.Valid() && container.UserInfo != nil {
 			allowed = f.validateAllClaims(container.Claims)
 		}
-	case checkOIDCAnyClaims:
+	case checkOIDCAnyClaims, checkOIDCAnyClaimsDropRegexp:
 		allowed = f.validateAnyClaims(container.Claims)
 	case checkOIDCAllClaims:
 		allowed = f.validateAllClaims(container.Claims)

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"text/template"
@@ -581,6 +582,22 @@ func TestNewOidc(t *testing.T) {
 			},
 			want: &tokenOidcSpec{typ: checkOIDCAllClaims, SecretsFile: "/foo", secretsRegistry: reg, options: OidcOptions{CookieValidity: 6 * time.Hour}},
 		},
+		{
+			name:    "test AnyClaimsDropRegexp",
+			args:    "/foo",
+			f:       NewOAuthOidcAnyClaimsDropRegexpWithOptions,
+			options: OidcOptions{},
+			want:    &tokenOidcSpec{typ: checkOIDCAnyClaims, SecretsFile: "/foo", secretsRegistry: reg, dropRegexpVariant: true},
+		},
+		{
+			name: "test AnyClaimsDropRegexp with options",
+			args: "/foo",
+			f:    NewOAuthOidcAnyClaimsDropRegexpWithOptions,
+			options: OidcOptions{
+				CookieValidity: 6 * time.Hour,
+			},
+			want: &tokenOidcSpec{typ: checkOIDCAnyClaims, SecretsFile: "/foo", secretsRegistry: reg, dropRegexpVariant: true, options: OidcOptions{CookieValidity: 6 * time.Hour}},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.f(tt.args, reg, tt.options); !reflect.DeepEqual(got, tt.want) {
@@ -721,6 +738,287 @@ func TestCreateFilterOIDC(t *testing.T) {
 
 			if got == nil && !tt.wantErr {
 				t.Errorf("Failed to create filter: got %v", got)
+			}
+		})
+	}
+}
+
+func TestOidcAnyClaimsDropRegexpName(t *testing.T) {
+	reg := secrets.NewRegistry()
+	spec := NewOAuthOidcAnyClaimsDropRegexpWithOptions("/foo", reg, OidcOptions{})
+	if spec.Name() != filters.OAuthOidcAnyClaimsDropRegexpName {
+		t.Errorf("Name() = %q, want %q", spec.Name(), filters.OAuthOidcAnyClaimsDropRegexpName)
+	}
+}
+
+func TestCreateFilterOIDCAnyClaimsDropRegexp(t *testing.T) {
+	oidcServer := createOIDCServer("", "", "", nil, nil)
+	defer oidcServer.Close()
+
+	for _, tt := range []struct {
+		name    string
+		args    []any
+		wantErr bool
+	}{
+		{
+			name: "valid 12 args",
+			args: []any{
+				oidcServer.URL,               // provider/issuer
+				"",                           // client ID
+				"",                           // client secret
+				oidcServer.URL + "/redirect", // redirect URL
+				"",                           // scopes
+				"",                           // claims
+				"",                           // auth code options
+				"",                           // upstream headers
+				"",                           // subdomains to remove
+				"",                           // cookie name
+				"groups",                     // claim name
+				"^LEGACY-",                   // regexp
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing claim and expression (10 args)",
+			args: []any{
+				oidcServer.URL,
+				"",
+				"",
+				oidcServer.URL + "/redirect",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing expression only (11 args)",
+			args: []any{
+				oidcServer.URL,
+				"",
+				"",
+				oidcServer.URL + "/redirect",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"groups",
+			},
+			wantErr: true,
+		},
+		{
+			name: "too many arguments (13 args)",
+			args: []any{
+				oidcServer.URL,
+				"",
+				"",
+				oidcServer.URL + "/redirect",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"groups",
+				"^LEGACY-",
+				"extra",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty claim name",
+			args: []any{
+				oidcServer.URL,
+				"",
+				"",
+				oidcServer.URL + "/redirect",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"", // empty claim
+				"^LEGACY-",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty expression",
+			args: []any{
+				oidcServer.URL,
+				"",
+				"",
+				oidcServer.URL + "/redirect",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"groups",
+				"", // empty regexp
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid expression",
+			args: []any{
+				oidcServer.URL,
+				"",
+				"",
+				oidcServer.URL + "/redirect",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"groups",
+				"[invalid", // bad regexp
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-string claim argument",
+			args: []any{
+				oidcServer.URL,
+				"",
+				"",
+				oidcServer.URL + "/redirect",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				42, // non-string
+				"^LEGACY-",
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &tokenOidcSpec{
+				typ:               checkOIDCAnyClaims,
+				SecretsFile:       "/foo",
+				secretsRegistry:   secrettest.NewTestRegistry(),
+				dropRegexpVariant: true,
+			}
+
+			got, err := spec.CreateFilter(tt.args)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error but got filter: %v", got)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !tt.wantErr && got != nil {
+				f := got.(*tokenOidcFilter)
+				if f.dropClaimName != "groups" {
+					t.Errorf("dropClaimName = %q, want %q", f.dropClaimName, "groups")
+				}
+				if f.dropClaimValueRegexp == nil {
+					t.Error("dropClaimValueRegexp is nil, want compiled regexp")
+				}
+			}
+		})
+	}
+}
+
+func TestDropClaimValues(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		claims    map[string]any
+		claimName string
+		regexp    string
+		want      map[string]any
+	}{
+		{
+			name:      "claim absent",
+			claims:    map[string]any{"sub": "user"},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"sub": "user"},
+		},
+		{
+			name:      "claim is not an array",
+			claims:    map[string]any{"groups": "scalar-value"},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": "scalar-value"},
+		},
+		{
+			name:      "no values match",
+			claims:    map[string]any{"groups": []any{"Admin", "Users"}},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": []any{"Admin", "Users"}},
+		},
+		{
+			name:      "one value matches",
+			claims:    map[string]any{"groups": []any{"Admin", "LEGACY-Support", "Users"}},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": []any{"Admin", "Users"}},
+		},
+		{
+			name:      "multiple values match",
+			claims:    map[string]any{"groups": []any{"LEGACY-A", "Admin", "LEGACY-B", "Users"}},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": []any{"Admin", "Users"}},
+		},
+		{
+			name:      "every value matches preserves empty array",
+			claims:    map[string]any{"groups": []any{"LEGACY-A", "LEGACY-B"}},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": []any{}},
+		},
+		{
+			name:      "non-string array values retained",
+			claims:    map[string]any{"groups": []any{"LEGACY-A", 42, true, "Admin"}},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": []any{42, true, "Admin"}},
+		},
+		{
+			name:      "input order preserved",
+			claims:    map[string]any{"groups": []any{"Z-Keep", "LEGACY-Drop", "A-Keep", "M-Keep"}},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": []any{"Z-Keep", "A-Keep", "M-Keep"}},
+		},
+		{
+			name:      "unanchored match",
+			claims:    map[string]any{"groups": []any{"foo-LEGACY-bar", "Admin"}},
+			claimName: "groups",
+			regexp:    "LEGACY",
+			want:      map[string]any{"groups": []any{"Admin"}},
+		},
+		{
+			name:      "anchored match respects boundaries",
+			claims:    map[string]any{"groups": []any{"LEGACY-A", "not-LEGACY-B", "Admin"}},
+			claimName: "groups",
+			regexp:    "^LEGACY-",
+			want:      map[string]any{"groups": []any{"not-LEGACY-B", "Admin"}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			re := regexp.MustCompile(tt.regexp)
+			f := &tokenOidcFilter{
+				dropClaimName:        tt.claimName,
+				dropClaimValueRegexp: re,
+			}
+			f.dropMatchingClaimValues(tt.claims)
+			if !reflect.DeepEqual(tt.claims, tt.want) {
+				t.Errorf("got %v, want %v", tt.claims, tt.want)
 			}
 		})
 	}
@@ -966,6 +1264,33 @@ func TestOIDCSetup(t *testing.T) {
 		expected:           200,
 		expectRequest:      "please-forward=me",
 		expectCookieDomain: "skipper.test",
+	}, {
+		msg:           "drop regexp prunes direct groups claim",
+		filter:        `oauthOidcAnyClaimsDropRegexp("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid", "groups", "", "x-auth-groups:claims.groups", "", "", "groups", "^LEGACY-")`,
+		extraClaims:   jwt.MapClaims{"groups": []string{"LEGACY-Support", "Admin", "LEGACY-Old", "Users"}},
+		expected:      200,
+		expectRequest: "X-Auth-Groups: [\"Admin\",\"Users\"]",
+	}, {
+		msg:    "drop regexp prunes distributed Azure groups",
+		filter: `oauthOidcAnyClaimsDropRegexp("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid", "groups", "", "x-auth-groups:claims.groups", "", "", "groups", "Purchasing")`,
+		extraClaims: jwt.MapClaims{
+			"oid":            "me",
+			"_claim_names":   map[string]string{"groups": "src1"},
+			"_claim_sources": map[string]map[string]string{"src1": {"endpoint": "http://graph.windows.net/distributedClaims/getMemberObjects"}},
+		},
+		expected:      200,
+		expectRequest: "X-Auth-Groups: [\"CD-Administrators\",\"AppX-Test-Users\",\"white space\"]",
+	}, {
+		msg:         "drop regexp removing all values preserves authorization",
+		filter:      `oauthOidcAnyClaimsDropRegexp("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid", "groups", "", "", "", "", "groups", ".*")`,
+		extraClaims: jwt.MapClaims{"groups": []string{"Admin", "Users"}},
+		expected:    200,
+	}, {
+		msg:              "drop regexp different expression changes default cookie name",
+		filter:           `oauthOidcAnyClaimsDropRegexp("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid", "groups", "", "", "", "", "groups", "^OTHER-")`,
+		extraClaims:      jwt.MapClaims{"groups": []string{"Admin"}},
+		expected:         200,
+		expectCookieName: "skipperOauthOidc",
 	}} {
 		t.Run(tc.msg, func(t *testing.T) {
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -993,6 +1318,7 @@ func TestOIDCSetup(t *testing.T) {
 			fr := make(filters.Registry)
 			fr.Register(NewOAuthOidcUserInfosWithOptions(secretsFile, secretsRegistry, OidcOptions{}))
 			fr.Register(NewOAuthOidcAnyClaimsWithOptions(secretsFile, secretsRegistry, OidcOptions{}))
+			fr.Register(NewOAuthOidcAnyClaimsDropRegexpWithOptions(secretsFile, secretsRegistry, OidcOptions{}))
 			fr.Register(NewOAuthOidcAllClaimsWithOptions(secretsFile, secretsRegistry, OidcOptions{}))
 
 			dc := testdataclient.New(nil)

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -744,11 +744,122 @@ func TestCreateFilterOIDC(t *testing.T) {
 }
 
 func TestOidcAnyClaimsDropRegexpName(t *testing.T) {
-	reg := secrets.NewRegistry()
-	spec := NewOAuthOidcAnyClaimsDropRegexpWithOptions("/foo", reg, OidcOptions{})
+	spec := NewOAuthOidcAnyClaimsDropRegexpWithOptions("/foo", secrettest.NewTestRegistry(), OidcOptions{})
 	if spec.Name() != filters.OAuthOidcAnyClaimsDropRegexpName {
 		t.Errorf("Name() = %q, want %q", spec.Name(), filters.OAuthOidcAnyClaimsDropRegexpName)
 	}
+}
+
+func TestOidcAnyClaimsDropRegexpCookieName(t *testing.T) {
+	oidcServer := createOIDCServer("", "", "", nil, nil)
+	defer oidcServer.Close()
+
+	createFilter := func(t *testing.T, dropVariant bool, args []any) *tokenOidcFilter {
+		t.Helper()
+		spec := &tokenOidcSpec{
+			typ:               checkOIDCAnyClaims,
+			SecretsFile:       "/foo",
+			secretsRegistry:   secrettest.NewTestRegistry(),
+			dropRegexpVariant: dropVariant,
+		}
+		f, err := spec.CreateFilter(args)
+		if err != nil {
+			t.Fatalf("CreateFilter failed: %v", err)
+		}
+		return f.(*tokenOidcFilter)
+	}
+
+	baseArgs := func(claimName, expr string) []any {
+		return []any{
+			oidcServer.URL,               // provider
+			"valid-client",               // client ID
+			"mysec",                      // client secret
+			oidcServer.URL + "/redirect", // callback URL
+			"uid",                        // scopes
+			"groups",                     // claims
+			"",                           // auth code options
+			"",                           // upstream headers
+			"",                           // subdomains to remove
+			"",                           // cookie name (empty = auto)
+			claimName,                    // drop claim name
+			expr,                         // drop claim regexp
+		}
+	}
+
+	t.Run("different regexp produces different cookie name", func(t *testing.T) {
+		f1 := createFilter(t, true, baseArgs("groups", "^LEGACY-"))
+		f2 := createFilter(t, true, baseArgs("groups", "^OTHER-"))
+		if f1.cookiename == f2.cookiename {
+			t.Errorf("expected different cookie names for different regexps, both got %q", f1.cookiename)
+		}
+	})
+
+	t.Run("different claim name produces different cookie name", func(t *testing.T) {
+		f1 := createFilter(t, true, baseArgs("groups", "^LEGACY-"))
+		f2 := createFilter(t, true, baseArgs("roles", "^LEGACY-"))
+		if f1.cookiename == f2.cookiename {
+			t.Errorf("expected different cookie names for different claim names, both got %q", f1.cookiename)
+		}
+	})
+
+	t.Run("drop-regexp variant differs from plain oauthOidcAnyClaims", func(t *testing.T) {
+		plainArgs := []any{
+			oidcServer.URL,               // provider
+			"valid-client",               // client ID
+			"mysec",                      // client secret
+			oidcServer.URL + "/redirect", // callback URL
+			"uid",                        // scopes
+			"groups",                     // claims
+			"",                           // auth code options
+			"",                           // upstream headers
+			"",                           // subdomains to remove
+			"",                           // cookie name
+		}
+		plainFilter := createFilter(t, false, plainArgs)
+		dropFilter := createFilter(t, true, baseArgs("groups", "^LEGACY-"))
+		if plainFilter.cookiename == dropFilter.cookiename {
+			t.Errorf("plain and drop-regexp filters must have different cookie names, both got %q", plainFilter.cookiename)
+		}
+	})
+
+	t.Run("explicit cookie name ignores pruning arguments", func(t *testing.T) {
+		args1 := []any{
+			oidcServer.URL,               // provider
+			"valid-client",               // client ID
+			"mysec",                      // client secret
+			oidcServer.URL + "/redirect", // callback URL
+			"uid",                        // scopes
+			"groups",                     // claims
+			"",                           // auth code options
+			"",                           // upstream headers
+			"",                           // subdomains to remove
+			"my-custom-cookie",           // explicit cookie name
+			"groups",                     // drop claim name
+			"^LEGACY-",                   // drop claim regexp
+		}
+		args2 := []any{
+			oidcServer.URL,               // provider
+			"valid-client",               // client ID
+			"mysec",                      // client secret
+			oidcServer.URL + "/redirect", // callback URL
+			"uid",                        // scopes
+			"groups",                     // claims
+			"",                           // auth code options
+			"",                           // upstream headers
+			"",                           // subdomains to remove
+			"my-custom-cookie",           // same explicit cookie name
+			"roles",                      // different claim name
+			"^OTHER-",                    // different regexp
+		}
+		f1 := createFilter(t, true, args1)
+		f2 := createFilter(t, true, args2)
+		if f1.cookiename != "my-custom-cookie" {
+			t.Errorf("expected explicit cookie name %q, got %q", "my-custom-cookie", f1.cookiename)
+		}
+		if f1.cookiename != f2.cookiename {
+			t.Errorf("explicit cookie name should be identical regardless of pruning args: %q vs %q", f1.cookiename, f2.cookiename)
+		}
+	})
 }
 
 func TestCreateFilterOIDCAnyClaimsDropRegexp(t *testing.T) {
@@ -1281,16 +1392,11 @@ func TestOIDCSetup(t *testing.T) {
 		expected:      200,
 		expectRequest: "X-Auth-Groups: [\"CD-Administrators\",\"AppX-Test-Users\",\"white space\"]",
 	}, {
-		msg:         "drop regexp removing all values preserves authorization",
-		filter:      `oauthOidcAnyClaimsDropRegexp("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid", "groups", "", "", "", "", "groups", ".*")`,
-		extraClaims: jwt.MapClaims{"groups": []string{"Admin", "Users"}},
-		expected:    200,
-	}, {
-		msg:              "drop regexp different expression changes default cookie name",
-		filter:           `oauthOidcAnyClaimsDropRegexp("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid", "groups", "", "", "", "", "groups", "^OTHER-")`,
-		extraClaims:      jwt.MapClaims{"groups": []string{"Admin"}},
-		expected:         200,
-		expectCookieName: "skipperOauthOidc",
+		msg:           "drop regexp removing all values preserves authorization",
+		filter:        `oauthOidcAnyClaimsDropRegexp("{{ .OIDCServerURL }}", "valid-client", "mysec", "{{ .RedirectURL }}", "uid", "groups", "", "x-auth-groups:claims.groups", "", "", "groups", ".*")`,
+		extraClaims:   jwt.MapClaims{"groups": []string{"Admin", "Users"}},
+		expected:      200,
+		expectRequest: "X-Auth-Groups: []",
 	}} {
 		t.Run(tc.msg, func(t *testing.T) {
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/filters/auth/oidc_test.go
+++ b/filters/auth/oidc_test.go
@@ -587,7 +587,7 @@ func TestNewOidc(t *testing.T) {
 			args:    "/foo",
 			f:       NewOAuthOidcAnyClaimsDropRegexpWithOptions,
 			options: OidcOptions{},
-			want:    &tokenOidcSpec{typ: checkOIDCAnyClaims, SecretsFile: "/foo", secretsRegistry: reg, dropRegexpVariant: true},
+			want:    &tokenOidcSpec{typ: checkOIDCAnyClaimsDropRegexp, SecretsFile: "/foo", secretsRegistry: reg},
 		},
 		{
 			name: "test AnyClaimsDropRegexp with options",
@@ -596,7 +596,7 @@ func TestNewOidc(t *testing.T) {
 			options: OidcOptions{
 				CookieValidity: 6 * time.Hour,
 			},
-			want: &tokenOidcSpec{typ: checkOIDCAnyClaims, SecretsFile: "/foo", secretsRegistry: reg, dropRegexpVariant: true, options: OidcOptions{CookieValidity: 6 * time.Hour}},
+			want: &tokenOidcSpec{typ: checkOIDCAnyClaimsDropRegexp, SecretsFile: "/foo", secretsRegistry: reg, options: OidcOptions{CookieValidity: 6 * time.Hour}},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -754,13 +754,12 @@ func TestOidcAnyClaimsDropRegexpCookieName(t *testing.T) {
 	oidcServer := createOIDCServer("", "", "", nil, nil)
 	defer oidcServer.Close()
 
-	createFilter := func(t *testing.T, dropVariant bool, args []any) *tokenOidcFilter {
+	createFilter := func(t *testing.T, typ roleCheckType, args []any) *tokenOidcFilter {
 		t.Helper()
 		spec := &tokenOidcSpec{
-			typ:               checkOIDCAnyClaims,
-			SecretsFile:       "/foo",
-			secretsRegistry:   secrettest.NewTestRegistry(),
-			dropRegexpVariant: dropVariant,
+			typ:             typ,
+			SecretsFile:     "/foo",
+			secretsRegistry: secrettest.NewTestRegistry(),
 		}
 		f, err := spec.CreateFilter(args)
 		if err != nil {
@@ -787,16 +786,16 @@ func TestOidcAnyClaimsDropRegexpCookieName(t *testing.T) {
 	}
 
 	t.Run("different regexp produces different cookie name", func(t *testing.T) {
-		f1 := createFilter(t, true, baseArgs("groups", "^LEGACY-"))
-		f2 := createFilter(t, true, baseArgs("groups", "^OTHER-"))
+		f1 := createFilter(t, checkOIDCAnyClaimsDropRegexp, baseArgs("groups", "^LEGACY-"))
+		f2 := createFilter(t, checkOIDCAnyClaimsDropRegexp, baseArgs("groups", "^OTHER-"))
 		if f1.cookiename == f2.cookiename {
 			t.Errorf("expected different cookie names for different regexps, both got %q", f1.cookiename)
 		}
 	})
 
 	t.Run("different claim name produces different cookie name", func(t *testing.T) {
-		f1 := createFilter(t, true, baseArgs("groups", "^LEGACY-"))
-		f2 := createFilter(t, true, baseArgs("roles", "^LEGACY-"))
+		f1 := createFilter(t, checkOIDCAnyClaimsDropRegexp, baseArgs("groups", "^LEGACY-"))
+		f2 := createFilter(t, checkOIDCAnyClaimsDropRegexp, baseArgs("roles", "^LEGACY-"))
 		if f1.cookiename == f2.cookiename {
 			t.Errorf("expected different cookie names for different claim names, both got %q", f1.cookiename)
 		}
@@ -815,8 +814,8 @@ func TestOidcAnyClaimsDropRegexpCookieName(t *testing.T) {
 			"",                           // subdomains to remove
 			"",                           // cookie name
 		}
-		plainFilter := createFilter(t, false, plainArgs)
-		dropFilter := createFilter(t, true, baseArgs("groups", "^LEGACY-"))
+		plainFilter := createFilter(t, checkOIDCAnyClaims, plainArgs)
+		dropFilter := createFilter(t, checkOIDCAnyClaimsDropRegexp, baseArgs("groups", "^LEGACY-"))
 		if plainFilter.cookiename == dropFilter.cookiename {
 			t.Errorf("plain and drop-regexp filters must have different cookie names, both got %q", plainFilter.cookiename)
 		}
@@ -851,8 +850,8 @@ func TestOidcAnyClaimsDropRegexpCookieName(t *testing.T) {
 			"roles",                      // different claim name
 			"^OTHER-",                    // different regexp
 		}
-		f1 := createFilter(t, true, args1)
-		f2 := createFilter(t, true, args2)
+		f1 := createFilter(t, checkOIDCAnyClaimsDropRegexp, args1)
+		f2 := createFilter(t, checkOIDCAnyClaimsDropRegexp, args2)
 		if f1.cookiename != "my-custom-cookie" {
 			t.Errorf("expected explicit cookie name %q, got %q", "my-custom-cookie", f1.cookiename)
 		}
@@ -1016,10 +1015,9 @@ func TestCreateFilterOIDCAnyClaimsDropRegexp(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := &tokenOidcSpec{
-				typ:               checkOIDCAnyClaims,
-				SecretsFile:       "/foo",
-				secretsRegistry:   secrettest.NewTestRegistry(),
-				dropRegexpVariant: true,
+				typ:             checkOIDCAnyClaimsDropRegexp,
+				SecretsFile:     "/foo",
+				secretsRegistry: secrettest.NewTestRegistry(),
 			}
 
 			got, err := spec.CreateFilter(tt.args)

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -323,6 +323,7 @@ const (
 	JwtMetricsName                             = "jwtMetrics"
 	OAuthOidcUserInfoName                      = "oauthOidcUserInfo"
 	OAuthOidcAnyClaimsName                     = "oauthOidcAnyClaims"
+	OAuthOidcAnyClaimsDropRegexpName           = "oauthOidcAnyClaimsDropRegexp"
 	OAuthOidcAllClaimsName                     = "oauthOidcAllClaims"
 	OidcClaimsQueryName                        = "oidcClaimsQuery"
 	DropRequestCookieName                      = "dropRequestCookie"

--- a/fuzz/dictionaries/FuzzParseEskip.dict
+++ b/fuzz/dictionaries/FuzzParseEskip.dict
@@ -94,6 +94,7 @@
 "oauthGrant"
 "oauthOidcAllClaims"
 "oauthOidcAnyClaims"
+"oauthOidcAnyClaimsDropRegexp"
 "oauthOidcUserInfo"
 "oauthTokeninfoAllKV"
 "oauthTokeninfoAllScope"

--- a/skipper.go
+++ b/skipper.go
@@ -2088,6 +2088,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		o.CustomFilters = append(o.CustomFilters,
 			auth.NewOAuthOidcUserInfosWithOptions(o.OIDCSecretsFile, o.SecretsRegistry, opts),
 			auth.NewOAuthOidcAnyClaimsWithOptions(o.OIDCSecretsFile, o.SecretsRegistry, opts),
+			auth.NewOAuthOidcAnyClaimsDropRegexpWithOptions(o.OIDCSecretsFile, o.SecretsRegistry, opts),
 			auth.NewOAuthOidcAllClaimsWithOptions(o.OIDCSecretsFile, o.SecretsRegistry, opts),
 		)
 	}


### PR DESCRIPTION
Ref #4225

Add a named variant of `oauthOidcAnyClaims` that removes matching string values from one configured JSON array claim before serializing the session cookie.

## Motivation

Large OIDC claims (e.g. Azure AD group lists with hundreds of entries) produce oversized `skipperOauthOidc*` cookies that exceed browser limits. This filter prunes irrelevant values at callback time, before cookie compression and encryption.

## Changes

- New filter `oauthOidcAnyClaimsDropRegexp` with 12 string arguments (the standard 10 + claim name + Go regexp)
- Pruning runs after distributed claims resolution, covering both direct ID-token claims and Azure AD paginated groups
- Only JSON array claims are pruned; missing or non-array claims are a no-op
- Claim key is preserved (empty array) when all values match, so authorization checks remain valid
- Full test coverage: constructor, CreateFilter validation, pruning helper, cookie-name differentiation, and end-to-end OIDC flow
- Filter reference documentation and fuzz dictionary entry

## Testing

```
GOWORK=off go test ./filters/auth/  # all pass
make fmt                             # clean
GOWORK=off go vet ./...              # clean
```

`make lint` could not be run; see #4227.


