### PR TITLE
fix: serialize eskip numbers without exponent notation

### DIFF
--- a/eskip/roundtrip_test.go
+++ b/eskip/roundtrip_test.go
@@ -182,3 +182,49 @@ func TestRoundtripLBZone(t *testing.T) {
 		assert.Equal(t, serialized, out.String(), "round-trip must be stable")
 	})
 }
+
+// Test various numbers are parsed to the same value after serialization
+func TestRoundtripNumber(t *testing.T) {
+	for _, value := range []float64{
+		0,
+		1,
+		-1,
+		0.5,
+		-0.5,
+		3.14,
+		0.0001,
+		0.00001,
+		0.000012345,
+		-0.00005,
+		1e-20,
+		1e21,
+		1234567890123456789,
+	} {
+		t.Run(fmt.Sprintf("%v", value), func(t *testing.T) {
+			in := &Route{
+				Predicates:  []*Predicate{{Name: "APredicate", Args: []interface{}{value}}},
+				Filters:     []*Filter{{Name: "afilter", Args: []interface{}{value}}},
+				BackendType: ShuntBackend,
+			}
+
+			serialized := in.String()
+			t.Logf("%v, %s", value, serialized)
+
+			outs, err := Parse(serialized)
+			require.NoError(t, err)
+			require.Len(t, outs, 1)
+
+			out := outs[0]
+
+			require.Len(t, out.Predicates, 1)
+			require.Len(t, out.Predicates[0].Args, 1)
+			assert.Equal(t, value, out.Predicates[0].Args[0])
+
+			require.Len(t, out.Filters, 1)
+			require.Len(t, out.Filters[0].Args, 1)
+			assert.Equal(t, value, out.Filters[0].Args[0])
+
+			assert.Equal(t, serialized, out.String(), "round-trip must be stable")
+		})
+	}
+}

--- a/eskip/string.go
+++ b/eskip/string.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -55,15 +55,8 @@ func argsString(args []interface{}) string {
 		case int:
 			sargs = appendFmt(sargs, "%d", a)
 		case float64:
-			f := "%g"
-
-			// imprecise elimination of 0 decimals
-			// TODO: better fix this issue on parsing side
-			if math.Floor(v) == v {
-				f = "%.0f"
-			}
-
-			sargs = appendFmt(sargs, f, a)
+			// the eskip number token does not support exponent notation
+			sargs = append(sargs, strconv.FormatFloat(v, 'f', -1, 64))
 		case string:
 			sargs = appendFmtEscape(sargs, `"%s"`, `"`, a)
 		default:


### PR DESCRIPTION
## Symptom

Skipper cannot read back the routes it prints when a filter or predicate argument is a float smaller than 0.0001. `Traffic()` accepts any probability in [0, 1], so a small canary share is a valid route:

```
canary: Traffic(0.00001) -> "https://canary.example.org";
main: * -> "https://main.example.org";
```

`eskip check` accepts the file, but the output of `eskip print` no longer parses:

```
$ ./bin/eskip check canary.eskip
$ echo $?
0

$ ./bin/eskip print canary.eskip
canary: Traffic(1e-05) -> "https://canary.example.org";
main: * -> "https://main.example.org";

$ ./bin/eskip print canary.eskip > printed.eskip
$ ./bin/eskip check printed.eskip
parse failed after token e, last route id: canary, position 18: syntax error
```

The `/routes` endpoint of a running skipper serves the same unreadable text:

```
$ ./bin/skipper -routes-file canary.eskip -address :9931 -support-listener :9932 &
$ curl -s localhost:9932/routes | tee dumped.eskip
canary: Traffic(1e-05)
  -> "https://canary.example.org";

main: *
  -> "https://main.example.org";

$ ./bin/eskip check dumped.eskip
parse failed after token e, last route id: canary, position 18: syntax error
```

`routesrv` serializes the routes it serves with the same `eskip.Fprint` (`routesrv/eskipbytes.go`), and skipper parses what routesrv serves. I did not set up a cluster, so I am only pointing at the code path rather than claiming a measured failure there.

## Cause

The eskip number token accepts digits, an optional leading `-` and a single decimal point, and no exponent (`scanNumber` in `eskip/lexer.go`). `argsString` in `eskip/string.go` serialized floats with `%g`, which switches to exponent notation once the exponent drops below -4. Anything under 0.0001 therefore comes out as `1e-05` and lexes as the three tokens `1`, `e`, `-05`.

## Fix

`strconv.FormatFloat(v, 'f', -1, 64)`. The `'f'` format never uses an exponent, and precision -1 prints the shortest representation that parses back to the same float64.

This also covers the case the removed `%.0f` branch handled: `FormatFloat` with precision -1 prints `2` for `2.0` and `1000000000000000000000` for `1e21`, so integral values keep their current form and the `TODO` about eliminating the decimals goes away.

## Reproduction

`go1.27.1 windows/amd64`. Before, with only the test of this PR applied on top of master:

```
$ go test ./eskip -run TestRoundtripNumber -v
=== RUN   TestRoundtripNumber/1e-05
    roundtrip_test.go:211: 1e-05, APredicate(1e-05) -> afilter(1e-05) -> <shunt>
    roundtrip_test.go:214:
        	Error:      	Received unexpected error:
        	            	parse failed after token e, position 13: syntax error
...
--- FAIL: TestRoundtripNumber (0.00s)
    --- PASS: TestRoundtripNumber/0
    --- PASS: TestRoundtripNumber/1
    --- PASS: TestRoundtripNumber/-1
    --- PASS: TestRoundtripNumber/0.5
    --- PASS: TestRoundtripNumber/-0.5
    --- PASS: TestRoundtripNumber/3.14
    --- PASS: TestRoundtripNumber/0.0001
    --- FAIL: TestRoundtripNumber/1e-05
    --- FAIL: TestRoundtripNumber/1.2345e-05
    --- FAIL: TestRoundtripNumber/-5e-05
    --- FAIL: TestRoundtripNumber/1e-20
    --- PASS: TestRoundtripNumber/1e+21
    --- PASS: TestRoundtripNumber/1.2345678901234568e+18
```

Four of thirteen fail. The nine that pass are the ones pinning existing behaviour, including the integral and large-magnitude cases, and they still pass after the change.

After:

```
$ go test ./eskip/...
ok  	github.com/zalando/skipper/eskip	0.570s

$ ./bin/eskip print canary.eskip
canary: Traffic(0.00001) -> "https://canary.example.org";
main: * -> "https://main.example.org";
$ ./bin/eskip print canary.eskip > printed.eskip && ./bin/eskip check printed.eskip
$ echo $?
0
```

## Packages run

`./eskip/...`, `./routing/...`, `./eskipfile/...`, `./cmd/eskip/...`, `./predicates/...`, `./dataclients/routestring/...` with `-test.short`.

Two things I could not verify on this machine, neither of them related to this change:

- `routing.TestStats` fails on unmodified master here as well (3 of 3 runs, `Failed to get drop probability: 0.00`).
- `./dataclients/kubernetes` fixture tests fail on unmodified master here because the fixture symlinks are checked out as plain text files on Windows (`yaml: cannot unmarshal !!str "../traf..."`). Identical failure list before and after.
- `-race` needs cgo and this machine has no C toolchain, so CI has to cover that.

`gofmt -l -s` and `go vet ./eskip` are clean.
