### PR TITLE
feat(cache): support Redis as L2 storage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -751,9 +751,9 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.SwarmStaticOther, "swarm-static-other", "", "set static swarm all nodes, for example 127.0.0.1:9002,127.0.0.1:9003")
 
 	// cache
-	flag.DurationVar(&cfg.CacheL1TTL, "cache-l1-ttl", 60*time.Second, "maximum TTL for write-through L1 warming in the cache() filter when Valkey is configured; set to 0 to disable (write-around)")
+	flag.DurationVar(&cfg.CacheL1TTL, "cache-l1-ttl", 60*time.Second, "maximum TTL for write-through L1 warming in the cache() filter when Valkey or Redis is configured; set to 0 to disable (write-around)")
 	flag.Int64Var(&cfg.CacheL1MaxMemoryBytes, "cache-l1-max-memory-bytes", 0, "maximum memory budget in bytes for the cache() filter's in-process LRU (L1); defaults to 25% of cgroup memory limit or 2 GB if unreadable")
-	flag.BoolVar(&cfg.EnableL2Cache, "enable-l2-cache", false, "enable Valkey as L2 backing store for the cache() filter when --swarm-valkey-urls is configured; by default only in-process LRU (L1) is used")
+	flag.BoolVar(&cfg.EnableL2Cache, "enable-l2-cache", false, "enable Valkey or Redis as L2 backing store for the cache() filter when a corresponding swarm backend is configured; by default only in-process LRU (L1) is used")
 
 	flag.IntVar(&cfg.ClusterRatelimitMaxGroupShards, "cluster-ratelimit-max-group-shards", 1, "sets the maximum number of group shards for the clusterRatelimit filter")
 

--- a/docs/operation/operation.md
+++ b/docs/operation/operation.md
@@ -1964,11 +1964,11 @@ r: SourceFromLast("9.0.0.0/24","2001:67c:20a0::/48") -> ...`
 ## Cache
 
 By default entries are stored in an in-process LRU (L1) local to each Skipper process.
-When `--swarm-valkey-urls` is configured and `--enable-l2-cache` is set, Valkey serves as a
-shared backing store (L2) accessible by all Skipper instances via a client-side consistent
-hash ring; every read checks L1 first and an L1 hit returns without contacting L2 cache.
-Without `--enable-l2-cache`, `--swarm-valkey-urls` wires Valkey into ratelimit only and the
-`cache()` filter uses L1 exclusively.
+When `--enable-swarm` and `--enable-l2-cache` are set, a configured Valkey
+(`--swarm-valkey-urls`) or Redis (`--swarm-redis-urls`) ring serves as a shared backing store
+(L2) accessible by all Skipper instances via client-side consistent hashing; every read checks
+L1 first and an L1 hit returns without contacting L2 cache. Without `--enable-l2-cache`, the
+configured ring is not used by the `cache()` filter, which uses L1 exclusively.
 
 On every successful L2 write the entry is also written to L1
 (write-through) with a TTL of `min(--cache-l1-ttl, entry.TTL)`. On a L2
@@ -2012,7 +2012,7 @@ falling back to 2 GB if the limit is unreadable. Override with
 ### Storage architecture
 
 - L1 implementation is in-memory (25% of memory set by cgroup or 2GB fix size)
-- L2 implementation is for example skpnet.ValkeyRingClient, reusing Valkey ring shards if available.
+- L2 implementation uses skpnet.ValkeyRingClient or skpnet.RedisRingClient, reusing the configured ring shards.
 
 ```mermaid
 flowchart TD
@@ -2054,7 +2054,7 @@ flowchart TD
 - `cache.reval_error`: Counter, background revalidation fetch failures
 - `cache.reval_duration`: Histogram, end-to-end duration of each background revalidation job
 
-**L2 (for example if Valkey is configured):**
+**L2 (if Valkey or Redis is configured):**
 
 - `cache.l1_hit`: Counter, L1 hits that bypassed L2
 - `cache.l2_miss`: Counter, L2 misses that proceeded to an upstream fetch

--- a/filters/cache/l2_storage.go
+++ b/filters/cache/l2_storage.go
@@ -12,10 +12,10 @@ import (
 
 const defaultMinTTL = time.Minute
 
+// L2Client provides the key-value operations required by L2Storage.
 type L2Client interface {
 	Get(ctx context.Context, key string) (string, error)
 	SetWithExpire(ctx context.Context, key string, value string, expire time.Duration) error
-	Expire(ctx context.Context, key string, d time.Duration) (int64, error)
 	Del(ctx context.Context, key string) (int64, error)
 }
 

--- a/filters/cache/l2_storage_valkey_test.go
+++ b/filters/cache/l2_storage_valkey_test.go
@@ -397,7 +397,7 @@ func TestValkeyStorage_SplitFallbackCounters(t *testing.T) {
 
 func TestValkeyStorage_DeleteCleansL1EvenOnValkeyError(t *testing.T) {
 	// Valkey is broken, so Set falls back to L1. Delete must still clean L1
-	// regardless of the Expire error from Valkey.
+	// regardless of the Delete error from Valkey.
 	stub := newBrokenStubValkeyClient()
 	lru := NewLRUStorage(64<<20, nil, metrics.Default)
 	s := NewL2Storage(stub, lru, &metricstest.MockMetrics{}, 0, valkey.IsValkeyNil)
@@ -412,7 +412,7 @@ func TestValkeyStorage_DeleteCleansL1EvenOnValkeyError(t *testing.T) {
 		t.Fatal("expected entry in L1 after Set fallback")
 	}
 
-	_ = s.Delete(ctx, "k") // Valkey Expire will error; L1 must still be cleaned
+	_ = s.Delete(ctx, "k") // Valkey Delete will error; L1 must still be cleaned
 
 	got, _ = lru.Get(ctx, "k")
 	if got != nil {

--- a/net/redisclient.go
+++ b/net/redisclient.go
@@ -419,6 +419,16 @@ func (r *RedisRingClient) Set(ctx context.Context, key string, value any, expira
 	return res.Result()
 }
 
+// SetWithExpire stores a string value and applies the provided expiration.
+func (r *RedisRingClient) SetWithExpire(ctx context.Context, key string, value string, expire time.Duration) error {
+	return r.ring.Set(ctx, key, value, expire).Err()
+}
+
+// Del deletes a key and returns the number of keys removed.
+func (r *RedisRingClient) Del(ctx context.Context, key string) (int64, error) {
+	return r.ring.Del(ctx, key).Result()
+}
+
 func (r *RedisRingClient) ZAdd(ctx context.Context, key string, val int64, score float64) (int64, error) {
 	res := r.ring.ZAdd(ctx, key, redis.Z{Member: val, Score: score})
 	return res.Val(), res.Err()

--- a/net/redisclient_test.go
+++ b/net/redisclient_test.go
@@ -2,12 +2,14 @@ package net
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/redis/go-redis/v9"
 	"github.com/zalando/skipper/net/redistest"
 	"github.com/zalando/skipper/tracing/tracers/basic"
 )
@@ -316,6 +318,60 @@ func TestRedisClientGetSet(t *testing.T) {
 				t.Errorf("Failed to get correct Get value, want '%v', got '%v'", tt.expect, val)
 			}
 		})
+	}
+}
+
+func TestRedisClientL2Operations(t *testing.T) {
+	redisAddr, done := redistest.NewTestRedis(t)
+	defer done()
+
+	cli := NewRedisRingClient(&RedisOptions{Addrs: []string{redisAddr}})
+	defer func() {
+		if !cli.closed {
+			t.Error("Redis client was not closed")
+		}
+	}()
+	defer cli.Close()
+
+	ctx := context.Background()
+	if err := cli.SetWithExpire(ctx, "expiring", "value", 100*time.Millisecond); err != nil {
+		t.Fatalf("SetWithExpire: %v", err)
+	}
+	got, err := cli.Get(ctx, "expiring")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "value" {
+		t.Fatalf("Get: got %q, want %q", got, "value")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, err = cli.Get(ctx, "expiring")
+		if errors.Is(err, redis.Nil) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Get while waiting for expiry: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("key did not expire")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := cli.SetWithExpire(ctx, "deleted", "value", time.Minute); err != nil {
+		t.Fatalf("SetWithExpire before Del: %v", err)
+	}
+	deleted, err := cli.Del(ctx, "deleted")
+	if err != nil {
+		t.Fatalf("Del: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("Del: got %d deleted keys, want 1", deleted)
+	}
+	if _, err := cli.Get(ctx, "deleted"); !errors.Is(err, redis.Nil) {
+		t.Fatalf("Get after Del: got error %v, want redis.Nil", err)
 	}
 }
 

--- a/skipper.go
+++ b/skipper.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -23,6 +24,7 @@ import (
 
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/valkey-io/valkey-go"
 	"go.opentelemetry.io/otel"
@@ -91,7 +93,10 @@ const (
 
 const DefaultPluginDir = "./plugins"
 
-var _ cache.L2Client = (*skpnet.ValkeyRingClient)(nil)
+var (
+	_ cache.L2Client = (*skpnet.RedisRingClient)(nil)
+	_ cache.L2Client = (*skpnet.ValkeyRingClient)(nil)
+)
 
 // Options to start skipper.
 type Options struct {
@@ -151,18 +156,17 @@ type Options struct {
 	// using a fixed 25% fraction. Set explicitly to override that behaviour.
 	ResponseCacheMaxMemoryBytes int64
 
-	// CacheL1TTL sets the maximum TTL for write-through L1 warming in ValkeyStorage.
-	// On a successful Valkey Set, L1 is warmed with min(CacheL1TTL, entry.TTL).
+	// CacheL1TTL sets the maximum TTL for write-through L1 warming in L2Storage.
+	// On a successful L2 Set, L1 is warmed with min(CacheL1TTL, entry.TTL).
 	// Set to 0 to disable write-through (write-around behaviour). Default: 60s.
 	CacheL1TTL time.Duration
 
-	// EnableL2Cache enables the L2 Cache. You need to pass
-	// L2CacheClient, which defaults to a valkey.Ring if not
-	// passed. Without enabling L2 cache, only in-process LRU (L1)
-	// is used.
+	// EnableL2Cache enables the L2 cache. L2CacheClient defaults to the
+	// configured Valkey or Redis ring. Without enabling L2 cache, only the
+	// in-process LRU (L1) is used.
 	EnableL2Cache bool
 
-	// L2CacheClient, defaults to valkey github.com/zalando/skipper/net.ValkeyRingClient
+	// L2CacheClient defaults to the configured ValkeyRingClient or RedisRingClient.
 	L2CacheClient cache.L2Client
 
 	// ReadMemoryLimit, when set, is called by the cache() filter initialiser
@@ -1455,6 +1459,26 @@ func (o *Options) cacheBudget() int64 {
 	return limit / cgroupFraction
 }
 
+func selectL2CacheClient(enabled bool, configured cache.L2Client, valkeyRing *skpnet.ValkeyRingClient, redisRing *skpnet.RedisRingClient) cache.L2Client {
+	if !enabled {
+		return nil
+	}
+	if configured != nil {
+		return configured
+	}
+	if valkeyRing != nil {
+		return valkeyRing
+	}
+	if redisRing != nil {
+		return redisRing
+	}
+	return nil
+}
+
+func isL2CacheMiss(err error) bool {
+	return valkey.IsValkeyNil(err) || errors.Is(err, redis.Nil)
+}
+
 // filterRegistry creates a filter registry with the builtin and
 // custom filter specs registered excluding disabled filters.
 // If [Options.RegisterFilters] callback is set, it will be called.
@@ -2260,6 +2284,15 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		defer valkeyRing.Close()
 	}
 
+	var redisRing *skpnet.RedisRingClient
+	if redisOptions != nil {
+		if redisOptions.MetricsPrefix == "" {
+			redisOptions.MetricsPrefix = ratelimit.RedisMetricsPrefix
+		}
+		redisRing = skpnet.NewRedisRingClient(redisOptions)
+		defer redisRing.Close()
+	}
+
 	var (
 		ratelimitRegistry                *ratelimit.Registry
 		failClosedRatelimitPostProcessor *ratelimitfilters.FailClosedPostProcessor
@@ -2271,13 +2304,8 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 		case valkeyRing != nil:
 			ratelimitRegistry = ratelimit.NewRatelimitRegistryValkey(valkeyRing, o.RatelimitSettings...)
 
-		case redisOptions != nil:
-			if redisOptions.MetricsPrefix == "" {
-				redisOptions.MetricsPrefix = ratelimit.RedisMetricsPrefix
-			}
-			redisRing := skpnet.NewRedisRingClient(redisOptions)
+		case redisRing != nil:
 			ratelimitRegistry = ratelimit.NewRatelimitRegistryRedis(redisRing, o.RatelimitSettings...)
-			defer redisRing.Close()
 
 		default:
 			// swim based Swarmer (deprecated)
@@ -2314,13 +2342,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 	}
 
 	if !slices.Contains(o.DisabledFilters, cache.Name) {
-		var l2Client cache.L2Client
-		if o.EnableL2Cache {
-			l2Client = o.L2CacheClient
-			if l2Client == nil {
-				l2Client = valkeyRing
-			}
-		}
+		l2Client := selectL2CacheClient(o.EnableL2Cache, o.L2CacheClient, valkeyRing, redisRing)
 		cacheSpec := cache.NewCacheFilter(
 			cache.Options{
 				MaxBytes:   o.cacheBudget(),
@@ -2334,7 +2356,7 @@ func run(o Options, sig chan os.Signal, idleConnsCH chan struct{}) error {
 					OpentracingEventsByTag:  o.OpenTracingClientTraceByTag,
 				},
 				L2Client:  l2Client,
-				IsNoL2Err: valkey.IsValkeyNil,
+				IsNoL2Err: isL2CacheMiss,
 				L1TTL:     o.CacheL1TTL,
 			},
 		)

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -15,16 +15,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
+	"github.com/valkey-io/valkey-go"
 
 	"github.com/zalando/skipper/dataclients/routestring"
 	"github.com/zalando/skipper/filters"
 	flog "github.com/zalando/skipper/filters/accesslog"
 	"github.com/zalando/skipper/filters/auth"
 	"github.com/zalando/skipper/filters/builtin"
+	"github.com/zalando/skipper/filters/cache"
 	fscheduler "github.com/zalando/skipper/filters/scheduler"
 	"github.com/zalando/skipper/loadbalancer"
 	"github.com/zalando/skipper/metrics/metricstest"
+	skpnet "github.com/zalando/skipper/net"
 	"github.com/zalando/skipper/proxy"
 	"github.com/zalando/skipper/ratelimit"
 	"github.com/zalando/skipper/routing"
@@ -143,6 +147,54 @@ func TestOptionsFilterRegistry(t *testing.T) {
 		assert.Contains(t, fr, filters.BearerInjectorName)
 		assert.Contains(t, fr, filters.WebhookName)
 	})
+}
+
+func TestSelectL2CacheClient(t *testing.T) {
+	configured := &skpnet.RedisRingClient{}
+	valkeyRing := &skpnet.ValkeyRingClient{}
+	redisRing := &skpnet.RedisRingClient{}
+
+	for _, tt := range []struct {
+		name       string
+		enabled    bool
+		configured cache.L2Client
+		valkeyRing *skpnet.ValkeyRingClient
+		redisRing  *skpnet.RedisRingClient
+		want       any
+	}{
+		{name: "disabled", configured: configured, valkeyRing: valkeyRing, redisRing: redisRing},
+		{name: "configured client", enabled: true, configured: configured, valkeyRing: valkeyRing, redisRing: redisRing, want: configured},
+		{name: "valkey ring", enabled: true, valkeyRing: valkeyRing, redisRing: redisRing, want: valkeyRing},
+		{name: "redis ring", enabled: true, redisRing: redisRing, want: redisRing},
+		{name: "no client", enabled: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectL2CacheClient(tt.enabled, tt.configured, tt.valkeyRing, tt.redisRing)
+			if any(got) != tt.want {
+				t.Errorf("selectL2CacheClient() = %T %p, want %T %p", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsL2CacheMiss(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil"},
+		{name: "valkey miss", err: valkey.Nil, want: true},
+		{name: "redis miss", err: redis.Nil, want: true},
+		{name: "wrapped redis miss", err: fmt.Errorf("wrapped: %w", redis.Nil), want: true},
+		{name: "other error", err: fmt.Errorf("connection failed")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isL2CacheMiss(tt.err); got != tt.want {
+				t.Errorf("isL2CacheMiss() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestOptionsOpenTracingTracerInstanceOverridesOpenTracing(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds Redis support as an L2 backing store for the cache() filter. RedisRingClient now implements the cache L2 client operations, and Skipper selects the configured Valkey or Redis ring for L2 caching.

## Why?

Issue #4237 requests Redis support alongside the existing Valkey L2 cache.

## Changes

- Add Redis ring SetWithExpire and Del operations.
- Allow cache L2 storage to recognize Redis cache misses.
- Reuse the Redis ring for rate limiting and L2 cache configuration.
- Update cache configuration documentation and tests.

Fixes #4237

## Validation

- go test -count=1 ./net -run TestRedisClientL2Operations
- go test -count=1 . -run "TestSelectL2CacheClient|TestIsL2CacheMiss"
- make lint
- make shortcheck