### PR TITLE
Avoid redundant Sprintf for string args in appendFmtEscape

### DIFF
--- a/eskip/string.go
+++ b/eskip/string.go
@@ -38,7 +38,11 @@ func appendFmt(s []string, format string, args ...interface{}) []string {
 func appendFmtEscape(s []string, format string, escapeChars string, args ...interface{}) []string {
 	eargs := make([]interface{}, len(args))
 	for i, arg := range args {
-		eargs[i] = escape(fmt.Sprintf("%v", arg), escapeChars)
+		str, ok := arg.(string)
+		if !ok {
+			str = fmt.Sprintf("%v", arg)
+		}
+		eargs[i] = escape(str, escapeChars)
 	}
 
 	return appendFmt(s, format, eargs...)


### PR DESCRIPTION
benchstat shows improvements in speed and allocations count (and hence gc pressure ) for
 `go test -run=NONE '-bench=BenchmarkRouteString$|BenchmarkRouteStringNoRepeatedPredicates$|BenchmarkFormatAndSet$|BenchmarkFormatAndSetNoChange$' -benchmem -count=6 ./eskip/ ./routesrv/`

```
+ benchstat base=/tmp/bench-format-base.txt working=/tmp/bench-format-work.txt
                                   │    base     │              working               │
                                   │   sec/op    │   sec/op     vs base               │
RouteString-10                       3.838µ ± 2%   3.298µ ± 1%  -14.06% (p=0.002 n=6)
RouteStringNoRepeatedPredicates-10   2.002µ ± 3%   1.716µ ± 2%  -14.29% (p=0.002 n=6)
FormatAndSet-10                      203.6m ± 3%   190.0m ± 2%   -6.69% (p=0.002 n=6)
FormatAndSetNoChange-10              40.57m ± 4%   38.16m ± 3%   -5.95% (p=0.002 n=6)
geomean                              501.9µ        450.0µ       -10.33%

                                   │     base     │              working               │
                                   │     B/op     │     B/op      vs base              │
RouteString-10                       2.180Ki ± 0%   2.148Ki ± 0%  -1.43% (p=0.002 n=6)
RouteStringNoRepeatedPredicates-10   1.086Ki ± 0%   1.070Ki ± 0%  -1.44% (p=0.002 n=6)
FormatAndSet-10                      231.5Mi ± 0%   227.8Mi ± 0%  -1.57% (p=0.002 n=6)
FormatAndSetNoChange-10              87.25Mi ± 0%   86.34Mi ± 0%  -1.04% (p=0.002 n=6)
geomean                              473.2Ki        466.7Ki       -1.37%

                                   │    base     │              working               │
                                   │  allocs/op  │  allocs/op   vs base               │
RouteString-10                        81.00 ± 0%    68.00 ± 0%  -16.05% (p=0.002 n=6)
RouteStringNoRepeatedPredicates-10    46.00 ± 0%    39.00 ± 0%  -15.22% (p=0.002 n=6)
FormatAndSet-10                      2.620M ± 0%   2.380M ± 0%   -9.16% (p=0.002 n=6)
FormatAndSetNoChange-10              760.0k ± 0%   700.0k ± 0%   -7.89% (p=0.002 n=6)
geomean                              9.281k        8.153k       -12.15%
```