### PR TITLE
fix: canonicalize header name in dropRequestHeaderRegexp and dropResponseHeaderRegexp

### DIFF
--- a/filters/builtin/header_test.go
+++ b/filters/builtin/header_test.go
@@ -185,6 +185,12 @@ func TestHeader(t *testing.T) {
 			valid:          true,
 			requestHeader:  http.Header{"X-Test-Name": []string{"value0", "value1"}},
 			expectedHeader: http.Header{},
+		}, {
+			msg:            "name parameter is case-insensitive",
+			args:           []any{"x-test-name", "^value1$"},
+			valid:          true,
+			requestHeader:  http.Header{"X-Test-Name": []string{"value0", "value1"}},
+			expectedHeader: http.Header{"X-Test-Request-Name": []string{"value0"}},
 		}},
 		"setResponseHeader": {{
 			msg:            "set response header when none",
@@ -284,6 +290,12 @@ func TestHeader(t *testing.T) {
 			valid:          true,
 			responseHeader: http.Header{"X-Test-Name": []string{"value0", "value1"}},
 			expectedHeader: http.Header{},
+		}, {
+			msg:            "name parameter is case-insensitive",
+			args:           []any{"x-test-name", "^value1$"},
+			valid:          true,
+			responseHeader: http.Header{"X-Test-Name": []string{"value0", "value1"}},
+			expectedHeader: http.Header{"X-Test-Name": []string{"value0"}},
 		}},
 		"setContextRequestHeader": {{
 			msg:            "set request header from context",
@@ -554,6 +566,53 @@ func TestHeader(t *testing.T) {
 					}
 				})
 			}
+		})
+	}
+}
+
+// Asserts on the header map of the filter context because the proxy copies
+// headers into their canonical form and therefore hides a value that was
+// stored under a non-canonical name behind random map iteration order.
+func TestDropHeaderRegexpCanonicalName(t *testing.T) {
+	for _, ti := range []struct {
+		msg  string
+		name string
+	}{{
+		msg:  "canonical name",
+		name: "X-Test-Name",
+	}, {
+		msg:  "lowercase name",
+		name: "x-test-name",
+	}} {
+		t.Run(ti.msg, func(t *testing.T) {
+			expected := http.Header{"X-Test-Name": []string{"value0"}}
+
+			t.Run("request", func(t *testing.T) {
+				f, err := NewDropRequestHeaderValueRegexp().CreateFilter([]any{ti.name, "^value1$"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				r, _ := http.NewRequest("GET", "http://example.com", nil)
+				r.Header["X-Test-Name"] = []string{"value0", "value1"}
+
+				f.Request(&filtertest.Context{FRequest: r})
+
+				assert.Equal(t, expected, r.Header)
+			})
+
+			t.Run("response", func(t *testing.T) {
+				f, err := NewDropResponseHeaderValueRegexp().CreateFilter([]any{ti.name, "^value1$"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				rsp := &http.Response{Header: http.Header{"X-Test-Name": []string{"value0", "value1"}}}
+
+				f.Response(&filtertest.Context{FResponse: rsp})
+
+				assert.Equal(t, expected, rsp.Header)
+			})
 		})
 	}
 }

--- a/filters/builtin/headerfilter.go
+++ b/filters/builtin/headerfilter.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"fmt"
+	"net/http"
 	"regexp"
 	"slices"
 	"strings"
@@ -253,8 +254,9 @@ func (spec *headerFilter) CreateFilter(config []any) (filters.Filter, error) {
 			return nil, fmt.Errorf("filter expects valid regex: %w", filters.ErrInvalidFilterParameters)
 		}
 		return &headerFilter{
-			typ:         spec.typ,
-			key:         key,
+			typ: spec.typ,
+			// filter writes the remaining values back into the header map directly
+			key:         http.CanonicalHeaderKey(key),
 			value:       value,
 			valueRegexp: re,
 		}, nil


### PR DESCRIPTION
## Symptom

`dropRequestHeaderRegexp` does not drop the matched value when the header name in the route is not in canonical form. Route:

```
r: * -> dropRequestHeaderRegexp("x-test-name", "^value1$") -> "http://127.0.0.1:9955"
```

Backend prints `r.Header["X-Test-Name"]`. Ten identical requests carrying `X-Test-Name: value0` and `X-Test-Name: value1`, through a skipper built from master:

```
backend received X-Test-Name: ["value0" ""]
backend received X-Test-Name: ["value0" ""]
backend received X-Test-Name: ["value0" ""]
backend received X-Test-Name: ["value0" ""]
backend received X-Test-Name: ["value0"]
backend received X-Test-Name: ["value0" ""]
backend received X-Test-Name: ["value0"]
backend received X-Test-Name: ["value0" ""]
backend received X-Test-Name: ["value0"]
backend received X-Test-Name: ["value0"]
```

The dropped value is replaced by an empty one on part of the requests instead of being removed. When every value of the header matches the expression, the header survives with an empty value instead of disappearing. Same route, requests carrying only `X-Test-Name: value1`:

```
backend received X-Test-Name: []
backend received X-Test-Name: [""]
backend received X-Test-Name: []
backend received X-Test-Name: [""]
backend received X-Test-Name: [""]
backend received X-Test-Name: [""]
backend received X-Test-Name: [""]
backend received X-Test-Name: [""]
backend received X-Test-Name: []
backend received X-Test-Name: []
```

`dropResponseHeaderRegexp` behaves the same way on the response.

With the canonical `X-Test-Name` both filters work. Every other header filter accepts any casing and says so in the tests: `dropRequestHeader`, `dropResponseHeader`, `copyRequestHeader` and `copyResponseHeader` each have a `name parameter is case-insensitive` case in `filters/builtin/header_test.go`. These two did not.

## Cause

`filters/builtin/headerfilter.go`:

```go
case dropRequestHeaderValueRegexp:
	if headerValue := header.Get(f.key); headerValue != "" {
		header[f.key] = slices.DeleteFunc(header.Values(f.key), f.valueRegexp.MatchString)
	}
```

`Header.Values` canonicalizes the name, so the values are read from `X-Test-Name` and `slices.DeleteFunc` compacts that slice in place, zeroing the tail. The shortened slice is then written back under the name exactly as configured, so with `x-test-name` the header map becomes

```
http.Header{"X-Test-Name":[]string{"value0", ""}, "x-test-name":[]string{"value0"}}
```

The original entry is still there with its matched values blanked, plus a second entry under the non-canonical name. When the outgoing request is built, `copyHeaderExcluding` canonicalizes both onto `X-Test-Name`, and since Go map iteration order is random either one can be written last. That is the split in the output above.

## Fix

Canonicalize the name once, when the filter is created, so the write targets the entry that was read. No per-request cost.

## Reproduction

`go1.27.1 windows/amd64`.

Before, with `filters/builtin/headerfilter.go` at master and only the test changes of this PR applied:

```
$ go test ./filters/builtin -run TestDropHeaderRegexpCanonicalName -v
--- FAIL: TestDropHeaderRegexpCanonicalName (0.00s)
    --- PASS: TestDropHeaderRegexpCanonicalName/canonical_name (0.00s)
    --- FAIL: TestDropHeaderRegexpCanonicalName/lowercase_name (0.00s)
        --- FAIL: TestDropHeaderRegexpCanonicalName/lowercase_name/request (0.00s)
        --- FAIL: TestDropHeaderRegexpCanonicalName/lowercase_name/response (0.00s)

        	Error:      	Not equal:
        	            	expected: http.Header{"X-Test-Name":[]string{"value0"}}
        	            	actual  : http.Header{"X-Test-Name":[]string{"value0", ""}, "x-test-name":[]string{"value0"}}
```

`go test ./filters/builtin -run TestDropHeaderRegexpCanonicalName -count=20` fails 20 out of 20.

The two new `TestHeader` table cases go through the proxy, so they only fail when the random map order picks the stale entry: 15 of 20 and 5 of 20 in one measurement, 8 of 20 and 10 of 20 in another. The assertion that fails deterministically is the one on the filter context, which is why this PR adds it in addition to the table cases.

After:

```
$ go test ./filters/builtin -run 'TestDropHeaderRegexpCanonicalName|TestHeader' -count=20
ok  	github.com/zalando/skipper/filters/builtin	2.177s

$ go test ./filters/builtin
ok  	github.com/zalando/skipper/filters/builtin	2.009s
```

End to end with the fixed binary, both scenarios above, 10 requests each:

```
backend received X-Test-Name: ["value0"]     (10/10)
backend received X-Test-Name: []             (10/10)
```

## Notes

- `gofmt -l -s` and `go vet ./filters/builtin` are clean.
- I could not run `-race` here: it needs cgo and this machine has no C toolchain. CI covers it.
- Behaviour for canonical names is unchanged; the existing `dropRequestHeaderRegexp` and `dropResponseHeaderRegexp` cases pass before and after.
