### PR TITLE
valkey: make operation SetWithExpire atomic

### DIFF
--- a/net/valkey.go
+++ b/net/valkey.go
@@ -294,12 +294,10 @@ func (vr *valkeyRing) Set(ctx context.Context, key, val string) valkey.ValkeyRes
 	shard := vr.shardForKey(key)
 	return shard.Do(ctx, shard.B().Set().Key(key).Value(val).Build())
 }
-func (vr *valkeyRing) SetWithExpire(ctx context.Context, key, val string, expire time.Duration) []valkey.ValkeyResult {
+
+func (vr *valkeyRing) SetWithExpire(ctx context.Context, key, val string, expire time.Duration) valkey.ValkeyResult {
 	shard := vr.shardForKey(key)
-	return shard.DoMulti(ctx,
-		shard.B().Set().Key(key).Value(val).Build(),
-		shard.B().Expire().Key(key).Seconds(int64(expire.Seconds())).Build(),
-	)
+	return shard.Do(ctx, shard.B().Set().Key(key).Value(val).PxMilliseconds(expire.Milliseconds()).Build())
 }
 
 func (vr *valkeyRing) ZAdd(ctx context.Context, key, val string, score float64) valkey.ValkeyResult {
@@ -544,16 +542,7 @@ func (vrc *ValkeyRingClient) Set(ctx context.Context, key, val string) (string, 
 }
 
 func (vrc *ValkeyRingClient) SetWithExpire(ctx context.Context, key string, value string, expire time.Duration) error {
-	results := vrc.ring.SetWithExpire(ctx, key, value, expire)
-	if len(results) == 0 {
-		return ErrValkeyNoResult
-	}
-	for _, res := range results {
-		if err := res.Error(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return vrc.ring.SetWithExpire(ctx, key, value, expire).Error()
 }
 
 func (vrc *ValkeyRingClient) ZAdd(ctx context.Context, key, val string, score float64) (int64, error) {

--- a/net/valkey_test.go
+++ b/net/valkey_test.go
@@ -666,6 +666,17 @@ func TestValkeyClientGetSetWithExpire(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "add one, get one, with sub-second expiration",
+			options: &ValkeyOptions{
+				Addrs: []string{valkeyAddr},
+			},
+			key:     "k1",
+			value:   "foo",
+			expire:  500 * time.Millisecond,
+			expect:  "foo",
+			wantErr: false,
+		},
+		{
 			name: "add one, get none, with expiration, wait to expire",
 			options: &ValkeyOptions{
 				Addrs: []string{valkeyAddr},


### PR DESCRIPTION
`SetWithExpire` previously sent separate `SET` and `EXPIRE` commands, which were not atomic and could leave a key without a TTL. It now uses a single `SET ... PX <milliseconds>` command.