### PR TITLE
otel: Test behaviour with different ordering of otel propagators

### DIFF
--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -2,8 +2,12 @@ package otel
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"testing"
+
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestOtel(t *testing.T) {
@@ -233,4 +237,124 @@ func TestOtel(t *testing.T) {
 		})
 	}
 
+}
+
+// TestPropagatorExtractMalformedTraceparent documents a trace-disconnection
+// bug. A spec-valid traceparent carrying a 64-bit ottrace id padded into W3C's
+// 128-bit form is accepted by tracecontext, but the chain [tracecontext,
+// ottrace, b3multi, baggage] lets b3multi run last and overwrite the
+// SpanContext with an unrelated b3 trace-id from an intermediate hop, so spans
+// exported under always_on appear disconnected in the backend UI.
+//
+// Subtests compare three configs:
+//
+//	(1) current prod (reproduces the bug)
+//	(2) a reorder-only workaround keeping b3multi,
+//	(3) the target config dropping b3multi, matching the pre-OTel LightStep
+//	(ottrace only) baseline via lightstep.PropagatorStack + LightStepPropagator.
+//
+// wantSampled reflects the upstream-signalled flag on the extracted parent
+// SpanContext.
+func TestPropagatorExtractMalformedTraceparent(t *testing.T) {
+	const (
+		otTraceID64  = "a66e94ab3ffc4fa1"
+		otTraceID128 = "0000000000000000a66e94ab3ffc4fa1"
+		otSpanID     = "28c00ede49b44eb1"
+		b3TraceID64  = "e132d03200cd1ed1"
+		b3TraceID128 = "0000000000000000e132d03200cd1ed1"
+		b3SpanID     = "e132d03200cd1ed1"
+	)
+
+	// Trace header from the upstream request that has smelly traceparent and b3
+	// headers that are not consistent with the traceparent not ottrace headers.
+	requestHeader := http.Header{
+		"Traceparent":       []string{"00-" + otTraceID128 + "-" + otSpanID + "-01"},
+		"Ot-Tracer-Traceid": []string{otTraceID64},
+		"Ot-Tracer-Spanid":  []string{otSpanID},
+		"Ot-Tracer-Sampled": []string{"true"},
+		"X-B3-Traceid":      []string{b3TraceID64},
+		"X-B3-Spanid":       []string{b3SpanID},
+		"Baggage":           []string{"traffic_info=traffic_type=allowed-crawler"},
+	}
+
+	for _, tt := range []struct {
+		name             string
+		propagators      []string
+		wantTraceID      string
+		wantSpanID       string
+		wantSampled      bool
+		wantSpanValid    bool
+		wantMatchesCause string
+	}{
+		{
+			// b3multi runs last among span-context writers and overwrites the
+			// SpanContext produced by tracecontext and ottrace with a b3 trace
+			// id injected by an intermediate Finagle hop.
+			name:             "current config - b3multi wins, trace disconnected",
+			propagators:      []string{"tracecontext", "ottrace", "b3multi", "baggage"},
+			wantTraceID:      b3TraceID128,
+			wantSpanID:       b3SpanID,
+			wantSampled:      false,
+			wantSpanValid:    true,
+			wantMatchesCause: "b3multi ran last among span-context writers; X-B3-Sampled absent so trace flag is 0",
+		},
+		{
+			// Keeping b3multi. tracecontext still runs last and accepts the smelly
+			// traceparent, so the resulting trace-id is the padded 128-bit form.
+			// This happens to match ottrace's trace, so the trace stays connected
+			// but only by coincidence.
+			name:             "reorder to prefer tracecontext - accidentally connects to ottrace",
+			propagators:      []string{"baggage", "b3multi", "ottrace", "tracecontext"},
+			wantTraceID:      otTraceID128,
+			wantSpanID:       otSpanID,
+			wantSampled:      true,
+			wantSpanValid:    true,
+			wantMatchesCause: "tracecontext ran last and accepted the padded traceparent; span id happens to match ottrace",
+		},
+		{
+			// Target config after removing b3multi. Rationale: the prior
+			// OpenTracing config only had `propagators=lightstep` (ottrace
+			// only) - see lightstep.PropagatorStack + LightStepPropagator - so
+			// dropping b3multi does not regress against the pre-OTel baseline.
+			//
+			// Under this config the upstream request lands on the ottrace
+			// SpanContext (ottrace runs after tracecontext and overwrites).
+			// The smelly traceparent still parses in tracecontext, but ottrace
+			// overwrites it with the same trace-id (64-bit id padded) and the
+			// same span-id, so the trace stays connected.
+			name:             "target config - drop b3multi, ottrace wins",
+			propagators:      []string{"tracecontext", "ottrace", "baggage"},
+			wantTraceID:      otTraceID128,
+			wantSpanID:       otSpanID,
+			wantSampled:      true,
+			wantSpanValid:    true,
+			wantMatchesCause: "ottrace runs after tracecontext and overwrites with the ottrace-derived trace-id",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := textMapPropagator(&Options{Propagators: tt.propagators})
+			if err != nil {
+				t.Fatalf("textMapPropagator: %v", err)
+			}
+
+			ctx := p.Extract(context.Background(), propagation.HeaderCarrier(requestHeader))
+			sc := trace.SpanContextFromContext(ctx)
+
+			if got, want := sc.IsValid(), tt.wantSpanValid; got != want {
+				t.Fatalf("SpanContext.IsValid() = %v, want %v (%s)", got, want, tt.wantMatchesCause)
+			}
+			if !tt.wantSpanValid {
+				return
+			}
+			if got, want := sc.TraceID().String(), tt.wantTraceID; got != want {
+				t.Errorf("TraceID = %q, want %q (%s)", got, want, tt.wantMatchesCause)
+			}
+			if got, want := sc.SpanID().String(), tt.wantSpanID; got != want {
+				t.Errorf("SpanID = %q, want %q (%s)", got, want, tt.wantMatchesCause)
+			}
+			if got, want := sc.IsSampled(), tt.wantSampled; got != want {
+				t.Errorf("IsSampled = %v, want %v (%s)", got, want, tt.wantMatchesCause)
+			}
+		})
+	}
 }


### PR DESCRIPTION
TestPropagatorExtractMalformedTraceparent documents a trace-disconnection bug in skipper's OTel propagator chain.

### Trigger:
  A request arrives with a traceparent whose 128-bit trace-id is a 64-bit
  ottrace id left-padded with 16 zero nibbles. This is spec-valid (SDK
  only rejects all-zero ids), so tracecontext accepts it.

### Root cause:
  With the current chain [tracecontext, ottrace, b3multi, baggage], the
  last propagator to write a valid SpanContext wins. b3multi runs last
  and overwrites the ottrace/W3C context with an unrelated b3 trace-id
  injected by an intermediate Finagle hop.

### Symptom:
  Because skipper's sampler is always_on, spans are still exported - but
  under the b3 trace-id, so the trace appears disconnected in the
  observability UI.

### Test scope:
  Three configs are compared — (1) current prod (reproduces bug),
  (2) reorder-only workaround keeping b3multi,
  (3) target config dropping b3multi, matching the pre-OTel LightStep
  (ottrace-only) baseline.