### PR TITLE
Cache parsed filters and predicates across RouteGroups

### DIFF
--- a/dataclients/kubernetes/clusterclient.go
+++ b/dataclients/kubernetes/clusterclient.go
@@ -422,6 +422,11 @@ func (c *clusterClient) LoadRouteGroups() ([]*definitions.RouteGroupItem, error)
 	}
 	log.Debugf("all routegroups received: %d", len(rgl.Items))
 
+	// Share a single filter/predicate parse cache across all RouteGroups so a
+	// definition string repeated across them (e.g. Method("GET")) is parsed once
+	// per load instead of once per RouteGroup.
+	rgl.ShareParseCache()
+
 	rgs := make([]*definitions.RouteGroupItem, 0, len(rgl.Items))
 	for _, i := range rgl.Items {
 		// Validate RouteGroup item.

--- a/dataclients/kubernetes/definitions/routegroup_test.go
+++ b/dataclients/kubernetes/definitions/routegroup_test.go
@@ -16,3 +16,57 @@ func TestSkipperBackendNil(t *testing.T) {
 		t.Fatalf("Failed to get nil: %q", skipperBackend)
 	}
 }
+
+func TestRouteGroupListShareParseCache(t *testing.T) {
+	list := &RouteGroupList{
+		Items: []*RouteGroupItem{
+			{Spec: &RouteGroupSpec{}},
+			{Spec: &RouteGroupSpec{}},
+			{Spec: nil}, // must be tolerated
+		},
+	}
+	list.ShareParseCache()
+
+	// The same definition string parsed through two different RouteGroups
+	// resolves to the same cached object, so it is parsed only once.
+	f0, err := list.Items[0].Spec.ParseFilter(`status(200)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f1, err := list.Items[1].Spec.ParseFilter(`status(200)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f0 != f1 {
+		t.Error("expected the filter to be shared across RouteGroups")
+	}
+
+	p0, err := list.Items[0].Spec.ParsePredicate(`Method("GET")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p1, err := list.Items[1].Spec.ParsePredicate(`Method("GET")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p0 != p1 {
+		t.Error("expected the predicate to be shared across RouteGroups")
+	}
+}
+
+func TestRouteGroupParseCacheIsPerRouteGroupWithoutSharing(t *testing.T) {
+	a := &RouteGroupSpec{}
+	b := &RouteGroupSpec{}
+
+	fa, err := a.ParseFilter(`status(200)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fb, err := b.ParseFilter(`status(200)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fa == fb {
+		t.Error("expected independent caches without ShareParseCache")
+	}
+}

--- a/dataclients/kubernetes/definitions/routegroups.go
+++ b/dataclients/kubernetes/definitions/routegroups.go
@@ -65,11 +65,13 @@ type RouteGroupSpec struct {
 	TLS []*RouteTLSSpec `json:"tls,omitempty"`
 
 	// parsedFilters and parsedPredicates cache the result of parsing a filter or
-	// predicate definition string, keyed by that string. Because the same strings
-	// repeat across the routes of a RouteGroup, validation and conversion parse
-	// each distinct string at most once per RouteGroup. The parsed objects are
-	// shared by every route that references the string and MUST NOT be mutated in
-	// place.
+	// predicate definition string, keyed by that string, so that validation and
+	// conversion parse each distinct string at most once. The same maps can be
+	// shared across the RouteGroups of a single load via
+	// RouteGroupList.ShareParseCache, so a string that repeats across RouteGroups
+	// (for example Method("GET")) is parsed once per load rather than once per
+	// RouteGroup. The parsed objects are shared by every route that references the
+	// string and MUST NOT be mutated in place.
 	parsedFilters    map[string]*eskip.Filter
 	parsedPredicates map[string]*eskip.Predicate
 }
@@ -112,6 +114,23 @@ func (rg *RouteGroupSpec) ParsePredicate(s string) (*eskip.Predicate, error) {
 	}
 	rg.parsedPredicates[s] = predicates[0]
 	return predicates[0], nil
+}
+
+// ShareParseCache makes every RouteGroup in the list share one filter and one
+// predicate parse cache, so a definition string that repeats across RouteGroups
+// is parsed once per load instead of once per RouteGroup. It must be called
+// before the RouteGroups are validated or converted. As with the per-RouteGroup
+// cache it replaces, the RouteGroups must be validated and converted from a
+// single goroutine, and the cached objects must not be mutated in place.
+func (l *RouteGroupList) ShareParseCache() {
+	parsedFilters := make(map[string]*eskip.Filter)
+	parsedPredicates := make(map[string]*eskip.Predicate)
+	for _, item := range l.Items {
+		if item.Spec != nil {
+			item.Spec.parsedFilters = parsedFilters
+			item.Spec.parsedPredicates = parsedPredicates
+		}
+	}
 }
 
 // SkipperBackend is the type safe version of skipperBackendParser


### PR DESCRIPTION
Fixes #4228.

### Problem

#4223 added a parse cache scoped to a single `RouteGroup`, so a filter or predicate string repeated across the routes of one RouteGroup is parsed once. In a real cluster many RouteGroups repeat the same strings (`Method("GET")` appears in almost every one), and those are still parsed once per RouteGroup.

### Change

`RouteGroupList.ShareParseCache()` gives every RouteGroup in a load one shared filter map and one shared predicate map. It is called in `clusterClient.LoadRouteGroups` right after the RouteGroups are fetched, before validation and conversion. Both phases already go through `RouteGroupSpec.ParseFilter` / `ParsePredicate`, so a string that repeats across RouteGroups is now parsed once per load instead of once per RouteGroup. `ParseFilter` / `ParsePredicate` are unchanged.

### Correctness

The parsed `*eskip.Filter` / `*eskip.Predicate` were already shared across the routes of a RouteGroup by #4223 and documented as "MUST NOT be mutated in place". Sharing them across RouteGroups keeps the same contract: conversion only appends them to route slices (`transformExplicitGroupRoute`), and eskip deep-copies routes (`Route.Copy`, which copies filters and predicates) before any mutation. Validation and conversion run from a single goroutine over the load, matching the previous per-RouteGroup cache, so no locking is added. `go test -race ./dataclients/kubernetes/...` passes.

### Benchmark

`BenchmarkRouteGroupsLoadAll` already loads 200 RouteGroups that repeat the same filter and predicate strings, so it exercises the cross-RouteGroup case directly. `benchstat` over 10 runs, per-RouteGroup cache (base) vs shared cache:

```
                    │    base    │              shared               │
                    │   sec/op   │   sec/op     vs base              │
RouteGroupsLoadAll-8   4.579m ± 1%   3.628m ± 0%  -20.76% (p=0.000 n=10)

                    │    base    │              shared               │
                    │    B/op    │    B/op      vs base              │
RouteGroupsLoadAll-8   2.420Mi ± 0%  2.133Mi ± 0%  -11.83% (p=0.000 n=10)

                    │    base    │              shared               │
                    │ allocs/op  │  allocs/op   vs base              │
RouteGroupsLoadAll-8   48.14k ± 0%   35.61k ± 0%  -26.04% (p=0.000 n=10)
```

### Testing

- Added `TestRouteGroupListShareParseCache` (a string parsed through two different RouteGroups resolves to the same cached object) and `TestRouteGroupParseCacheIsPerRouteGroupWithoutSharing` (independent caches without the call).
- `go test ./dataclients/kubernetes/...` and `-race` pass; `staticcheck -checks "all,-ST1003,-ST1020"` and `gofmt -s` are clean.
