### PR TITLE
fix: document the registered names of the drop header regexp filters

### DIFF
--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -186,7 +186,7 @@ Example:
 foo: * -> dropRequestHeader("User-Agent") -> "https://backend.example.org";
 ```
 
-### dropRequestHeaderValueRegexp
+### dropRequestHeaderRegexp
 
 Removes header values matched by regex from the request
 
@@ -198,7 +198,7 @@ Parameters:
 Example:
 
 ```
-foo: * -> dropRequestHeaderValueRegexp("User-Agent", "^value.") -> "https://backend.example.org";
+foo: * -> dropRequestHeaderRegexp("User-Agent", "^value.") -> "https://backend.example.org";
 ```
 
 ### modResponseHeader
@@ -239,9 +239,9 @@ Same as [appendRequestHeader](#appendrequestheader), only for responses
 
 Same as [dropRequestHeader](#droprequestheader) but for responses from the backend
 
-### dropResponseHeaderValueRegexp
+### dropResponseHeaderRegexp
 
-Same as [dropRequestHeaderValueRegexp](#droprequestheadervalueregexp) but for responses from the backend
+Same as [dropRequestHeaderRegexp](#droprequestheaderregexp) but for responses from the backend
 
 ### setContextRequestHeader
 


### PR DESCRIPTION
## Symptom

The filter reference documents `dropRequestHeaderValueRegexp` and `dropResponseHeaderValueRegexp`, but no filter with those names is registered, so a route copied from the documentation is thrown away.

Running skipper with the example exactly as printed in the docs:

```
$ ./bin/skipper -inline-routes='foo: * -> dropRequestHeaderValueRegexp("User-Agent", "^value.") -> "https://backend.example.org"' -address :9921
level=info msg="Listen on :9921"
level=error msg="failed to process route foo: unknown_filter: filter \"dropRequestHeaderValueRegexp\" not found"

$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9921/
404
```

The names the filters are actually registered under are `dropRequestHeaderRegexp` and `dropResponseHeaderRegexp`. They are the values of `filters.DropRequestHeaderValueRegexpName` and `filters.DropResponseHeaderValueRegexpName` in `filters/filters.go`, and they are what `filters/builtin/header_test.go` uses.

With the documented name corrected, the route is accepted:

```
$ ./bin/skipper -inline-routes='foo: * -> dropRequestHeaderRegexp("User-Agent", "^value.") -> "https://backend.example.org"' -address :9941
level=info msg="Listen on :9941"
(no unknown_filter error)

$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9941/
502
```

502 because `backend.example.org` is not reachable from here, which is the point: the route matched.

## Change

Documentation only. The two section headings, the example and the cross reference in `docs/reference/filters.md` now use the registered names. The Go identifiers are untouched, so nothing that already works breaks.

Built and run with go1.27.1.
