### PR TITLE
fix: modRequestHeader and modResponseHeader drop all but the first header value

### DIFF
--- a/filters/builtin/mod_header.go
+++ b/filters/builtin/mod_header.go
@@ -65,11 +65,14 @@ func (f *modRequestHeader) Request(ctx filters.FilterContext) {
 		return
 	}
 
-	if _, ok := req.Header[http.CanonicalHeaderKey(f.headerName)]; !ok {
+	values, ok := req.Header[http.CanonicalHeaderKey(f.headerName)]
+	if !ok {
 		return
 	}
 
-	req.Header.Set(f.headerName, f.rx.ReplaceAllString(req.Header.Get(f.headerName), f.replacement))
+	for i, value := range values {
+		values[i] = f.rx.ReplaceAllString(value, f.replacement)
+	}
 }
 
 func (*modRequestHeader) Response(filters.FilterContext) {}
@@ -124,9 +127,12 @@ func (*modResponseHeader) Request(filters.FilterContext) {}
 func (f *modResponseHeader) Response(ctx filters.FilterContext) {
 	resp := ctx.Response()
 
-	if _, ok := resp.Header[http.CanonicalHeaderKey(f.headerName)]; !ok {
+	values, ok := resp.Header[http.CanonicalHeaderKey(f.headerName)]
+	if !ok {
 		return
 	}
 
-	resp.Header.Set(f.headerName, f.rx.ReplaceAllString(resp.Header.Get(f.headerName), f.replacement))
+	for i, value := range values {
+		values[i] = f.rx.ReplaceAllString(value, f.replacement)
+	}
 }

--- a/filters/builtin/mod_header_test.go
+++ b/filters/builtin/mod_header_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/zalando/skipper/filters"
 	"github.com/zalando/skipper/filters/filtertest"
 	"net/http"
+	"slices"
 	"testing"
 )
 
@@ -225,6 +226,49 @@ func TestModResponseHeader(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestModHeaderMultipleValues(t *testing.T) {
+	t.Run("request", func(t *testing.T) {
+		spec := NewModRequestHeader()
+		f, err := spec.CreateFilter([]any{"X-Forwarded-Host", `^internal\.`, "public."})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req, err := http.NewRequest("GET", "https://example.org/path/yo", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header["X-Forwarded-Host"] = []string{"internal.example.org", "internal.example.com"}
+
+		f.Request(&filtertest.Context{FRequest: req})
+
+		want := []string{"public.example.org", "public.example.com"}
+		if got := req.Header.Values("X-Forwarded-Host"); !slices.Equal(got, want) {
+			t.Errorf("failed to modify all request header values, got: %q, want: %q", got, want)
+		}
+	})
+
+	t.Run("response", func(t *testing.T) {
+		spec := NewModResponseHeader()
+		f, err := spec.CreateFilter([]any{"Set-Cookie", `Domain=internal\.example\.org`, "Domain=example.org"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rsp := &http.Response{Header: http.Header{"Set-Cookie": []string{
+			"a=1; Domain=internal.example.org",
+			"b=2; Domain=internal.example.org",
+		}}}
+
+		f.Response(&filtertest.Context{FResponse: rsp})
+
+		want := []string{"a=1; Domain=example.org", "b=2; Domain=example.org"}
+		if got := rsp.Header.Values("Set-Cookie"); !slices.Equal(got, want) {
+			t.Errorf("failed to modify all response header values, got: %q, want: %q", got, want)
+		}
+	})
 }
 
 func TestModifyHostWithInvalidExpression(t *testing.T) {


### PR DESCRIPTION
## Symptom

`modResponseHeader` deletes cookies. Rewriting the cookie domain of a backend that sets more than one cookie:

```
r: * -> modResponseHeader("Set-Cookie", "Domain=internal\\.example\\.org", "Domain=example.org") -> "http://backend"
```

Backend response:

```
Set-Cookie: a=1; Domain=internal.example.org
Set-Cookie: b=2; Domain=internal.example.org
```

What the client gets through the proxy:

```
client received Set-Cookie: ["a=1; Domain=example.org"]
```

The second cookie is gone. Expected:

```
client received Set-Cookie: ["a=1; Domain=example.org" "b=2; Domain=example.org"]
```

`modRequestHeader` does the same to the request, so a route rewriting a repeated request header forwards only the first value.

The documentation says the filter replaces "all matched regex expressions in the given header" and says nothing about the other values of that header being discarded.

## Cause

`filters/builtin/mod_header.go`:

```go
resp.Header.Set(f.headerName, f.rx.ReplaceAllString(resp.Header.Get(f.headerName), f.replacement))
```

`Header.Get` returns the first value only, and `Header.Set` replaces the whole entry with the single value it is given, so everything after the first value is dropped whether or not the expression matched it.

## Fix

Apply the expression to every value of the header, in place. The `Host` branch of `modRequestHeader` is untouched.

## Reproduction

`go1.27.1 windows/amd64`. Before, with `filters/builtin/mod_header.go` at master and only the test of this PR applied:

```
$ go test ./filters/builtin -run TestModHeaderMultipleValues -v
=== RUN   TestModHeaderMultipleValues/request
    mod_header_test.go:249: failed to modify all request header values, got: ["public.example.org"], want: ["public.example.org" "public.example.com"]
=== RUN   TestModHeaderMultipleValues/response
    mod_header_test.go:269: failed to modify all response header values, got: ["a=1; Domain=example.org"], want: ["a=1; Domain=example.org" "b=2; Domain=example.org"]
--- FAIL: TestModHeaderMultipleValues (0.00s)
    --- FAIL: TestModHeaderMultipleValues/request (0.00s)
    --- FAIL: TestModHeaderMultipleValues/response (0.00s)
```

The `Set-Cookie` output at the top of this description comes from a throwaway `proxytest` route with the same filter, run once against master and once against this branch, so the symptom is the proxy's and not just the filter's.

After:

```
$ go test ./filters/builtin -run 'TestModHeaderMultipleValues|TestModRequestHeader|TestModResponseHeader|TestModRequestHostHeader|TestModifyHost|TestCreateModHost' -count=3
ok  	github.com/zalando/skipper/filters/builtin

$ go test ./filters/builtin
ok  	github.com/zalando/skipper/filters/builtin	2.165s
```

All existing `TestModRequestHostHeader`, `TestModRequestHeader` and `TestModResponseHeader` cases pass before and after; they only ever use single-valued headers, which is why this went unnoticed.

## Notes

- `gofmt -l -s` and `go vet ./filters/builtin` are clean.
- `-race` needs cgo and there is no C toolchain on this machine, so CI has to cover that.
